### PR TITLE
[Bug]Fix version conflict for plugins

### DIFF
--- a/packages/osd-plugin-helpers/src/cli.ts
+++ b/packages/osd-plugin-helpers/src/cli.ts
@@ -94,9 +94,9 @@ export function runCli() {
           plugin
         );
 
-        if (semver.satisfies(opensearchDashboardsVersion, '>1.0')) {
+        if (semver.satisfies(opensearchDashboardsVersion, '>=2.0.0')) {
           log.error(
-            'These tools are not designed to work with version greater than 1.0, please checkout an earlier version of OpenSearch Dashboards to build your plugin'
+            'These tools are not designed to work with version greater than 1.x, please checkout an earlier version of OpenSearch Dashboards to build your plugin'
           );
           process.exit(1);
         }

--- a/packages/osd-plugin-helpers/src/cli.ts
+++ b/packages/osd-plugin-helpers/src/cli.ts
@@ -94,16 +94,11 @@ export function runCli() {
           plugin
         );
 
-        if (semver.satisfies(opensearchDashboardsVersion, '<7.9')) {
+        if (semver.satisfies(opensearchDashboardsVersion, '>1.0')) {
           log.error(
-            'These tools are not designed to work with version before 7.9, please checkout an earlier version of OpenSearch Dashboards to build your plugin'
+            'These tools are not designed to work with version greater than 1.0, please checkout an earlier version of OpenSearch Dashboards to build your plugin'
           );
           process.exit(1);
-        }
-        if (semver.satisfies(opensearchDashboardsVersion, '~7.9.0')) {
-          log.warning(
-            'These tools might work with 7.9 versions, but there are known workarounds required. See https://github.com/elastic/kibana/issues/82466 for more info'
-          );
         }
 
         const sourceDir = plugin.directory;

--- a/packages/osd-plugin-helpers/src/cli.ts
+++ b/packages/osd-plugin-helpers/src/cli.ts
@@ -32,7 +32,6 @@
 
 import Path from 'path';
 
-import semver from 'semver';
 import { RunWithCommands, createFlagError, createFailError } from '@osd/dev-utils';
 
 import { findOpenSearchDashboardsJson } from './find_opensearch_dashboards_json';
@@ -93,13 +92,6 @@ export function runCli() {
           versionFlag,
           plugin
         );
-
-        if (semver.satisfies(opensearchDashboardsVersion, '>=2.0.0')) {
-          log.error(
-            'These tools are not designed to work with version greater than 1.x, please checkout an earlier version of OpenSearch Dashboards to build your plugin'
-          );
-          process.exit(1);
-        }
 
         const sourceDir = plugin.directory;
         const buildDir = Path.resolve(


### PR DESCRIPTION
Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Description
Main branch is on version 1.0.0, but there is a version check expecting 7.9 when building plugins. This PR fixes the issue by revising the version check to unblock plugin build. 

 
### Issues Resolved
[#309](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/309)
[#224](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/224)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 