### PR TITLE
Add proper dependency resolution for dns-packet

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "resolutions": {
     "**/@types/node": ">=10.17.17 <10.20.0",
     "**/cross-fetch/node-fetch": "^2.6.1",
+    "**/dns-packet": "^1.3.4",
     "**/fast-deep-equal": "^3.1.1",
     "**/graphql-toolkit/lodash": "^4.17.15",
     "**/hoist-non-react-statics": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9161,7 +9161,7 @@ dns-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
-dns-packet@^1.3.1:
+dns-packet@^1.3.1, dns-packet@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.4.tgz#e3455065824a2507ba886c55a89963bb107dec6f"
   integrity sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==


### PR DESCRIPTION
### Description
Dependabot bumped the dependency from 1.3.1 to 1.3.4 in #381, but it edited the yarn.lock file directly. This is not the recommended short- or long-term solution.

Signed-off-by: Tommy Markley <markleyt@amazon.com>

```
$ yarn why dns-packet
yarn why v1.22.10
[1/4] Why do we have the module "dns-packet"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "dns-packet@1.3.4"
info Reasons this module exists
   - "_project_#@osd#ui-framework#webpack-dev-server#bonjour#multicast-dns" depends on it
   - Hoisted from "_project_#@osd#ui-framework#webpack-dev-server#bonjour#multicast-dns#dns-packet"
info Disk size without dependencies: "44KB"
info Disk size with unique dependencies: "152KB"
info Disk size with transitive dependencies: "152KB"
info Number of shared dependencies: 2
Done in 1.48s.
```

The longer-term solution involves upgrading `webpack` and `webpack-dev-server`.

### Testing
Changes for #456, #457, #458, #460, #461, and #476 were merged into the same branch and tested together. All tests passed.

#### Unit
```
$ yarn test:jest
...
Test Suites: 23 skipped, 1411 passed, 1411 of 1434 total
Tests:       256 skipped, 9 todo, 10364 passed, 10629 total
Snapshots:   2363 passed, 2363 total
Time:        156.76 s
Ran all test suites.
Done in 159.62s.
```

#### Integration
```
$ yarn test:jest_integration
...
Test Suites: 2 skipped, 48 passed, 48 of 50 total
Tests:       19 skipped, 418 passed, 437 total
Snapshots:   73 passed, 73 total
Time:        222.992 s
Ran all test suites.
Done in 225.23s.
```

#### Functional
![Screen Shot 2021-06-10 at 10 31 39 PM](https://user-images.githubusercontent.com/5437176/121630363-a03df780-ca42-11eb-991d-a3d629341a8e.png)
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 