### PR TITLE
Fix broken link in the Overview page

### DIFF
--- a/src/plugins/opensearch_dashboards_overview/public/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/opensearch_dashboards_overview/public/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -29,21 +29,23 @@ exports[`AddData render 1`] = `
       className="osdOverviewDataAdd__actions"
       grow={false}
     >
-      <div>
-        <EuiButtonEmpty
-          className="osdOverviewDataAdd__actionButton"
-          flush="left"
-          href="#/tutorial_directory/sampleData"
-          iconType="visTable"
-          size="xs"
-        >
-          <FormattedMessage
-            defaultMessage="Try our sample data"
-            id="opensearchDashboardsOverview.addData.sampleDataButtonLabel"
-            values={Object {}}
-          />
-        </EuiButtonEmpty>
-      </div>
+      <RedirectAppLinks>
+        <div>
+          <EuiButtonEmpty
+            className="osdOverviewDataAdd__actionButton"
+            flush="left"
+            href="/app/home#/tutorial_directory/sampleData"
+            iconType="visTable"
+            size="xs"
+          >
+            <FormattedMessage
+              defaultMessage="Try our sample data"
+              id="opensearchDashboardsOverview.addData.sampleDataButtonLabel"
+              values={Object {}}
+            />
+          </EuiButtonEmpty>
+        </div>
+      </RedirectAppLinks>
     </EuiFlexItem>
   </EuiFlexGroup>
   <EuiSpacer

--- a/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.tsx
@@ -68,20 +68,22 @@ export const AddData: FC<Props> = ({ addBasePath, features }) => {
         </EuiFlexItem>
 
         <EuiFlexItem className="osdOverviewDataAdd__actions" grow={false}>
-          <div>
-            <EuiButtonEmpty
-              className="osdOverviewDataAdd__actionButton"
-              flush="left"
-              href={addBasePath('#/tutorial_directory/sampleData')}
-              iconType="visTable"
-              size="xs"
-            >
-              <FormattedMessage
-                id="opensearchDashboardsOverview.addData.sampleDataButtonLabel"
-                defaultMessage="Try our sample data"
-              />
-            </EuiButtonEmpty>
-          </div>
+          <RedirectAppLinks application={application}>
+            <div>
+              <EuiButtonEmpty
+                className="osdOverviewDataAdd__actionButton"
+                flush="left"
+                href={addBasePath('/app/home#/tutorial_directory/sampleData')}
+                iconType="visTable"
+                size="xs"
+              >
+                <FormattedMessage
+                  id="opensearchDashboardsOverview.addData.sampleDataButtonLabel"
+                  defaultMessage="Try our sample data"
+                />
+              </EuiButtonEmpty>
+            </div>
+          </RedirectAppLinks>
         </EuiFlexItem>
       </EuiFlexGroup>
 


### PR DESCRIPTION
### Description

The 'Try our sample data' link in the opensearch dashboards overview page is broken. It has to be pointed to the path `/app/home#/tutorial_directory/sampleData`. This commit fixes this bug. The snapshots are updated accordingly.
 
### Issues Resolved

Fixes #193 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 