### PR TITLE
Auto-focus on the Field input when clicking Add filter

### DIFF
--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -121,7 +121,7 @@ function FilterBarUI(props: Props) {
           withTitle
           panelPaddingSize="none"
           ownFocus={true}
-          initialFocus=".filterEditor__hiddenItem"
+          initialFocus='[data-test-subj="filterFieldSuggestionList"] [data-test-subj="comboBoxSearchInput"]'
           repositionOnScroll
         >
           <EuiFlexItem grow={false}>

--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -121,7 +121,7 @@ function FilterBarUI(props: Props) {
           withTitle
           panelPaddingSize="none"
           ownFocus={true}
-          initialFocus='[data-test-subj="filterFieldSuggestionList"] [data-test-subj="comboBoxSearchInput"]'
+          initialFocus=".globalFilterEditor__fieldInput input"
           repositionOnScroll
         >
           <EuiFlexItem grow={false}>


### PR DESCRIPTION
Signed-off-by: galangel <gal0angel@gmail.com>

### Description
Added Auto-focus on the Field input when clicking Add filter
Done by setting the initial focus of the popover with the relevant selector

example:
![autofocus](https://user-images.githubusercontent.com/8701610/118149091-e55a1400-b419-11eb-919f-b63207086851.gif)
 


### Issues Resolved
[Add filter form initial focus should be the Field input](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/354)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 