### PR TITLE
[PURIFY][BUILD] Remove isOss flag and defaults to oss build

### DIFF
--- a/src/dev/build/README.md
+++ b/src/dev/build/README.md
@@ -1,6 +1,6 @@
 # dev/build
 
-Build the default and OSS distributables of OpenSearch Dashboards.
+Build the distributables of OpenSearch Dashboards.
 
 # Quick Start
 
@@ -12,8 +12,8 @@ node scripts/build --help
 # build a release version
 node scripts/build --release
 
-# reuse already downloaded node executables, turn on debug logging, and only build the default distributable
-node scripts/build --skip-node-download --debug --no-oss
+# reuse already downloaded node executables, turn on debug logging
+node scripts/build --skip-node-download --debug
 ```
 
 # Fixing out of memory issues
@@ -30,7 +30,7 @@ NODE_OPTIONS="--max-old-space-size=4096" node scripts/build --release
 
 The majority of this logic is extracted from the grunt build that has existed forever, and is designed to maintain the general structure grunt provides including tasks and config. The [build_distributables.js] file defines which tasks are run.
 
-**Task**: [tasks/\*] define individual parts of the build. Each task is an object with a `run()` method, a `description` property, and optionally a `global` property. They are executed with the runner either once (if they are global) or once for each build. Non-global/local tasks are called once for each build, meaning they will be called twice be default, once for the OSS build and once for the default build and receive a build object as the third argument to `run()` which can be used to determine paths and properties for that build.
+**Task**: [tasks/\*] define individual parts of the build. Each task is an object with a `run()` method, a `description` property, and optionally a `global` property. They are executed with the runner either once (if they are global) or once for each build. Non-global/local tasks are called once for each build, meaning they will be called twice be default, once for the build and receive a build object as the third argument to `run()` which can be used to determine paths and properties for that build.
 
 **Config**: [lib/config.js] defines the config used to execute tasks. It is mostly used to determine absolute paths to specific locations, and to get access to the Platforms.
 

--- a/src/dev/build/args.test.ts
+++ b/src/dev/build/args.test.ts
@@ -37,8 +37,6 @@ it('build default and oss dist for current platform, without packages, by defaul
   expect(readCliArgs(['node', 'scripts/build'])).toMatchInlineSnapshot(`
     Object {
       "buildOptions": Object {
-        "buildDefaultDist": true,
-        "buildOssDist": true,
         "createArchives": true,
         "createDebPackage": false,
         "createDockerPackage": false,
@@ -60,8 +58,6 @@ it('builds packages if --all-platforms is passed', () => {
   expect(readCliArgs(['node', 'scripts/build', '--all-platforms'])).toMatchInlineSnapshot(`
     Object {
       "buildOptions": Object {
-        "buildDefaultDist": true,
-        "buildOssDist": true,
         "createArchives": true,
         "createDebPackage": true,
         "createDockerPackage": true,
@@ -83,8 +79,6 @@ it('limits packages if --rpm passed with --all-platforms', () => {
   expect(readCliArgs(['node', 'scripts/build', '--all-platforms', '--rpm'])).toMatchInlineSnapshot(`
     Object {
       "buildOptions": Object {
-        "buildDefaultDist": true,
-        "buildOssDist": true,
         "createArchives": true,
         "createDebPackage": false,
         "createDockerPackage": false,
@@ -106,8 +100,6 @@ it('limits packages if --deb passed with --all-platforms', () => {
   expect(readCliArgs(['node', 'scripts/build', '--all-platforms', '--deb'])).toMatchInlineSnapshot(`
     Object {
       "buildOptions": Object {
-        "buildDefaultDist": true,
-        "buildOssDist": true,
         "createArchives": true,
         "createDebPackage": true,
         "createDockerPackage": false,
@@ -130,8 +122,6 @@ it('limits packages if --docker passed with --all-platforms', () => {
     .toMatchInlineSnapshot(`
     Object {
       "buildOptions": Object {
-        "buildDefaultDist": true,
-        "buildOssDist": true,
         "createArchives": true,
         "createDebPackage": false,
         "createDockerPackage": true,
@@ -154,8 +144,6 @@ it('limits packages if --docker passed with --skip-docker-ubi and --all-platform
     .toMatchInlineSnapshot(`
     Object {
       "buildOptions": Object {
-        "buildDefaultDist": true,
-        "buildOssDist": true,
         "createArchives": true,
         "createDebPackage": false,
         "createDockerPackage": true,

--- a/src/dev/build/args.ts
+++ b/src/dev/build/args.ts
@@ -26,8 +26,6 @@ export function readCliArgs(argv: string[]) {
   const unknownFlags: string[] = [];
   const flags = getopts(argv, {
     boolean: [
-      'oss',
-      'no-oss',
       'skip-archives',
       'skip-os-packages',
       'rpm',
@@ -54,7 +52,6 @@ export function readCliArgs(argv: string[]) {
       rpm: null,
       deb: null,
       docker: null,
-      oss: null,
       'version-qualifier': '',
     },
     unknown: (flag) => {
@@ -100,8 +97,6 @@ export function readCliArgs(argv: string[]) {
   const buildOptions: BuildOptions = {
     isRelease: Boolean(flags.release),
     versionQualifier: flags['version-qualifier'],
-    buildOssDist: flags.oss !== false,
-    buildDefaultDist: !flags.oss,
     downloadFreshNode: !Boolean(flags['skip-node-download']),
     createArchives: !Boolean(flags['skip-archives']),
     createRpmPackage: isOsPackageDesired('rpm'),

--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -24,8 +24,6 @@ import * as Tasks from './tasks';
 
 export interface BuildOptions {
   isRelease: boolean;
-  buildOssDist: boolean;
-  buildDefaultDist: boolean;
   downloadFreshNode: boolean;
   createArchives: boolean;
   createRpmPackage: boolean;
@@ -44,8 +42,6 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
   const run = createRunner({
     config,
     log,
-    buildDefaultDist: options.buildDefaultDist,
-    buildOssDist: options.buildOssDist,
   });
 
   /**

--- a/src/dev/build/cli.ts
+++ b/src/dev/build/cli.ts
@@ -44,8 +44,6 @@ if (showHelp) {
       build the OpenSearch Dashboards distributable
 
       options:
-        --oss                   {dim Only produce the OSS distributable of OpenSearch Dashboards}
-        --no-oss                {dim Only produce the default distributable of OpenSearch Dashboards}
         --skip-archives         {dim Don't produce tar/zip archives}
         --skip-os-packages      {dim Don't produce rpm/deb/docker packages}
         --all-platforms         {dim Produce archives for all platforms, not just this one}

--- a/src/dev/build/lib/build.test.ts
+++ b/src/dev/build/lib/build.test.ts
@@ -54,45 +54,29 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-const ossBuild = new Build(config, true);
-const defaultBuild = new Build(config, false);
-
-describe('#isOss()', () => {
-  it('returns true for oss', () => {
-    expect(ossBuild.isOss()).toBe(true);
-  });
-
-  it('returns false for default build', () => {
-    expect(defaultBuild.isOss()).toBe(false);
-  });
-});
+const build = new Build(config);
 
 describe('#getName()', () => {
-  it('returns opensearch-dashboards for default build', () => {
-    expect(defaultBuild.getName()).toBe('opensearch-dashboards');
-  });
-
-  it('returns opensearch-dashboards-oss for oss', () => {
-    expect(ossBuild.getName()).toBe('opensearch-dashboards-oss');
+  it('returns opensearch-dashboards for  build', () => {
+    expect(build.getName()).toBe('opensearch-dashboards');
   });
 });
 
 describe('#getLogTag()', () => {
   it('returns string with build name in it', () => {
-    expect(defaultBuild.getLogTag()).toContain(defaultBuild.getName());
-    expect(ossBuild.getLogTag()).toContain(ossBuild.getName());
+    expect(build.getLogTag()).toContain(build.getName());
   });
 });
 
 describe('#resolvePath()', () => {
   it('uses passed config to resolve a path relative to the repo', () => {
-    expect(ossBuild.resolvePath('bar')).toMatchInlineSnapshot(
-      `<absolute path>/build/opensearch-dashboards-oss/bar`
+    expect(build.resolvePath('bar')).toMatchInlineSnapshot(
+      `<absolute path>/build/opensearch-dashboards/bar`
     );
   });
 
   it('passes all arguments to config.resolveFromRepo()', () => {
-    expect(defaultBuild.resolvePath('bar', 'baz', 'box')).toMatchInlineSnapshot(
+    expect(build.resolvePath('bar', 'baz', 'box')).toMatchInlineSnapshot(
       `<absolute path>/build/opensearch-dashboards/bar/baz/box`
     );
   });
@@ -100,22 +84,22 @@ describe('#resolvePath()', () => {
 
 describe('#resolvePathForPlatform()', () => {
   it('uses config.resolveFromRepo(), config.getBuildVersion(), and platform.getBuildName() to create path', () => {
-    expect(ossBuild.resolvePathForPlatform(linuxPlatform, 'foo', 'bar')).toMatchInlineSnapshot(
-      `<absolute path>/build/oss/opensearch-dashboards-8.0.0-linux-x86_64/foo/bar`
+    expect(build.resolvePathForPlatform(linuxPlatform, 'foo', 'bar')).toMatchInlineSnapshot(
+      `<absolute path>/build/opensearch-dashboards-8.0.0-linux-x86_64/foo/bar`
     );
   });
 });
 
 describe('#getPlatformArchivePath()', () => {
   it('creates correct path for different platforms', () => {
-    expect(ossBuild.getPlatformArchivePath(linuxPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-oss-8.0.0-linux-x86_64.tar.gz`
+    expect(build.getPlatformArchivePath(linuxPlatform)).toMatchInlineSnapshot(
+      `<absolute path>/target/opensearch-dashboards-8.0.0-linux-x86_64.tar.gz`
     );
-    expect(ossBuild.getPlatformArchivePath(linuxArmPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-oss-8.0.0-linux-aarch64.tar.gz`
+    expect(build.getPlatformArchivePath(linuxArmPlatform)).toMatchInlineSnapshot(
+      `<absolute path>/target/opensearch-dashboards-8.0.0-linux-aarch64.tar.gz`
     );
-    expect(ossBuild.getPlatformArchivePath(windowsPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-oss-8.0.0-windows-x86_64.zip`
+    expect(build.getPlatformArchivePath(windowsPlatform)).toMatchInlineSnapshot(
+      `<absolute path>/target/opensearch-dashboards-8.0.0-windows-x86_64.zip`
     );
   });
 });

--- a/src/dev/build/lib/build.ts
+++ b/src/dev/build/lib/build.ts
@@ -23,16 +23,9 @@ import { Config } from './config';
 import { Platform } from './platform';
 
 export class Build {
-  private name = this.oss ? 'opensearch-dashboards-oss' : 'opensearch-dashboards';
-  private logTag = this.oss
-    ? chalk`{magenta [opensearch-dashboards-oss]}`
-    : chalk`{cyan [  opensearch-dashboards  ]}`;
+  private name = 'opensearch-dashboards';
 
-  constructor(private config: Config, private oss: boolean) {}
-
-  isOss() {
-    return !!this.oss;
-  }
+  constructor(private config: Config) {}
 
   resolvePath(...args: string[]) {
     return this.config.resolveFromRepo('build', this.name, ...args);
@@ -41,7 +34,6 @@ export class Build {
   resolvePathForPlatform(platform: Platform, ...args: string[]) {
     return this.config.resolveFromRepo(
       'build',
-      this.oss ? 'oss' : 'default',
       `opensearch-dashboards-${this.config.getBuildVersion()}-${platform.getBuildName()}`,
       ...args
     );
@@ -60,6 +52,6 @@ export class Build {
   }
 
   getLogTag() {
-    return this.logTag;
+    return chalk`{cyan [  opensearch-dashboards  ]}`;
   }
 }

--- a/src/dev/build/lib/runner.test.ts
+++ b/src/dev/build/lib/runner.test.ts
@@ -56,7 +56,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-const setup = async (opts: { buildDefaultDist: boolean; buildOssDist: boolean }) => {
+const setup = async () => {
   const config = await Config.create({
     isRelease: true,
     targetAllPlatforms: true,
@@ -66,97 +66,14 @@ const setup = async (opts: { buildDefaultDist: boolean; buildOssDist: boolean })
   const run = createRunner({
     config,
     log,
-    ...opts,
   });
 
   return { config, run };
 };
 
-describe('buildOssDist = true, buildDefaultDist = true', () => {
+describe('dist', () => {
   it('runs global task once, passing config and log', async () => {
-    const { config, run } = await setup({
-      buildDefaultDist: true,
-      buildOssDist: true,
-    });
-
-    const mock = jest.fn();
-
-    await run({
-      global: true,
-      description: 'foo',
-      run: mock,
-    });
-
-    expect(mock).toHaveBeenCalledTimes(1);
-    expect(mock).toHaveBeenLastCalledWith(config, log, [expect.any(Build), expect.any(Build)]);
-  });
-
-  it('calls local tasks twice, passing each build', async () => {
-    const { config, run } = await setup({
-      buildDefaultDist: true,
-      buildOssDist: true,
-    });
-
-    const mock = jest.fn();
-
-    await run({
-      description: 'foo',
-      run: mock,
-    });
-
-    expect(mock).toHaveBeenCalledTimes(2);
-    expect(mock).toHaveBeenCalledWith(config, log, expect.any(Build));
-  });
-});
-
-describe('just default dist', () => {
-  it('runs global task once, passing config and log', async () => {
-    const { config, run } = await setup({
-      buildDefaultDist: true,
-      buildOssDist: false,
-    });
-
-    const mock = jest.fn();
-
-    await run({
-      global: true,
-      description: 'foo',
-      run: mock,
-    });
-
-    expect(mock).toHaveBeenCalledTimes(1);
-    expect(mock).toHaveBeenLastCalledWith(config, log, [expect.any(Build)]);
-  });
-
-  it('calls local tasks once, passing the default build', async () => {
-    const { config, run } = await setup({
-      buildDefaultDist: true,
-      buildOssDist: false,
-    });
-
-    const mock = jest.fn();
-
-    await run({
-      description: 'foo',
-      run: mock,
-    });
-
-    expect(mock).toHaveBeenCalledTimes(1);
-    expect(mock).toHaveBeenCalledWith(config, log, expect.any(Build));
-    const [args] = mock.mock.calls;
-    const [, , build] = args;
-    if (build.isOss()) {
-      throw new Error('expected build to be the default dist, not the oss dist');
-    }
-  });
-});
-
-describe('just oss dist', () => {
-  it('runs global task once, passing config and log', async () => {
-    const { config, run } = await setup({
-      buildDefaultDist: false,
-      buildOssDist: true,
-    });
+    const { config, run } = await setup();
 
     const mock = jest.fn();
 
@@ -171,10 +88,7 @@ describe('just oss dist', () => {
   });
 
   it('calls local tasks once, passing the oss build', async () => {
-    const { config, run } = await setup({
-      buildDefaultDist: false,
-      buildOssDist: true,
-    });
+    const { config, run } = await setup();
 
     const mock = jest.fn();
 
@@ -185,20 +99,12 @@ describe('just oss dist', () => {
 
     expect(mock).toHaveBeenCalledTimes(1);
     expect(mock).toHaveBeenCalledWith(config, log, expect.any(Build));
-    const [args] = mock.mock.calls;
-    const [, , build] = args;
-    if (!build.isOss()) {
-      throw new Error('expected build to be the oss dist, not the default dist');
-    }
   });
 });
 
 describe('task rejection', () => {
   it('rejects, logs error, and marks error logged', async () => {
-    const { run } = await setup({
-      buildDefaultDist: true,
-      buildOssDist: false,
-    });
+    const { run } = await setup();
 
     const error = new Error('FOO');
     expect(isErrorLogged(error)).toBe(false);
@@ -224,10 +130,7 @@ describe('task rejection', () => {
   });
 
   it('just rethrows errors that have already been logged', async () => {
-    const { run } = await setup({
-      buildDefaultDist: true,
-      buildOssDist: false,
-    });
+    const { run } = await setup();
 
     const error = markErrorLogged(new Error('FOO'));
     const promise = run({

--- a/src/dev/build/lib/runner.ts
+++ b/src/dev/build/lib/runner.ts
@@ -27,8 +27,6 @@ import { Config } from './config';
 interface Options {
   config: Config;
   log: ToolingLog;
-  buildOssDist: boolean;
-  buildDefaultDist: boolean;
 }
 
 export interface GlobalTask {
@@ -43,7 +41,7 @@ export interface Task {
   run(config: Config, log: ToolingLog, build: Build): Promise<void>;
 }
 
-export function createRunner({ config, log, buildOssDist, buildDefaultDist }: Options) {
+export function createRunner({ config, log }: Options) {
   async function execTask(desc: string, task: Task | GlobalTask, lastArg: any) {
     log.info(desc);
     log.indent(4);
@@ -73,13 +71,7 @@ export function createRunner({ config, log, buildOssDist, buildDefaultDist }: Op
     }
   }
 
-  const builds: Build[] = [];
-  if (buildDefaultDist) {
-    builds.push(new Build(config, false));
-  }
-  if (buildOssDist) {
-    builds.push(new Build(config, true));
-  }
+  const builds: Build[] = [new Build(config)];
 
   /**
    * Run a task by calling its `run()` method with three arguments:

--- a/src/dev/build/tasks/build_opensearch_dashboards_platform_plugins.ts
+++ b/src/dev/build/tasks/build_opensearch_dashboards_platform_plugins.ts
@@ -35,7 +35,7 @@ export const BuildOpenSearchDashboardsPlatformPlugins: Task = {
       repoRoot: REPO_ROOT,
       outputRoot: build.resolvePath(),
       cache: false,
-      oss: build.isOss(),
+      oss: true,
       examples: false,
       watch: false,
       dist: true,

--- a/src/dev/build/tasks/build_packages_task.ts
+++ b/src/dev/build/tasks/build_packages_task.ts
@@ -74,7 +74,7 @@ export const BuildPackages: Task = {
     await buildProductionProjects({
       opensearchDashboardsRoot: config.resolveFromRepo(),
       buildRoot: build.resolvePath(),
-      onlyOSS: build.isOss(),
+      onlyOSS: true,
     });
   },
 };

--- a/src/dev/build/tasks/clean_tasks.ts
+++ b/src/dev/build/tasks/clean_tasks.ts
@@ -168,16 +168,6 @@ export const CleanExtraFilesFromModules: Task = {
         regularExpressions,
       })
     );
-
-    if (!build.isOss()) {
-      log.info(
-        'Deleted %d files',
-        await scanDelete({
-          directory: build.resolvePath('x-pack/node_modules'),
-          regularExpressions,
-        })
-      );
-    }
   },
 };
 

--- a/src/dev/build/tasks/create_archives_task.ts
+++ b/src/dev/build/tasks/create_archives_task.ts
@@ -86,14 +86,14 @@ export const CreateArchives: Task = {
     const metrics: CiStatsMetrics = [];
     for (const { format, path, fileCount } of archives) {
       metrics.push({
-        group: `${build.isOss() ? 'oss ' : ''}distributable size`,
+        group: `distributable size`,
         id: format,
         value: (await asyncStat(path)).size,
       });
 
       metrics.push({
         group: 'distributable file count',
-        id: build.isOss() ? 'oss' : 'default',
+        id: 'distribution',
         value: fileCount,
       });
     }

--- a/src/dev/build/tasks/create_package_json_task.ts
+++ b/src/dev/build/tasks/create_package_json_task.ts
@@ -49,12 +49,6 @@ export const CreatePackageJson: Task = {
       dependencies: pkg.dependencies,
     };
 
-    if (build.isOss()) {
-      newPkg.workspaces.packages = newPkg.workspaces.packages.filter(
-        (p) => !p.startsWith('x-pack')
-      );
-    }
-
     await write(build.resolvePath('package.json'), JSON.stringify(newPkg, null, '  '));
   },
 };

--- a/src/dev/build/tasks/install_chromium.js
+++ b/src/dev/build/tasks/install_chromium.js
@@ -20,10 +20,7 @@
 export const InstallChromium = {
   description: 'Installing Chromium',
 
-  async run(config, log, build) {
-    if (build.isOss()) {
-      return;
-    }
+  async run() {
     return;
   },
 };

--- a/src/dev/build/tasks/license_file_task.ts
+++ b/src/dev/build/tasks/license_file_task.ts
@@ -21,20 +21,11 @@ import { write, read, Task } from '../lib';
 
 export const UpdateLicenseFile: Task = {
   description: 'Updating LICENSE.txt file',
-
   async run(config, log, build) {
-    if (build.isOss()) {
-      log.info('Copying Apache 2.0 license to LICENSE.txt');
-      await write(
-        build.resolvePath('LICENSE.txt'),
-        await read(config.resolveFromRepo('licenses/APACHE-LICENSE-2.0.txt'))
-      );
-    } else {
-      log.info('Copying Elastic license to LICENSE.txt');
-      await write(
-        build.resolvePath('LICENSE.txt'),
-        await read(config.resolveFromRepo('licenses/ELASTIC-LICENSE.txt'))
-      );
-    }
+    log.info('Copying Apache 2.0 license to LICENSE.txt');
+    await write(
+      build.resolvePath('LICENSE.txt'),
+      await read(config.resolveFromRepo('licenses/APACHE-LICENSE-2.0.txt'))
+    );
   },
 };

--- a/src/dev/build/tasks/notice_file_task.ts
+++ b/src/dev/build/tasks/notice_file_task.ts
@@ -31,7 +31,7 @@ export const CreateNoticeFile: Task = {
     log.info('Generating notice from source');
     log.indent(4);
     const noticeFromSource = await generateNoticeFromSource({
-      productName: build.isOss() ? 'OpenSearch Dashboards' : 'OpenSearch Dashboards',
+      productName: 'OpenSearch Dashboards',
       directory: build.resolvePath(),
       log,
     });

--- a/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
+++ b/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
@@ -46,7 +46,7 @@ export const CreateDockerPackage: Task = {
   description: 'Creating docker package',
 
   async run(config, log, build) {
-    // Builds Docker targets for default and oss
+    // Builds Docker targets
     await runDockerGenerator(config, log, build);
   },
 };

--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -45,19 +45,15 @@ export async function runDockerGenerator(
   const ubiImageFlavor = ubi ? `-${ubiVersionTag}` : '';
 
   // General docker var config
-  const license = build.isOss() ? 'ASL 2.0' : 'Elastic License';
-  const imageFlavor = build.isOss() ? '-oss' : '';
+  const license = 'ASL 2.0';
+  const imageFlavor = '';
   const imageTag = 'docker.opensearch.co/opensearch-dashboards/opensearch-dashboards';
   const version = config.getBuildVersion();
   const artifactTarball = `opensearch-dashboards${imageFlavor}-${version}-linux-x86_64.tar.gz`;
   const artifactsDir = config.resolveFromTarget('.');
   const dockerBuildDate = new Date().toISOString();
   // That would produce oss, default and default-ubi7
-  const dockerBuildDir = config.resolveFromRepo(
-    'build',
-    'opensearch-dashboards-docker',
-    build.isOss() ? `oss` : `default${ubiImageFlavor}`
-  );
+  const dockerBuildDir = config.resolveFromRepo('build', 'opensearch-dashboards-docker');
   const dockerTargetFilename = config.resolveFromTarget(
     `opensearch-dashboards${imageFlavor}${ubiImageFlavor}-${version}-docker-image.tar.gz`
   );
@@ -128,9 +124,5 @@ export async function runDockerGenerator(
 
 export async function runDockerGeneratorForUBI(config: Config, log: ToolingLog, build: Build) {
   // Only run ubi docker image build for default distribution
-  if (build.isOss()) {
-    return;
-  }
-
-  await runDockerGenerator(config, log, build, true);
+  return;
 }

--- a/src/dev/build/tasks/os_packages/run_fpm.ts
+++ b/src/dev/build/tasks/os_packages/run_fpm.ts
@@ -38,11 +38,7 @@ export async function runFpm(
   const fromBuild = (...paths: string[]) => build.resolvePathForPlatform(linux, ...paths);
 
   const pickLicense = () => {
-    if (build.isOss()) {
-      return type === 'rpm' ? 'ASL 2.0' : 'ASL-2.0';
-    } else {
-      return type === 'rpm' ? 'ASL 2.0' : 'ASL-2.0';
-    }
+    return type === 'rpm' ? 'ASL 2.0' : 'ASL-2.0';
   };
 
   const args = [
@@ -65,7 +61,7 @@ export async function runFpm(
 
     // general info about the package
     '--name',
-    build.isOss() ? 'opensearch-dashboards' : 'opensearch-dashboards',
+    'opensearch-dashboards',
     '--description',
     'Explore and visualize your Elasticsearch data',
     '--version',
@@ -81,8 +77,7 @@ export async function runFpm(
 
     // prevent installing opensearch-dashboards if installing opensearch-dashboards-oss and vice versa
     '--conflicts',
-    build.isOss() ? 'opensearch-dashboards' : 'opensearch-dashboards',
-
+    'opensearch-dashboards',
     // define install/uninstall scripts
     '--after-install',
     resolve(__dirname, 'package_scripts/post_install.sh'),


### PR DESCRIPTION
### Description
[Describe what this change achieves] Remove `isOSS` `oss` and `-no-ss` flag from the build distribution code. This still has some hard coded flag, which needs to be removed from other packages, i'll create follow up PRs for the same.

To test this :
```
* Checkout this PR
* yarn osd bootstrap
* yarn build
* verify `build` and `target` dirs.
```
 
### Issues Resolved
[List any issues this PR will resolve]  #26 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff  
Signed-off-by: Mihir Soni <mihirsoni.123@gmail.com>