### PR TITLE
[Build] fix icons, app titles, and overview route

### DIFF
--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -154,7 +154,7 @@ export class ChromeService {
   }: StartDeps): Promise<InternalChromeStart> {
     this.initVisibility(application);
 
-    const appTitle$ = new BehaviorSubject<string>('OpenSearchDashboards');
+    const appTitle$ = new BehaviorSubject<string>('Overview');
     const brand$ = new BehaviorSubject<ChromeBrand>({});
     const applicationClasses$ = new BehaviorSubject<Set<string>>(new Set());
     const helpExtension$ = new BehaviorSubject<ChromeHelpExtension | undefined>(undefined);

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -43,7 +43,7 @@ interface Props {
 }
 
 export function HeaderBreadcrumbs({ appTitle$, breadcrumbs$ }: Props) {
-  const appTitle = useObservable(appTitle$, 'OpenSearchDashboards');
+  const appTitle = useObservable(appTitle$, 'OpenSearch Dashboards');
   const breadcrumbs = useObservable(breadcrumbs$, []);
   let crumbs = breadcrumbs;
 

--- a/src/core/server/core_app/core_app.ts
+++ b/src/core/server/core_app/core_app.ts
@@ -52,7 +52,10 @@ export class CoreApp {
     const httpSetup = coreSetup.http;
     const router = httpSetup.createRouter('/');
     router.get({ path: '/', validate: false }, async (context, req, res) => {
-      const defaultRoute = await context.core.uiSettings.client.get<string>('defaultRoute');
+      let defaultRoute = await context.core.uiSettings.client.get<string>('defaultRoute');
+      // TODO: [RENAMEME] Temporary code for backwards compatibility.
+      // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/334
+      defaultRoute = defaultRoute.replace('kibana_overview', 'opensearch_dashboards_overview');
       const basePath = httpSetup.basePath.get(req);
       const url = `${basePath}${defaultRoute}`;
 

--- a/src/plugins/data/public/ui/typeahead/__snapshots__/suggestion_component.test.tsx.snap
+++ b/src/plugins/data/public/ui/typeahead/__snapshots__/suggestion_component.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`SuggestionComponent Should display the suggestion and use the provided 
       className="osdSuggestionItem__type"
     >
       <EuiIcon
-        type="dqlValue"
+        type="kqlValue"
       />
     </div>
     <div
@@ -52,7 +52,7 @@ exports[`SuggestionComponent Should make the element active if the selected prop
       className="osdSuggestionItem__type"
     >
       <EuiIcon
-        type="dqlValue"
+        type="kqlValue"
       />
     </div>
     <div

--- a/src/plugins/data/public/ui/typeahead/suggestion_component.tsx
+++ b/src/plugins/data/public/ui/typeahead/suggestion_component.tsx
@@ -38,15 +38,15 @@ import { QuerySuggestion } from '../../autocomplete';
 function getEuiIconType(type: string) {
   switch (type) {
     case 'field':
-      return 'dqlField';
+      return 'kqlField';
     case 'value':
-      return 'dqlValue';
+      return 'kqlValue';
     case 'recentSearch':
       return 'search';
     case 'conjunction':
-      return 'dqlSelector';
+      return 'kqlSelector';
     case 'operator':
-      return 'dqlOperand';
+      return 'kqlOperand';
     default:
       throw new Error(`Unknown type: ${type}`);
   }

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/table.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`Table prevents saved objects from being deleted 1`] = `
               Object {
                 "data-test-subj": "savedObjectsTableAction-relationships",
                 "description": "View the relationships this saved object has to other saved objects",
-                "icon": "dqlSelector",
+                "icon": "kqlSelector",
                 "name": "Relationships",
                 "onClick": [Function],
                 "type": "icon",
@@ -373,7 +373,7 @@ exports[`Table should render normally 1`] = `
               Object {
                 "data-test-subj": "savedObjectsTableAction-relationships",
                 "description": "View the relationships this saved object has to other saved objects",
-                "icon": "dqlSelector",
+                "icon": "kqlSelector",
                 "name": "Relationships",
                 "onClick": [Function],
                 "type": "icon",

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
@@ -294,7 +294,7 @@ export class Table extends PureComponent<TableProps, TableState> {
               }
             ),
             type: 'icon',
-            icon: 'dqlSelector',
+            icon: 'kqlSelector',
             onClick: (object) => onShowRelationships(object),
             'data-test-subj': 'savedObjectsTableAction-relationships',
           },


### PR DESCRIPTION
### Description
Icons were renamed from `kql` to `dql` which doesn't exist. Restoring the
correct icon fixes the error in the browser as well.

Some minor spacing issues in OpenSearch Dashboards fixed by updating the
title and replacing with Overview.

If default route was stored as kibana_overview, the default route will
modified in code to the updated opensearch_dashboards_overview.

Closed PR for reference https://github.com/opensearch-project/OpenSearch-Dashboards/pull/437

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/428
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/431

Issues Partially Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/334
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 