### PR TITLE
Add proper dependency resolution for ssri

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "**/react-syntax-highlighter": "^15.3.1",
     "**/react-syntax-highlighter/**/highlight.js": "^10.4.1",
     "**/request": "^2.88.2",
+    "**/ssri": "^6.0.2",
     "**/trim": "^0.0.3",
     "**/typescript": "4.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -21966,27 +21966,12 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-ssri@^6.0.1:
+ssri@^6.0.1, ssri@^6.0.2, ssri@^7.0.0, ssri@^8.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
   integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
   dependencies:
     figgy-pudding "^3.5.1"
-
-ssri@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-7.1.0.tgz#92c241bf6de82365b5c7fb4bd76e975522e1294d"
-  integrity sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==
-  dependencies:
-    figgy-pudding "^3.5.1"
-    minipass "^3.1.1"
-
-ssri@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.0.tgz#79ca74e21f8ceaeddfcb4b90143c458b8d988808"
-  integrity sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==
-  dependencies:
-    minipass "^3.1.1"
 
 stable@^0.1.8:
   version "0.1.8"


### PR DESCRIPTION
### Description
Dependabot bumped the dependency from 6.0.1 to 6.0.2 in #332, but it edited the yarn.lock file directly. This left older versions of the dependency in the lockfile.

Signed-off-by: Tommy Markley <markleyt@amazon.com>

```
$ yarn why ssri
yarn why v1.22.10
[1/4] Why do we have the module "ssri"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "ssri@8.0.0"
info Reasons this module exists
   - "_project_#cacache" depends on it
   - Hoisted from "_project_#cacache#ssri"
info Disk size without dependencies: "56KB"
info Disk size with unique dependencies: "104KB"
info Disk size with transitive dependencies: "136KB"
info Number of shared dependencies: 2
=> Found "terser-webpack-plugin#ssri@7.1.0"
info Reasons this module exists
   - "_project_#@osd#optimizer#terser-webpack-plugin#cacache" depends on it
   - Hoisted from "_project_#@osd#optimizer#terser-webpack-plugin#cacache#ssri"
info Disk size without dependencies: "52KB"
info Disk size with unique dependencies: "132KB"
info Disk size with transitive dependencies: "164KB"
info Number of shared dependencies: 3
=> Found "webpack#ssri@6.0.2"
info Reasons this module exists
   - "_project_#@osd#monaco#webpack#terser-webpack-plugin#cacache" depends on it
   - Hoisted from "_project_#@osd#monaco#webpack#terser-webpack-plugin#cacache#ssri"
Done in 1.49s.
```

Longer term solution involves upgrading `webpack` for the `@osd/optimizer` and `@osd/monaco` packages and remove the manual resolution.

### Testing
Changes for #456, #457, #458, #460, #461, and #476 were merged into the same branch and tested together. All tests passed.

#### Unit
```
$ yarn test:jest
...
Test Suites: 23 skipped, 1411 passed, 1411 of 1434 total
Tests:       256 skipped, 9 todo, 10364 passed, 10629 total
Snapshots:   2363 passed, 2363 total
Time:        156.76 s
Ran all test suites.
Done in 159.62s.
```

#### Integration
```
$ yarn test:jest_integration
...
Test Suites: 2 skipped, 48 passed, 48 of 50 total
Tests:       19 skipped, 418 passed, 437 total
Snapshots:   73 passed, 73 total
Time:        222.992 s
Ran all test suites.
Done in 225.23s.
```

#### Functional
![Screen Shot 2021-06-10 at 10 31 39 PM](https://user-images.githubusercontent.com/5437176/121630363-a03df780-ca42-11eb-991d-a3d629341a8e.png)
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 