### PR TITLE
Change x86_64 to x64 and aarch64 to arm64 following industry conventions

### DIFF
--- a/packages/osd-opensearch/src/artifact.js
+++ b/packages/osd-opensearch/src/artifact.js
@@ -129,7 +129,7 @@ async function getArtifactSpecForSnapshot(urlVersion, license, log) {
   const manifest = JSON.parse(json);
 
   const platform = process.platform === 'win32' ? 'windows' : process.platform;
-  const arch = process.arch === 'arm64' ? 'aarch64' : 'x86_64';
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
 
   const archive = manifest.archives.find(
     (archive) =>

--- a/packages/osd-opensearch/src/artifact.test.js
+++ b/packages/osd-opensearch/src/artifact.test.js
@@ -41,7 +41,7 @@ const log = new ToolingLog();
 let MOCKS;
 
 const PLATFORM = process.platform === 'win32' ? 'windows' : process.platform;
-const ARCHITECTURE = process.arch === 'arm64' ? 'aarch64' : 'x86_64';
+const ARCHITECTURE = process.arch === 'arm64' ? 'arm64' : 'x64';
 const MOCK_VERSION = 'test-version';
 const MOCK_URL = 'http://127.0.0.1:12345';
 const MOCK_FILENAME = 'test-filename';

--- a/packages/osd-opensearch/src/custom_snapshots.js
+++ b/packages/osd-opensearch/src/custom_snapshots.js
@@ -42,7 +42,7 @@ function getCustomSnapshotUrl() {
     !process.env.OSD_OPENSEARCH_SNAPSHOT_URL &&
     !process.argv.some(isVersionFlag)
   ) {
-    // return 'https://storage.googleapis.com/kibana-ci-tmp-artifacts/{name}-{version}-{os}-x86_64.{ext}'; //TODO
+    // return 'https://storage.googleapis.com/kibana-ci-tmp-artifacts/{name}-{version}-{os}-x64.{ext}'; //TODO
     return undefined;
   }
 

--- a/src/dev/build/lib/build.test.ts
+++ b/src/dev/build/lib/build.test.ts
@@ -93,7 +93,7 @@ describe('#resolvePath()', () => {
 describe('#resolvePathForPlatform()', () => {
   it('uses config.resolveFromRepo(), config.getBuildVersion(), and platform.getBuildName() to create path', () => {
     expect(build.resolvePathForPlatform(linuxPlatform, 'foo', 'bar')).toMatchInlineSnapshot(
-      `<absolute path>/build/opensearch-dashboards-8.0.0-linux-x86_64/foo/bar`
+      `<absolute path>/build/opensearch-dashboards-8.0.0-linux-x64/foo/bar`
     );
   });
 });
@@ -101,13 +101,13 @@ describe('#resolvePathForPlatform()', () => {
 describe('#getPlatformArchivePath()', () => {
   it('creates correct path for different platforms', () => {
     expect(build.getPlatformArchivePath(linuxPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-8.0.0-linux-x86_64.tar.gz`
+      `<absolute path>/target/opensearch-dashboards-8.0.0-linux-x64.tar.gz`
     );
     expect(build.getPlatformArchivePath(linuxArmPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-8.0.0-linux-aarch64.tar.gz`
+      `<absolute path>/target/opensearch-dashboards-8.0.0-linux-arm64.tar.gz`
     );
     expect(build.getPlatformArchivePath(windowsPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-8.0.0-windows-x86_64.zip`
+      `<absolute path>/target/opensearch-dashboards-8.0.0-windows-x64.zip`
     );
   });
 });

--- a/src/dev/build/lib/platform.test.ts
+++ b/src/dev/build/lib/platform.test.ts
@@ -41,7 +41,7 @@ describe('getNodeArch()', () => {
 
 describe('getBuildName()', () => {
   it('returns the build name for the passed name', () => {
-    expect(new Platform('linux', 'arm64', 'linux-aarch64').getBuildName()).toBe('linux-aarch64');
+    expect(new Platform('linux', 'arm64', 'linux-arm64').getBuildName()).toBe('linux-arm64');
   });
 });
 

--- a/src/dev/build/lib/platform.ts
+++ b/src/dev/build/lib/platform.ts
@@ -65,8 +65,8 @@ export class Platform {
 }
 
 export const ALL_PLATFORMS = [
-  new Platform('linux', 'x64', 'linux-x86_64'),
-  new Platform('linux', 'arm64', 'linux-aarch64'),
-  new Platform('darwin', 'x64', 'darwin-x86_64'),
-  new Platform('win32', 'x64', 'windows-x86_64'),
+  new Platform('linux', 'x64', 'linux-x64'),
+  new Platform('linux', 'arm64', 'linux-arm64'),
+  new Platform('darwin', 'x64', 'darwin-x64'),
+  new Platform('win32', 'x64', 'windows-x64'),
 ];

--- a/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.test.ts
@@ -133,7 +133,7 @@ it('checks shasums for each downloaded node build', async () => {
           <Config>,
           Platform {
             "architecture": "x64",
-            "buildName": "linux-x86_64",
+            "buildName": "linux-x64",
             "name": "linux",
           },
         ],
@@ -141,7 +141,7 @@ it('checks shasums for each downloaded node build', async () => {
           <Config>,
           Platform {
             "architecture": "arm64",
-            "buildName": "linux-aarch64",
+            "buildName": "linux-arm64",
             "name": "linux",
           },
         ],
@@ -149,7 +149,7 @@ it('checks shasums for each downloaded node build', async () => {
           <Config>,
           Platform {
             "architecture": "x64",
-            "buildName": "darwin-x86_64",
+            "buildName": "darwin-x64",
             "name": "darwin",
           },
         ],
@@ -157,7 +157,7 @@ it('checks shasums for each downloaded node build', async () => {
           <Config>,
           Platform {
             "architecture": "x64",
-            "buildName": "windows-x86_64",
+            "buildName": "windows-x64",
             "name": "win32",
           },
         ],

--- a/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
+++ b/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
@@ -46,7 +46,7 @@ export const CreateRpmPackage: Task = {
   description: 'Creating rpm package',
 
   async run(config, log, build) {
-    await runFpm(config, log, build, 'rpm', ['--architecture', 'x86_64', '--rpm-os', 'linux']);
+    await runFpm(config, log, build, 'rpm', ['--architecture', 'x64', '--rpm-os', 'linux']);
   },
 };
 

--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -57,7 +57,7 @@ export async function runDockerGenerator(
   const imageFlavor = '';
   const imageTag = 'docker.opensearch.org/opensearch-dashboards/opensearch-dashboards';
   const version = config.getBuildVersion();
-  const artifactTarball = `opensearch-dashboards${imageFlavor}-${version}-linux-x86_64.tar.gz`;
+  const artifactTarball = `opensearch-dashboards${imageFlavor}-${version}-linux-x64.tar.gz`;
   const artifactsDir = config.resolveFromTarget('.');
   const dockerBuildDate = new Date().toISOString();
   // That would produce oss, default and default-ubi7

--- a/src/plugins/apm_oss/server/tutorial/instructions/apm_server_instructions.ts
+++ b/src/plugins/apm_oss/server/tutorial/instructions/apm_server_instructions.ts
@@ -87,9 +87,9 @@ const createDownloadServerTitle = () =>
 export const createDownloadServerOsx = () => ({
   title: createDownloadServerTitle(),
   commands: [
-    'curl -L -O https://artifacts.opensearch.org/downloads/apm-server/apm-server-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-    'tar xzvf apm-server-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-    'cd apm-server-{config.opensearchDashboards.version}-darwin-x86_64/',
+    'curl -L -O https://artifacts.opensearch.org/downloads/apm-server/apm-server-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+    'tar xzvf apm-server-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+    'cd apm-server-{config.opensearchDashboards.version}-darwin-x64/',
   ],
 });
 
@@ -110,8 +110,8 @@ export const createDownloadServerDeb = () => ({
 export const createDownloadServerRpm = () => ({
   title: createDownloadServerTitle(),
   commands: [
-    'curl -L -O https://artifacts.opensearch.org/downloads/apm-server/apm-server-{config.opensearchDashboards.version}-x86_64.rpm',
-    'sudo rpm -vi apm-server-{config.opensearchDashboards.version}-x86_64.rpm',
+    'curl -L -O https://artifacts.opensearch.org/downloads/apm-server/apm-server-{config.opensearchDashboards.version}-x64.rpm',
+    'sudo rpm -vi apm-server-{config.opensearchDashboards.version}-x64.rpm',
   ],
   textPost: i18n.translate('apmOss.tutorial.downloadServerRpm', {
     defaultMessage: 'Looking for the 32-bit packages? See the [Download page]({downloadPageLink}).',

--- a/src/plugins/home/server/tutorials/instructions/auditbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/auditbeat_instructions.ts
@@ -48,9 +48,9 @@ export const createAuditbeatInstructions = (context?: TutorialContext) => ({
         },
       }),
       commands: [
-        'curl -L -O https://artifacts.opensearch.org/downloads/beats/auditbeat/auditbeat-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-        'tar xzvf auditbeat-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-        'cd auditbeat-{config.opensearchDashboards.version}-darwin-x86_64/',
+        'curl -L -O https://artifacts.opensearch.org/downloads/beats/auditbeat/auditbeat-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+        'tar xzvf auditbeat-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+        'cd auditbeat-{config.opensearchDashboards.version}-darwin-x64/',
       ],
     },
     DEB: {
@@ -85,8 +85,8 @@ export const createAuditbeatInstructions = (context?: TutorialContext) => ({
         },
       }),
       commands: [
-        'curl -L -O https://artifacts.opensearch.org/downloads/beats/auditbeat/auditbeat-{config.opensearchDashboards.version}-x86_64.rpm',
-        'sudo rpm -vi auditbeat-{config.opensearchDashboards.version}-x86_64.rpm',
+        'curl -L -O https://artifacts.opensearch.org/downloads/beats/auditbeat/auditbeat-{config.opensearchDashboards.version}-x64.rpm',
+        'sudo rpm -vi auditbeat-{config.opensearchDashboards.version}-x64.rpm',
       ],
       textPost: i18n.translate('home.tutorials.common.auditbeatInstructions.install.rpmTextPost', {
         defaultMessage: 'Looking for the 32-bit packages? See the [Download page]({linkUrl}).',

--- a/src/plugins/home/server/tutorials/instructions/filebeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/filebeat_instructions.ts
@@ -48,9 +48,9 @@ export const createFilebeatInstructions = (context?: TutorialContext) => ({
         },
       }),
       commands: [
-        'curl -L -O https://artifacts.opensearch.org/downloads/beats/filebeat/filebeat-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-        'tar xzvf filebeat-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-        'cd filebeat-{config.opensearchDashboards.version}-darwin-x86_64/',
+        'curl -L -O https://artifacts.opensearch.org/downloads/beats/filebeat/filebeat-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+        'tar xzvf filebeat-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+        'cd filebeat-{config.opensearchDashboards.version}-darwin-x64/',
       ],
     },
     DEB: {
@@ -85,8 +85,8 @@ export const createFilebeatInstructions = (context?: TutorialContext) => ({
         },
       }),
       commands: [
-        'curl -L -O https://artifacts.opensearch.org/downloads/beats/filebeat/filebeat-{config.opensearchDashboards.version}-x86_64.rpm',
-        'sudo rpm -vi filebeat-{config.opensearchDashboards.version}-x86_64.rpm',
+        'curl -L -O https://artifacts.opensearch.org/downloads/beats/filebeat/filebeat-{config.opensearchDashboards.version}-x64.rpm',
+        'sudo rpm -vi filebeat-{config.opensearchDashboards.version}-x64.rpm',
       ],
       textPost: i18n.translate('home.tutorials.common.filebeatInstructions.install.rpmTextPost', {
         defaultMessage: 'Looking for the 32-bit packages? See the [Download page]({linkUrl}).',

--- a/src/plugins/home/server/tutorials/instructions/functionbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/functionbeat_instructions.ts
@@ -48,9 +48,9 @@ export const createFunctionbeatInstructions = (context?: TutorialContext) => ({
         },
       }),
       commands: [
-        'curl -L -O https://artifacts.opensearch.org/downloads/beats/functionbeat/functionbeat-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-        'tar xzvf functionbeat-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-        'cd functionbeat-{config.opensearchDashboards.version}-darwin-x86_64/',
+        'curl -L -O https://artifacts.opensearch.org/downloads/beats/functionbeat/functionbeat-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+        'tar xzvf functionbeat-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+        'cd functionbeat-{config.opensearchDashboards.version}-darwin-x64/',
       ],
     },
     LINUX: {
@@ -67,9 +67,9 @@ export const createFunctionbeatInstructions = (context?: TutorialContext) => ({
         }
       ),
       commands: [
-        'curl -L -O https://artifacts.opensearch.org/downloads/beats/functionbeat/functionbeat-{config.opensearchDashboards.version}-linux-x86_64.tar.gz',
-        'tar xzvf functionbeat-{config.opensearchDashboards.version}-linux-x86_64.tar.gz',
-        'cd functionbeat-{config.opensearchDashboards.version}-linux-x86_64/',
+        'curl -L -O https://artifacts.opensearch.org/downloads/beats/functionbeat/functionbeat-{config.opensearchDashboards.version}-linux-x64.tar.gz',
+        'tar xzvf functionbeat-{config.opensearchDashboards.version}-linux-x64.tar.gz',
+        'cd functionbeat-{config.opensearchDashboards.version}-linux-x64/',
       ],
     },
     WINDOWS: {

--- a/src/plugins/home/server/tutorials/instructions/heartbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/heartbeat_instructions.ts
@@ -46,9 +46,9 @@ export const createHeartbeatInstructions = (context?: TutorialContext) => ({
         values: { link: '{config.docs.beats.heartbeat}/heartbeat-installation-configuration.html' },
       }),
       commands: [
-        'curl -L -O https://artifacts.opensearch.org/downloads/beats/heartbeat/heartbeat-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-        'tar xzvf heartbeat-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-        'cd heartbeat-{config.opensearchDashboards.version}-darwin-x86_64/',
+        'curl -L -O https://artifacts.opensearch.org/downloads/beats/heartbeat/heartbeat-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+        'tar xzvf heartbeat-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+        'cd heartbeat-{config.opensearchDashboards.version}-darwin-x64/',
       ],
     },
     DEB: {
@@ -77,8 +77,8 @@ export const createHeartbeatInstructions = (context?: TutorialContext) => ({
         values: { link: '{config.docs.beats.heartbeat}/heartbeat-installation-configuration.html' },
       }),
       commands: [
-        'curl -L -O https://artifacts.opensearch.org/downloads/beats/heartbeat/heartbeat-{config.opensearchDashboards.version}-x86_64.rpm',
-        'sudo rpm -vi heartbeat-{config.opensearchDashboards.version}-x86_64.rpm',
+        'curl -L -O https://artifacts.opensearch.org/downloads/beats/heartbeat/heartbeat-{config.opensearchDashboards.version}-x64.rpm',
+        'sudo rpm -vi heartbeat-{config.opensearchDashboards.version}-x64.rpm',
       ],
       textPost: i18n.translate('home.tutorials.common.heartbeatInstructions.install.debTextPost', {
         defaultMessage: 'Looking for the 32-bit packages? See the [Download page]({link}).',

--- a/src/plugins/home/server/tutorials/instructions/metricbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/metricbeat_instructions.ts
@@ -48,9 +48,9 @@ export const createMetricbeatInstructions = (context?: TutorialContext) => ({
         },
       }),
       commands: [
-        'curl -L -O https://artifacts.opensearch.org/downloads/beats/metricbeat/metricbeat-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-        'tar xzvf metricbeat-{config.opensearchDashboards.version}-darwin-x86_64.tar.gz',
-        'cd metricbeat-{config.opensearchDashboards.version}-darwin-x86_64/',
+        'curl -L -O https://artifacts.opensearch.org/downloads/beats/metricbeat/metricbeat-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+        'tar xzvf metricbeat-{config.opensearchDashboards.version}-darwin-x64.tar.gz',
+        'cd metricbeat-{config.opensearchDashboards.version}-darwin-x64/',
       ],
     },
     DEB: {
@@ -83,8 +83,8 @@ export const createMetricbeatInstructions = (context?: TutorialContext) => ({
         },
       }),
       commands: [
-        'curl -L -O https://artifacts.opensearch.org/downloads/beats/metricbeat/metricbeat-{config.opensearchDashboards.version}-x86_64.rpm',
-        'sudo rpm -vi metricbeat-{config.opensearchDashboards.version}-x86_64.rpm',
+        'curl -L -O https://artifacts.opensearch.org/downloads/beats/metricbeat/metricbeat-{config.opensearchDashboards.version}-x64.rpm',
+        'sudo rpm -vi metricbeat-{config.opensearchDashboards.version}-x64.rpm',
       ],
       textPost: i18n.translate('home.tutorials.common.metricbeatInstructions.install.debTextPost', {
         defaultMessage: 'Looking for the 32-bit packages? See the [Download page]({link}).',

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/filters/_columns.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/filters/_columns.js
@@ -35,7 +35,7 @@ import _ from 'lodash';
 export default {
   columns: [
     {
-      label: 'Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1: agent.raw',
+      label: 'Mozilla/5.0 (X11; Linux x64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1: agent.raw',
       xAxisLabel: 'filters',
       yAxisLabel: 'Count of documents',
       series: [

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/range/_rows.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/range/_rows.js
@@ -35,7 +35,7 @@ import _ from 'lodash';
 export default {
   rows: [
     {
-      label: 'Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1: agent.raw',
+      label: 'Mozilla/5.0 (X11; Linux x64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1: agent.raw',
       xAxisLabel: 'bytes ranges',
       yAxisLabel: 'Count of documents',
       series: [

--- a/tasks/config/run.js
+++ b/tasks/config/run.js
@@ -35,7 +35,7 @@ import { getFunctionalTestGroupRunConfigs } from '../function_test_groups';
 const { version } = require('../../package.json');
 const OPENSEARCH_DASHBOARDS_INSTALL_DIR =
   process.env.OPENSEARCH_DASHBOARDS_INSTALL_DIR ||
-  `./build/oss/opensearch-dashboards-${version}-SNAPSHOT-${process.platform}-x86_64`;
+  `./build/oss/opensearch-dashboards-${version}-SNAPSHOT-${process.platform}-x64`;
 
 module.exports = function () {
   const NODE = 'node';


### PR DESCRIPTION
Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Description
Move Dashboards to the naming convention as the plugins.
Here are the naming changes required:
* x86_64 to x64
* aarch64 to arm64
 
### Issues Resolved
[#311](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/311) 
 