### PR TITLE
Renamed words in /docs/migration/* files. Elastic/elastic not changed.

### DIFF
--- a/docs/migration/migrate_7_0.asciidoc
+++ b/docs/migration/migrate_7_0.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 This section discusses the changes that you need to be aware of when migrating
-your application to Kibana 7.0.
+your application to OpenSearchDashboards 7.0.
 
 See also <<whats-new>> and <<release-notes>>.
 
@@ -89,8 +89,8 @@ Example structure after:
 
 [float]
 ==== Removed support for using PhantomJS browser for screenshots in Reporting
-*Details:* Since the first release of Kibana Reporting, PhantomJS was used as
-the headless browser to capture screenshots of Kibana dashboards and
+*Details:* Since the first release of OpenSearchDashboards Reporting, PhantomJS was used as
+the headless browser to capture screenshots of OpenSearchDashboards dashboards and
 visualizations. In that short time, Chromium has started offering a new
 headless browser library and the PhantomJS maintainers abandoned their project.
 We started planning for a transition in 6.5.0, when we made Chromium the
@@ -100,26 +100,26 @@ will still exist for compatibility, but the only valid option will be
 `chromium`.
 
 *Impact:* Before upgrading to 7.0, if you have `xpack.reporting.capture.browser.type`
-set in kibana.yml, make sure it is set to `chromium`.
+set in opensearch_dashboards.yml, make sure it is set to `chromium`.
 
 [NOTE]
 ============
 Reporting 7.0 uses a version of the Chromium headless browser that RHEL 6,
 CentOS 6.x, and other old versions of Linux derived from RHEL 6. This change
-effectively removes RHEL 6 OS server support from Kibana Reporting. Users with
-RHEL 6 must upgrade to RHEL 7 to use Kibana Reporting starting with version
+effectively removes RHEL 6 OS server support from OpenSearchDashboards Reporting. Users with
+RHEL 6 must upgrade to RHEL 7 to use OpenSearchDashboards Reporting starting with version
 7.0.0 of the Elastic stack.
 ============
 
 
 [float]
-==== Legacy browsers (namely IE11) will see a security warning message whenever they load Kibana
-*Details:* Kibana now has a Content Security Policy, but it's only effective if browsers enforce it, and since older
-browsers like Internet Explorer 11 do not support CSP, we show them a warning message whenever they load Kibana.
+==== Legacy browsers (namely IE11) will see a security warning message whenever they load OpenSearchDashboards
+*Details:* OpenSearchDashboards now has a Content Security Policy, but it's only effective if browsers enforce it, and since older
+browsers like Internet Explorer 11 do not support CSP, we show them a warning message whenever they load OpenSearchDashboards.
 
 *Impact:* Nothing needs to be done necessarily, but if you don't need to support legacy browsers like IE11, we recommend
-that you set `csp.strict: true` in your kibana.yml to block access to those browsers entirely. If your organization requires
-users to use IE11, you might like to disable the warning entirely with `csp.warnLegacyBrowsers: false` in your kibana.yml.
+that you set `csp.strict: true` in your opensearch_dashboards.yml to block access to those browsers entirely. If your organization requires
+users to use IE11, you might like to disable the warning entirely with `csp.warnLegacyBrowsers: false` in your opensearch_dashboards.yml.
 
 
 [float]
@@ -131,7 +131,7 @@ users to use IE11, you might like to disable the warning entirely with `csp.warn
 
 *Details:* Overseas territories in the France Departments vector layer have 
 been removed. These territories have no ISO 3166-2 or INSEE codes to join to 
-{es} data.
+{opensearch} data.
 
 *Impact:* Region Map, Vega, and Maps plugin visualizations using the France 
 Departments layer will not show overseas territories. 
@@ -153,11 +153,11 @@ in some areas. Also, some zip codes have been deprecated and new ones have been 
 === Packaging changes
 
 [float]
-==== Removed support for running Kibana with a global Node.js installation
-*Details:* Previous versions of Kibana would fallback to using a global installation of Node.js if the distribution included with Kibana was not found.
-Kibana 7.0 will only use the Node.js distribution included in the package.
+==== Removed support for running OpenSearchDashboards with a global Node.js installation
+*Details:* Previous versions of OpenSearchDashboards would fallback to using a global installation of Node.js if the distribution included with OpenSearchDashboards was not found.
+OpenSearchDashboards 7.0 will only use the Node.js distribution included in the package.
 
-*Impact:* There is no expected impact unless Kibana is installed in a non-standard way.
+*Impact:* There is no expected impact unless OpenSearchDashboards is installed in a non-standard way.
 
 [float]
 [[breaking_70_plugin_changes]]
@@ -165,30 +165,30 @@ Kibana 7.0 will only use the Node.js distribution included in the package.
 
 [float]
 ==== Optimization step deferred until server start
-*Details:* Prior versions of Kibana would run the optimization step after each plugin installation.  This is now run on server start when necessary.
+*Details:* Prior versions of OpenSearchDashboards would run the optimization step after each plugin installation.  This is now run on server start when necessary.
 
-*Impact:* Users can trigger a standalone optimization after all plugins have been installed with `bin/kibana --optimize` or let the server manage it on startup.
+*Impact:* Users can trigger a standalone optimization after all plugins have been installed with `bin/opensearch-dashboards --optimize` or let the server manage it on startup.
 
 [float]
 [[breaking_70_security_changes]]
 === Security changes
 
 [float]
-==== Removed support for users relying on direct index privileges to the Kibana index in Elasticsearch
-*Details:* With the introduction of Kibana RBAC in 6.4, users no longer require privileges to the Kibana index in Elasticsearch. Instead, users
-should be granted <<kibana-privileges>>. Prior to 7.0, when a user who relies upon direct index privileges logged into Kibana, a deprecation warning was logged. 
+==== Removed support for users relying on direct index privileges to the OpenSearchDashboards index in OpenSearch
+*Details:* With the introduction of OpenSearchDashboards RBAC in 6.4, users no longer require privileges to the OpenSearchDashboards index in OpenSearch. Instead, users
+should be granted <<opensearch-dashboards-privileges>>. Prior to 7.0, when a user who relies upon direct index privileges logged into OpenSearchDashboards, a deprecation warning was logged. 
 
-*Impact:* You must change any roles that grant access to Kibana using index privileges to use <<kibana-privileges>> instead. 
+*Impact:* You must change any roles that grant access to OpenSearchDashboards using index privileges to use <<opensearch-dashboards-privileges>> instead. 
 Watcher jobs using the Reporting attachment type must also be updated.
 
-If you use a custom `kibana.index` for multitenancy, you can 
-no longer use `kibana_user` or `kibana_dashboard_only_user` to provide access, 
-and will have to start using {kib} privileges.
+If you use a custom `opensearch-dashboards.index` for multitenancy, you can 
+no longer use `opensearch_dashboards_user` or `opensearch_dashboards_dashboard_only_user` to provide access, 
+and will have to start using {osd} privileges.
 
-In addition, roles cannot be shared across Kibana tenants when granting access to Kibana privileges.
-For example, a tenant using `kibana.index: .kibana` will have its own set 
-of roles created to grant access to Kibana. If you create another tenant 
-at `kibana.index: .some-other-index`, it will need its own set of roles 
+In addition, roles cannot be shared across OpenSearchDashboards tenants when granting access to OpenSearchDashboards privileges.
+For example, a tenant using `opensearch-dashboards.index: .opensearchDashboards` will have its own set 
+of roles created to grant access to OpenSearchDashboards. If you create another tenant 
+at `opensearch-dashboards.index: .some-other-index`, it will need its own set of roles 
 to grant access to that tenant.
 
 [float]
@@ -197,54 +197,54 @@ to grant access to that tenant.
 
 [float]
 ==== Removed support for tribe nodes
-*Details:* Elasticsearch 7.0 removes the tribe node feature, so Kibana removes it as well.
+*Details:* OpenSearch 7.0 removes the tribe node feature, so OpenSearchDashboards removes it as well.
 
-*Impact:* You must remove any tribe node configurations in Kibana. Consider using <<management-cross-cluster-search>> instead, which does not require kibana.yml configurations in Kibana.
+*Impact:* You must remove any tribe node configurations in OpenSearchDashboards. Consider using <<management-cross-cluster-search>> instead, which does not require opensearch_dashboards.yml configurations in OpenSearchDashboards.
 
 
 [float]
-==== `elasticsearch.ssl.ca` is no longer valid
+==== `opensearch.ssl.ca` is no longer valid
 
-*Details:* The deprecated `elasticsearch.ssl.ca` setting in the `kibana.yml` 
+*Details:* The deprecated `opensearch.ssl.ca` setting in the `opensearch_dashboards.yml` 
 file has been removed.
 
-*Impact:* Use `elasticsearch.ssl.certificateAuthorities` instead.
+*Impact:* Use `opensearch.ssl.certificateAuthorities` instead.
 
 [float]
-==== `elasticsearch.ssl.cert` is no longer valid
+==== `opensearch.ssl.cert` is no longer valid
 
-*Details:* The deprecated `elasticsearch.ssl.cert` setting in the `kibana.yml`
+*Details:* The deprecated `opensearch.ssl.cert` setting in the `opensearch_dashboards.yml`
 file has been removed.
 
-*Impact:* Use `elasticsearch.ssl.certificate` instead.
+*Impact:* Use `opensearch.ssl.certificate` instead.
 
 [float]
-==== `elasticsearch.ssl.verify` is no longer valid
+==== `opensearch.ssl.verify` is no longer valid
 
-*Details:* The deprecated `elasticsearch.ssl.verify` setting in the `kibana.yml`
+*Details:* The deprecated `opensearch.ssl.verify` setting in the `opensearch_dashboards.yml`
 file has been removed.
 
-*Impact:* Use `elasticsearch.ssl.verificationMode` instead. If you set
-`elasticsearch.ssl.verify` to `true`, that is equal to setting 
-`elasticsearch.ssl.verificationMode` to `full`.
+*Impact:* Use `opensearch.ssl.verificationMode` instead. If you set
+`opensearch.ssl.verify` to `true`, that is equal to setting 
+`opensearch.ssl.verificationMode` to `full`.
 
 [float]
-==== `elasticsearch.url` is no longer valid
+==== `opensearch.url` is no longer valid
 
-*Details:* The deprecated `elasticsearch.url` setting in the `kibana.yml` file
+*Details:* The deprecated `opensearch.url` setting in the `opensearch_dashboards.yml` file
 has been removed. 
 
-*Impact:* Use `elasticsearch.hosts` instead. In prior versions of Kibana, if no
-port was specified in `elasticsearch.url`, a default of 9200 was chosen. The
-port in `elasticsearch.hosts` is protocol dependent: https ports will use 443,
-and http ports will use 80. If your `elasticsearch.url` setting was dependent on
+*Impact:* Use `opensearch.hosts` instead. In prior versions of OpenSearchDashboards, if no
+port was specified in `opensearch.url`, a default of 9200 was chosen. The
+port in `opensearch.hosts` is protocol dependent: https ports will use 443,
+and http ports will use 80. If your `opensearch.url` setting was dependent on
 an unspecified port set to 9200, append `:9200` to the url in the
-`elasticsearch.hosts` setting.
+`opensearch.hosts` setting.
 
 [float]
 ==== `i18n.defaultLocale` is no longer valid
 
-*Details:* The deprecated `i18n.defaultLocale` setting in the `kibana.yml` file
+*Details:* The deprecated `i18n.defaultLocale` setting in the `opensearch_dashboards.yml` file
 has been removed.
 
 *Impact:* Use `i18n.locale` instead.
@@ -252,7 +252,7 @@ has been removed.
 [float]
 ==== `index_management.<any setting>` is no longer valid
 
-*Details:* The deprecated `index_management.*` settings in the `kibana.yml`
+*Details:* The deprecated `index_management.*` settings in the `opensearch_dashboards.yml`
 file have been removed.
 
 *Impact:* Use `xpack.index_management.<any setting>` instead.
@@ -260,7 +260,7 @@ file have been removed.
 [float]
 ==== `license_management.<any setting>` is no longer valid
 
-*Details:* The deprecated `license_management.*` settings in the `kibana.yml`
+*Details:* The deprecated `license_management.*` settings in the `opensearch_dashboards.yml`
 file have been removed.
 
 *Impact:* Use `xpack.license_management.<any setting>` instead.
@@ -268,7 +268,7 @@ file have been removed.
 [float]
 ==== `logging.useUTC` is no longer valid
 
-*Details:* The deprecated `logging.useUTC` setting in the `kibana.yml` file has
+*Details:* The deprecated `logging.useUTC` setting in the `opensearch_dashboards.yml` file has
 been removed. 
 
 *Impact:* If `logging.useUTC` was set to `true` (its default value), the
@@ -278,7 +278,7 @@ specified by canonical id.
 [float]
 ==== `regionmap` is no longer valid
 
-*Details:* The deprecated `regionmap` setting in the `kibana.yml` file has been
+*Details:* The deprecated `regionmap` setting in the `opensearch_dashboards.yml` file has been
 removed.
 
 *Impact:* Use `map.regionmap` instead.
@@ -286,7 +286,7 @@ removed.
 [float]
 ==== `rollup.<any setting>` is no longer valid
 
-*Details:* The deprecated `rollup.*` settings in the `kibana.yml` file have been
+*Details:* The deprecated `rollup.*` settings in the `opensearch_dashboards.yml` file have been
 removed.
 
 *Impact:* Use `xpack.rollup.<any setting>` instead.
@@ -294,7 +294,7 @@ removed.
 [float]
 ==== `server.ssl.cert` is no longer valid
 
-*Details:* The deprecated `server.ssl.cert` setting in the `kibana.yml` file has
+*Details:* The deprecated `server.ssl.cert` setting in the `opensearch_dashboards.yml` file has
 been removed.
 
 *Impact:* Use `server.ssl.certificate` instead
@@ -303,7 +303,7 @@ been removed.
 ==== `server.ssl.enabled` must be set to `true` to enable SSL
 
 *Details:* Previously, if the `server.ssl.certificate` and `server.ssl.key`
-settins were specified in the `kibana.yml` file, SSL would be automatically
+settins were specified in the `opensearch_dashboards.yml` file, SSL would be automatically
 enabled. It's now required that you set `server.ssl.enabled` to `true` for this
 to occur.
 
@@ -315,15 +315,15 @@ now also set `server.ssl.enabled` to enable SSL.
 
 *Details:* By default, TLSv1 support has been removed. It's still possible to
 opt-in to TLSv1 support by explicitly setting `server.ssl.supportedProtocols` in
-the `kibana.yml` file.
+the `opensearch_dashboards.yml` file.
 
-*Impact:* Users relying on TLSv1 will be unable to use Kibana unless
+*Impact:* Users relying on TLSv1 will be unable to use OpenSearchDashboards unless
 `server.ssl.supportedProtocols` is explicitly set.
 
 [float]
 ==== `tilemap` is no longer valid
 
-*Details:* The deprecated `tilemap` setting in the `kibana.yml` file has been
+*Details:* The deprecated `tilemap` setting in the `opensearch_dashboards.yml` file has been
 removed.
 
 *Impact:* Use `map.tilemap` instead.
@@ -331,7 +331,7 @@ removed.
 [float]
 ==== `upgrade_assistant.<any setting>` is no longer valid
 
-*Details:* The deprecated `upgrade_assistant.*` settings in the `kibana.yml`
+*Details:* The deprecated `upgrade_assistant.*` settings in the `opensearch_dashboards.yml`
 file have been removed.
 
 *Impact:* Use `xpack.upgrade_assistant.<any setting>` instead.
@@ -340,7 +340,7 @@ file have been removed.
 ==== `xpack.monitoring.beats.index_pattern` is no longer valid
 
 *Details:* The unsupported `xpack.monitoring.beats.index_pattern` setting in the
-`kibana.yml` file has been officially removed.
+`opensearch_dashboards.yml` file has been officially removed.
 
 *Impact:* The ability to customize this pattern is no longer supported.
 
@@ -348,70 +348,70 @@ file have been removed.
 ==== `xpack.monitoring.cluster_alerts.index` is no longer valid
 
 *Details:* The unsupported `xpack.monitoring.cluster_alerts.index` setting in
-the `kibana.yml` file has been officially removed. 
+the `opensearch_dashboards.yml` file has been officially removed. 
 
 *Impact:* The ability to customize this index is no longer supported.
 
 [float]
-==== `xpack.monitoring.elasticsearch.index_pattern` is no longer valid
+==== `xpack.monitoring.opensearch.index_pattern` is no longer valid
 
-*Details:* The unsupported `xpack.monitoring.elasticsearch.index_pattern`
-setting in the `kibana.yml` file has been officially removed.
+*Details:* The unsupported `xpack.monitoring.opensearch.index_pattern`
+setting in the `opensearch_dashboards.yml` file has been officially removed.
 
 *Impact:* The ability to customize this pattern is no longer supported.
 
 [float]
-==== `xpack.monitoring.elasticsearch.ssl.ca` is no longer valid
+==== `xpack.monitoring.opensearch.ssl.ca` is no longer valid
 
-*Details:* The deprecated `xpack.monitoring.elasticsearch.ssl.ca` setting in the
-`kibana.yml` file has been removed. 
+*Details:* The deprecated `xpack.monitoring.opensearch.ssl.ca` setting in the
+`opensearch_dashboards.yml` file has been removed. 
 
-*Impact:* Use `xpack.monitoring.elasticsearch.ssl.certificateAuthorities` instead.
-
-[float]
-==== `xpack.monitoring.elasticsearch.ssl.cert` is no longer valid
-
-*Details:* The deprecated `xpack.monitoring.elasticsearch.ssl.cert` setting in
-the `kibana.yml` file has been removed. 
-
-*Impact:* Use `xpack.monitoring.elasticsearch.ssl.certificate` instead.
+*Impact:* Use `xpack.monitoring.opensearch.ssl.certificateAuthorities` instead.
 
 [float]
-==== `xpack.monitoring.elasticsearch.ssl.verify` is no longer valid
+==== `xpack.monitoring.opensearch.ssl.cert` is no longer valid
 
-*Details:* The deprecated `xpack.monitoring.elasticsearch.ssl.verify` setting in
-the `kibana.yml` file has been removed. 
+*Details:* The deprecated `xpack.monitoring.opensearch.ssl.cert` setting in
+the `opensearch_dashboards.yml` file has been removed. 
 
-*Impact:* Use `xpack.monitoring.elasticsearch.ssl.verificationMode` instead. If
-you previously set `xpack.monitoring.elasticsearch.ssl.verify` to `true`, it is
-equal to setting `xpack.monitoring.elasticsearch.ssl.verificationMode` to `full`.
+*Impact:* Use `xpack.monitoring.opensearch.ssl.certificate` instead.
 
 [float]
-==== `xpack.monitoring.elasticsearch.url` is no longer valid
+==== `xpack.monitoring.opensearch.ssl.verify` is no longer valid
 
-*Details:* The deprecated `xpack.monitoring.elasticsearch.url` setting in the
-`kibana.yml` file has been removed. 
+*Details:* The deprecated `xpack.monitoring.opensearch.ssl.verify` setting in
+the `opensearch_dashboards.yml` file has been removed. 
 
-*Impact:* Use `xpack.monitoring.elasticsearch.hosts` instead. In prior versions
-of Kibana, if no port was specified in `xpack.monitoring.elasticsearch.url` a
-default of 9200 was chosen. The port in `xpack.monitoring.elasticsearch.hosts`
+*Impact:* Use `xpack.monitoring.opensearch.ssl.verificationMode` instead. If
+you previously set `xpack.monitoring.opensearch.ssl.verify` to `true`, it is
+equal to setting `xpack.monitoring.opensearch.ssl.verificationMode` to `full`.
+
+[float]
+==== `xpack.monitoring.opensearch.url` is no longer valid
+
+*Details:* The deprecated `xpack.monitoring.opensearch.url` setting in the
+`opensearch_dashboards.yml` file has been removed. 
+
+*Impact:* Use `xpack.monitoring.opensearch.hosts` instead. In prior versions
+of OpenSearchDashboards, if no port was specified in `xpack.monitoring.opensearch.url` a
+default of 9200 was chosen. The port in `xpack.monitoring.opensearch.hosts`
 is protocol dependent: https ports will use 443, and http ports will use 80. If
-`xpack.monitoring.elasticsearch.url` was dependent on an unspecified port set to
-9200, append `:9200` to the url in `xpack.monitoring.elasticsearch.hosts`.
+`xpack.monitoring.opensearch.url` was dependent on an unspecified port set to
+9200, append `:9200` to the url in `xpack.monitoring.opensearch.hosts`.
 
 [float]
 ==== `xpack.monitoring.index_pattern` is no longer valid
 
 *Details:* The unsupported `xpack.monitoring.index_pattern` setting in the
-`kibana.yml` file has been officially removed.
+`opensearch_dashboards.yml` file has been officially removed.
 
 *Impact:* The ability to customize this pattern is no longer supported.
 
 [float]
-==== `xpack.monitoring.kibana.index_pattern` is no longer valid
+==== `xpack.monitoring.opensearchDashboards.index_pattern` is no longer valid
 
-*Details:* The unsupported `xpack.monitoring.kibana.index_pattern` setting in
-the `kibana.yml` file has been officially removed.
+*Details:* The unsupported `xpack.monitoring.opensearchDashboards.index_pattern` setting in
+the `opensearch_dashboards.yml` file has been officially removed.
 
 *Impact:* The ability to customize this pattern is no longer supported.
 
@@ -419,7 +419,7 @@ the `kibana.yml` file has been officially removed.
 ==== `xpack.monitoring.logstash.index_pattern` is no longer valid
 
 *Details:* The unsupported `xpack.monitoring.logstash.index_pattern` setting in
-the `kibana.yml` file has been officially removed.
+the `opensearch_dashboards.yml` file has been officially removed.
 
 *Impact:* The ability to customize this pattern is no longer supported.
 
@@ -427,12 +427,12 @@ the `kibana.yml` file has been officially removed.
 ==== `xpack.monitoring.node_resolver` is no longer valid
 
 *Details:* The deprecated `xpack.monitoring.node_resolver` setting in the
-`kibana.yml` file has been removed. This setting has been deprecated since 5.6,
+`opensearch_dashboards.yml` file has been removed. This setting has been deprecated since 5.6,
 when it was explicitly recommended to use `uuid` as its value.
 
 *Impact:* This setting is no longer necessary. If you enable the {stack}
-{monitor-features}, a monitoring agent runs on each Elasticsearch node, Logstash
-node, Kibana instance, and Beat to collect and index metrics. Each node and
+{monitor-features}, a monitoring agent runs on each OpenSearch node, Logstash
+node, OpenSearchDashboards instance, and Beat to collect and index metrics. Each node and
 instance is considered unique based on its persistent UUID, which is written to
 the `path.data` directory when the node or instance starts.
 
@@ -440,17 +440,17 @@ the `path.data` directory when the node or instance starts.
 ==== `xpack.monitoring.report_stats` is no longer valid
 
 *Details:* The deprecated `xpack.monitoring.report_stats` setting in the
-`kibana.yml` file has been removed. 
+`opensearch_dashboards.yml` file has been removed. 
 
 *Impact:* Use `xpack.xpack_main.telemetry.enabled` instead.
 
 [float]
-==== `management/kibana/(index|indices)` => `management/kibana/index_pattern(?s)`
+==== `management/opensearch-dashboards/(index|indices)` => `management/opensearch-dashboards/index_pattern(?s)`
 
-*Details:* Kibana management URLs pertaining to index patterns have been changed
-to accurately reflect their content, from `management/kibana/index` or
-`management/kibana/indices` to `managemen/kibana/index_pattern` or
-`management/kibana/index_patterns`. 
+*Details:* OpenSearchDashboards management URLs pertaining to index patterns have been changed
+to accurately reflect their content, from `management/opensearch-dashboards/index` or
+`management/opensearch-dashboards/indices` to `managemen/opensearch-dashboards/index_pattern` or
+`management/opensearch-dashboards/index_patterns`. 
 
 *Impact:* References to these URLs will need to be updated.
 
@@ -461,7 +461,7 @@ to accurately reflect their content, from `management/kibana/index` or
 
 [float]
 ==== Advanced setting query:queryString:options no longer applies to filters
-*Details:* In previous versions of Kibana the Advanced Setting `query:queryString:options` was applied to both queries
+*Details:* In previous versions of OpenSearchDashboards the Advanced Setting `query:queryString:options` was applied to both queries
 and custom filters using the `query_string` query. This could cause errors if a custom filter used options that
 conflicted with the Advanced Setting. In 7.0 `query:queryString:options` will no longer be applied to filters so that
 users can have full control over their custom filters.
@@ -471,16 +471,16 @@ users can have full control over their custom filters.
 
 [float]
 ==== Advanced setting query:queryString:options no longer applies `default_field: *` by default.
-*Details:* Elasticsearch removed the ability to create indices with an _all field in 6.0. As a result, a user could end
-up with a mix of indices with and without _all fields if they upgraded from an older version of ES. This could lead to
+*Details:* OpenSearch removed the ability to create indices with an _all field in 6.0. As a result, a user could end
+up with a mix of indices with and without _all fields if they upgraded from an older version of OPENSEARCH. This could lead to
 inconsistent highlighting in Discover. To work around this issue we added `default_field: *` to query:queryString:options
 to force consistent querying across indices with and without _all. In 7.0 the _all field will be gone from all indices
 so we no longer need this workaround.
 
-*Impact:* Since we'll no longer send the `default_field` parameter in Kibana's query_string query, Elasticsearch
+*Impact:* Since we'll no longer send the `default_field` parameter in OpenSearchDashboards's query_string query, OpenSearch
 will use the index setting instead. The default for the index setting is also `*`, so most users should not be impacted.
 If some of your indices have a non-default `default_field` setting, you may want to update it or re-add the parameter
-to Kibana's advanced setting.
+to OpenSearchDashboards's advanced setting.
 
 [float]
 [[breaking_70_UI_changes]]
@@ -520,20 +520,20 @@ should be required as a result of this change, but be aware that users with save
 multiple split tables will now see those tables rendered differently.
 
 [float]
-==== Imported Kibana dashboards might require small grid layout adjustments due to design changes
-*Details:* Kibana 7.0 introduces a new default font for the application and also comes with several design changes in dashboards that slightly change padding and margin for dashboard panels. You may find you need to adjust grid layouts to compensate.
+==== Imported OpenSearchDashboards dashboards might require small grid layout adjustments due to design changes
+*Details:* OpenSearchDashboards 7.0 introduces a new default font for the application and also comes with several design changes in dashboards that slightly change padding and margin for dashboard panels. You may find you need to adjust grid layouts to compensate.
 
 *Impact:* Minimal. In most cases, the dashboards should render as they did previously. In some cases, panels might overflow and require scroll bars where they did not previously. Simply adjust the panel sizes and edit your dashboard layouts if these bother you.
 
 [float]
 ==== Timelion no longer appears in the side navigation
 *Details:* Timelion sheets will continue to work in *Visualize*, but the 
-Timelion application no longer appears by default in the {kib} side navigation. 
+Timelion application no longer appears by default in the {osd} side navigation. 
 
 *Impact:* To create a Timelion visualization, go to *Visualize* and select 
 *Timelion* from the visualization types. If you have a lot of existing Timelion 
 visualizations and want to add Timelion back in the side
-navigation, set `timelion.ui.enabled` to `true` in `kibana.yml`.
+navigation, set `timelion.ui.enabled` to `true` in `opensearch_dashboards.yml`.
 
 
 

--- a/docs/migration/migrate_7_10.asciidoc
+++ b/docs/migration/migrate_7_10.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 This page discusses the breaking changes that you need to be aware of when migrating
-your application to {kib} 7.10.
+your application to {osd} 7.10.
 
 * <<user-facing-changes-7-10, Breaking changes for users>>
 * <<general-plugin-API-changes-7-10, Breaking changes for plugin developers>>
@@ -20,22 +20,22 @@ your application to {kib} 7.10.
 
 
 [discrete]
-[[breaking_kibana_legacy_plugins]]
+[[breaking_opensearch_dashboards_legacy_plugins]]
 ==== Legacy plugins support removed
 
 The legacy plugin system and the legacy plugin API have been removed.
-Legacy plugin owners should migrate their plugins to the {kib} Platform plugin API.
+Legacy plugin owners should migrate their plugins to the {osd} Platform plugin API.
 
-*via https://github.com/elastic/kibana/pull/77599[#77599]*
+*via https://github.com/elastic/opensearch-dashboards/pull/77599[#77599]*
 
 [discrete]
-[[breaking_kibana_plugins]]
-==== Support added for Kibana Platform plugins
+[[breaking_opensearch_dashboards_plugins]]
+==== Support added for OpenSearchDashboards Platform plugins
 
-The `bin/kibana-plugin` CLI has been updated to work with the new {kib}
+The `bin/opensearch-dashboards-plugin` CLI has been updated to work with the new {osd}
 Platform plugin format instead of the legacy plugin format.
 
-*via https://github.com/elastic/kibana/pull/74604[#74604]*
+*via https://github.com/elastic/opensearch-dashboards/pull/74604[#74604]*
 
 [discrete]
 [[breaking_vega_visualizations]]
@@ -51,7 +51,7 @@ param exists, an error message is returned.
 Refer to the https://vega.github.io/vega/docs/specification/[Vega docs] for
 more information about this property.
 
-*via https://github.com/elastic/kibana/pull/73805[#73805]*
+*via https://github.com/elastic/opensearch-dashboards/pull/73805[#73805]*
 
 // end::notable-breaking-changes[]
 
@@ -66,10 +66,10 @@ more information about this property.
 
 To rename the Ingest Manger plugin to Fleet:
 
-* The {kib} config for Ingest Manager moved from `xpack.ingestManager.*` to `xpack.fleet.*`.
+* The {osd} config for Ingest Manager moved from `xpack.ingestManager.*` to `xpack.fleet.*`.
 * The config options specific to agents moved to `xpack.ingestManager.fleet.*` and `xpack.fleet.agents.*`.
 
-*via https://github.com/elastic/kibana/pull/79406[#79406]*
+*via https://github.com/elastic/opensearch-dashboards/pull/79406[#79406]*
 
 ====
 
@@ -78,12 +78,12 @@ To rename the Ingest Manger plugin to Fleet:
 [%collapsible]
 ====
 
-Kibana plugins can no longer rely on their server code being automatically transpiled with Babel.
-The https://github.com/elastic/kibana/tree/master/packages/kbn-plugin-helpers[`@kbn/plugin-helpers`]
+OpenSearchDashboards plugins can no longer rely on their server code being automatically transpiled with Babel.
+The https://github.com/elastic/opensearch-dashboards/tree/master/packages/osd-plugin-helpers[`@osd/plugin-helpers`]
 provide a build task that will transform a plugin's server code to plain JS via Babel,
 but plugin authors can use a tool of their choosing to accomplish the same result.
 
-*via https://github.com/elastic/kibana/pull/79176[#79176]* and https://github.com/elastic/kibana/pull/79379[#79379]*
+*via https://github.com/elastic/opensearch-dashboards/pull/79176[#79176]* and https://github.com/elastic/opensearch-dashboards/pull/79379[#79379]*
 
 ====
 
@@ -100,7 +100,7 @@ The following Ingest Manager API routes changed:
 ** `/api/ingest_manager/fleet/enrollment-api-keys` => `/api/fleet/enrollment-api-keys`
 * The Fleet setup API moved from `/api/ingest_manager/fleet/setup` to `/api/fleet/agents/setup`
 
-*via https://github.com/elastic/kibana/pull/79193[#79193]*
+*via https://github.com/elastic/opensearch-dashboards/pull/79193[#79193]*
 
 ====
 
@@ -117,7 +117,7 @@ function async myRouteHandler(context, request, response) {
 }
 ```
 
-*via https://github.com/elastic/kibana/pull/78383[#78383]*
+*via https://github.com/elastic/opensearch-dashboards/pull/78383[#78383]*
 
 ====
 
@@ -133,7 +133,7 @@ This release introduces the following `search` helpers:
 * `isPartialResponse`
 
 
-*via https://github.com/elastic/kibana/pull/78006[#78006]*
+*via https://github.com/elastic/opensearch-dashboards/pull/78006[#78006]*
 
 ====
 
@@ -164,7 +164,7 @@ The refactoring includes the following changes:
 ** `indexPatternService.createAndSave(indexPatternSpec)` convenience method added
 ** `indexPatternService.getFieldsForWildcard` can be called directly. Previously a temp index pattern had to be created.
 
-*via https://github.com/elastic/kibana/pull/77791[#77791]*
+*via https://github.com/elastic/opensearch-dashboards/pull/77791[#77791]*
 
 ====
 
@@ -192,7 +192,7 @@ data.search.search(...)
    }
 ```
 
-*via https://github.com/elastic/kibana/pull/77788[#77788]*
+*via https://github.com/elastic/opensearch-dashboards/pull/77788[#77788]*
 
 ====
 
@@ -203,18 +203,18 @@ data.search.search(...)
 
 A `className` prop was added to the main container of the QueryStringInput component.
 
-*via https://github.com/elastic/kibana/pull/76848[#76848]*
+*via https://github.com/elastic/opensearch-dashboards/pull/76848[#76848]*
 
 ====
 
 [[breaking_plugin_v7.10.0_76822]]
-.KibanaRequest now has a `uuid` property
+.OpenSearchDashboardsRequest now has a `uuid` property
 [%collapsible]
 ====
 
-`KibanaRequest` now has a `uuid` property, which is a UUID that uniquely identifies the request.
+`OpenSearchDashboardsRequest` now has a `uuid` property, which is a UUID that uniquely identifies the request.
 
-*via https://github.com/elastic/kibana/pull/76822[#76822]*
+*via https://github.com/elastic/opensearch-dashboards/pull/76822[#76822]*
 
 ====
 
@@ -225,7 +225,7 @@ A `className` prop was added to the main container of the QueryStringInput compo
 
 `IndexPattern.save` has been replaced with `IndexPatternsService.save`.
 
-*via https://github.com/elastic/kibana/pull/76706[#76706]*
+*via https://github.com/elastic/opensearch-dashboards/pull/76706[#76706]*
 
 ====
 
@@ -237,22 +237,22 @@ A `className` prop was added to the main container of the QueryStringInput compo
 The `FetchOptions` type was removed&mdash;use the `ISearchOptions` type instead.
 The `ISearchOptions` `signal` option was renamed to `abortSignal`.
 
-*via https://github.com/elastic/kibana/pull/76538[#76538]*
+*via https://github.com/elastic/opensearch-dashboards/pull/76538[#76538]*
 
 ====
 
 [[breaking_plugin_v7.10.0_75943]]
-.Legacy {es} client APIs removed
+.Legacy {opensearch} client APIs removed
 [%collapsible]
 ====
 
 The `__LEGACY` APIs have been removed from the `data` plugin's client-side search service.
-Specifically, `data.search.__LEGACY.esClient` is no longer exposed,
- and the legacy `elasticsearch-browser` package has been removed from the repo.
+Specifically, `data.search.__LEGACY.opensearchClient` is no longer exposed,
+ and the legacy `opensearch-browser` package has been removed from the repo.
  If you rely on this client in your plugin, we recommend migrating to
- the new https://github.com/elastic/elasticsearch-js[`elasticsearch-js` client].
+ the new https://github.com/elastic/opensearch-js[`opensearch-js` client].
 
-*via https://github.com/elastic/kibana/pull/75943[#75943]*
+*via https://github.com/elastic/opensearch-dashboards/pull/75943[#75943]*
 
 ====
 
@@ -261,22 +261,22 @@ Specifically, `data.search.__LEGACY.esClient` is no longer exposed,
 [%collapsible]
 ====
 
-Kibana Platform plugins can now read the status of their dependencies,
+OpenSearchDashboards Platform plugins can now read the status of their dependencies,
 their plugin's default status, and manually override that status as
 reported to the end user and on the `/api/status` endpoint.
 
 ```ts
 class MyPlugin {
   setup(core) {
-    // Override default behavior and only elevate severity when elasticsearch is not available
+    // Override default behavior and only elevate severity when opensearch is not available
     core.status.set(
-      core.status.core$.pipe(core => core.elasticsearch);
+      core.status.core$.pipe(core => core.opensearch);
     );
   }
 }
 ```
 
-*via https://github.com/elastic/kibana/pull/75819[#75819]*
+*via https://github.com/elastic/opensearch-dashboards/pull/75819[#75819]*
 
 ====
 
@@ -287,17 +287,17 @@ class MyPlugin {
 
 The behavior of how search requests timeout changed:
 
- * The {kib} server uses the new {es} client. The client already uses all timeout configurations
+ * The {osd} server uses the new {opensearch} client. The client already uses all timeout configurations
  such as `requestTimeout`, `shardTimeout`, and `maxRetries`.
  Because the client can't override those settings, in OSS,
- we removed the code governing the {es} timeout on the client. Instead, this change adds handling for a timeout error response.
+ we removed the code governing the {opensearch} timeout on the client. Instead, this change adds handling for a timeout error response.
   A nice side effect is being able to remove `injectDefaultVars` from the legacy core plugin.
 * With Basic+ licenses, users can control the maximum time for a search session
  (for example, a single re-load of a dashboard), per space. Aa new Advanced Setting
  can be set to a positive value, or to 0, allowing queries to run without a timeout, as long as a user stays on screen.
 
 
-*via https://github.com/elastic/kibana/pull/75728[#75728]*
+*via https://github.com/elastic/opensearch-dashboards/pull/75728[#75728]*
 
 ====
 
@@ -309,7 +309,7 @@ The behavior of how search requests timeout changed:
 The `IndexPattern` class now takes `shortDotsEnable` (boolean) and `metaFields` (string[]) as arguments.
 These were formerly provided by `uiSettings`
 
-*via https://github.com/elastic/kibana/pull/75717[#75717]*
+*via https://github.com/elastic/opensearch-dashboards/pull/75717[#75717]*
 
 ====
 
@@ -323,10 +323,10 @@ which were designed for internal use in Canvas.
 In the unlikely event that you rely on the `expressions.__LEGACY` namespace,
 you will need to copy the relevant code into your plugin before updating.
 
-Also removed is the `createKibanaUtilsCore` helper from the `kibana_utils` plugin,
+Also removed is the `createOpenSearchDashboardsUtilsCore` helper from the `opensearch_dashboards_utils` plugin,
 which was only used in the legacy Expressions APIs.
 
-*via https://github.com/elastic/kibana/pull/75517[#75517]*
+*via https://github.com/elastic/opensearch-dashboards/pull/75517[#75517]*
 
 ====
 
@@ -345,12 +345,12 @@ helper, update the dependencies passed to it as follows:
        const params = getSearchParamsFromRequest(request, {
 -          injectedMetadata: core.injectedMetadata,
 -          uiSettings: core.uiSettings,
-+          esShardTimeout: core.injectedMetadata.getInjectedVar('esShardTimeout') as number,
++          opensearchShardTimeout: core.injectedMetadata.getInjectedVar('opensearchShardTimeout') as number,
 +          getConfig: core.uiSettings.get.bind(core.uiSettings),
        });
 ```
 
-*via https://github.com/elastic/kibana/pull/75368[#75368]*
+*via https://github.com/elastic/opensearch-dashboards/pull/75368[#75368]*
 
 ====
 
@@ -376,7 +376,7 @@ Instead it throws `FieldTypeUnknownError`.
 - `toSpec` now takes an optional argument, `{ getFormatterForField }`. This argument takes
 the field as an argument and returns a formatter.
 
-*via https://github.com/elastic/kibana/pull/75185[#75185]*
+*via https://github.com/elastic/opensearch-dashboards/pull/75185[#75185]*
 
 ====
 
@@ -403,7 +403,7 @@ The following Ingest Manager settings changed:
 - `xpack.ingestManager.fleet.agentConfigRolloutRateLimitIntervalMs` renamed to `xpack.fleet.agents.agentPolicyRolloutRateLimitIntervalMs`
 - `xpack.fleet.agents.agentConfigRolloutRateLimitRequestPerInterval` renamed to `xpack.fleet.agents.agentPolicyRolloutRateLimitRequestPerInterval`
 
-*via https://github.com/elastic/kibana/pull/74914[#74914]*
+*via https://github.com/elastic/opensearch-dashboards/pull/74914[#74914]*
 
 ====
 
@@ -417,7 +417,7 @@ removed from the static exports of the `data` plugin's contract.
 If you rely on these, copy the code directly into your plugin.
 The `SearchError` interface is still exposed.
 
-*via https://github.com/elastic/kibana/pull/74607[#74607]*
+*via https://github.com/elastic/opensearch-dashboards/pull/74607[#74607]*
 
 ====
 
@@ -431,7 +431,7 @@ The usage is the same as on the client, except that a scoped saved objects clien
 must be provided on the server to retrieve the `start` contract:
 
 ```ts
-const savedObjectsClient = savedObjects.getScopedClient(kibanaRequest);
+const savedObjectsClient = savedObjects.getScopedClient(opensearchDashboardsRequest);
 // `aggs.asScopedToClient` will return the same contract as is available in the browser
 const aggs = await data.search.aggs.asScopedToClient(savedObjectsClient);
 const allAggTypes = aggs.types.getAll();
@@ -439,7 +439,7 @@ const allAggTypes = aggs.types.getAll();
 
 The `calculateAutoTimeExpression` method was removed from the `setup` contract,
 and now only exists on the `data` plugin's `start` contract. The method was
-was not used in `setup` elsewhere in {kib}, so it was removed for simplicity.
+was not used in `setup` elsewhere in {osd}, so it was removed for simplicity.
 
 In addition, the agg types registry changed and now accepts a provider
 function, which is used to inject dependencies. This might be needed in the agg type definition,
@@ -466,7 +466,7 @@ const getMyAgg = ({ getConfig }) =>
 dataSetup.search.aggs.registerMetric('myAgg', getMyAgg);
 ```
 
-*via https://github.com/elastic/kibana/pull/74472[#74472]*
+*via https://github.com/elastic/opensearch-dashboards/pull/74472[#74472]*
 
 ====
 
@@ -477,23 +477,23 @@ dataSetup.search.aggs.registerMetric('myAgg', getMyAgg);
 
 Route definitions can now specify the `idleSocket` timeout in addition to the `payload` timeout.
 
-Resolves https://github.com/elastic/kibana/issues/73557[#73557].
+Resolves https://github.com/elastic/opensearch-dashboards/issues/73557[#73557].
 
-*via https://github.com/elastic/kibana/pull/73730[#73730]*
+*via https://github.com/elastic/opensearch-dashboards/pull/73730[#73730]*
 
 ====
 
 [[breaking_plugin_v7.10.0_73651]]
-.New {es} client exposed
+.New {opensearch} client exposed
 [%collapsible]
 ====
 
-{kib} provides the new {es} client
-as a part of the {es} service on the server-side.
+{osd} provides the new {opensearch} client
+as a part of the {opensearch} service on the server-side.
 The legacy client is deprecated on and subject for removal in `7.x`. Reference
-the https://github.com/elastic/kibana/blob/master/src/core/MIGRATION_EXAMPLES.md#elasticsearch-client[migration guide] to refactor your code
+the https://github.com/elastic/opensearch-dashboards/blob/master/src/core/MIGRATION_EXAMPLES.md#opensearch-client[migration guide] to refactor your code
 
-*via https://github.com/elastic/kibana/pull/73651[#73651]*
+*via https://github.com/elastic/opensearch-dashboards/pull/73651[#73651]*
 
 ====
 
@@ -510,13 +510,13 @@ data.query.state$.subscribe((queryState: QueryState) => {...})
 ```
 
 This PR also adds the `data.query.queryString` service, allowing to you set the
-query string https://github.com/elastic/kibana/issues/52522[programmatically].
+query string https://github.com/elastic/opensearch-dashboards/issues/52522[programmatically].
 ```TypeScript
 data.query.queryString.setQuery({query: 'abc', language: 'kuery'});
 ```
 
 
-*via https://github.com/elastic/kibana/pull/72093[#72093]*
+*via https://github.com/elastic/opensearch-dashboards/pull/72093[#72093]*
 
 ====
 
@@ -526,7 +526,7 @@ data.query.queryString.setQuery({query: 'abc', language: 'kuery'});
 ====
 
 This PR allows you to assign privileges to the Alerting framework when
-defining your feature in *Kibana*. When registering your feature, you can add
+defining your feature in *OpenSearchDashboards*. When registering your feature, you can add
 a list of AlertTypes under your `read` and `all` keys of the `privileges` object, as such:
 
 ```ts
@@ -600,7 +600,7 @@ The one exception to this is when the _producer_ is `alerts`, which represents a
 in which case we only check for _consumer_ privileges as all users are privileged to create built-in types by definition.
 
 
-*via https://github.com/elastic/kibana/pull/67157[#67157]*
+*via https://github.com/elastic/opensearch-dashboards/pull/67157[#67157]*
 
 ====
 
@@ -632,10 +632,10 @@ This example shows a provider for the alert SavedObject type,
 which creates a new AlertsClient for the request and returns a getter
 that attempts to get the SavedObject by its id.
 
-*via https://github.com/elastic/kibana/pull/73257[#73257]*
+*via https://github.com/elastic/opensearch-dashboards/pull/73257[#73257]*
 
 ```ts
-eventLogService.registerSavedObjectProvider('alert', (request: KibanaRequest) => {
+eventLogService.registerSavedObjectProvider('alert', (request: OpenSearchDashboardsRequest) => {
     const client = getAlertsClientWithRequest(request);
     return (type: string, id: string) => client.get({ id });
 });
@@ -652,19 +652,19 @@ This means a single provider is used for multiple gets made by the request.
 ====
 
 [[breaking_plugin_v7.10.0_72289]]
-.New {es} client in SO service
+.New {opensearch} client in SO service
 [%collapsible]
 ====
 
-The SO service was refactored to use https://github.com/elastic/elasticsearch-js[elasticsearch-js]
+The SO service was refactored to use https://github.com/elastic/opensearch-js[opensearch-js]
 under the hood. This change might affect plugins reading the response status field
-from the SO error bubbled to the Solutions code because the {es} error no longer
+from the SO error bubbled to the Solutions code because the {opensearch} error no longer
 provides the status field (statusCode is still provided).
 
 Several plugins were adjusted to check SO errors with `SavedObjectsErrorHelpers`.
 Plugins must use this because we are going to stop wrapping errors in the Boom object.
 
-*via https://github.com/elastic/kibana/pull/72289[#72289]*
+*via https://github.com/elastic/opensearch-dashboards/pull/72289[#72289]*
 
 ====
 
@@ -696,13 +696,13 @@ to every role granted the `read` privilege to the Feature via Feature Controls.
 
 You're likely to have to specify this in 3 places in your plugin
 to cover all 3 scenarios. Although this is more verbose than before,
-it aligns with the rest of {kib}.
+it aligns with the rest of {osd}.
 It also means that the Triggers and Actions plugin no longer needs to
 know about each plugin that wants to gain access
-(which means {kib} can more easily support future alerting usage).
+(which means {osd} can more easily support future alerting usage).
 
 
-*via https://github.com/elastic/kibana/pull/72029[#72029]*
+*via https://github.com/elastic/opensearch-dashboards/pull/72029[#72029]*
 
 ====
 
@@ -714,7 +714,7 @@ know about each plugin that wants to gain access
 
 `casesConfiguration` was renamed to `incidentConfiguration`. Added optional `attributeisCaseOwned`.
 
-*via https://github.com/elastic/kibana/pull/73778[#73778]*
+*via https://github.com/elastic/opensearch-dashboards/pull/73778[#73778]*
 
 ====
 
@@ -726,7 +726,7 @@ know about each plugin that wants to gain access
 
 `casesConfiguration` was renamed to `incidentConfiguration`. Added optional `attributeisCaseOwned`.
 
-*via https://github.com/elastic/kibana/pull/74357[#74357]*
+*via https://github.com/elastic/opensearch-dashboards/pull/74357[#74357]*
 
 ====
 
@@ -736,19 +736,19 @@ know about each plugin that wants to gain access
 [%collapsible]
 ====
 
-- To create a case (`POST <kibana host>:<port>/api/cases`), you must provide a `connector`.
+- To create a case (`POST <opensearchDashboards host>:<port>/api/cases`), you must provide a `connector`.
 Requests without a `connector` get a `400 Bad Request`.
-- To update the connector of a case (`PATCH <kibana host>:<port>/api/cases`),
+- To update the connector of a case (`PATCH <opensearchDashboards host>:<port>/api/cases`),
 you must provide the `connector`. The `connector_id` attribute has been
 removed in favor of the `connector` attribute.
-- To set the default connector (`POST <kibana host>:<port>/api/cases/configure`),
+- To set the default connector (`POST <opensearchDashboards host>:<port>/api/cases/configure`),
 you must provide a `connector`. The `connector_id` and `connector_name`
 attributes have been removed in favor of the `connector` attribute.
 - To update the connector’s case closure settings
-(`PATCH <kibana host>:<port>/api/cases/configure`), you must provide a `connector`.
+(`PATCH <opensearchDashboards host>:<port>/api/cases/configure`), you must provide a `connector`.
 The `connector_id` and `connector_name` attributes have been removed in
 favor of the `connector` attribute.
 
-*via https://github.com/elastic/kibana/pull/77327[#77327]*
+*via https://github.com/elastic/opensearch-dashboards/pull/77327[#77327]*
 
 ====

--- a/docs/migration/migrate_7_2.asciidoc
+++ b/docs/migration/migrate_7_2.asciidoc
@@ -5,9 +5,9 @@
 ++++
 
 This section discusses the changes that you need to be aware of when migrating
-your application to Kibana 7.2.
+your application to OpenSearchDashboards 7.2.
 
-See also {kibana-ref-all}/7.2/release-highlights-7.2.0.html[release highlights]
+See also {opensearch-dashboards-ref-all}/7.2/release-highlights-7.2.0.html[release highlights]
 and <<release-notes-7.2.0, release notes>>.
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
@@ -24,7 +24,7 @@ and <<release-notes-7.2.0, release notes>>.
 === Time-based internal index patterns queried as wildcard index patterns
 *Details:* Time-based interval index patterns were deprecated in 5.x. In 6.x, 
 you could no longer create time-based interval index patterns, but they continued 
-to function as expected. In 7.2, functionality has changed such that {kib} will 
+to function as expected. In 7.2, functionality has changed such that {osd} will 
 automatically query a time-based interval index pattern as a wildcard index pattern.
 Support for time-based index patterns will be removed in 8.0. You can migrate your 
 time-based index patterns to a wildcard pattern to prepare for this change.

--- a/docs/migration/migrate_7_3.asciidoc
+++ b/docs/migration/migrate_7_3.asciidoc
@@ -5,9 +5,9 @@
 ++++
 
 This section discusses the changes that you need to be aware of when migrating
-your application to Kibana 7.3.
+your application to OpenSearchDashboards 7.3.
 
-See also {kibana-ref-all}/7.3/release-highlights-7.3.0.html[release highlights] 
+See also {opensearch-dashboards-ref-all}/7.3/release-highlights-7.3.0.html[release highlights] 
 and <<release-notes-7.3.0, release notes>>.
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the

--- a/docs/migration/migrate_7_4.asciidoc
+++ b/docs/migration/migrate_7_4.asciidoc
@@ -5,9 +5,9 @@
 ++++
 
 This section discusses the changes that you need to be aware of when migrating
-your application to Kibana 7.4.
+your application to OpenSearchDashboards 7.4.
 
-//See also {kibana-ref-all}/7.4/release-highlights-7.4.0.html[release highlights] and <<release-notes-7.4.0, release notes>>.
+//See also {opensearch-dashboards-ref-all}/7.4/release-highlights-7.4.0.html[release highlights] and <<release-notes-7.4.0, release notes>>.
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
@@ -30,7 +30,7 @@ We now use `_search` when batching is disabled.
 
 *Impact:*
 When the advanced setting `courier:batchSearches` is disabled, 
-requests from *Discover*, *Visualize*, and *Dashboard* will now query {es} 
+requests from *Discover*, *Visualize*, and *Dashboard* will now query {opensearch} 
 using the `_search` endpoint rather than the `_msearch` endpoint.
 
 

--- a/docs/migration/migrate_7_5.asciidoc
+++ b/docs/migration/migrate_7_5.asciidoc
@@ -5,9 +5,9 @@
 ++++
 
 This page discusses the breaking changes that you need to be aware of when migrating
-your application to Kibana 7.5.
+your application to OpenSearchDashboards 7.5.
 
-//See also {kibana-ref-all}/7.5/release-highlights-7.5.0.html[release highlights] and <<release-notes-7.4.0, release notes>>.
+//See also {opensearch-dashboards-ref-all}/7.5/release-highlights-7.5.0.html[release highlights] and <<release-notes-7.4.0, release notes>>.
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
@@ -25,7 +25,7 @@ The following section is re-used in the Installation and Upgrade Guide
 
 *Details:*
 Changing the default setting for `courier:batchSearches` to `false` means
-that search requests will use the `_search` {es} endpoint rather than `_msearch`.
+that search requests will use the `_search` {opensearch} endpoint rather than `_msearch`.
 
 *Impact:*
 Dashboard panels will load individually, and search requests will terminate
@@ -42,7 +42,7 @@ decided not to pursue further development of the code app at this time.
 
 *Impact:*
 Any installs that previously enabled the Code app will now log a warning when
-Kibana starts up. It's safe to remove all configurations starting with
+OpenSearchDashboards starts up. It's safe to remove all configurations starting with
 `xpack.code.`. Starting in 8.0, these warnings will become errors that prevent
-Kibana from starting up.
+OpenSearchDashboards from starting up.
 // end::notable-breaking-changes[]

--- a/docs/migration/migrate_7_6.asciidoc
+++ b/docs/migration/migrate_7_6.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 This page discusses the breaking changes that you need to be aware of when migrating
-your application to Kibana 7.6.
+your application to OpenSearchDashboards 7.6.
 
 * <<user-facing-changes, Breaking changes for users>>
 * <<general-plugin-API-changes, Breaking changes for plugin developers>>
@@ -26,15 +26,15 @@ There are no user-facing breaking changes in 7.6.
 === Breaking changes for plugin developers
 
 [float]
-==== {kib} no longer crashes when a plugin version does not match the server
-{kib-pull}54404[#54404]
+==== {osd} no longer crashes when a plugin version does not match the server
+{osd-pull}54404[#54404]
 
-{kib} no longer crashes when a plugin is used against an incompatible {kib} version.
+{osd} no longer crashes when a plugin is used against an incompatible {osd} version.
 A warning is now displayed in the console instead of throwing and crashing.
 
 [float]
 ==== Generate legacy vars when rendering all applications
-{kib-pull}54768[#54768]
+{osd-pull}54768[#54768]
 
 Rendering any type of application, even ones for the new platform,
 should still generate legacy vars injected into the page metadata.
@@ -42,7 +42,7 @@ This ensures these vars are injected for HTTP route rendering as well.
 
 [float]
 ==== `uiSettings` image upload field config
-{kib-pull}54522[#54522]
+{osd-pull}54522[#54522]
 
 In `uiSettings`, the image upload field required specifying `maxSize`
 via the `options` field. This was in conflict with the stated use and
@@ -50,25 +50,25 @@ type of `options`, which is a `string[]` used to populate select fields.
 `uiOptions` has been provided instead, accepting `Record<string, any>` values.
 
 [float]
-==== Replaced `map.manifestServiceUrl` setting in kibana.yml with `map.emsTileApiUrl` and `map.emsFileApiUrl`
-{kib-pull}54399[#54399]
+==== Replaced `map.manifestServiceUrl` setting in opensearch_dashboards.yml with `map.emsTileApiUrl` and `map.emsFileApiUrl`
+{osd-pull}54399[#54399]
 
-The undocumented `map.manifestServiceUrl` setting in kibana.yml has been replaced
+The undocumented `map.manifestServiceUrl` setting in opensearch_dashboards.yml has been replaced
 by `map.emsTileApiUrl` and `map.emsFileApiUrl`. These settings configure the
 base URL for the tile basemap manifest and vector file manifests used in
 Elastic Maps and the region map and coordinate map.visualizations.
 
 [float]
-==== Don't expose {es} client as Observable
-{kib-pull}53824[#53824]
+==== Don't expose {opensearch} client as Observable
+{osd-pull}53824[#53824]
 
-{es} clients aren't exposed via the Observable interface anymore.
-{es} client provides a static API that handles all {es} config updates under the hood,
+{opensearch} clients aren't exposed via the Observable interface anymore.
+{opensearch} client provides a static API that handles all {opensearch} config updates under the hood,
 transparent to the end-user.
 
 ```js
 
-const client = core.elasticsearch.dataClient;
+const client = core.opensearch.dataClient;
 
 const data = await client.callAsInternalUser('endpoint');
 
@@ -76,7 +76,7 @@ const data = await client.callAsInternalUser('endpoint');
 
 [float]
 ==== Reduce license plugin API
-{kib-pull}53489[#53489]
+{osd-pull}53489[#53489]
 
 License method `isOneOf` was superseded by `hasAtLeast`, which checks
 the current license is not less than passes minimal required license.
@@ -95,16 +95,16 @@ license.hasAtLeast('platinum')
 
 [float]
 ==== State containers
-{kib-pull}52384[#52384]
+{osd-pull}52384[#52384]
 
 State containers have now been rewritten and to create state container you
 use `createStateContainer` instead of previous `createStore`.
-https://github.com/streamich/kibana/blob/state-containers/src/plugins/kibana_utils/docs/state_containers/README.md[See full documentation].
+https://github.com/streamich/opensearch-dashboards/blob/state-containers/src/plugins/opensearch_dashboards_utils/docs/state_containers/README.md[See full documentation].
 
 
 ```ts
 
-import { createStateContainer } from 'src/plugins/kibana_utils';
+import { createStateContainer } from 'src/plugins/opensearch_dashboards_utils';
 
 const container = createStateContainer(0, {
 
@@ -126,7 +126,7 @@ console.log(container.get()); // 10
 
 [float]
 ==== Add pre-response HTTP interceptor
-{kib-pull}52366[#52366]
+{osd-pull}52366[#52366]
 
 HttpService provides `onPreResponse` interceptor. Interceptor supports extending a response with custom headers.
 
@@ -156,7 +156,7 @@ HttpService provides `onPreResponse` interceptor. Interceptor supports extending
 
 [float]
 ==== Add server rendering service to enable standalone route rendering
-{kib-pull}52161[#52161]
+{osd-pull}52161[#52161]
 
 Render a bootstrapped HTML page from a route handler using the `RenderingService` from your server plugin:
 
@@ -188,7 +188,7 @@ router.get(
 
 [float]
 ==== Disabled actions
-{kib-pull}51975[#51975]
+{osd-pull}51975[#51975]
 
 Embeddable input now has `disabledActions` property. Actions with ID listed
 in `disabledActions` will not be rendered by embeddable panel in drop down context menu and badge list.
@@ -215,7 +215,7 @@ const embeddable = await embeddableFactory.createFromState(
 
 [float]
 ==== Allow chromeless applications to render via non-/app routes
-{kib-pull}51527[#51527]
+{osd-pull}51527[#51527]
 
 Allow applications to routable from paths that do not start with `/app`.
 This is first enabled via the `appRoute` flag during UI application registration.
@@ -252,7 +252,7 @@ export class MyPlugin implements Plugin {
 
 [float]
 ==== Add compatibility wrapper for Boom errors thrown from route handler
-{kib-pull}51157[#51157]
+{osd-pull}51157[#51157]
 
 Added a new `handleLegacyErrors` method to core `HttpService` router. The method wraps a `RequestHandler` to intercept any thrown `Boom` errors and converts them into proper NP error response.
 
@@ -260,7 +260,7 @@ Added a new `handleLegacyErrors` method to core `HttpService` router. The method
 
 // plugins/myplugin/server/plugin.ts
 
-import { schema } from '@kbn/config-schema';
+import { schema } from '@osd/config-schema';
 
 import { CoreSetup } from 'src/core/server';
 
@@ -298,7 +298,7 @@ class Plugin {
 
 [float]
 ==== Move SavedQuery to New Platform
-{kib-pull}51024[#51024]
+{osd-pull}51024[#51024]
 
 **Saved Query Service**
 
@@ -341,21 +341,21 @@ Save query form
 image::images/breaking_changes_save_query.png[Save Query Form]
 
 [float]
-==== Kibana app migration: Remove old APIs
-{kib-pull}50881[#50881]
+==== OpenSearchDashboards app migration: Remove old APIs
+{osd-pull}50881[#50881]
 
 
 The following undocumented APIs for scroll search and index document count have been removed:
 
-* `POST /api/kibana/legacy_scroll_continue`
+* `POST /api/opensearch-dashboards/legacy_scroll_continue`
 
-* `POST /api/kibana/legacy_scroll_start`
+* `POST /api/opensearch-dashboards/legacy_scroll_start`
 
-* `POST /api/kibana/{id}/_count`
+* `POST /api/opensearch-dashboards/{id}/_count`
 
 [float]
 ==== ChromeHelpExtension
-{kib-pull}50736[#50736]
+{osd-pull}50736[#50736]
 
 The `chrome.helpExtension` has been updated to where it no longer just accepts a function to spit out any content. Now, the extension looks like:
 
@@ -377,7 +377,7 @@ export interface ChromeHelpExtension {
 
 [float]
 ==== Allows plugins to define validation schema for "enabled" flag
-{kib-pull}50286[#50286]
+{osd-pull}50286[#50286]
 
 If you want your plugin to be disabled by default you can specify it via config:
 
@@ -393,7 +393,7 @@ export const config = {
 
 [float]
 ==== Add getStartServices API
-{kib-pull}50231[#50231]
+{osd-pull}50231[#50231]
 
 Context is being deprecated on the front-end and replaced by the `core.getStartServices()` API.
 
@@ -430,10 +430,10 @@ class Plugin {
 ```
 
 [float]
-==== Relocated `@kbn/es-query` package to `data` plugin
-{kib-pull}50182[#50182]
+==== Relocated `@osd/opensearch-query` package to `data` plugin
+{osd-pull}50182[#50182]
 
-The `@kbn/es-query` package has been moved to `src/plugins/data` and is available under the `esQuery` namespace on both the client and the server.
+The `@osd/opensearch-query` package has been moved to `src/plugins/data` and is available under the `opensearchQuery` namespace on both the client and the server.
 
 ```ts
 
@@ -441,9 +441,9 @@ The `@kbn/es-query` package has been moved to `src/plugins/data` and is availabl
 
 import {
 
-  buildEsQuery,
+  buildOpenSearchQuery,
 
-  EsQueryConfig,
+  OpenSearchQueryConfig,
 
   buildQueryFromFilters,
 
@@ -451,22 +451,22 @@ import {
 
   decorateQuery,
 
-  getEsQueryConfig,
+  getOpenSearchQueryConfig,
 
-} from '@kbn/es-query';
+} from '@osd/opensearch-query';
 
 // new
 
-import { esQuery } from 'src/plugins/data/public'; // or `src/plugins/data/server`
+import { opensearchQuery } from 'src/plugins/data/public'; // or `src/plugins/data/server`
 
-esQuery.buildEsQuery(...);
+opensearchQuery.buildOpenSearchQuery(...);
 
 ```
 
 
 [float]
 ==== Migrate share registry
-{kib-pull}50137[#50137]
+{osd-pull}50137[#50137]
 
 The `ui/share` registry is removed in favor of the `share` plugin which exposes a `register` method in the setup contract. The interface of share menu providers does not change except for the removal of angular dependency injection. The function to render the menu also moves into a function exposed by the `share` plugin in the start phase instead of a function which has to be called with the menu item providers. The following items have also been renamed:
 
@@ -478,15 +478,15 @@ The `ui/share` registry is removed in favor of the `share` plugin which exposes 
 
 [float]
 ==== Ensure chromeless applications hide left navbar link
-{kib-pull}50060[#50060]
+{osd-pull}50060[#50060]
 
 Chromeless applications no longer display a navigation link in the left application menu.
 
 [float]
-==== Allow registered applications to hide Kibana chrome
-{kib-pull}49795[#49795]
+==== Allow registered applications to hide OpenSearchDashboards chrome
+{osd-pull}49795[#49795]
 
-When registering an application, you can now use the `chromeless` option to hide the Kibana chrome UI when the application is mounted.
+When registering an application, you can now use the `chromeless` option to hide the OpenSearchDashboards chrome UI when the application is mounted.
 
 ```ts
 
@@ -508,24 +508,24 @@ application.register({
 
 [float]
 ==== Remove react references from core `Notifications` APIs
-{kib-pull}49573[#49573]
+{osd-pull}49573[#49573]
 
 The core `NotificationService` and `ToastsApi` methods are now framework agnostic
-and no longer accept react components as input. Please use `kibana_react`'s`toMountPoint`
+and no longer accept react components as input. Please use `opensearch_dashboards_react`'s`toMountPoint`
 utility to convert a react node to a mountPoint.
 
 [float]
 ==== Shim dev tools
-{kib-pull}49349[#49349]
+{osd-pull}49349[#49349]
 
 The `ui/registry/dev_tools` is removed in favor of the `DevTools` plugin,
 which exposes a `register` method in the setup contract.
 Registering app works mostly the same as registering apps in `core.application.register`.
-Routing will be handled by the id of the dev tool - your dev tool will be mounted when the URL matches `/app/kibana#/dev_tools/<YOUR ID>`. This API doesn't support angular, for registering angular dev tools, bootstrap a local module on mount into the given HTML element.
+Routing will be handled by the id of the dev tool - your dev tool will be mounted when the URL matches `/app/opensearch-dashboards#/dev_tools/<YOUR ID>`. This API doesn't support angular, for registering angular dev tools, bootstrap a local module on mount into the given HTML element.
 
 [float]
-==== Kibana app migration: Shim dashboard
-{kib-pull}48913[#48913]
+==== OpenSearchDashboards app migration: Shim dashboard
+{osd-pull}48913[#48913]
 
 The route flag `requireDefaultIndex` making sure there are index patterns
 and the `defaultIndex` advanced setting is set was removed.
@@ -535,10 +535,10 @@ helper function `ensureDefaultIndexPattern` from `ui/legacy_compat` within the `
 
 [float]
 ==== Remove react references from core `OverlayService` apis
-{kib-pull}48431[#48431]
+{osd-pull}48431[#48431]
 
 The core `OverlayService` methods are now framework agnostic and no longer accept react components as input.
-Please use `kibana_react`'s`toMountPoint` utility to convert a react component to a mountPoint.
+Please use `opensearch_dashboards_react`'s`toMountPoint` utility to convert a react component to a mountPoint.
 
 For exemple:
 
@@ -558,14 +558,14 @@ core.overlays.openModal(toMountPoint(<MyComponent/>))
 
 [float]
 ==== Supply deprecated req and res properties on IHttpFetchError for legacy compatibility
-{kib-pull}48430[#48430]
+{osd-pull}48430[#48430]
 
 Expose deprecated `req: Request` and `res: Response` properties on `IHttpFetchError`s
 to help plugins migrated faster by removing an additional migration burden.
 
 [float]
 ==== Timelion server API
-{kib-pull}47813[#47813]
+{osd-pull}47813[#47813]
 
 The server side AOU of Timelion `/api/timelion/run` used to
 accept datemath strings (like `now`) for the `time.from` and `time.to` properties.
@@ -573,7 +573,7 @@ This PR removes support for datemath, from now on only ISO8601 encoded strings a
 
 [float]
 ==== Pass along request object to all HTTP interceptors
-{kib-pull}47258[#47258]
+{osd-pull}47258[#47258]
 
 Make the `Request` instance available to all HTTP interceptors, which is now in a read-only state.
 You may now also under-specify the object returned from HTTP response interceptors
@@ -581,7 +581,7 @@ to only overwrite specific properties.
 
 [float]
 ==== Expose whitelisted config values to client-side plugin
-{kib-pull}50641[#50641]
+{osd-pull}50641[#50641]
 
 New Platform plugins with both a server and client parts can now expose configuration properties to the client-side plugin.
 
@@ -643,7 +643,7 @@ export class Plugin implements Plugin<PluginSetup, PluginStart> {
 
 [float]
 ==== Allow registering per-app navigation items
-{kib-pull}53136[#53136]
+{osd-pull}53136[#53136]
 
 Allow registering per-app TopNavMenuItems&mdash;have a plugin register menu items into another application.
 
@@ -702,16 +702,16 @@ npSetup.plugins.navigation.registerMenuItem(customDiscoverExtension);
 ```
 
 [float]
-==== Management API for Kibana Platform
-{kib-pull}52579[#52579]
+==== Management API for OpenSearchDashboards Platform
+{osd-pull}52579[#52579]
 
-Management API for Kibana Platform implemented.
+Management API for OpenSearchDashboards Platform implemented.
 Demonstration code available at `test/plugin_functional/plugins/management_test_plugin/public/plugin.tsx`
 
 
 [float]
 ==== New platform applications can now prompt user with a message
-{kib-pull}54221[#54221]
+{osd-pull}54221[#54221]
 
 New platform applications can now prompt a message when users are trying to
 leave the app, allowing to notify them if some changes are unsaved.
@@ -760,19 +760,19 @@ leave the app, allowing to notify them if some changes are unsaved.
 
 [float]
 ==== [NP] Add lifecycle timeout
-{kib-pull}54129[#54129]
+{osd-pull}54129[#54129]
 
-{kib} platform deprecates async lifecycles by `v8` release.
-{kib} supports async lifecycles for BWC, but limits their time duration to 30 sec.
+{osd} platform deprecates async lifecycles by `v8` release.
+{osd} supports async lifecycles for BWC, but limits their time duration to 30 sec.
 
 
 [float]
 ==== Migrate config deprecations and `ShieldUser` functionality to the New Platform
-{kib-pull}53768[#53768]
+{osd-pull}53768[#53768]
 
 In the Security Plugin, the
 Legacy `ShieldUser` angular service has been removed and replaced with
-the dedicated method on the {kib} platform plugin `setup` contract:
+the dedicated method on the {osd} platform plugin `setup` contract:
 
 **Before**:
 
@@ -794,7 +794,7 @@ const currentUser = await npSetup.plugins.security.authc.getCurrentUser();
 
 ```
 
-Kibana platform plugin:
+OpenSearchDashboards platform plugin:
 
 ```json
 
@@ -822,10 +822,10 @@ public setup(core: CoreSetup, { security }: PluginSetupDependencies) {
 
 [float]
 ==== NP Migration: Move doc views registry and existing doc views into discover plugin
-{kib-pull}53465[#53465]
+{osd-pull}53465[#53465]
 
 The `ui/registry/doc_views` registry is removed in favor of the same
-functionality exposed through the setup contract of the `discover` plugin in `core_plugins/kibana`.
+functionality exposed through the setup contract of the `discover` plugin in `core_plugins/opensearch-dashboards`.
 
 Old way of registering a doc view:
 
@@ -849,7 +849,7 @@ New way of registering a doc view:
 
 ```ts
 
-import { setup } from '../src/legacy/core_plugins/kibana/public/discover';
+import { setup } from '../src/legacy/core_plugins/opensearch-dashboards/public/discover';
 
 setup.addDocView({
 
@@ -866,7 +866,7 @@ setup.addDocView({
 
 [float]
 ==== bfetch
-{kib-pull}52888[#52888]
+{osd-pull}52888[#52888]
 
 `ajax_stream` has been ported to the New Platform. Use `fetchStreaming()` method of `bfetch` plugin instead.
 
@@ -880,9 +880,9 @@ const { stream, promise } = npStart.plugins.bfetch.fetchStreaming({ url: 'http:/
 
 [float]
 ==== Move CSP options to New Platform
-{kib-pull}52698[#52698]
+{osd-pull}52698[#52698]
 
-The default options used for managing Kibana's Content Security Policy have been moved into core for the new platform. Relevant items exposed from `src/core/server` include:
+The default options used for managing OpenSearchDashboards's Content Security Policy have been moved into core for the new platform. Relevant items exposed from `src/core/server` include:
 
 - `CspConfig`: TypeScript class for generating CSP configuration. Will generate default configuration for any properties not specified in initialization.
 
@@ -893,7 +893,7 @@ The default options used for managing Kibana's Content Security Policy have been
 
 [float]
 ==== Implements config deprecation in New Platform
-{kib-pull}52251[#52251]
+{osd-pull}52251[#52251]
 
 
 New platform plugin's configuration now supports deprecation. Use the `deprecations` key of a plugin's config descriptor to register them.
@@ -902,9 +902,9 @@ New platform plugin's configuration now supports deprecation. Use the `deprecati
 
  // my_plugin/server/index.ts
 
- import { schema, TypeOf } from '@kbn/config-schema';
+ import { schema, TypeOf } from '@osd/config-schema';
 
- import { PluginConfigDescriptor } from 'kibana/server';
+ import { PluginConfigDescriptor } from 'opensearch-dashboards/server';
 
 
 
@@ -939,36 +939,36 @@ New platform plugin's configuration now supports deprecation. Use the `deprecati
 
 [float]
 ==== [Telemetry] Migrate ui_metric plugin to NP under usageCollection
-{kib-pull}51972[#51972]
+{osd-pull}51972[#51972]
 
 Migrates `ui_metrics` to NP under `usageCollection`.
 
 [float]
 ==== NP licensing plugin improvements
-{kib-pull}51818[#51818]
+{osd-pull}51818[#51818]
 
 
-Licensing plugin retrieves license data from {es} and
-becomes a source of license data for all {kib} plugins on server-side and client-side.
+Licensing plugin retrieves license data from {opensearch} and
+becomes a source of license data for all {osd} plugins on server-side and client-side.
 
 *Server-side API*
 
-The licensing plugin retrieves license data from {es} at regular configurable intervals.
+The licensing plugin retrieves license data from {opensearch} at regular configurable intervals.
 
 - `license$: Observable<ILicense>` Provides a steam of license data ILicense.
 Plugin emits new value whenever it detects changes in license info.
-If the plugin cannot retrieve a license from **Elasticsearch**, it will emit `an empty license` object.
+If the plugin cannot retrieve a license from **OpenSearch**, it will emit `an empty license` object.
 
 - `refresh: () => Promise<ILicense>` allows a plugin to enforce license retrieval.
 
 *Client-side API*
 
-The licensing plugin retrieves license data from licensing Kibana plugin
-and does not communicate with Elasticsearch directly.
+The licensing plugin retrieves license data from licensing OpenSearchDashboards plugin
+and does not communicate with OpenSearch directly.
 
 - `license$: Observable<ILicense>` Provides a steam of license data ILicense.
 Plugin emits new value whenever it detects changes in license info. If the plugin cannot retrieve a
-license from **Kibana**, it will emit `an empty license` object.
+license from **OpenSearchDashboards**, it will emit `an empty license` object.
 
 - `refresh: () => Promise<ILicense>` allows a plugin to enforce license retrieval.
 
@@ -976,7 +976,7 @@ license from **Kibana**, it will emit `an empty license` object.
 
 [float]
 ==== [Cloud] move cloud plugin to New Platform
-{kib-pull}51789[#51789]
+{osd-pull}51789[#51789]
 
 Fully migrates `cloud` plugin over to NP. To use the NP contract exposed by
 the cloud plugin (ex `cloudId` or `isCloudEnabled`) follow this quick guide below.
@@ -984,7 +984,7 @@ Note that all the plugins are already migrated to use the NP plugin in this very
 
 ```json
 
-// plugin/kibana.json
+// plugin/opensearch_dashboards.json
 
 {
 
@@ -1040,8 +1040,8 @@ const isCloudEnabled = get<boolean>(cloud, 'isCloudEnabled', false);
 ```
 
 [float]
-==== [Telemetry] Migrate Usage Collector Set to the new Kibana Platform
-{kib-pull}51618[#51618]
+==== [Telemetry] Migrate Usage Collector Set to the new OpenSearchDashboards Platform
+{osd-pull}51618[#51618]
 
 Fully migrate (`server.usage.collectorSet`) to New Platform under (`UsageCollection`) plugin.
 To use the `UsageCollector` plugin to collect server side stats with the NP follow the quick guide below (Note that all the plugins are already migrated to use this new plugin in this very same PR):
@@ -1050,7 +1050,7 @@ Make sure `usageCollection` is in your optional Plugins:
 
 ```json
 
-// plugin/kibana.json
+// plugin/opensearch_dashboards.json
 
 {
 
@@ -1088,7 +1088,7 @@ Create and register a Usage Collector. Ideally collectors would be defined in a 
 
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 
-import { CallCluster } from 'src/legacy/core_plugins/elasticsearch';
+import { CallCluster } from 'src/legacy/core_plugins/opensearch';
 
 export function registerMyPluginUsageCollector(usageCollection?: UsageCollectionSetup): void {
 
@@ -1108,7 +1108,7 @@ export function registerMyPluginUsageCollector(usageCollection?: UsageCollection
 
     fetch: async (callCluster: CallCluster) => {
 
-    // query ES and get some data
+    // query OPENSEARCH and get some data
 
     // summarize the data into a model
 
@@ -1138,7 +1138,7 @@ export function registerMyPluginUsageCollector(usageCollection?: UsageCollection
 
 [float]
 ==== Move SearchBar to NP
-{kib-pull}51028[#51028]
+{osd-pull}51028[#51028]
 
 The SearchBar component is now available by importing from the data plugin.
 
@@ -1180,7 +1180,7 @@ export class MyPublicPlugin {
 
 [float]
 ==== Move QueryBarInput to New Platform
-{kib-pull}51023[#51023]
+{osd-pull}51023[#51023]
 
 
 * `QueryBarInput` was renamed to `QueryStringInput` and moved to `src/plugins/data/public`
@@ -1195,7 +1195,7 @@ export class MyPublicPlugin {
 
 [float]
 ==== Move ApplyFiltersPopover to New Platform
-{kib-pull}51022[#51022]
+{osd-pull}51022[#51022]
 
 The `ApplyFiltersPopover` component is no longer exported.
 
@@ -1216,14 +1216,14 @@ use the Actions API from within an `embeddable`:
 
 [float]
 ==== Deprecated the `filter-bar` directive
-{kib-pull}51020[#51020]
+{osd-pull}51020[#51020]
 
 If you need to render a filter bar from `angular`,
-use the `kbn-top-nav` directive with the following configuration:
+use the `osd-top-nav` directive with the following configuration:
 
 ```ts
 
-<kbn-top-nav
+<osd-top-nav
 
   app-name="'my-app'"
 
@@ -1243,7 +1243,7 @@ use the `kbn-top-nav` directive with the following configuration:
 
 >
 
-</kbn-top-nav>
+</osd-top-nav>
 
 ```
 
@@ -1262,22 +1262,22 @@ import { FilterBar } from '../../../plugins/data/public';
 
  * `getDisplayValueFromFilter` ⇒ `data.utils`
 
- * `buildCustomFilter` ⇒ `esFilters.buildCustomFilter`
+ * `buildCustomFilter` ⇒ `opensearchFilters.buildCustomFilter`
 
- * `buildFilter` ⇒ `esFilters.buildFilter`
+ * `buildFilter` ⇒ `opensearchFilters.buildFilter`
 
- * `getFilterParams` ⇒ `esFilters.getFilterParams`
+ * `getFilterParams` ⇒ `opensearchFilters.getFilterParams`
 
  * `getIndexPatternFromFilter` ⇒ `utils.getIndexPatternFromFilter`
 
- * `getQueryDslFromFilter` ⇒ replaced with `esFilters.cleanFIlter`
+ * `getQueryDslFromFilter` ⇒ replaced with `opensearchFilters.cleanFIlter`
 
  * `isFilterable` ⇒ import from `data`
 
 
 [float]
-==== NP Kibana plugin home feature catalogue
-{kib-pull}50838[#50838]
+==== NP OpenSearchDashboards plugin home feature catalogue
+{osd-pull}50838[#50838]
 
 The `ui/registries/feature_catalogue` module has been deprecated for removal in 8.0.
 
@@ -1293,7 +1293,7 @@ npSetup.plugins.home.featureCatalogue.register(/* same details here */);
 
 // For new plugins: first add 'home` to the list of `optionalPlugins`
 
