### PR TITLE
Renamed words in /docs/dev-tools/* files. Elastic/elastic not changed.

### DIFF
--- a/docs/dev-tools/console/console.asciidoc
+++ b/docs/dev-tools/console/console.asciidoc
@@ -1,9 +1,9 @@
-[[console-kibana]]
+[[console-opensearch-dashboards]]
 == Console
 
-Console enables you to interact with the REST API of {es}. You can:
+Console enables you to interact with the REST API of {opensearch}. You can:
 
-* Send requests to {es} and view the responses
+* Send requests to {opensearch} and view the responses
 * View API documentation
 * Get your request history
 
@@ -12,14 +12,14 @@ To get started, open the main menu, click *Dev Tools*, then click *Console*.
 [role="screenshot"]
 image::dev-tools/console/images/console.png["Console"]
 
-NOTE: You are unable to interact with the REST API of {kib} with the Console.
+NOTE: You are unable to interact with the REST API of {osd} with the Console.
 
 [float]
 [[console-api]]
 === Write requests
 
 Console understands commands in a cURL-like syntax.
-For example, the following is a `GET` request to the {es} `_search` API.
+For example, the following is a `GET` request to the {opensearch} `_search` API.
 
 [source,js]
 ----------------------------------
@@ -43,7 +43,7 @@ curl -XGET "http://localhost:9200/_search" -d'
 }'
 ----------------------------------
 
-When you paste the command into Console, {kib} automatically converts it
+When you paste the command into Console, {osd} automatically converts it
 to Console syntax.  Alternatively, if you want to see Console syntax in cURL, 
 click the action icon (image:dev-tools/console/images/wrench.png[]) and select *Copy as cURL*.
 
@@ -76,7 +76,7 @@ image::dev-tools/console/images/request.png["Console close-up"]
 
 If you select *Auto indent* on a request that is already well formatted,
 Console collapses the request body to a single line per document.
-This is helpful when working with the {es} {ref}/docs-bulk.html[bulk APIs].
+This is helpful when working with the {opensearch} {ref}/docs-bulk.html[bulk APIs].
 
 
 
@@ -84,11 +84,11 @@ This is helpful when working with the {es} {ref}/docs-bulk.html[bulk APIs].
 [[console-request]]
 === Submit requests
 
-When you're ready to submit the request to {es}, click the
+When you're ready to submit the request to {opensearch}, click the
 green triangle.
 
 You can select multiple requests and submit them together.
-Console sends the requests to {es} one by one and shows the output
+Console sends the requests to {opensearch} one by one and shows the output
 in the response pane. Submitting multiple request is helpful when you're debugging an issue or trying query
 combinations in multiple scenarios.
 
@@ -105,9 +105,9 @@ the action icon (image:dev-tools/console/images/wrench.png[]) and select
 [[console-history]]
 === Get your request history
 
-Console maintains a list of the last 500 requests that {es} successfully executed.
+Console maintains a list of the last 500 requests that {opensearch} successfully executed.
 To view your most recent requests, click *History*. If you select a request
-and click *Apply*, {kib} adds it to the editor at the current cursor position.
+and click *Apply*, {osd} adds it to the editor at the current cursor position.
 
 [float]
 [[configuring-console]]
@@ -131,6 +131,6 @@ shortcuts, click *Help*.
 === Disable Console
 
 If you don’t want to use Console, you can disable it by setting `console.enabled`
-to `false` in your `kibana.yml` configuration file. Changing this setting
+to `false` in your `opensearch_dashboards.yml` configuration file. Changing this setting
 causes the server to regenerate assets on the next startup,
 which might cause a delay before pages start being served.

--- a/docs/dev-tools/grokdebugger/index.asciidoc
+++ b/docs/dev-tools/grokdebugger/index.asciidoc
@@ -2,7 +2,7 @@
 [[xpack-grokdebugger]]
 == Debugging grok expressions
 
-You can build and debug grok patterns in the {kib} *Grok Debugger*
+You can build and debug grok patterns in the {osd} *Grok Debugger*
 before you use them in your data processing pipelines. Grok is a pattern 
 matching syntax that you can use to parse arbitrary text and
 structure it. Grok is good for parsing syslog, apache, and other
@@ -17,7 +17,7 @@ for more information on the syntax for a grok pattern.
 
 The Elastic Stack ships
 with more than 120 reusable grok patterns. See
-https://github.com/elastic/elasticsearch/tree/master/libs/grok/src/main/resources/patterns[Ingest node grok patterns] and https://github.com/logstash-plugins/logstash-patterns-core/tree/master/patterns[Logstash grok patterns]
+https://github.com/elastic/opensearch/tree/master/libs/grok/src/main/resources/patterns[Ingest node grok patterns] and https://github.com/logstash-plugins/logstash-patterns-core/tree/master/patterns[Logstash grok patterns]
 for the complete list of patterns.
 
 Because
@@ -30,7 +30,7 @@ in ingest node and Logstash.
 === Getting started with the Grok Debugger
 
 This example walks you through using the *Grok Debugger*. This tool
-is automatically enabled in {kib}. 
+is automatically enabled in {osd}. 
 
 NOTE: If you're using {stack-security-features}, you must have the `manage_pipeline`
 permission to use the Grok Debugger.

--- a/docs/dev-tools/painlesslab/index.asciidoc
+++ b/docs/dev-tools/painlesslab/index.asciidoc
@@ -7,7 +7,7 @@ beta::[]
 The Painless Lab is an interactive code editor that lets you test and
 debug {ref}/modules-scripting-painless.html[Painless scripts] in real-time.
 You can use the Painless scripting
-language to create <<scripted-fields, {kib} scripted fields>>,
+language to create <<scripted-fields, {osd} scripted fields>>,
 process {ref}/docs-reindex.html[reindexed data], define complex
 <<watcher-create-advanced-watch, Watcher conditions>>,
 and work with data in other contexts.

--- a/docs/dev-tools/searchprofiler/getting-started.asciidoc
+++ b/docs/dev-tools/searchprofiler/getting-started.asciidoc
@@ -2,7 +2,7 @@
 [[profiler-getting-started]]
 === Getting Started
 
-The {searchprofiler} is automatically enabled in {kib}. Open the main menu, click *Dev Tools*, then click *Search Profiler*
+The {searchprofiler} is automatically enabled in {osd}. Open the main menu, click *Dev Tools*, then click *Search Profiler*
 to get started.
 
 {searchprofiler} displays the names of the indices searched, the shards in each index,
@@ -10,7 +10,7 @@ and how long it took for the query to complete. To try it out, replace the defau
 with the query you want to profile and click *Profile*.
 
 The following example shows the results of profiling the `match_all` query.
-If we take a closer look at the information for the `.kibana_1` sample index, the
+If we take a closer look at the information for the `.opensearch_dashboards_1` sample index, the
 Cumulative Time field shows us that the query took 1.279ms to execute.
 
 [role="screenshot"]
@@ -42,8 +42,8 @@ to `GET /_search`. It searches across your entire cluster (all indices, all type
 If you need to query a specific index or type (or several), you can use the Index
 and Type filters.
 
-In the following example, the query is executed against the indices `test` and `kibana_1`
-and the type `my_type`. This is equivalent making a request to `GET /test,kibana_1/my_type/_search`.
+In the following example, the query is executed against the indices `test` and `opensearch_dashboards_1`
+and the type `my_type`. This is equivalent making a request to `GET /test,opensearch_dashboards_1/my_type/_search`.
 
 [role="screenshot"]
 image::dev-tools/searchprofiler/images/filter.png["Filtering by index and type"]

--- a/docs/dev-tools/searchprofiler/gs-index.asciidoc
+++ b/docs/dev-tools/searchprofiler/gs-index.asciidoc
@@ -4,7 +4,7 @@
 
 [partintro]
 --
-{es} has a powerful {ref}/search-profile.html[Profile API] which can be used to inspect and analyze
+{opensearch} has a powerful {ref}/search-profile.html[Profile API] which can be used to inspect and analyze
 your search queries. The response returns a large JSON blob, which can be
 difficult to analyze manually.
 

--- a/docs/dev-tools/searchprofiler/index.asciidoc
+++ b/docs/dev-tools/searchprofiler/index.asciidoc
@@ -2,7 +2,7 @@
 [[xpack-profiler]]
 == Profiling queries and aggregations
 
-{es} has a powerful {ref}/search-profile.html[Profile API] which can be used to inspect and analyze
+{opensearch} has a powerful {ref}/search-profile.html[Profile API] which can be used to inspect and analyze
 your search queries. The response returns a large JSON blob, which can be
 difficult to analyze manually.
 

--- a/docs/dev-tools/searchprofiler/pasting.asciidoc
+++ b/docs/dev-tools/searchprofiler/pasting.asciidoc
@@ -2,7 +2,7 @@
 [[profiler-render]]
 === Rendering pre-captured profiler JSON
 
-The {searchprofiler} queries the cluster that the Kibana node is attached to.
+The {searchprofiler} queries the cluster that the OpenSearchDashboards node is attached to.
 It does this by executing the query against the cluster and collecting the results.
 
 But sometimes you may want to investigate performance problems that are temporal in nature. 


### PR DESCRIPTION
*Issue #, if available:*
[#37](https://github.com/opendistro-for-elasticsearch/website/issues/37)

*Description of changes:*
Renamed words in /docs/dev-tools/* files. Elastic/elastic not changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
