### PR TITLE
[BUILD] Maps service config

### DIFF
--- a/src/plugins/maps_legacy/config.ts
+++ b/src/plugins/maps_legacy/config.ts
@@ -35,8 +35,8 @@ import { configSchema as tilemapSchema } from '../tile_map/config';
 import { configSchema as regionmapSchema } from '../region_map/config';
 
 export const configSchema = schema.object({
-  includeOpenSearchDashboardsMapsService: schema.boolean({ defaultValue: true }),
-  proxyOpenSearchDashboardsMapsServiceInMaps: schema.boolean({ defaultValue: false }),
+  includeOpenSearchMapsService: schema.boolean({ defaultValue: true }),
+  proxyOpenSearchMapsServiceInMaps: schema.boolean({ defaultValue: false }),
   tilemap: tilemapSchema,
   regionmap: regionmapSchema,
   manifestServiceUrl: schema.string({ defaultValue: '' }),

--- a/src/plugins/maps_legacy/public/map/base_maps_visualization.js
+++ b/src/plugins/maps_legacy/public/map/base_maps_visualization.js
@@ -107,7 +107,7 @@ export function BaseMapsVisualizationProvider() {
       options.center = centerFromUIState ? centerFromUIState : this.vis.params.mapCenter;
 
       const modules = await lazyLoadMapsLegacyModules();
-      this._opensearchDashboardsMap = new modules.OpenSearchDashboardMap(this._container, options);
+      this._opensearchDashboardsMap = new modules.OpenSearchDashboardsMap(this._container, options);
       this._opensearchDashboardsMap.setMinZoom(WMS_MINZOOM); //use a default
       this._opensearchDashboardsMap.setMaxZoom(WMS_MAXZOOM); //use a default
 

--- a/src/plugins/maps_legacy/public/map/service_settings.js
+++ b/src/plugins/maps_legacy/public/map/service_settings.js
@@ -119,7 +119,7 @@ export class ServiceSettings {
   };
 
   async getFileLayers() {
-    if (!this._mapConfig.includeOpenSearchDashboardsMapsService) {
+    if (!this._mapConfig.includeOpenSearchMapsService) {
       return [];
     }
 
@@ -141,7 +141,7 @@ export class ServiceSettings {
       allServices.push(tmsService);
     }
 
-    if (this._mapConfig.includeOpenSearchDashboardsMapsService) {
+    if (this._mapConfig.includeOpenSearchMapsService) {
       const servicesFromManifest = await this._emsClient.getTMSServices();
       const strippedServiceFromManifest = await Promise.all(
         servicesFromManifest

--- a/src/plugins/maps_legacy/public/map/service_settings.test.js
+++ b/src/plugins/maps_legacy/public/map/service_settings.test.js
@@ -53,7 +53,7 @@ describe('service_settings (FKA tile_map test)', function () {
   const defaultMapConfig = {
     emsFileApiUrl,
     emsTileApiUrl,
-    includeOpenSearchDashboardsMapsService: true,
+    includeOpenSearchMapsService: true,
     emsTileLayerId: {
       bright: 'road_map',
       desaturated: 'road_map_desaturated',
@@ -252,7 +252,7 @@ describe('service_settings (FKA tile_map test)', function () {
       it('should exclude EMS', async () => {
         serviceSettings = makeServiceSettings(
           {
-            includeOpenSearchDashboardsMapsService: false,
+            includeOpenSearchMapsService: false,
           },
           {
             url: 'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
@@ -276,7 +276,7 @@ describe('service_settings (FKA tile_map test)', function () {
 
       it('should exclude all when not configured', async () => {
         serviceSettings = makeServiceSettings({
-          includeOpenSearchDashboardsMapsService: false,
+          includeOpenSearchMapsService: false,
         });
         const tilemapServices = await serviceSettings.getTMSServices();
         const expected = [];
@@ -331,7 +331,7 @@ describe('service_settings (FKA tile_map test)', function () {
 
     it('should exclude all when not configured', async () => {
       const serviceSettings = makeServiceSettings({
-        includeOpenSearchDashboardsMapsService: false,
+        includeOpenSearchMapsService: false,
       });
       const fileLayers = await serviceSettings.getFileLayers();
       const expected = [];

--- a/src/plugins/maps_legacy/server/index.ts
+++ b/src/plugins/maps_legacy/server/index.ts
@@ -38,8 +38,8 @@ import { getUiSettings } from './ui_settings';
 
 export const config: PluginConfigDescriptor<MapsLegacyConfig> = {
   exposeToBrowser: {
-    includeOpenSearchDashboardsMapsService: true,
-    proxyOpenSearchDashboardsMapsServiceInMaps: true,
+    includeOpenSearchMapsService: true,
+    proxyOpenSearchMapsServiceInMaps: true,
     tilemap: true,
     regionmap: true,
     manifestServiceUrl: true,


### PR DESCRIPTION
### Description
This doesn't fix the maps out of the box but fixes the issues that prevented users from settings the maps service in the config.

Which can be set by adding the following to opensearch_dashboards.yml:

```
map.tilemap.url: "https://tiles.maps.search-services.aws.a2z.com/tiles/{z}/{x}/{y}.png"
map.includeOpenSearchMapsService: false
```

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
Partial: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/221
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (besides functional tests)
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 