-// in your kibana.json file. Then access the plugin directly in `setup`:
+// in your opensearch_dashboards.json file. Then access the plugin directly in `setup`:
 
 class MyPlugin {
 
@@ -1315,10 +1315,10 @@ Note that the old module supported providing a Angular DI function to receive An
 
 
 [float]
-==== [NP Kibana Migrations ] Kibana plugin home
-{kib-pull}50444[#50444]
+==== [NP OpenSearchDashboards Migrations ] OpenSearchDashboards plugin home
+{osd-pull}50444[#50444]
 
-The API to register new tutorials was moved to the new platform. You are now able to add new tutorials by creating a plugin in the new platform, adding a dependency to `home` in its `kibana.json` and using the `tutorials.registerTutorial` method in the setup lifecycle:
+The API to register new tutorials was moved to the new platform. You are now able to add new tutorials by creating a plugin in the new platform, adding a dependency to `home` in its `opensearch_dashboards.json` and using the `tutorials.registerTutorial` method in the setup lifecycle:
 
 ```ts
 
@@ -1344,7 +1344,7 @@ server.newPlatform.setup.plugins.home.tutorials.registerTutorial(() => ({ /* tut
 
 [float]
 ==== Expressions fully migrated to the New Platform
-{kib-pull}50294[#50294]
+{osd-pull}50294[#50294]
 
 The Expressions service has been moved to the New Platform. Moving forward, any expressions-related code should be consumed via the new plugin's contracts (`src/plugins/expressions`).
 
@@ -1390,7 +1390,7 @@ npStart.plugins.expressions.execute(myExpression);
 
 [float]
 ==== Move generateFilters to NP
-{kib-pull}50118[#50118]
+{osd-pull}50118[#50118]
 
 Filter generator is now available as a utility function in the `data` plugin.
 
@@ -1406,7 +1406,7 @@ const filters = generateFilters(filterManager, field, values, negate, indexStrin
 
 [float]
 ==== Move Query type to NP
-{kib-pull}49636[#49636]
+{osd-pull}49636[#49636]
 
 Moved the data `Query` type, used to represent a query string in a specific querying language  to `src/plugins/data`.
 
@@ -1424,7 +1424,7 @@ import { Query } from `src/plugins/data/public`;
 
 [float]
 ==== Move Timefilter service to NP
-{kib-pull}49491[#49491]
+{osd-pull}49491[#49491]
 
 Moved the `timefilter` service to New Platform.
 
@@ -1470,9 +1470,9 @@ class MyPlugin {
 
 [float]
 ==== Move Storage to New Platform
-{kib-pull}49448[#49448]
+{osd-pull}49448[#49448]
 
-Move `Storage` to `kibana_utils`.
+Move `Storage` to `opensearch_dashboards_utils`.
 
  - Move `Storage` class to NP, and introduce the interface `IStorageWrapper` for when we only pass storage around.
 
@@ -1482,7 +1482,7 @@ Move `Storage` to `kibana_utils`.
 
 [float]
 ==== Licensing plugin
-{kib-pull}49345[#49345]
+{osd-pull}49345[#49345]
 
 Add x-pack plugin for new platform public licensing information. This will eventually replace the licensing information consumed via `xpack_main`. Upon setup, this plugin exposes an observable API for inspecting and making checks against the license information.
 
@@ -1510,7 +1510,7 @@ license$.subscribe(license => {
 
 [float]
 ==== Migrate ui/registry/feature_catalogue to New Platform plugin
-{kib-pull}48818[#48818]
+{osd-pull}48818[#48818]
 
 The `ui/registries/feature_catalogue` module has been deprecated for removal in 8.0.
 
@@ -1526,7 +1526,7 @@ npSetup.plugins.feature_catalogue.register(/* same details here */);
 
 // For new plugins: first add 'feature_catalogue` to the list of `optionalPlugins`
 
-// in your kibana.json file. Then access the plugin directly in `setup`:
+// in your opensearch_dashboards.json file. Then access the plugin directly in `setup`:
 
 class MyPlugin {
 
@@ -1548,7 +1548,7 @@ Note that the old module supported providing a Angular DI function to receive An
 
 [float]
 ==== Migrate necessary ui/autoload functionality to NP
-{kib-pull}48689[#48689]
+{osd-pull}48689[#48689]
 
 The `ui/autoload/styles` and `ui/autoload/settings` modules have been removed and are no longer necessary to import in your plugin code. Remove these imports starting in 7.6.
 
@@ -1562,7 +1562,7 @@ import 'font-awesome/less/font-awesome';
 
 [float]
 ==== Provide uiSettings service in NP
-{kib-pull}48413[#48413]
+{osd-pull}48413[#48413]
 
 New platform plugins can register custom uiSettings via the `uiSettings.register` method.
 
@@ -1622,7 +1622,7 @@ public start({ uiSettings }) {
 
 [float]
 ==== Move FilterManager to New Platform
-{kib-pull}48391[#48391]
+{osd-pull}48391[#48391]
 
 Moved Filter Manager to New Platform.
 
@@ -1662,7 +1662,7 @@ class MyPlugin {
 
 [float]
 ==== Migrate ui/doc_title to New platform
-{kib-pull}48121[#48121]
+{osd-pull}48121[#48121]
 
 Migrate `chrome.docTitle` to new platform. Plugins can now change the page title using this API.
 
@@ -1674,7 +1674,7 @@ coreStart.docTitle.change('My Title');
 
 [float]
 ==== Use NP registry instead of ui/registry/field_formats
-{kib-pull}48108[#48108]
+{osd-pull}48108[#48108]
 
 The `FieldFormats` service has been moved to the `data` plugin in the New Platform.
 If your plugin has any imports from `ui/registry/field_formats`, you'll need to update your imports as follows:
@@ -1721,7 +1721,7 @@ npStart.plugins.data.fieldFormats.getType(myFieldFormatId);
 
 [float]
 ==== ui/management to New Platform
-{kib-pull}45747[#45747]
+{osd-pull}45747[#45747]
 
 The following interfaces were previously available under `ui/management`
 and are now available via `import { setup as managementSetup }``
@@ -1735,11 +1735,11 @@ from `'${correct path to top dir}src/legacy/core_plugins/management/public/legac
 
 [float]
 ==== `ui/public` cleanup
-{kib-pull}43511[#43511]
+{osd-pull}43511[#43511]
 
 **Removed / moved modules**
 
-In preparation for Kibana's upcoming new platform, we are in the process
+In preparation for OpenSearchDashboards's upcoming new platform, we are in the process
 of migrating awayfrom the `ui/public` directory.
 Over time, the contents of this directory will be either deprecated or
 housed inside a parent plugin.
@@ -1751,10 +1751,10 @@ or copy the relevant code into your plugin.
 
 [float]
 **`ui/state_management`**
-{kib-pull}51835[#51835]
-{kib-pull}52172[#52172]
-{kib-pull}52280[#52280]
-{kib-pull}53582[#53582]
+{osd-pull}51835[#51835]
+{osd-pull}52172[#52172]
+{osd-pull}52280[#52280]
+{osd-pull}53582[#53582]
 
 The `hashUrl` and `unhashUrl` functions no longer rely on states being provided as an argument, therefore `getUnhashableStates`/`getUnhashableStatesProvider` have been removed.
 
@@ -1779,7 +1779,7 @@ hashUrl([new AppState(), globalState], myRedirectUrl);
 
 // new
 
-import { hashUrl, unhashUrl } from '../../plugins/kibana_utils/public'
+import { hashUrl, unhashUrl } from '../../plugins/opensearch_dashboards_utils/public'
 
 hashUrl(window.location.href);
 
@@ -1787,7 +1787,7 @@ unhashUrl(myRedirectUrl);
 
 ```
 
-HashedItemStore was also moved to the `kibana_utils` plugin.
+HashedItemStore was also moved to the `opensearch_dashboards_utils` plugin.
 
 ```ts
 // old
@@ -1796,7 +1796,7 @@ import { HashedItemStoreSingleton } from 'ui/state_management/state_storage'
 
 // new
 
-import { hashedItemStore } from '../../plugins/kibana_utils/public'
+import { hashedItemStore } from '../../plugins/opensearch_dashboards_utils/public'
 
 ```
 
@@ -1808,45 +1808,45 @@ This should become a replacement for `AppState` and `GlobalState` in NP.
 
 **`ui/public/utils` cleanup**
 
-- `base_object` and `find_by_param` utilities have been removed {kib-pull}52500[#52500]
+- `base_object` and `find_by_param` utilities have been removed {osd-pull}52500[#52500]
 
-- `decode_geo_hash` and `zoom_to_precision` utilities have been moved to `ui/vis/map`{kib-pull}52615[#52615]
+- `decode_geo_hash` and `zoom_to_precision` utilities have been moved to `ui/vis/map`{osd-pull}52615[#52615]
 
-- `range` utility has beed moved to `ui/vis/editors/default` {kib-pull}52615[#52615]
+- `range` utility has beed moved to `ui/vis/editors/default` {osd-pull}52615[#52615]
 
-- `cidr_mask`, `date_range`, `geo_utils`,  `ip_range`, `ordinal_suffix` utilities have been moved to `ui/agg_types` {kib-pull}52744[#52744]
+- `cidr_mask`, `date_range`, `geo_utils`,  `ip_range`, `ordinal_suffix` utilities have been moved to `ui/agg_types` {osd-pull}52744[#52744]
 
-- `case_conversion` {kib-pull}53819[#53819]
+- `case_conversion` {osd-pull}53819[#53819]
 
     - `keysToSnakeCaseShallow` moved to `src/legacy/server/status/lib`
 
-    - `keysToCamelCaseShallow` moved to `src/legacy/core_plugins/kibana/public/management`
+    - `keysToCamelCaseShallow` moved to `src/legacy/core_plugins/opensearch-dashboards/public/management`
 
-- `collection` {kib-pull}53819[#53819]
+- `collection` {osd-pull}53819[#53819]
 
     - `organizeBy moved to `src/legacy/ui/public/indexed_array`
 
     - `pushAll` was removed
 
-- `diff_object moved to `ui/state_management` {kib-pull}53819[#53819]
+- `diff_object moved to `ui/state_management` {osd-pull}53819[#53819]
 
-- `function` was removed {kib-pull}53819[#53819]
+- `function` was removed {osd-pull}53819[#53819]
 
-- `key_map` moved to `ui/directives` {kib-pull}53819[#53819]
+- `key_map` moved to `ui/directives` {osd-pull}53819[#53819]
 
-- `math` moved to `ui/vis`  {kib-pull}53819[#53819]
+- `math` moved to `ui/vis`  {osd-pull}53819[#53819]
 
-- `numeric` moved to `src/legacy/core_plugins/kibana/public/management` {kib-pull}53819[#53819]
+- `numeric` moved to `src/legacy/core_plugins/opensearch-dashboards/public/management` {osd-pull}53819[#53819]
 
-- `parse_interval` moved to`src/legacy/core_plugins/data/common` {kib-pull}53819[#53819]
+- `parse_interval` moved to`src/legacy/core_plugins/data/common` {osd-pull}53819[#53819]
 
-- `sort_prefix_first` moved to `x-pack/legacy/plugins/kuery_autocomplete` {kib-pull}53819[#53819]
+- `sort_prefix_first` moved to `x-pack/legacy/plugins/kuery_autocomplete` {osd-pull}53819[#53819]
 
-- `supports` moved to `src/legacy/core_plugins/tile_map/public` {kib-pull}53819[#53819]
+- `supports` moved to `src/legacy/core_plugins/tile_map/public` {osd-pull}53819[#53819]
 
 [float]
 ==== Index Patterns moved to New Platform
-{kib-pull}43438[#43438]
+{osd-pull}43438[#43438]
 
 The `indexPatterns` service is now available from the data plugin.
 

--- a/docs/migration/migrate_7_7.asciidoc
+++ b/docs/migration/migrate_7_7.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 This page discusses the breaking changes that you need to be aware of when migrating
-your application to Kibana 7.7.
+your application to OpenSearchDashboards 7.7.
 
 // The following section is re-used in the Installation and Upgrade Guide
 // tag::notable-breaking-changes[]
@@ -25,7 +25,7 @@ There are no user-facing breaking changes in 7.7.
 
 This Info toast will be used for the async search notifications.
 
-*via {kib-pull}60574[#60574]*
+*via {osd-pull}60574[#60574]*
 
 [discrete]
 ==== Goodbye, legacy data plugin
@@ -48,14 +48,14 @@ For scenario 2, the equivalent static code you've been importing should now be a
 + import { someStaticUtilOrType } from 'src/plugins/data/public';
 ```
 
-For scenario 3, you should be able to safely drop the reference to the plugin, and add `data` to your list of dependencies in `kibana.json` whenever your plugin migrates to the new Kibana platform:
+For scenario 3, you should be able to safely drop the reference to the plugin, and add `data` to your list of dependencies in `opensearch_dashboards.json` whenever your plugin migrates to the new OpenSearchDashboards platform:
 ```diff
 // index.ts
 const myPluginInitializer: LegacyPluginInitializer = ({ Plugin }: LegacyPluginApi) =>
   new Plugin({
     id: 'my_plugin',
--    require: ['kibana', 'elasticsearch', 'visualizations', 'data'],
-+    require: ['kibana', 'elasticsearch', 'visualizations'],
+-    require: ['opensearchDashboards', 'opensearch', 'visualizations', 'data'],
++    require: ['opensearchDashboards', 'opensearch', 'visualizations'],
     ...,
   })
 );
@@ -63,24 +63,24 @@ const myPluginInitializer: LegacyPluginInitializer = ({ Plugin }: LegacyPluginAp
 
 For more information on where to locate new platform `data` services,
 please refer to the table of
-https://github.com/elastic/kibana/blob/master/src/core/MIGRATION.md#plugins-for-shared-application-services[plugins for shared application services]
+https://github.com/elastic/opensearch-dashboards/blob/master/src/core/MIGRATION.md#plugins-for-shared-application-services[plugins for shared application services]
 in `src/core/MIGRATION.md`.
 
-*via {kib-pull}60449[#60449]*
+*via {osd-pull}60449[#60449]*
 
 [discrete]
 ==== Delete FilterStateManager and QueryFilter
 
 Delete unused legacy exports `FilterStateManager`, `QueryFilter`, and `SavedQuery`.
 
-*via {kib-pull}59872[#59872]*
+*via {osd-pull}59872[#59872]*
 
 [discrete]
-==== Add UiSettings validation & Kibana default route redirection
+==== Add UiSettings validation & OpenSearchDashboards default route redirection
 
 UiSettings definition allows to specify validation functions:
 ```js
-import { schema } from '@kbn/config-schema';
+import { schema } from '@osd/config-schema';
 
 uiSettings.register({
    myUiSetting: {
@@ -91,7 +91,7 @@ uiSettings.register({
 })
 ```
 
-*via {kib-pull}59694[#59694]*
+*via {osd-pull}59694[#59694]*
 
 [discrete]
 ==== Allow disabling xsrf protection per an endpoint
@@ -101,7 +101,7 @@ Route configuration allows to disable xsrf protection for destructive HTTP metho
 ```js
 routet.get({ path: ..., validate: ..., options: { xsrfRequired: false } })
 ```
-*via {kib-pull}58717[#58717]*
+*via {osd-pull}58717[#58717]*
 
 [discrete]
 ==== Add core metrics service
@@ -115,7 +115,7 @@ core.metrics.getOpsMetrics$().subscribe(metrics => {
 })
 ```
 
-*via {kib-pull}58623[#58623]*
+*via {osd-pull}58623[#58623]*
 
 [discrete]
 ==== Add an optional authentication mode for HTTP resources
@@ -125,7 +125,7 @@ A route config accepts `authRequired: 'optional'`. A user can access a resource 
 router.get( { path: '/',  options: { authRequired: 'optional' } }, handler);
 ```
 
-*via {kib-pull}58589[#58589]*
+*via {osd-pull}58589[#58589]*
 
 [discrete]
 ==== Migrate doc view part of discover
@@ -152,7 +152,7 @@ export class MyPlugin implements Plugin<void, void> {
 
 ```
 
-*via {kib-pull}58094[#58094]*
+*via {osd-pull}58094[#58094]*
 
 [discrete]
 ==== [Telemetry] Server backpressure mechanism
@@ -165,18 +165,18 @@ request before `POST`ing the data to our cluster to ensure the endpoint is reach
 [discrete]
 *Fallback mechanism*
 
-. Always send usage from browser regardless of the `telemetry.sendUsageFrom` kibana config.
+. Always send usage from browser regardless of the `telemetry.sendUsageFrom` opensearchDashboards config.
 
 
 *Server usage backpressure*
 
 . Send usage from server in addition to browser if `telemetry.sendUsageFrom` is set to `server`.
 
-. Initial server usage attempt is after 5 minutes from starting kibana. Attempt to send every 12 hours afterwards.
+. Initial server usage attempt is after 5 minutes from starting OpenSearch Dashboards. Attempt to send every 12 hours afterwards.
 
 . Stop attempting to send usage from the server if the attempts fail three times (initial attempt 5 minutes from server start, and two consecutive 12 hours attempts).
 
-. Restart attempt count after each kibana version upgrade (patch/minor/major).
+. Restart attempt count after each OpenSearch Dashboards version upgrade (patch/minor/major).
 
 . Restart attempt count if it succeeds in any of the 3 tries.
 
@@ -188,19 +188,19 @@ Send `OPTIONS` request before attempting to send telemetry from server. `OPTIONS
 
 * If `OPTIONS` request fails; dont send usage and follow the retry logic above.
 
-*via {kib-pull}57556[#57556]*
+*via {osd-pull}57556[#57556]*
 
 [discrete]
 ==== Expressions server-side
 
-It is now possible to register expression functions and types on the Kibana server and execute expressions on the server. The API is the same as in the browser-side plugin, e.g:
+It is now possible to register expression functions and types on the OpenSearchDashboards server and execute expressions on the server. The API is the same as in the browser-side plugin, e.g:
 
 ```ts
 plugins.expressions.registerFunction(/* ... */);
 const result = await plugins.expressions.run('var_set name="foo" value="bar" | var name="foo"', null);
 ```
 
-*via {kib-pull}57537[#57537]*
+*via {osd-pull}57537[#57537]*
 
 [discrete]
 ==== Local actions
@@ -220,15 +220,15 @@ const trigger = {
 };
 ```
 
-*via {kib-pull}57451[#57451]*
+*via {osd-pull}57451[#57451]*
 
 [discrete]
 ==== Use log4j pattern syntax
 
 Logging output of the New platform plugins can use adjusted
-via https://github.com/elastic/kibana/blob/master/src/core/server/logging/README.md[new config].
+via https://github.com/elastic/opensearch-dashboards/blob/master/src/core/server/logging/README.md[new config].
 
-*via {kib-pull}57433[#57433]*
+*via {osd-pull}57433[#57433]*
 
 [discrete]
 ==== Allow savedObjects types registration from NP
@@ -274,7 +274,7 @@ export class Plugin() {
 
 Please check the migration guide for more complete examples and migration procedure.
 
-*via {kib-pull}57430[#57430]*
+*via {osd-pull}57430[#57430]*
 
 [discrete]
 ==== Expose Vis on the contract as it requires visTypes
@@ -292,12 +292,12 @@ new visualizationsStart.Vis(....);
 import { Vis } from '../../../../../core_plugins/visualizations/public';
 ```
 
-*via {kib-pull}56968[#56968]*
+*via {osd-pull}56968[#56968]*
 
 [discrete]
 ==== Add ScopedHistory to AppMountParams
 
-Kibana Platform applications should use the provided `history` instance to integrate routing rather than setting up their own using `appBasePath` (which is now deprecated).
+OpenSearchDashboards Platform applications should use the provided `history` instance to integrate routing rather than setting up their own using `appBasePath` (which is now deprecated).
 
 *Before*
 
@@ -332,7 +332,7 @@ core.application.register({
 });
 ```
 
-*via {kib-pull}56705[#56705]*
+*via {osd-pull}56705[#56705]*
 
 [discrete]
 ==== Move new_vis_modal to visualizations plugin
@@ -348,14 +348,14 @@ NewVisModal component and showNewVisModal function were statically exported and 
 ```tsx
 npStart.plugins.visualizations.showNewVisModal();
 ```
-*via {kib-pull}56654[#56654]*
+*via {osd-pull}56654[#56654]*
 
 [discrete]
 ==== UiComponent
 
-`UiComponent` interface was added to `kibana_utils` plugin. `UiComponent` represents a user interface building block, like a React component, but `UiComponent` does not have to be implemented in React&mdash;it can be implemented in plain JS or React, or Angular, etc.
+`UiComponent` interface was added to `opensearch_dashboards_utils` plugin. `UiComponent` represents a user interface building block, like a React component, but `UiComponent` does not have to be implemented in React&mdash;it can be implemented in plain JS or React, or Angular, etc.
 
-In many places in Kibana we want to be agnostic to frontend view library, i.e. instead of exposing React-specific APIs we want to expose APIs that are orthogonal to any rendering library. `UiComponent` interface represents such UI components. UI component receives a DOM element and `props` through `render()` method, the `render()` method can be called many times.
+In many places in OpenSearchDashboards we want to be agnostic to frontend view library, i.e. instead of exposing React-specific APIs we want to expose APIs that are orthogonal to any rendering library. `UiComponent` interface represents such UI components. UI component receives a DOM element and `props` through `render()` method, the `render()` method can be called many times.
 
 ```ts
 export type UiComponent<Props extends object = object> = () => {
@@ -364,13 +364,13 @@ export type UiComponent<Props extends object = object> = () => {
 };
 ```
 
-Although Kibana aims to be library agnostic, Kibana itself is written in React,
+Although OpenSearchDashboards aims to be library agnostic, OpenSearchDashboards itself is written in React,
 therefore `UiComponent` is designed such that it maps directly to a
 functional React component: `UiCompnent` interface corresponds
 to `React.ComponentType` type and `UiCompnent` props map to React component props.
 
 To help use `UiComponent` interface in the codebase `uiToReactComponent` and
-`reactToUiComponent` helper functions were added to `kibana_react` plugin,
+`reactToUiComponent` helper functions were added to `opensearch_dashboards_react` plugin,
 they transform a `UiComponent` into a React component and vice versa, respectively.
 
 ```ts
@@ -378,23 +378,23 @@ const uiToReactComponent: (comp: UiComponent) => React.ComponentType;
 const reactToUiComponent: (comp: React.ComponentType) => UiComponent;
 ```
 
-*via {kib-pull}56555[#56555]*
+*via {osd-pull}56555[#56555]*
 
 [discrete]
 ==== Start consuming np logging config
 
 Provides experimental support of new logging format for **new platform plugins**.
-More about https://github.com/elastic/kibana/blob/master/src/core/server/logging/README.md[the logging format].
+More about https://github.com/elastic/opensearch-dashboards/blob/master/src/core/server/logging/README.md[the logging format].
 
-*via {kib-pull}56480[#56480]*
+*via {osd-pull}56480[#56480]*
 
 [discrete]
 ==== [State Management] State syncing utils docs
 
-Refer to https://github.com/elastic/kibana/tree/master/src/plugins/kibana_utils/docs/state_sync[these docs]
+Refer to https://github.com/elastic/opensearch-dashboards/tree/master/src/plugins/opensearch_dashboards_utils/docs/state_sync[these docs]
 on state syncing utils.
 
-*via {kib-pull}56479[#56479]*
+*via {osd-pull}56479[#56479]*
 
 
 [discrete]
@@ -402,7 +402,7 @@ on state syncing utils.
 
 `SavedObjectSaveModal`, `showSaveModal` and `SaveResult` from _`ui/saved_objects`_,
 and `SavedObjectFinderUi`, `SavedObjectMetaData` and `OnSaveProps`
-from _`src/plugins/kibana_react/public`_ were moved to a new plugin **`src/plugins/saved_objects`**.
+from _`src/plugins/opensearch_dashboards_react/public`_ were moved to a new plugin **`src/plugins/saved_objects`**.
 
 Also now `showSaveModal` requires the second argument  - `I18nContext`:
 
@@ -414,7 +414,7 @@ showSaveModal(saveModal, npStart.core.i18n.Context);
 
 ```
 
-*via {kib-pull}56383[#56383]*
+*via {osd-pull}56383[#56383]*
 
 [discrete]
 ==== [State Management] State syncing helpers for query service
@@ -440,7 +440,7 @@ interface QueryStateChange {
 state$: Observable<{ changes: QueryStateChange; state: QueryState }>;
 ```
 
-*via {kib-pull}56128[#56128]*
+*via {osd-pull}56128[#56128]*
 
 [discrete]
 ==== Migrate saved_object_save_as_checkbox directive to Timelion
@@ -460,25 +460,25 @@ import { SavedObjectSaveModal } from 'ui/saved_objects/components/saved_object_s
  />
 ```
 
-*via {kib-pull}56114[#56114]*
+*via {osd-pull}56114[#56114]*
 
 [discrete]
 ==== `ui/public` cleanup
 
 *Removed / moved modules*
 
-In preparation for Kibana's upcoming https://github.com/elastic/kibana/issues/9675[new platform],
-we are in the process of https://github.com/elastic/kibana/issues/26505[migrating away]
+In preparation for OpenSearchDashboards's upcoming https://github.com/elastic/opensearch-dashboards/issues/9675[new platform],
+we are in the process of https://github.com/elastic/opensearch-dashboards/issues/26505[migrating away]
 from the `ui/public` directory. Over time, the contents of this directory will
 be either deprecated or housed inside a parent plugin. If your plugin imports
 the listed items from the following `ui/public` modules, you will need to
 either update your import statements as indicated below, so that you are
 pulling these modules from their new locations, or copy the relevant code directly into your plugin.
 
-*`ui/agg_types`* https://github.com/elastic/kibana/pull/59605[#59605]
+*`ui/agg_types`* https://github.com/elastic/opensearch-dashboards/pull/59605[#59605]
 
 The `ui/agg_types` module has been removed in favor of the service provided by
-the `data` plugin in the new Kibana platform.
+the `data` plugin in the new OpenSearchDashboards platform.
 
 Additionally, `aggTypes` and `AggConfigs` have been removed in favor of a
 `types` registry and a `createAggConfigs` function:
@@ -507,11 +507,11 @@ import { BUCKET_TYPES, METRIC_TYPES } from 'src/plugins/data/public';
 
 The above examples are not comprehensive, but represent some of the more
 common uses of `agg_types`. For more details, please refer to the interfaces
-in https://github.com/elastic/kibana/blob/master/src/plugins/data/public/types.ts#L50[the source code],
-as well as the data plugin's https://github.com/elastic/kibana/blob/master/src/plugins/data/public/index.ts#L282[`public/index` file].
+in https://github.com/elastic/opensearch-dashboards/blob/master/src/plugins/data/public/types.ts#L50[the source code],
+as well as the data plugin's https://github.com/elastic/opensearch-dashboards/blob/master/src/plugins/data/public/index.ts#L282[`public/index` file].
 
 
-*`ui/time_buckets`* https://github.com/elastic/kibana/pull/58805[#58805]
+*`ui/time_buckets`* https://github.com/elastic/opensearch-dashboards/pull/58805[#58805]
 
 The `ui/time_buckets` module has been removed and is now internal to the `data` plugin's
 search & aggregations infrastructure. We are working on an improved set of helper utilities
@@ -520,12 +520,12 @@ to eventually replace the need for the `TimeBuckets` class.
 In the meantime, if you currently rely on `TimeBuckets`, please copy the relevant pieces into your plugin code.
 
 
-*`ui/filter_manager`* https://github.com/elastic/kibana/pull/59872[#59872]
+*`ui/filter_manager`* https://github.com/elastic/opensearch-dashboards/pull/59872[#59872]
 
 The `ui/filter_manager` module has been removed and now services and UI components
 are available on the `data` plugin's query infrastructure.
 
-*via {kib-pull}55926[#55926]*
+*via {osd-pull}55926[#55926]*
 
 [discrete]
 ==== Add savedObjects mappings API to core
@@ -558,7 +558,7 @@ export const mappings: SavedObjectsTypeMappingDefinitions = {
  }
 ```
 
-*via {kib-pull}55825[#55825]*
+*via {osd-pull}55825[#55825]*
 
 [discrete]
 ==== Remove the VisEditorTypesRegistryProvider
@@ -579,7 +579,7 @@ a class with your own controller as a value in a vis type definition:
   }
 ```
 
-*via {kib-pull}55370[#55370]*
+*via {osd-pull}55370[#55370]*
 
 [discrete]
 ==== Explicitly test custom appRoutes
@@ -587,7 +587,7 @@ a class with your own controller as a value in a vis type definition:
 Tests for custom `appRoute`s are now more clear and explicitly separate
 from those that test other rendering service interactions.
 
-*via {kib-pull}55405[#55405]*
+*via {osd-pull}55405[#55405]*
 
 [discrete]
 ==== [NP] Platform exposes API to get authenticated user data
@@ -601,7 +601,7 @@ HttpService exposes:
 
 * `auth.isAuthenticated()` - returns true, if `auth` interceptor successfully authenticated a user.
 
-*via {kib-pull}55327[#55327]*
+*via {osd-pull}55327[#55327]*
 
 [discrete]
 ==== Implements `getStartServices` on server-side
@@ -624,7 +624,7 @@ class MyPlugin implements Plugin {
 }
 ```
 
-*via {kib-pull}55156[#55156]*
+*via {osd-pull}55156[#55156]*
 
 [discrete]
 ====  Expressions refactor
@@ -632,7 +632,7 @@ class MyPlugin implements Plugin {
 * `context.types` > `inputTypes`
 * Objects should be registered instead of function wrappers around those objects.
 
-*via {kib-pull}54342[#54342]*
+*via {osd-pull}54342[#54342]*
 
 [discrete]
 ==== Refactor saved object management registry usage
@@ -667,13 +667,13 @@ const savedVisualizations = createSavedVisLoader(servicesForVisualizations);
 const savedDashboards = createSavedDashboardLoader(services);
 ```
 
-*via {kib-pull}54155[#54155]*
+*via {osd-pull}54155[#54155]*
 
 [discrete]
 ==== Enforce camelCase format for a plugin id
 
 When creating a new platform plugin, you need to make sure that
-pluginId declared in camelCase within `kibana.json` manifest file.
+pluginId declared in camelCase within `opensearch_dashboards.json` manifest file.
 It might not match `pluginPath`, which is recommended to be in snake_case format.
 
 ```js
@@ -685,12 +685,12 @@ It might not match `pluginPath`, which is recommended to be in snake_case format
 "id": "fooBar"
 ```
 
-*via {kib-pull}53759[#53759]*
+*via {osd-pull}53759[#53759]*
 
 [discrete]
 ==== bfetch (2)
 
-Request batching and response streaming functionality of legacy Interpreter plugin has been moved out into a separate `bfetch` Kibana platform plugin. Now every plugin can create server endpoints and browser wrappers that can batch HTTP requests and stream responses back.
+Request batching and response streaming functionality of legacy Interpreter plugin has been moved out into a separate `bfetch` OpenSearchDashboards platform plugin. Now every plugin can create server endpoints and browser wrappers that can batch HTTP requests and stream responses back.
 
 As an example, we will create a batch processing endpoint that receives a number then doubles it
 and streams it back. We will also consider the number to be time in milliseconds
@@ -736,27 +736,27 @@ double({ num: 2 }).then(console.log, console.error); // { num: 4 }
 double({ num: 3 }).then(console.log, console.error); // { num: 6 }
 ```
 
-*via {kib-pull}53711[#53711]*
+*via {osd-pull}53711[#53711]*
 
 [discrete]
-==== Grouped Kibana nav
+==== Grouped OpenSearchDashboards nav
 
 Plugins should now define a category if they have a navigation item:
 
 * If you want to fit into our default categories, you can use our `DEFAULT_APP_CATEGORIES` defined in `src/core/utils/default_app_categories.ts`.
 * If you want to create their own category, you can also provide any object matching the `AppCategory` interface defined in `src/core/types/app_category.ts`.
 
-*via {kib-pull}53545[#53545]*
+*via {osd-pull}53545[#53545]*
 
 [discrete]
-==== Expose Elasticsearch from start and deprecate from setup
+==== Expose OpenSearch from start and deprecate from setup
 
 Remove any API that could allow access/query to savedObjects from core setup
 contract, and move them to the start contract instead. Deprecate
-the `CoreSetup.elasticsearch` API and expose `CoreStart.elasticsearch` instead.
+the `CoreSetup.opensearch` API and expose `CoreStart.opensearch` instead.
 
 
-*via {kib-pull}59886[#59886]*
+*via {osd-pull}59886[#59886]*
 
 [discrete]
 ==== Embeddable triggers
@@ -774,7 +774,7 @@ class MyEmbeddable extends Embeddable {
 The returned list of triggers will be used in the drilldowns feature on Dashboard,
 where users will be able to add drilldowns to embeddable triggers.
 
-*via {kib-pull}58440[#58440]*
+*via {osd-pull}58440[#58440]*
 
 [discrete]
 ==== Force savedObject API consumers to define SO type explicitly
@@ -783,14 +783,14 @@ The new interface enforces API consumers to specify SO type explicitly.
 Plugins can use `SavedObjectAttributes` to ensure their type are serializable,
 but it shouldn't be used as their domain-specific type.
 
-*via {kib-pull}58022[#58022]*
+*via {osd-pull}58022[#58022]*
 
 [discrete]
 ==== Trigger context
 
 Improved types for trigger contexts, which are consumed by actions.
 
-*via {kib-pull}57870[#57870]*
+*via {osd-pull}57870[#57870]*
 
 [discrete]
 ==== Expressions debug mode
@@ -799,7 +799,7 @@ Add ability to execute expression in "debug" mode, which would collect execution
 information about each function. This is used in the Expression Explorer
 (developed by Canvas) and in Canvas when the expression editor is open.
 
-*via {kib-pull}57841[#57841]*
+*via {osd-pull}57841[#57841]*
 
 [discrete]
 ==== Move ui/agg_types in to shim data plugin
@@ -810,7 +810,7 @@ information about each function. This is used in the Expression Explorer
 ** Right now these are just re-exporting the class as a type;
 eventually we should put more detailed typings in place.
 
-*via {kib-pull}56353[#56353]*
+*via {osd-pull}56353[#56353]*
 
 [discrete]
 ==== Stateful search bar default behaviors
@@ -819,7 +819,7 @@ The goal of the stateful version of SearchBar / TopNavMenu is to be an easy way
 to consume the services offered by `plugins.data.query` where developers
 should be able to provide minimal configuration and get a fully working SearchBar.
 
-*via {kib-pull}56160[#56160]*
+*via {osd-pull}56160[#56160]*
 
 [discrete]
 ==== Guide for creating alert / action types in the UI
@@ -827,15 +827,15 @@ should be able to provide minimal configuration and get a fully working SearchBa
 Documentation to help developers integrate their alert / action type within
 our Management UIs
 
-*via {kib-pull}55963[#55963]*
+*via {osd-pull}55963[#55963]*
 
 [discrete]
 ==== Move search service code to NP
 
-Move all of the search service code to Kibana new platform. Also deletes `courier` folder
+Move all of the search service code to OpenSearchDashboards new platform. Also deletes `courier` folder
 and moves `getFlattenedObject` to `src/core/utils`.
 
-*via {kib-pull}55430[#55430]*
+*via {osd-pull}55430[#55430]*
 
 [discrete]
 ==== Expose NP FieldFormats service to server side
@@ -844,20 +844,20 @@ The fieldFormats service is used on the server side as well.
 At the moment, it resides in `src/legacy/ui/field_formats/mixin/field_formats_service.ts`
 and only the FE plugin exposes it.
 
-*via {kib-pull}55419[#55419]*
+*via {osd-pull}55419[#55419]*
 
 [discrete]
 ==== Update plugin generator to generate NP plugins
 
-Add more options for Kibana new platform plugin generator.
+Add more options for OpenSearchDashboards new platform plugin generator.
 
 * Generate FE components
 * Generate server side endpoint
 * Generate SCSS
-* Generate an optional .eslintrc.js file (for 3rd party plugins mostly)
+* Generate an optional .opensearchlintrc.js file (for 3rd party plugins mostly)
 * Init git repo (for 3rd party plugins)
 
-*via {kib-pull}55281[#55281]*
+*via {osd-pull}55281[#55281]*
 
 [discrete]
 ==== Run SO migration after plugins setup phase
@@ -873,7 +873,7 @@ SO repository provider when registering the client factory.
 * Adapts the existing plugin calls to the removed APIs from `setup` to be now
 using `getStartServices` to access them on the core `start` contract.
 
-*via {kib-pull}55012[#55012]*
+*via {osd-pull}55012[#55012]*
 
 [discrete]
 ==== Build immutable bundles for new platform plugins
@@ -881,19 +881,19 @@ using `getStartServices` to access them on the core `start` contract.
 Plugins that have been migrated to the "new platform" are built with a new system
 into their own `target/public` directory. To build third-party plugin's with
 this new system either pass `--plugin-path` to `node scripts/build_new_platform_plugins`
-or use the `@kbn/optimizer` package in the Kibana repo to build your plugin as
+or use the `@osd/optimizer` package in the OpenSearchDashboards repo to build your plugin as
 described in the readme for that package.
 
-*via {kib-pull}53976[#53976]*
+*via {osd-pull}53976[#53976]*
 
 
 [discrete]
-==== [Search service] Asynchronous ES search strategy
+==== [Search service] Asynchronous OPENSEARCH search strategy
 
-Adds an async {es} search strategy, which utilizes the async search strategy to
-call the `_async_search` APIs in Elasticsearch, returning an observable over the responses.
+Adds an async {opensearch} search strategy, which utilizes the async search strategy to
+call the `_async_search` APIs in OpenSearch, returning an observable over the responses.
 
-*via {kib-pull}53538[#53538]*
+*via {osd-pull}53538[#53538]*
 
 [discrete]
 ==== [Vis: Default editor] EUIficate and Reactify the sidebar
@@ -920,12 +920,12 @@ These tabs should be React components:
   }
 ```
 
-*via {kib-pull}49864[#49864]*
+*via {osd-pull}49864[#49864]*
 
 [discrete]
 ==== [test] Consolidate top-level yarn scripts
 
-Over time Kibana has added a number of testing frameworks,
+Over time OpenSearchDashboards has added a number of testing frameworks,
 but our top-level scripts have remained the same to avoid workflow changes.
 The current naming convention with the number of test options can leave room for ambiguity.
 
@@ -936,4 +936,4 @@ frameworks out and avoid workflow interruptions (`grunt/gulp -> node scripts/*`)
 type (`yarn test:server -> yarn test:mocha`)
 
 
-*via {kib-pull}44679[#44679]*
+*via {osd-pull}44679[#44679]*

--- a/docs/migration/migrate_7_8.asciidoc
+++ b/docs/migration/migrate_7_8.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 This page discusses the breaking changes that you need to be aware of when migrating
-your application to Kibana 7.8.
+your application to OpenSearchDashboards 7.8.
 
 * <<user-facing-changes-78, Breaking changes for users>>
 * <<general-plugin-API-changes-78, Breaking changes for plugin developers>>
@@ -36,7 +36,7 @@ but their action messages might no longer provide useful information and
 must be reconfigured. The new default action message will show an example
 of how to use `context.reason`.
 
-*via https://github.com/elastic/kibana/pull/64365[#64365]*
+*via https://github.com/elastic/opensearch-dashboards/pull/64365[#64365]*
 
 
 [float]
@@ -50,7 +50,7 @@ In dashboard in view mode, `.panels` are no longer synced with the URL.
 *Impact* +
 This fixes the Back button when navigating between dashboards using drilldowns.
 
-*via https://github.com/elastic/kibana/pull/62415[#62415]*
+*via https://github.com/elastic/opensearch-dashboards/pull/62415[#62415]*
 ====
 
 
@@ -67,7 +67,7 @@ This fixes the Back button when navigating between dashboards using drilldowns.
 ====
 
 The following action plugin REST APIs changed so that they are consistent with the
-{kib} styleguide.
+{osd} styleguide.
 
 * `GET /api/action/_getAll` -> `GET /api/actions`
 * `GET /api/action/types` -> `GET /api/actions/list_action_types`
@@ -77,20 +77,20 @@ The following action plugin REST APIs changed so that they are consistent with t
 * `DELETE /api/action/{id}` -> `DELETE /api/actions/action/{id}`
 * `POST /api/action/{id}/_execute` -> `POST /api/actions/action/{id}/_execute`
 
-*via https://github.com/elastic/kibana/pull/65936[#65936]*
+*via https://github.com/elastic/opensearch-dashboards/pull/65936[#65936]*
 
 ====
 
 
 [[breaking_78_canvas]]
-.Canvas applications now run on the new {kib} platform
+.Canvas applications now run on the new {osd} platform
 [%collapsible]
 ====
 
 Any existing user-created plugins that extend
-Canvas functionality must also move to the Kibana Platform to continue extending Canvas.
+Canvas functionality must also move to the OpenSearchDashboards Platform to continue extending Canvas.
 
-*via https://github.com/elastic/kibana/pull/64831[#64831]*
+*via https://github.com/elastic/opensearch-dashboards/pull/64831[#64831]*
 
 ====
 
@@ -119,7 +119,7 @@ discriminate between the different values it passes between functions.
 The `filter` function was the only function that exposed this field to users.
 After this change, all expression values will consistently use `type` to determine a type of expression value.
 
-*via https://github.com/elastic/kibana/pull/64215[#64215]*
+*via https://github.com/elastic/opensearch-dashboards/pull/64215[#64215]*
 
 ====
 
@@ -130,7 +130,7 @@ After this change, all expression values will consistently use `type` to determi
 Calling `core.application.navigateToApp` to a legacy
 application now retains the `path` specified.
 
-*via https://github.com/elastic/kibana/pull/65112[#65112]*
+*via https://github.com/elastic/opensearch-dashboards/pull/65112[#65112]*
 
 ====
 
@@ -168,7 +168,7 @@ search.aggs.convertDateRangeToString,
 search.aggs.convertIPRangeToString,
 ```
 
-*via https://github.com/elastic/kibana/pull/64719[#64719]*
+*via https://github.com/elastic/opensearch-dashboards/pull/64719[#64719]*
 
 ====
 
@@ -177,7 +177,7 @@ search.aggs.convertIPRangeToString,
 [%collapsible]
 ====
 
-{kib} platform applications can now define and update the `defaultPath`
+{osd} platform applications can now define and update the `defaultPath`
 to use when navigating to them from another application or from the navigation bar.
 
 
@@ -201,7 +201,7 @@ core.application.register({
 appUpdater.next(() => ({ defaultPath: '/some-updated-path' }));
 ```
 
-*via https://github.com/elastic/kibana/pull/64498[#64498]*
+*via https://github.com/elastic/opensearch-dashboards/pull/64498[#64498]*
 
 ====
 
@@ -210,7 +210,7 @@ appUpdater.next(() => ({ defaultPath: '/some-updated-path' }));
 [%collapsible]
 ====
 
-{kib} static assets are now served under a release-specific URL
+{osd} static assets are now served under a release-specific URL
 with long-term caching headers `Cache-Control: max-age=31536000`.
 
 Before:
@@ -221,7 +221,7 @@ After:
 
 http://localhost:5601/bundles/8467/plugin/dashboard/dashboard.plugin.js
 
-*via https://github.com/elastic/kibana/pull/64414[#64414]*
+*via https://github.com/elastic/opensearch-dashboards/pull/64414[#64414]*
 
 ====
 
@@ -230,14 +230,14 @@ http://localhost:5601/bundles/8467/plugin/dashboard/dashboard.plugin.js
 [%collapsible]
 ====
 
-{kib} developers can now create example plugins in
-X-Pack&mdash;create your plugin in `/x-pack/examples` folder and start {kib} with:
+{osd} developers can now create example plugins in
+X-Pack&mdash;create your plugin in `/x-pack/examples` folder and start {osd} with:
 
 ```ts
 yarn start --run-examples
 ```
 
-*via https://github.com/elastic/kibana/pull/63823[#63823]*
+*via https://github.com/elastic/opensearch-dashboards/pull/63823[#63823]*
 
 ====
 
@@ -250,7 +250,7 @@ yarn start --run-examples
 `getHref` is now used only to support right click behavior.
 `execute()` takes control on regular click.
 
-*via https://github.com/elastic/kibana/pull/63228[#63228]*
+*via https://github.com/elastic/opensearch-dashboards/pull/63228[#63228]*
 
 ====
 
@@ -261,7 +261,7 @@ yarn start --run-examples
 
 State syncing utils now seamlessly support the platform's `ScopedHistory`.
 
-*via https://github.com/elastic/kibana/pull/62761[#62761]*
+*via https://github.com/elastic/opensearch-dashboards/pull/62761[#62761]*
 
 ====
 
@@ -270,14 +270,14 @@ State syncing utils now seamlessly support the platform's `ScopedHistory`.
 [%collapsible]
 ====
 
-When the TSVB visualization was added to {kib},
+When the TSVB visualization was added to {osd},
 two configuration properties were declared: `chartResolution` and `minimumBucketSize`.
 No one used these properties, and
 an implementation has not been added.
 The `chartResolution` and `minimumBucketSize` are now marked as deprecated configuration
 properties for TSVB.
 
-*via https://github.com/elastic/kibana/pull/62543[#62543]*
+*via https://github.com/elastic/opensearch-dashboards/pull/62543[#62543]*
 
 ====
 
@@ -287,7 +287,7 @@ properties for TSVB.
 ====
 
 If your server-side plugin needs to respond to an incoming request with the
-HTML page bootstrapping {kib} client app, a custom HTML page, or a custom JS script,
+HTML page bootstrapping {osd} client app, a custom HTML page, or a custom JS script,
 you can use the `HttpResources` service.
 
 ```js
@@ -304,7 +304,7 @@ httpResources.register({ path: 'my_app/bar', validate: false }, (context, req, r
 );
 ```
 
-*via https://github.com/elastic/kibana/pull/61797[#61797]*
+*via https://github.com/elastic/opensearch-dashboards/pull/61797[#61797]*
 
 ====
 
@@ -314,7 +314,7 @@ httpResources.register({ path: 'my_app/bar', validate: false }, (context, req, r
 ====
 
 The legacy `embeddable_api` plugin in `src/legacy/core_plugins/embeddable_api`
-has been removed in favor of the `embeddable` plugin in the new {kib} Platform.
+has been removed in favor of the `embeddable` plugin in the new {osd} Platform.
 If you used the `embeddable_api` in `7.7`, you already used the new
 `embeddable` plugin API, which was re-exported from the legacy platform as a convenience.
 
@@ -343,19 +343,19 @@ For plugins using the legacy platform, you also must remove
 the `embeddable_api` from your list of required plugins in your plugin's `index.ts`:
 
 ```diff
-export default function MyPlugin(kibana: any) {
+export default function MyPlugin(opensearchDashboards: any) {
   const config: Legacy.PluginSpecOptions = {
     id: 'my_plugin',
--    require: ['kibana', 'elasticsearch', 'embeddable_api'],
-+    require: ['kibana', 'elasticsearch'],
+-    require: ['opensearchDashboards', 'opensearch', 'embeddable_api'],
++    require: ['opensearchDashboards', 'opensearch'],
     ...,
   };
-  return new kibana.Plugin(config);
+  return new opensearchDashboards.Plugin(config);
 }
 ```
 
-For plugins using the new {kib} platform, make sure to list `embeddable` as
-either a required or optional dependency in your `kibana.json`:
+For plugins using the new {osd} platform, make sure to list `embeddable` as
+either a required or optional dependency in your `opensearch_dashboards.json`:
 
 ```diff
 {
@@ -369,7 +369,7 @@ either a required or optional dependency in your `kibana.json`:
 }
 ```
 
-*via https://github.com/elastic/kibana/pull/61767[#61767]*
+*via https://github.com/elastic/opensearch-dashboards/pull/61767[#61767]*
 
 ====
 
@@ -383,10 +383,10 @@ The corresponding code was previously moved to the new platform.
 
 For more information on where to locate new platform `data` services,
 refer to the
-https://github.com/elastic/kibana/blob/master/src/core/MIGRATION.md#plugins-for-shared-application-services[plugins for shared application services]
+https://github.com/elastic/opensearch-dashboards/blob/master/src/core/MIGRATION.md#plugins-for-shared-application-services[plugins for shared application services]
 in `src/core/MIGRATION.md`.
 
-*via https://github.com/elastic/kibana/pull/61618[#61618]*
+*via https://github.com/elastic/opensearch-dashboards/pull/61618[#61618]*
 
 ====
 
@@ -395,10 +395,10 @@ in `src/core/MIGRATION.md`.
 [%collapsible]
 ====
 
-The {kib} Platform serves plugin static assets from the
+The {osd} Platform serves plugin static assets from the
 `my_plugin/public/assets` folder. No additional configuration is required.
 
-*via https://github.com/elastic/kibana/pull/60490[#60490]*
+*via https://github.com/elastic/opensearch-dashboards/pull/60490[#60490]*
 
 ====
 
@@ -519,5 +519,5 @@ Response
 }
 ```
 
-*via https://github.com/elastic/kibana/pull/63450[#63450]*
+*via https://github.com/elastic/opensearch-dashboards/pull/63450[#63450]*
 ====

--- a/docs/migration/migrate_7_9.asciidoc
+++ b/docs/migration/migrate_7_9.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 This page discusses the breaking changes that you need to be aware of when migrating
-your application to Kibana 7.9.
+your application to OpenSearchDashboards 7.9.
 
 * <<user-facing-changes-79, Breaking changes for users>>
 * <<general-plugin-API-changes-79, Breaking changes for plugin developers>>
@@ -21,15 +21,15 @@ your application to Kibana 7.9.
 // tag::notable-breaking-changes[]
 
 [float]
-[[breaking_kibana_keystore]]
-==== `kibana.keystore` moved from the data folder to the config folder
+[[breaking_opensearch_dashboards_keystore]]
+==== `opensearchDashboards.keystore` moved from the data folder to the config folder
 
-`kibana.keystore` has moved from the configured `path.data`
-folder to `<root>/config` for archive distributions and `/etc/kibana` for
+`opensearchDashboards.keystore` has moved from the configured `path.data`
+folder to `<root>/config` for archive distributions and `/etc/opensearch-dashboards` for
 package distributions. If a pre-existing keystore exists in the data directory,
 that path will continue to be used.
 
-*via https://github.com/elastic/kibana/pull/57856[#57856]*
+*via https://github.com/elastic/opensearch-dashboards/pull/57856[#57856]*
 
 // end::notable-breaking-changes[]
 
@@ -38,7 +38,7 @@ that path will continue to be used.
 === Breaking changes for plugin developers
 
 [[breaking_79_actions_api]]
-.aborted$ event fixed and completed$ event added to `KibanaRequest`
+.aborted$ event fixed and completed$ event added to `OpenSearchDashboardsRequest`
 [%collapsible]
 ====
 
@@ -48,7 +48,7 @@ response to be sent before completing.
 A new `request.events.completed$` API is available that will emit once
 a request has been completely handled or aborted.
 
-*via https://github.com/elastic/kibana/pull/73898[#73898]*
+*via https://github.com/elastic/opensearch-dashboards/pull/73898[#73898]*
 
 ====
 
@@ -62,7 +62,7 @@ new interface, `sections`, which is a map of management sections provided by the
 replaces `getSection`. Public start interfaces have been removed as all
 registration should occur in the `setup` lifecycle.
 
-*via https://github.com/elastic/kibana/pull/71144[#71144]*
+*via https://github.com/elastic/opensearch-dashboards/pull/71144[#71144]*
 
 ====
 
@@ -71,10 +71,10 @@ registration should occur in the `setup` lifecycle.
 [%collapsible]
 ====
 
-Kibana now allows the creation of filters from fields
+OpenSearchDashboards now allows the creation of filters from fields
 with a null or undefined value.
 
-*via https://github.com/elastic/kibana/pull/70936[#70936]*
+*via https://github.com/elastic/opensearch-dashboards/pull/70936[#70936]*
 
 ====
 
@@ -88,7 +88,7 @@ reflect its place in the execution order&mdash;it is now called right before the
 A new `onPreAuth` interceptor is executed before the `Auth` lifecycle step,
 but after the `onPreRouting` step.
 
-*via https://github.com/elastic/kibana/pull/70775[#70775]*
+*via https://github.com/elastic/opensearch-dashboards/pull/70775[#70775]*
 
 ====
 
@@ -100,7 +100,7 @@ but after the `onPreRouting` step.
 The Metric service API exposed from the `setup` contract has been moved
 to the `start` lifecycle.
 
-*via https://github.com/elastic/kibana/pull/69787[#69787]*
+*via https://github.com/elastic/opensearch-dashboards/pull/69787[#69787]*
 
 ====
 
@@ -147,7 +147,7 @@ In addition, the legacy formatting helpers that were exported from
 If your plugin imports from this directory, please update your code to use
 the `fieldFormats` service directly.
 
-*via https://github.com/elastic/kibana/pull/69762[#69762]*
+*via https://github.com/elastic/opensearch-dashboards/pull/69762[#69762]*
 
 ====
 
@@ -305,7 +305,7 @@ const migration780 = encryptedSavedObjects.createMigration<RawAlert, RawAlert>(
   }
 );
 ```
-*via https://github.com/elastic/kibana/pull/69513[#69513]*
+*via https://github.com/elastic/opensearch-dashboards/pull/69513[#69513]*
 
 ====
 
@@ -318,7 +318,7 @@ Previously, workpad templates were added through the Canvas API client side.
 Workpad templates are now stored as saved objects, so an API is no longer required for adding them.
 You can add templates through `SavedObject` management.
 
-*via https://github.com/elastic/kibana/pull/69438[#69438]*
+*via https://github.com/elastic/opensearch-dashboards/pull/69438[#69438]*
 
 ====
 
@@ -333,7 +333,7 @@ following API methods were removed from the `data.search` plugin:
  * `registerSearchStrategy`
  * `getSearchStrategy`
 
-*via https://github.com/elastic/kibana/pull/69333[#69333]*
+*via https://github.com/elastic/opensearch-dashboards/pull/69333[#69333]*
 
 ====
 
@@ -344,7 +344,7 @@ following API methods were removed from the `data.search` plugin:
 
 The docLinks service API exposed from the `setup` contract has been moved to the `start` lifecycle.
 
-*via https://github.com/elastic/kibana/pull/68745[#68745]*
+*via https://github.com/elastic/opensearch-dashboards/pull/68745[#68745]*
 
 ====
 
@@ -369,7 +369,7 @@ core.logging.configure(of(
 ))
 ```
 
-*via https://github.com/elastic/kibana/pull/68704[#68704]*
+*via https://github.com/elastic/opensearch-dashboards/pull/68704[#68704]*
 
 ====
 
@@ -382,36 +382,36 @@ The <<development,developer guide>> includes the following improvements:
 
 * Migrates CONTRIBUTING.md content into AsciiDoc
 * Moves CONTRIBUTING content into the developer guide
-* Removes https://github.com/elastic/kibana/issues/67782[outdated content]
+* Removes https://github.com/elastic/opensearch-dashboards/issues/67782[outdated content]
 * Creates
-https://github.com/elastic/kibana/issues/41833#issuecomment-646195319[the structure proposed
+https://github.com/elastic/opensearch-dashboards/issues/41833#issuecomment-646195319[the structure proposed
 in this issue]
 
-*via https://github.com/elastic/kibana/pull/67764[#67764]*
+*via https://github.com/elastic/opensearch-dashboards/pull/67764[#67764]*
 
 ====
 
-[[breaking_79_es_api]]
-.{es} API exposed from `setup` contract is deprecated
+[[breaking_79_opensearch_api]]
+.{opensearch} API exposed from `setup` contract is deprecated
 [%collapsible]
 ====
 
-The {es} API exposed from the `setup` contract is not available
+The {opensearch} API exposed from the `setup` contract is not available
 and will be deleted without notice. Use the core start API instead.
 
 ```typescript
 // before
 setup(core: CoreSetup) {
-   core.elasticsearch.dataClient(...)
-   core.elasticsearch.adminClient(...)
+   core.opensearch.dataClient(...)
+   core.opensearch.adminClient(...)
 }
 // after
 setup(core: CoreSetup) {
-   core.elasticsearch.legacy.client(...)
+   core.opensearch.legacy.client(...)
 }
 ```
 
-*via https://github.com/elastic/kibana/pull/67596[#67596]*
+*via https://github.com/elastic/opensearch-dashboards/pull/67596[#67596]*
 
 ====
 
@@ -422,47 +422,47 @@ setup(core: CoreSetup) {
 
 The API reference docs for `state_sync` and `state_containers` are now available:
 
-* https://github.com/elastic/kibana/blob/master/docs/development/plugins/kibana_utils/public/state_sync/kibana-plugin-plugins-kibana_utils-public-state_sync.md[state_sync]
-* https://github.com/elastic/kibana/blob/master/docs/development/plugins/kibana_utils/common/state_containers/kibana-plugin-plugins-kibana_utils-common-state_containers.md[state_containers]
+* https://github.com/elastic/opensearch-dashboards/blob/master/docs/development/plugins/opensearch_dashboards_utils/public/state_sync/opensearch-dashboards-plugin-plugins-opensearch_dashboards_utils-public-state_sync.md[state_sync]
+* https://github.com/elastic/opensearch-dashboards/blob/master/docs/development/plugins/opensearch_dashboards_utils/common/state_containers/opensearch-dashboards-plugin-plugins-opensearch_dashboards_utils-common-state_containers.md[state_containers]
 
-*via https://github.com/elastic/kibana/pull/67354[#67354]*
+*via https://github.com/elastic/opensearch-dashboards/pull/67354[#67354]*
 
 ====
 
-[[breaking_79_es_request]]
-.Elasticsearch client exposed via request context marked as deprecated
+[[breaking_79_opensearch_request]]
+.OpenSearch client exposed via request context marked as deprecated
 [%collapsible]
 ====
 
-The Elasticsearch service no longer provides separate `data` and `admin` clients.
-The Elasticsearch service client is marked as deprecated and is superseded by a new one.
+The OpenSearch service no longer provides separate `data` and `admin` clients.
+The OpenSearch service client is marked as deprecated and is superseded by a new one.
 
 ```diff
 // in route handler
 router.get(
 ...
 async function handler (context) {
----  return await context.elasticsearch.adminClient.callAsInternalUser('endpoint');
-+++  return await context.elasticsearch.legacy.client.callAsInternalUser('endpoint');
+---  return await context.opensearch.adminClient.callAsInternalUser('endpoint');
++++  return await context.opensearch.legacy.client.callAsInternalUser('endpoint');
 })
 // in plugin
 setup(core){
   return {
     async search(id) {
----     return await context.elasticsearch.adminClient.callAsInternalUser('endpoint', id);
-+++     return await context.elasticsearch.legacy.client.callAsInternalUser('endpoint', id);
+---     return await context.opensearch.adminClient.callAsInternalUser('endpoint', id);
++++     return await context.opensearch.legacy.client.callAsInternalUser('endpoint', id);
     }
   }
 }
 ```
 
-*via https://github.com/elastic/kibana/pull/67319[#67319]*
+*via https://github.com/elastic/opensearch-dashboards/pull/67319[#67319]*
 
 
 ====
 
 [[breaking_79_licensing]]
-.Licensing now uses {es} from `start` contract
+.Licensing now uses {opensearch} from `start` contract
 [%collapsible]
 ====
 
@@ -481,7 +481,7 @@ start(core, plugins){
 }
 ```
 
-*via https://github.com/elastic/kibana/pull/67291[#67291]*
+*via https://github.com/elastic/opensearch-dashboards/pull/67291[#67291]*
 
 ====
 
@@ -501,7 +501,7 @@ core.savedObjects.getScopedClient(request, { includedHiddenTypes: ['action'] })
 Do not circumvent the authorization model by accessing these objects directly.
 Use `AlertsClient` instead.
 
-*via https://github.com/elastic/kibana/pull/67109[#67109]*
+*via https://github.com/elastic/opensearch-dashboards/pull/67109[#67109]*
 
 ====
 
@@ -530,19 +530,19 @@ The `EncryptedSavedObject` plugin no longer exposes a single client as part of i
 `start` contract. Instead it exposes a `getClient` API that exposes the client API.
 The `getClient` can also specify a list of hidden types to gain access to which are hidden by default.
 
-For example, given a {kib} platform plugin that has specified `encryptedSavedObjects` as a `Setup` dependency:
+For example, given a {osd} platform plugin that has specified `encryptedSavedObjects` as a `Setup` dependency:
 
 ```ts
 const encryptedSavedObjectsClient = plugins.encryptedSavedObjects.getClient(['hiddenType']);
 return encryptedSavedObjectsClient.getDecryptedAsInternalUser('hiddenType',  '123',   { namespace: 'some-namespace' });
 ```
 
-*via https://github.com/elastic/kibana/pull/66879[#66879]*
+*via https://github.com/elastic/opensearch-dashboards/pull/66879[#66879]*
 
 ====
 
 [[breaking_79_alerting_api]]
-.The `alerting` plugin was renamed `alerts` to follow the {kib} styleguide
+.The `alerting` plugin was renamed `alerts` to follow the {osd} styleguide
 [%collapsible]
 ====
 
@@ -564,7 +564,7 @@ This includes the following API changes:
 * Changed POST `/api/alert/{id}/_update_api_key` to POST `/api/alerts/alert/{id}/_update_api_key`
 * Changed POST `/api/alert/{alertId}/alert_instance/{alertInstanceId}/_unmute` to POST `/api/alerts/alert/{alertId}/alert_instance/{alertInstanceId}/_unmute`
 
-*via https://github.com/elastic/kibana/pull/66838[#66838]*
+*via https://github.com/elastic/opensearch-dashboards/pull/66838[#66838]*
 
 
 ====
@@ -580,7 +580,7 @@ This change:
 * Implements a landing page and sidebar in the Management plugin.
 * Removes the legacy API from `src/plugins/management/public/plugin.ts` and related code.
 
-*via https://github.com/elastic/kibana/pull/66781[#66781]*
+*via https://github.com/elastic/opensearch-dashboards/pull/66781[#66781]*
 
 ====
 
@@ -600,18 +600,18 @@ core.savedObjects.getScopedClient(request, { includedHiddenTypes: ['alert'] })
 Do not circumvent the authorization model by accessing these objects directly.
 Use AlertsClient instead.
 
-*via https://github.com/elastic/kibana/pull/66719[#66719]*
+*via https://github.com/elastic/opensearch-dashboards/pull/66719[#66719]*
 
 ====
 
 [[breaking_79_oss_features]]
-.Open source features registration moved to Kibana platform
+.Open source features registration moved to OpenSearchDashboards platform
 [%collapsible]
 ====
 
-{kib} now allows the `getFeatures` plugin method to be called within the `start` lifecycle.
+{osd} now allows the `getFeatures` plugin method to be called within the `start` lifecycle.
 
-*via https://github.com/elastic/kibana/pull/66524[#66524]*
+*via https://github.com/elastic/opensearch-dashboards/pull/66524[#66524]*
 
 ====
 
@@ -621,7 +621,7 @@ Use AlertsClient instead.
 ====
 
 
-To use SavedObjects, you must move your plugin to the {kib} platform.
+To use SavedObjects, you must move your plugin to the {osd} platform.
 
 ```js
 // before in the legacy plugin
@@ -636,7 +636,7 @@ export default function ({ Plugin }) {
       },
    },
 }),
-// in the Kibana platform plugin
+// in the OpenSearchDashboards platform plugin
 export class MyPlugin implements Plugin {
   constructor(context: PluginInitializerContext) {}
   setup(core: CoreSetup) {
@@ -648,7 +648,7 @@ export class MyPlugin implements Plugin {
 }
 ```
 
-*via https://github.com/elastic/kibana/pull/66203[#66203]*
+*via https://github.com/elastic/opensearch-dashboards/pull/66203[#66203]*
 
 
 ====
@@ -658,7 +658,7 @@ export class MyPlugin implements Plugin {
 [%collapsible]
 ====
 
-Links from one application to another are now automatically handled by the {kib} platform
+Links from one application to another are now automatically handled by the {osd} platform
 to perform the navigation without a full page refresh and the need to
 manually add a click handler to call `application.navigateToApp`.
 
@@ -667,12 +667,12 @@ attribute on the link (`a`) element or any of its parent.
 
 This feature is not enabled for legacy applications.
 
-*via https://github.com/elastic/kibana/pull/65164[#65164]*
+*via https://github.com/elastic/opensearch-dashboards/pull/65164[#65164]*
 
 ====
 
 [[breaking_79_field_formatters]]
-.Field format editors API migrated to Kibana Platform
+.Field format editors API migrated to OpenSearchDashboards Platform
 [%collapsible]
 ====
 
@@ -680,7 +680,7 @@ Field format editors (used by index pattern management) are no longer added
 via the field formatters registry, `ui/registry/field_format_editors`. They
 are now added via the `indexPatternManagement` plugin.
 
-*via https://github.com/elastic/kibana/pull/65026[#65026]*
+*via https://github.com/elastic/opensearch-dashboards/pull/65026[#65026]*
 
 ====
 
@@ -690,7 +690,7 @@ are now added via the `indexPatternManagement` plugin.
 ====
 
 The `expressions` plugin introduces a set of helpers that make it easier to
-manipulate expression ASTs. Refer to https://github.com/elastic/kibana/pull/64395[this PR]
+manipulate expression ASTs. Refer to https://github.com/elastic/opensearch-dashboards/pull/64395[this PR]
 for more detailed examples.
 
 ```ts
@@ -718,7 +718,7 @@ const exp = buildExpression([
 ]);
 const fns = exp.findFunction<MyFnExpressionFunctionDefinition>('myFn');
 ```
-*via https://github.com/elastic/kibana/pull/64395[#64395]*
+*via https://github.com/elastic/opensearch-dashboards/pull/64395[#64395]*
 
 ====
 
@@ -730,7 +730,7 @@ const fns = exp.findFunction<MyFnExpressionFunctionDefinition>('myFn');
 Applications that are mounted via the `core.application.register`
 interface from the legacy `ui/new_platform` module are now mounted inside a
 new `div` inside of the `<div class="application />` node rather than directly inside that node.
-This makes the legacy bridge consistent with how true {kib} platform applications are mounted.
+This makes the legacy bridge consistent with how true {osd} platform applications are mounted.
 
-*via https://github.com/elastic/kibana/pull/63930[#63930]*
+*via https://github.com/elastic/opensearch-dashboards/pull/63930[#63930]*
 ====


### PR DESCRIPTION
*Issue #, if available:*
[#37](https://github.com/opendistro-for-elasticsearch/website/issues/37) 

*Description of changes:*
Renamed words in /docs/migration/* files. Elastic/elastic not changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
