### PR TITLE
Increase filters popover size and use full width in form components 

### DIFF
--- a/src/plugins/data/public/ui/filter_bar/_index.scss
+++ b/src/plugins/data/public/ui/filter_bar/_index.scss
@@ -1,4 +1,3 @@
 @import 'variables';
 @import 'global_filter_group';
 @import 'global_filter_item';
-@import 'filter_editor/index';

--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -125,7 +125,7 @@ function FilterBarUI(props: Props) {
           repositionOnScroll
         >
           <EuiFlexItem grow={false}>
-            <div style={{ width: 400 }}>
+            <div style={{ width: 600 }}>
               <FilterEditor
                 filter={newFilter}
                 indexPatterns={props.indexPatterns}

--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -30,7 +30,13 @@
  * GitHub history for details.
  */
 
-import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiPopover } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiResizeObserver,
+} from '@elastic/eui';
 import { FormattedMessage, InjectedIntl, injectI18n } from '@osd/i18n/react';
 import classNames from 'classnames';
 import React, { useState } from 'react';
@@ -60,9 +66,12 @@ interface Props {
   intl: InjectedIntl;
 }
 
+const maxFilterWidth = 600;
+
 function FilterBarUI(props: Props) {
   const [isAddFilterPopoverOpen, setIsAddFilterPopoverOpen] = useState(false);
   const opensearchDashboards = useOpenSearchDashboards();
+  const [filterWidth, setFilterWidth] = useState(maxFilterWidth);
 
   const uiSettings = opensearchDashboards.services.uiSettings;
   if (!uiSettings) return null;
@@ -87,6 +96,10 @@ function FilterBarUI(props: Props) {
         />
       </EuiFlexItem>
     ));
