### PR TITLE
docker: add .dockerignore, add build instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+Dockerfile
+node_modules
+packages/

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -40,6 +40,15 @@ Or
 * While OpenSearch is running locally, run ```yarn start```
 * You can now navigate to ```http://localhost:5601``` where Dashboards runs by default
 
+### Building the Docker Image
+
+To build the Docker image, run the following:
+
+```
+yarn osd bootstrap
+yarn build --docker
+```
+
 ## General
 
 ### Filenames


### PR DESCRIPTION
### Description
The change adds an entry in the README on how to build the Docker image,
additionally a `.dockerignore` has been added.
 
### Issues Resolved
None
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 