### PR TITLE
Add proper dependency resolution for locutus

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "**/isomorphic-fetch/node-fetch": "^2.6.1",
     "**/istanbul-instrumenter-loader/schema-utils": "1.0.0",
     "**/load-grunt-config/lodash": "^4.17.20",
+    "**/locutus": "^2.0.14",
     "**/minimist": "^1.2.5",
     "**/node-jose/node-forge": "^0.10.0",
     "**/prismjs": "1.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16054,12 +16054,10 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-locutus@^2.0.5:
-  version "2.0.14"
-  resolved "https://registry.yarnpkg.com/locutus/-/locutus-2.0.14.tgz#53d259ac7200b0621ed4e5604b6c49993415a455"
-  integrity sha512-0H1o1iHNEp3kJ5rW57bT/CAP5g6Qm0Zd817Wcx2+rOMTYyIJoc482Ja1v9dB6IUjwvWKcBNdYi7x2lRXtlJ3bA==
-  dependencies:
-    es6-promise "^4.2.5"
+locutus@^2.0.14, locutus@^2.0.5:
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/locutus/-/locutus-2.0.15.tgz#d75b9100713aaaf30be8b38ed6543910498c0db0"
+  integrity sha512-2xWC4RkoAoCVXEb/stzEgG1TNgd+mrkLBj6TuEDNyUoKeQ2XzDTyJUC23sMiqbL6zJmJSP3w59OZo+zc4IBOmA==
 
 lodash-es@^4.17.11:
   version "4.17.15"


### PR DESCRIPTION
Signed-off-by: Tommy Markley <markleyt@amazon.com>

### Description
Dependabot bumped locutus from 2.0.10 to 2.0.14 in #348, but it edited the lockfile directly. This is not the recommended short- or long-term solution.

TODO: will be submitting similar PRs for other Dependabot changes, testing them all together, and providing the test results.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 