### PR TITLE
Added link to MAINTAINERS.md from the Contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,8 @@ We deeply appreciate everyone who takes the time to make a contribution. We will
 
 During the PR process, expect that there will be some back-and-forth. Please try to respond to comments in a timely fashion, and if you don't wish to continue with the PR, let us know. If a PR takes too many iterations for its complexity or size, we may reject it. Additionally, if you stop responding we may close the PR as abandoned. In either case, if you feel this was done in error, please add a comment on the PR.
 
-If we accept the PR, we will merge your change and usually take care of backporting it to appropriate branches ourselves.
+If we accept the PR, a [maintainer](MAINTAINERS.md) will merge your change and usually take care of backporting it to appropriate branches ourselves.
+
 If we reject the PR, we will close the pull request with a comment explaining why. This decision isn't always final: if you feel we have misunderstood your intended change or otherwise think that we should reconsider then please continue the conversation with a comment on the PR and we'll do our best to address any further points you raise.
 
 w00t!!!


### PR DESCRIPTION
Added a link to the maintainer file in the step where we talk about merging PRs in the contributing guide. This provides a bit more visibility into who could be expected to be merging those changes.

Signed-off-by: Dawn M. Foster <fosterd@vmware.com>
