### PR TITLE
[Rename] Fix display issue

### DIFF
--- a/src/core/test_helpers/osd_server.ts
+++ b/src/core/test_helpers/osd_server.ts
@@ -262,7 +262,7 @@ export function createTestServers({
             ...usersToBeAdded,
             // user elastic
             opensearchTestConfig.getUrlParts(),
-            // user openSearchDashboards
+            // user opensearchDashboards
             osdTestConfig.getUrlParts(),
           ],
         });

--- a/src/core/utils/default_app_categories.ts
+++ b/src/core/utils/default_app_categories.ts
@@ -22,9 +22,9 @@ import { AppCategory } from '../types';
 
 /** @internal */
 export const DEFAULT_APP_CATEGORIES: Record<string, AppCategory> = Object.freeze({
-  openSearchDashboards: {
-    id: 'openSearchDashboards',
-    label: i18n.translate('core.ui.openSearchDashboardsNavList.label', {
+  opensearchDashboards: {
+    id: 'opensearchDashboards',
+    label: i18n.translate('core.ui.opensearchDashboardsNavList.label', {
       defaultMessage: 'OpenSearch Dashboards',
     }),
     euiIconType: 'logoKibana',


### PR DESCRIPTION
Find a minor renaming error in src/core/utils/default_app_categories.ts which will cause navLinks returns undefined category in src/plugins/opensearch_dashboards_overview/publid/plugin.ts
          