### PR TITLE
[Build] add plugins to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ target
 /test/*/screenshots/visual_regression_gallery.html
 /html_docs
 .eslintcache
-/plugins/
 /data
 disabledPlugins
 webpackstats.json

--- a/packages/osd-plugin-generator/src/integration_tests/generate_plugin.test.ts
+++ b/packages/osd-plugin-generator/src/integration_tests/generate_plugin.test.ts
@@ -43,11 +43,15 @@ const GENERATED_DIR = Path.resolve(REPO_ROOT, `plugins`);
 expect.addSnapshotSerializer(createAbsolutePathSerializer());
 
 beforeEach(async () => {
-  await del(GENERATED_DIR, { force: true });
+  await del([`${GENERATED_DIR}/**`, `!${GENERATED_DIR}`, `!${GENERATED_DIR}/.gitignore`], {
+    force: true,
+  });
 });
 
 afterEach(async () => {
-  await del(GENERATED_DIR, { force: true });
+  await del([`${GENERATED_DIR}/**`, `!${GENERATED_DIR}`, `!${GENERATED_DIR}/.gitignore`], {
+    force: true,
+  });
 });
 
 it('generates a plugin', async () => {
@@ -66,6 +70,7 @@ it('generates a plugin', async () => {
 
   expect(paths.sort((a, b) => a.localeCompare(b))).toMatchInlineSnapshot(`
     Array [
+      <absolute path>/plugins/.gitignore,
       <absolute path>/plugins/foo/.eslintrc.js,
       <absolute path>/plugins/foo/.gitignore,
       <absolute path>/plugins/foo/.i18nrc.json,
@@ -105,6 +110,7 @@ it('generates a plugin without UI', async () => {
 
   expect(paths.sort((a, b) => a.localeCompare(b))).toMatchInlineSnapshot(`
     Array [
+      <absolute path>/plugins/.gitignore,
       <absolute path>/plugins/bar/.eslintrc.js,
       <absolute path>/plugins/bar/.gitignore,
       <absolute path>/plugins/bar/.i18nrc.json,
@@ -137,6 +143,7 @@ it('generates a plugin without server plugin', async () => {
 
   expect(paths.sort((a, b) => a.localeCompare(b))).toMatchInlineSnapshot(`
     Array [
+      <absolute path>/plugins/.gitignore,
       <absolute path>/plugins/baz/.eslintrc.js,
       <absolute path>/plugins/baz/.gitignore,
       <absolute path>/plugins/baz/.i18nrc.json,

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
### Description
Adding plugins to root directory and updates the generate
plugin integration test to not delete the directory automatically.

It cleans up the directory and leaves the gitignore and the parent
directory. This directory is for chokidar and a start up check
the fails to start if the directory isn't there.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ x Commits are signed per the DCO using --signoff 