### PR TITLE
Fix DCO CLI example in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Each commit must include a DCO which looks like this
 Signed-off-by: Richie Cunningham <richie.cunningham@email.com>
 ```
 
-You may type this line on your own when writing your commit messages. However, if your user.name and user.email are set in your git configs, you can use `-s` or `– – signoff` to add the `Signed-off-by` line to the end of the commit message.
+You may type this line on your own when writing your commit messages. However, if your user.name and user.email are set in your git configs, you can use `-s` or `--signoff` to add the `Signed-off-by` line to the end of the commit message.
 
 ## Review Process
 


### PR DESCRIPTION
### Description
Fixes the example flag passed in the DCO CLI example to not have added whitespace.
 