### PR TITLE
[PURIFY][BUILD] Removes oss flag from underlaying packages

### DIFF
--- a/packages/osd-optimizer/README.md
+++ b/packages/osd-optimizer/README.md
@@ -80,7 +80,6 @@ const log = new ToolingLog({
 const config = OptimizerConfig.create({
   repoRoot: Path.resolve(__dirname, '../../..'),
   watch: false,
-  oss: true,
   dist: true
 });
 

--- a/packages/osd-optimizer/src/cli.ts
+++ b/packages/osd-optimizer/src/cli.ts
@@ -38,11 +38,6 @@ run(
       throw createFlagError('expected --watch to have no value');
     }
 
-    const oss = flags.oss ?? false;
-    if (typeof oss !== 'boolean') {
-      throw createFlagError('expected --oss to have no value');
-    }
-
     const cache = flags.cache ?? true;
     if (typeof cache !== 'boolean') {
       throw createFlagError('expected --cache to have no value');
@@ -109,7 +104,6 @@ run(
       repoRoot: REPO_ROOT,
       watch,
       maxWorkerCount,
-      oss: oss && !(validateLimits || updateLimits),
       dist: dist || updateLimits,
       cache,
       examples: examples && !(validateLimits || updateLimits),
@@ -148,7 +142,6 @@ run(
       boolean: [
         'core',
         'watch',
-        'oss',
         'examples',
         'dist',
         'cache',
@@ -169,7 +162,6 @@ run(
       help: `
         --watch            run the optimizer in watch mode
         --workers          max number of workers to use
-        --oss              only build oss plugins
         --profile          profile the webpack builds and write stats.json files to build outputs
         --no-core          disable generating the core bundle
         --no-cache         disable the cache

--- a/packages/osd-optimizer/src/optimizer/optimizer_config.test.ts
+++ b/packages/osd-optimizer/src/optimizer/optimizer_config.test.ts
@@ -128,7 +128,6 @@ describe('OptimizerConfig::parseOptions()', () => {
         "pluginPaths": Array [],
         "pluginScanDirs": Array [
           <absolute path>/src/plugins,
-          <absolute path>/x-pack/plugins,
           <absolute path>/plugins,
           <absolute path>/opensearch-dashboards-extra,
         ],
@@ -156,7 +155,6 @@ describe('OptimizerConfig::parseOptions()', () => {
         "pluginPaths": Array [],
         "pluginScanDirs": Array [
           <absolute path>/src/plugins,
-          <absolute path>/x-pack/plugins,
           <absolute path>/plugins,
           <absolute path>/opensearch-dashboards-extra,
         ],
@@ -184,10 +182,8 @@ describe('OptimizerConfig::parseOptions()', () => {
         "pluginPaths": Array [],
         "pluginScanDirs": Array [
           <absolute path>/src/plugins,
-          <absolute path>/x-pack/plugins,
           <absolute path>/plugins,
           <absolute path>/examples,
-          <absolute path>/x-pack/examples,
           <absolute path>/opensearch-dashboards-extra,
         ],
         "profileWebpack": false,
@@ -200,7 +196,6 @@ describe('OptimizerConfig::parseOptions()', () => {
     expect(
       OptimizerConfig.parseOptions({
         repoRoot: REPO_ROOT,
-        oss: true,
       })
     ).toMatchInlineSnapshot(`
       Object {

--- a/packages/osd-optimizer/src/optimizer/optimizer_config.ts
+++ b/packages/osd-optimizer/src/optimizer/optimizer_config.ts
@@ -85,8 +85,6 @@ interface Options {
   /** set to true to inspecting workers when the parent process is being inspected */
   inspectWorkers?: boolean;
 
-  /** include only oss plugins in default scan dirs */
-  oss?: boolean;
   /** include examples in default scan dirs */
   examples?: boolean;
   /** absolute paths to specific plugins that should be built */
@@ -143,7 +141,6 @@ export interface ParsedOptions {
 export class OptimizerConfig {
   static parseOptions(options: Options): ParsedOptions {
     const watch = !!options.watch;
-    const oss = !!options.oss;
     const dist = !!options.dist;
     const examples = !!options.examples;
     const profileWebpack = !!options.profileWebpack;
@@ -169,10 +166,8 @@ export class OptimizerConfig {
      */
     const pluginScanDirs = options.pluginScanDirs || [
       Path.resolve(repoRoot, 'src/plugins'),
-      ...(oss ? [] : [Path.resolve(repoRoot, 'x-pack/plugins')]),
       Path.resolve(repoRoot, 'plugins'),
       ...(examples ? [Path.resolve('examples')] : []),
-      ...(examples && !oss ? [Path.resolve('x-pack/examples')] : []),
       Path.resolve(repoRoot, 'opensearch-dashboards-extra'),
     ];
 

--- a/packages/osd-pm/dist/index.js
+++ b/packages/osd-pm/dist/index.js
@@ -27282,13 +27282,6 @@ function getProjectPaths({
   projectPaths.push(Object(path__WEBPACK_IMPORTED_MODULE_0__["resolve"])(rootPath, 'test/interpreter_functional/plugins/*'));
   projectPaths.push(Object(path__WEBPACK_IMPORTED_MODULE_0__["resolve"])(rootPath, 'examples/*'));
 
-  if (!ossOnly) {
-    projectPaths.push(Object(path__WEBPACK_IMPORTED_MODULE_0__["resolve"])(rootPath, 'x-pack'));
-    projectPaths.push(Object(path__WEBPACK_IMPORTED_MODULE_0__["resolve"])(rootPath, 'x-pack/plugins/*'));
-    projectPaths.push(Object(path__WEBPACK_IMPORTED_MODULE_0__["resolve"])(rootPath, 'x-pack/legacy/plugins/*'));
-    projectPaths.push(Object(path__WEBPACK_IMPORTED_MODULE_0__["resolve"])(rootPath, 'x-pack/test/functional_with_es_ssl/fixtures/plugins/*'));
-  }
-
   if (!skipOpenSearchDashboardsPlugins) {
     projectPaths.push(Object(path__WEBPACK_IMPORTED_MODULE_0__["resolve"])(rootPath, '../opensearch-dashboards-extra/*'));
     projectPaths.push(Object(path__WEBPACK_IMPORTED_MODULE_0__["resolve"])(rootPath, '../opensearch-dashboards-extra/*/packages/*'));
@@ -38181,7 +38174,7 @@ async function validateDependencies(osd, yarnLock) {
     `);
     process.exit(1);
   } // look for packages that have the the `opensearchDashboards.devOnly` flag in their package.json
-  // and make sure they aren't included in the production dependencies of OpenSearch Dashboards 
+  // and make sure they aren't included in the production dependencies of OpenSearch Dashboards
 
 
   const devOnlyProjectsInProduction = getDevOnlyProductionDepsTree(osd, 'opensearch-dashboards');
@@ -58228,10 +58221,9 @@ __webpack_require__.r(__webpack_exports__);
 
 async function buildProductionProjects({
   opensearchDashboardsRoot,
-  buildRoot,
-  onlyOSS
+  buildRoot
 }) {
-  const projects = await getProductionProjects(opensearchDashboardsRoot, onlyOSS);
+  const projects = await getProductionProjects(opensearchDashboardsRoot);
   const projectGraph = Object(_utils_projects__WEBPACK_IMPORTED_MODULE_7__["buildProjectGraph"])(projects);
   const batchedProjects = Object(_utils_projects__WEBPACK_IMPORTED_MODULE_7__["topologicallyBatchProjects"])(projects, projectGraph);
   const projectNames = [...projects.values()].map(project => project.name);
@@ -58253,31 +58245,22 @@ async function buildProductionProjects({
  * is supplied, we omit projects with build.oss in their package.json set to false.
  */
 
-async function getProductionProjects(rootPath, onlyOSS) {
+async function getProductionProjects(rootPath) {
   const projectPaths = Object(_config__WEBPACK_IMPORTED_MODULE_3__["getProjectPaths"])({
     rootPath
   });
   const projects = await Object(_utils_projects__WEBPACK_IMPORTED_MODULE_7__["getProjects"])(rootPath, projectPaths);
   const projectsSubset = [projects.get('opensearch-dashboards')];
-
-  if (projects.has('x-pack')) {
-    projectsSubset.push(projects.get('x-pack'));
-  }
-
   const productionProjects = Object(_utils_projects__WEBPACK_IMPORTED_MODULE_7__["includeTransitiveProjects"])(projectsSubset, projects, {
     onlyProductionDependencies: true
-  }); // We remove OpenSearch Dashboards , as we're already building OpenSearch Dashboards 
+  }); // We remove OpenSearch Dashboards , as we're already building OpenSearch Dashboards
 
   productionProjects.delete('opensearch-dashboards');
-
-  if (onlyOSS) {
-    productionProjects.forEach(project => {
-      if (project.getBuildConfig().oss === false) {
-        productionProjects.delete(project.json.name);
-      }
-    });
-  }
-
+  productionProjects.forEach(project => {
+    if (project.getBuildConfig().oss === false) {
+      productionProjects.delete(project.json.name);
+    }
+  });
   return productionProjects;
 }
 

--- a/packages/osd-pm/src/production/build_production_projects.ts
+++ b/packages/osd-pm/src/production/build_production_projects.ts
@@ -36,13 +36,11 @@ import {
 export async function buildProductionProjects({
   opensearchDashboardsRoot,
   buildRoot,
-  onlyOSS,
 }: {
   opensearchDashboardsRoot: string;
   buildRoot: string;
-  onlyOSS?: boolean;
 }) {
-  const projects = await getProductionProjects(opensearchDashboardsRoot, onlyOSS);
+  const projects = await getProductionProjects(opensearchDashboardsRoot);
   const projectGraph = buildProjectGraph(projects);
   const batchedProjects = topologicallyBatchProjects(projects, projectGraph);
 
@@ -65,7 +63,7 @@ export async function buildProductionProjects({
  * we only include OpenSearch Dashboards 's transitive _production_ dependencies. If onlyOSS
  * is supplied, we omit projects with build.oss in their package.json set to false.
  */
-async function getProductionProjects(rootPath: string, onlyOSS?: boolean) {
+async function getProductionProjects(rootPath: string) {
   const projectPaths = getProjectPaths({ rootPath });
   const projects = await getProjects(rootPath, projectPaths);
   const projectsSubset = [projects.get('opensearch-dashboards')!];
@@ -77,14 +75,11 @@ async function getProductionProjects(rootPath: string, onlyOSS?: boolean) {
   // We remove OpenSearch Dashboards , as we're already building OpenSearch Dashboards
   productionProjects.delete('opensearch-dashboards');
 
-  if (onlyOSS) {
-    productionProjects.forEach((project) => {
-      if (project.getBuildConfig().oss === false) {
-        productionProjects.delete(project.json.name);
-      }
-    });
-  }
-
+  productionProjects.forEach((project) => {
+    if (project.getBuildConfig().oss === false) {
+      productionProjects.delete(project.json.name);
+    }
+  });
   return productionProjects;
 }
 

--- a/src/dev/build/tasks/build_opensearch_dashboards_platform_plugins.ts
+++ b/src/dev/build/tasks/build_opensearch_dashboards_platform_plugins.ts
@@ -35,7 +35,6 @@ export const BuildOpenSearchDashboardsPlatformPlugins: Task = {
       repoRoot: REPO_ROOT,
       outputRoot: build.resolvePath(),
       cache: false,
-      oss: true,
       examples: false,
       watch: false,
       dist: true,

--- a/src/dev/build/tasks/build_packages_task.ts
+++ b/src/dev/build/tasks/build_packages_task.ts
@@ -74,7 +74,6 @@ export const BuildPackages: Task = {
     await buildProductionProjects({
       opensearchDashboardsRoot: config.resolveFromRepo(),
       buildRoot: build.resolvePath(),
-      onlyOSS: true,
     });
   },
 };


### PR DESCRIPTION
Signed-off-by: Mihir Soni <mihirsoni.123@gmail.com>

Issues : https://github.com/opensearch-project/OpenSearch-Dashboards/issues/26

This PR removes underlaying isOOS flag being used for build artifacts from `osd-pm` and `osd-optimizer`