### PR TITLE
[Rename] remove securityOss from optimizer

### DIFF
--- a/packages/osd-optimizer/limits.yml
+++ b/packages/osd-optimizer/limits.yml
@@ -67,7 +67,6 @@ pageLoadAssetSize:
   savedObjectsManagement: 100503
   searchprofiler: 67224
   security: 189428
-  securityOss: 30806
   securitySolution: 638231
   share: 99205
   snapshotRestore: 79176


### PR DESCRIPTION
Security OSS was removed from the project but it was
missed here. I am currently unable to create it at
HEAD but I saw a memory leak related to securityOss
and optimizer. So removing this might help.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>