### PR TITLE
Added a maintainers file 

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,10 @@
+# OpenSearch-Dashboards Maintainers
+
+## Maintainers
+| Maintainer | GitHub ID | Affiliation |
+| --------------- | --------- | ----------- |
+| Anan | [ananzh](https://github.com/ananzh) | Amazon |
+| Bishoy Boktor | [boktorbb-amzn](https://github.com/boktorbb-amzn) | Amazon |
+| Mihir Soni | [mihirsoni](https://github.com/mihirsoni) | Amazon |
+| Rocky | [kavilla](https://github.com/kavilla) | Amazon |
+| Sean Neumann | [seanneumann](https://github.com/seanneumann) | Amazon | 


### PR DESCRIPTION
This is based on the maintainers list that CEHENKLE posted in the [forums](https://discuss.opendistrocommunity.dev/t/preparing-opensearch-and-opensearch-dashboards-for-release/5567).

It is similar to the [maintainers file merged for OpenSearch](https://github.com/opensearch-project/OpenSearch/blob/main/MAINTAINERS.md)

Signed-off-by: Dawn M. Foster <fosterd@vmware.com>