### PR TITLE
Add proper dependency resolution for url-parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "**/react-syntax-highlighter/**/highlight.js": "^10.4.1",
     "**/request": "^2.88.2",
     "**/trim": "0.0.3",
-    "**/typescript": "4.0.2"
+    "**/typescript": "4.0.2",
+    "**/url-parse": "^1.5.1"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -24219,7 +24219,7 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3, url-parse@^1.4.7:
+url-parse@^1.4.3, url-parse@^1.4.7, url-parse@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
   integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==


### PR DESCRIPTION
Signed-off-by: Tommy Markley <markleyt@amazon.com>

### Description
Dependabot bumped url-parse from 1.4.7 to 1.5.1 in #343, but it edited the yarn.lock file directly. This is not the recommended short- or long-term solution. url-parse is a downstream dependency of @elastic/eui, so this line should be removed after that dependency is upgraded.

TODO: will be submitting similar PRs for other Dependabot changes, testing them all together, and providing the test results.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 