### PR TITLE
Change Version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "dashboarding"
   ],
   "private": true,
-  "version": "7.10.2",
-  "branch": "7.10",
+  "version": "1.0.0",
+  "branch": "main",
   "types": "./opensearch_dashboards.d.ts",
   "tsdocMetadata": "./build/tsdoc-metadata.json",
   "build": {


### PR DESCRIPTION
Signed-off-by: Mihir Soni <mihirsoni.123@gmail.com>

### Description
[Describe what this change achieves] This change will reset the version of Dashboards to `1.0.0`. This will be going to main branch as of now more details on this https://github.com/opensearch-project/OpenSearch/issues/95#issuecomment-819813769
* All unit test cases passes.
* All integration test pases.
* FTR is still pending.

##### Testing
In order to test this
* Clone this branch [opensearch](https://github.com/opensearch-project/OpenSearch/tree/opensearch/rebaseVersion)
* `./gradlew :distribution:archives:oss-linux-tar:assemble`
* Use generated distribution to start the OpenSearch
* Start dashbaords.
 
### Issues Resolved
[List any issues this PR will resolve] #226 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 