### PR TITLE
[Build] fix overview default route

### DIFF
--- a/src/core/server/core_app/core_app.ts
+++ b/src/core/server/core_app/core_app.ts
@@ -52,7 +52,10 @@ export class CoreApp {
     const httpSetup = coreSetup.http;
     const router = httpSetup.createRouter('/');
     router.get({ path: '/', validate: false }, async (context, req, res) => {
-      const defaultRoute = await context.core.uiSettings.client.get<string>('defaultRoute');
+      let defaultRoute = await context.core.uiSettings.client.get<string>('defaultRoute');
+      // TODO: [RENAMEME] Temporary code for backwards compatibility.
+      // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/334
+      defaultRoute = defaultRoute.replace('kibana_overview', 'opensearch_dashboards_overview');
       const basePath = httpSetup.basePath.get(req);
       const url = `${basePath}${defaultRoute}`;
 


### PR DESCRIPTION
### Description
If default route was stored as kibana_overview, the default route will
modified in code to the updated opensearch_dashboards_overview.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/334
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 