### PR TITLE
Default to converting folder name for cli plugin to kebab-case

### DIFF
--- a/src/cli_plugin/install/install.js
+++ b/src/cli_plugin/install/install.js
@@ -41,6 +41,7 @@ import { cleanPrevious, cleanArtifacts } from './cleanup';
 import { extract, getPackData } from './pack';
 import { renamePlugin } from './rename';
 import { existingInstall, assertVersion } from './opensearch_dashboards';
+import { kebabCase } from 'lodash';
 
 const mkdir = promisify(Fs.mkdir);
 
@@ -62,7 +63,7 @@ export async function install(settings, logger) {
 
     assertVersion(settings);
 
-    const targetDir = path.join(settings.pluginDir, settings.plugins[0].id);
+    const targetDir = path.join(settings.pluginDir, kebabCase(settings.plugins[0].id));
     await renamePlugin(settings.workingPath, targetDir);
 
     logger.log('Plugin installation complete');

--- a/src/cli_plugin/install/opensearch_dashboards.js
+++ b/src/cli_plugin/install/opensearch_dashboards.js
@@ -32,12 +32,13 @@
 
 import path from 'path';
 import { statSync } from 'fs';
+import { kebabCase } from 'lodash';
 
 import { versionSatisfies, cleanVersion } from '../../legacy/utils/version';
 
 export function existingInstall(settings, logger) {
   try {
-    statSync(path.join(settings.pluginDir, settings.plugins[0].id));
+    statSync(path.join(settings.pluginDir, kebabCase(settings.plugins[0].id)));
 
     logger.error(
       `Plugin ${settings.plugins[0].id} already exists, please remove before installing a new version`


### PR DESCRIPTION
### Description
This change intends to default the folder name for plugins being installed through cli to kebab-case. 

To test the change, I ran `./bin/opensearch-dashboards-plugin install file:///anomalyDetectionDashboards-1.0.0.0-beta1.zip` to verify the folder name generated which is now in kebab-case: `anomaly-detection-dashboards`.
 
### Issues Resolved
Part 1 of #322
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 