### PR TITLE
[Bug] Replace EuiLoadingElastic to EuiLoadingSpinner

### DIFF
--- a/src/plugins/newsfeed/public/components/__snapshots__/loading_news.test.tsx.snap
+++ b/src/plugins/newsfeed/public/components/__snapshots__/loading_news.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`news_loading rendering renders the default News Loading 1`] = `
     </p>
   }
   title={
-    <EuiLoadingElastic
+    <EuiLoadingSpinner
       size="xl"
     />
   }

--- a/src/plugins/newsfeed/public/components/loading_news.tsx
+++ b/src/plugins/newsfeed/public/components/loading_news.tsx
@@ -28,12 +28,12 @@ import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
 
 import { EuiEmptyPrompt } from '@elastic/eui';
-import { EuiLoadingElastic } from '@elastic/eui';
+import { EuiLoadingSpinner } from '@elastic/eui';
 
 export const NewsLoadingPrompt = () => {
   return (
     <EuiEmptyPrompt
-      title={<EuiLoadingElastic size="xl" />}
+      title={<EuiLoadingSpinner size="xl" />}
       body={
         <p>
           <FormattedMessage

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
@@ -48,7 +48,7 @@ import {
   EuiSelect,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiLoadingElastic,
+  EuiLoadingSpinner,
   EuiCallOut,
   EuiSpacer,
   EuiLink,
@@ -624,7 +624,7 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
       return (
         <EuiFlexGroup justifyContent="spaceAround">
           <EuiFlexItem grow={false}>
-            <EuiLoadingElastic size="xl" />
+            <EuiLoadingSpinner size="xl" />
             <EuiSpacer size="m" />
             <EuiText>
               <p>{loadingMessage}</p>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
@@ -100,7 +100,7 @@ describe('Relationships', () => {
     const component = shallowWithI18nProvider(<Relationships {...props} />);
 
     // Make sure we are showing loading
-    expect(component.find('EuiLoadingElastic').length).toBe(1);
+    expect(component.find('EuiLoadingSpinner').length).toBe(1);
 
     // Ensure all promises resolve
     await new Promise((resolve) => process.nextTick(resolve));
@@ -167,7 +167,7 @@ describe('Relationships', () => {
     const component = shallowWithI18nProvider(<Relationships {...props} />);
 
     // Make sure we are showing loading
-    expect(component.find('EuiLoadingElastic').length).toBe(1);
+    expect(component.find('EuiLoadingSpinner').length).toBe(1);
 
     // Ensure all promises resolve
     await new Promise((resolve) => process.nextTick(resolve));
@@ -234,7 +234,7 @@ describe('Relationships', () => {
     const component = shallowWithI18nProvider(<Relationships {...props} />);
 
     // Make sure we are showing loading
-    expect(component.find('EuiLoadingElastic').length).toBe(1);
+    expect(component.find('EuiLoadingSpinner').length).toBe(1);
 
     // Ensure all promises resolve
     await new Promise((resolve) => process.nextTick(resolve));
@@ -301,7 +301,7 @@ describe('Relationships', () => {
     const component = shallowWithI18nProvider(<Relationships {...props} />);
 
     // Make sure we are showing loading
-    expect(component.find('EuiLoadingElastic').length).toBe(1);
+    expect(component.find('EuiLoadingSpinner').length).toBe(1);
 
     // Ensure all promises resolve
     await new Promise((resolve) => process.nextTick(resolve));

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.tsx
@@ -39,7 +39,7 @@ import {
   EuiLink,
   EuiIcon,
   EuiCallOut,
-  EuiLoadingElastic,
+  EuiLoadingSpinner,
   EuiInMemoryTable,
   EuiToolTip,
   EuiText,
@@ -132,7 +132,7 @@ export class Relationships extends Component<RelationshipsProps, RelationshipsSt
     }
 
     if (isLoading) {
-      return <EuiLoadingElastic size="xl" />;
+      return <EuiLoadingSpinner size="xl" />;
     }
 
     const columns = [

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -40,7 +40,7 @@ import {
   EuiInMemoryTable,
   EuiIcon,
   EuiConfirmModal,
-  EuiLoadingElastic,
+  EuiLoadingSpinner,
   EuiOverlayMask,
   EUI_MODAL_CONFIRM_BUTTON,
   EuiCheckboxGroup,
@@ -558,7 +558,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
 
     if (isDeleting) {
       // Block the user from interacting with the table while its contents are being deleted.
-      modal = <EuiLoadingElastic size="xl" />;
+      modal = <EuiLoadingSpinner size="xl" />;
     } else {
       const onCancel = () => {
         this.setState({ isShowingDeleteConfirmModal: false });


### PR DESCRIPTION
Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Description
We found some logo hidden in Stack Management > Saved Objects > Import > select a file > Import> Elastic logo (spinner)
 
### Issues Resolved
[#338 ](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/338)

### Work
Replace EuiLoadingElastic to EuiLoadingSpinner.
Test(local): unit and integration
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 