+  }
+
+  function onResize(dimensions: { height: number; width: number }) {
+    setFilterWidth(dimensions.width);
   }
 
   function renderAddFilter() {
@@ -121,20 +134,24 @@ function FilterBarUI(props: Props) {
           withTitle
           panelPaddingSize="none"
           ownFocus={true}
-          initialFocus=".filterEditor__hiddenItem"
+          initialFocus=".globalFilterEditor__fieldInput input"
           repositionOnScroll
         >
-          <EuiFlexItem grow={false}>
-            <div style={{ width: 600 }}>
-              <FilterEditor
-                filter={newFilter}
-                indexPatterns={props.indexPatterns}
-                onSubmit={onAdd}
-                onCancel={() => setIsAddFilterPopoverOpen(false)}
-                key={JSON.stringify(newFilter)}
-              />
-            </div>
-          </EuiFlexItem>
+          <EuiResizeObserver onResize={onResize}>
+            {(resizeRef) => (
+              <div style={{ width: maxFilterWidth, maxWidth: '100%' }} ref={resizeRef}>
+                <EuiFlexItem style={{ width: filterWidth }} grow={false}>
+                  <FilterEditor
+                    filter={newFilter}
+                    indexPatterns={props.indexPatterns}
+                    onSubmit={onAdd}
+                    onCancel={() => setIsAddFilterPopoverOpen(false)}
+                    key={JSON.stringify(newFilter)}
+                  />
+                </EuiFlexItem>
+              </div>
+            )}
+          </EuiResizeObserver>
         </EuiPopover>
       </EuiFlexItem>
     );

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/_filter_editor.scss
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/_filter_editor.scss
@@ -1,3 +1,0 @@
-.globalFilterEditor__fieldInput {
-  max-width: $euiSize * 13;
-}

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/_index.scss
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/_index.scss
@@ -1,1 +1,0 @@
-@import 'filter_editor';

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/index.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/index.tsx
@@ -283,6 +283,7 @@ class FilterEditorUI extends Component<Props, State> {
       >
         <FieldComboBox
           id="fieldInput"
+          fullWidth={true}
           isDisabled={!selectedIndexPattern}
           placeholder={this.props.intl.formatMessage({
             id: 'data.filter.filterEditor.fieldSelectPlaceholder',
@@ -294,7 +295,6 @@ class FilterEditorUI extends Component<Props, State> {
           onChange={this.onFieldChange}
           singleSelection={{ asPlainText: true }}
           isClearable={false}
-          className="globalFilterEditor__fieldInput"
           data-test-subj="filterFieldSuggestionList"
         />
       </EuiFormRow>
@@ -342,6 +342,7 @@ class FilterEditorUI extends Component<Props, State> {
         label={i18n.translate('data.filter.filterEditor.queryDslLabel', {
           defaultMessage: 'OpenSearch Query DSL',
         })}
+        fullWidth={true}
       >
         <EuiCodeEditor
           value={this.state.queryDsl}

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/index.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/index.tsx
@@ -163,12 +163,14 @@ class FilterEditorUI extends Component<Props, State> {
               <div>
                 <EuiSpacer size="m" />
                 <EuiFormRow
+                  fullWidth={true}
                   label={this.props.intl.formatMessage({
                     id: 'data.filter.filterEditor.createCustomLabelInputLabel',
                     defaultMessage: 'Custom label',
                   })}
                 >
                   <EuiFieldText
+                    fullWidth={true}
                     value={`${this.state.customLabel}`}
                     onChange={this.onCustomLabelChange}
                   />
@@ -295,6 +297,7 @@ class FilterEditorUI extends Component<Props, State> {
           onChange={this.onFieldChange}
           singleSelection={{ asPlainText: true }}
           isClearable={false}
+          className="globalFilterEditor__fieldInput"
           data-test-subj="filterFieldSuggestionList"
         />
       </EuiFormRow>

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/phrase_value_input.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/phrase_value_input.tsx
@@ -49,6 +49,7 @@ class PhraseValueInputUI extends PhraseSuggestorUI<Props> {
   public render() {
     return (
       <EuiFormRow
+        fullWidth={true}
         label={this.props.intl.formatMessage({
           id: 'data.filter.filterEditor.valueInputLabel',
           defaultMessage: 'Value',
@@ -58,6 +59,7 @@ class PhraseValueInputUI extends PhraseSuggestorUI<Props> {
           this.renderWithSuggestions()
         ) : (
           <ValueInputType
+            fullWidth={true}
             placeholder={this.props.intl.formatMessage({
               id: 'data.filter.filterEditor.valueInputPlaceholder',
               defaultMessage: 'Enter a value',
@@ -83,6 +85,7 @@ class PhraseValueInputUI extends PhraseSuggestorUI<Props> {
           id: 'data.filter.filterEditor.valueSelectPlaceholder',
           defaultMessage: 'Select a value',
         })}
+        fullWidth={true}
         options={options}
         getLabel={(option) => option}
         selectedOptions={value ? [valueAsStr] : []}

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/phrases_values_input.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/phrases_values_input.tsx
@@ -51,6 +51,7 @@ class PhrasesValuesInputUI extends PhraseSuggestorUI<Props> {
     const options = values ? uniq([...values, ...suggestions]) : suggestions;
     return (
       <EuiFormRow
+        fullWidth={true}
         label={intl.formatMessage({
           id: 'data.filter.filterEditor.valuesSelectLabel',
           defaultMessage: 'Values',
@@ -61,6 +62,7 @@ class PhrasesValuesInputUI extends PhraseSuggestorUI<Props> {
             id: 'data.filter.filterEditor.valuesSelectPlaceholder',
             defaultMessage: 'Select values',
           })}
+          fullWidth={true}
           options={options}
           getLabel={(option) => option}
           selectedOptions={values || []}

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/range_value_input.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/range_value_input.tsx
@@ -84,6 +84,7 @@ function RangeValueInputUI(props: Props) {
   return (
     <div>
       <EuiFormControlLayoutDelimited
+        fullWidth={false}
         aria-label={props.intl.formatMessage({
           id: 'data.filter.filterEditor.rangeInputLabel',
           defaultMessage: 'Range',

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/range_value_input.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/range_value_input.tsx
@@ -84,7 +84,7 @@ function RangeValueInputUI(props: Props) {
   return (
     <div>
       <EuiFormControlLayoutDelimited
-        fullWidth={false}
+        fullWidth={true}
         aria-label={props.intl.formatMessage({
           id: 'data.filter.filterEditor.rangeInputLabel',
           defaultMessage: 'Range',

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/value_input_type.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/value_input_type.tsx
@@ -41,6 +41,7 @@ interface Props {
   type: string;
   onChange: (value: string | number | boolean) => void;
   onBlur?: (value: string | number | boolean) => void;
+  fullWidth?: boolean;
   placeholder: string;
   intl: InjectedIntl;
   controlOnly?: boolean;
@@ -55,6 +56,7 @@ class ValueInputTypeUI extends Component<Props> {
       case 'string':
         inputElement = (
           <EuiFieldText
+            fullWidth={this.props.fullWidth}
             placeholder={this.props.placeholder}
             value={value}
             onChange={this.onChange}
@@ -66,6 +68,7 @@ class ValueInputTypeUI extends Component<Props> {
       case 'number':
         inputElement = (
           <EuiFieldNumber
+            fullWidth={this.props.fullWidth}
             placeholder={this.props.placeholder}
             value={typeof value === 'string' ? parseFloat(value) : value}
             onChange={this.onChange}
@@ -77,6 +80,7 @@ class ValueInputTypeUI extends Component<Props> {
       case 'date':
         inputElement = (
           <EuiFieldText
+            fullWidth={this.props.fullWidth}
             placeholder={this.props.placeholder}
             value={value}
             onChange={this.onChange}
@@ -90,6 +94,7 @@ class ValueInputTypeUI extends Component<Props> {
       case 'ip':
         inputElement = (
           <EuiFieldText
+            fullWidth={this.props.fullWidth}
             placeholder={this.props.placeholder}
             value={value}
             onChange={this.onChange}
@@ -102,6 +107,7 @@ class ValueInputTypeUI extends Component<Props> {
       case 'boolean':
         inputElement = (
           <EuiSelect
+            fullWidth={this.props.fullWidth}
             options={[
               { value: undefined, text: this.props.placeholder },
               {

--- a/src/plugins/data/public/ui/filter_bar/filter_item.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_item.tsx
@@ -241,7 +241,7 @@ export function FilterItem(props: Props) {
       },
       {
         id: 1,
-        width: 420,
+        width: 600,
         content: (
           <div>
             <FilterEditor


### PR DESCRIPTION
Signed-off-by: galangel <gal0angel@gmail.com>

### Description
The change resizes the modal to 600 ( instead of 400 ) and uses the full-width prop in the form components to take advantage of the space.
also Removed the unused styles 

<img width="618" alt="Screen Shot 2021-05-13 at 15 05 18" src="https://user-images.githubusercontent.com/8701610/118123510-0a8c5980-b3fd-11eb-80b1-52d2d68a11e3.png">
<img width="624" alt="Screen Shot 2021-05-13 at 15 05 35" src="https://user-images.githubusercontent.com/8701610/118123516-0ceeb380-b3fd-11eb-98dd-2b5924d77602.png">
<img width="611" alt="Screen Shot 2021-05-13 at 15 04 35" src="https://user-images.githubusercontent.com/8701610/118123523-10823a80-b3fd-11eb-881f-14c287b9e331.png">

I explicitly left the range input at false because I think it looks better like this than with full width
<img width="616" alt="Screen Shot 2021-05-13 at 15 05 50" src="https://user-images.githubusercontent.com/8701610/118123533-12e49480-b3fd-11eb-9e3c-04b8f3f11b18.png">


Fullscreen at 100%
<img width="1789" alt="Screen Shot 2021-05-13 at 15 04 12" src="https://user-images.githubusercontent.com/8701610/118123673-432c3300-b3fd-11eb-8a9a-dc05bbbd573e.png">




### Issues Resolved
[Filters popover modal is too small](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/351)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 