### PR TITLE
Add proper dependency resolution for locutus

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "**/isomorphic-fetch/node-fetch": "^2.6.1",
     "**/istanbul-instrumenter-loader/schema-utils": "^1.0.0",
     "**/load-grunt-config/lodash": "^4.17.20",
+    "**/locutus": "^2.0.14",
     "**/minimist": "^1.2.5",
     "**/node-jose/node-forge": "^0.10.0",
     "**/prismjs": "^1.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15912,12 +15912,10 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-locutus@^2.0.5:
-  version "2.0.14"
-  resolved "https://registry.yarnpkg.com/locutus/-/locutus-2.0.14.tgz#53d259ac7200b0621ed4e5604b6c49993415a455"
-  integrity sha512-0H1o1iHNEp3kJ5rW57bT/CAP5g6Qm0Zd817Wcx2+rOMTYyIJoc482Ja1v9dB6IUjwvWKcBNdYi7x2lRXtlJ3bA==
-  dependencies:
-    es6-promise "^4.2.5"
+locutus@^2.0.14, locutus@^2.0.5:
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/locutus/-/locutus-2.0.15.tgz#d75b9100713aaaf30be8b38ed6543910498c0db0"
+  integrity sha512-2xWC4RkoAoCVXEb/stzEgG1TNgd+mrkLBj6TuEDNyUoKeQ2XzDTyJUC23sMiqbL6zJmJSP3w59OZo+zc4IBOmA==
 
 lodash-es@^4.17.11:
   version "4.17.15"


### PR DESCRIPTION
### Description
Dependabot bumped locutus from 2.0.10 to 2.0.14 in #348, but it edited the lockfile directly. This is not the recommended short- or long-term solution.

Signed-off-by: Tommy Markley <markleyt@amazon.com>

```
$ yarn why locutus
yarn why v1.22.10
[1/4] Why do we have the module "locutus"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "locutus@2.0.14"
info Reasons this module exists
   - "_project_#@osd#ui-framework#yo#yeoman-doctor#twig" depends on it
   - Hoisted from "_project_#@osd#ui-framework#yo#yeoman-doctor#twig#locutus"
info Disk size without dependencies: "4.11MB"
info Disk size with unique dependencies: "4.49MB"
info Disk size with transitive dependencies: "4.49MB"
info Number of shared dependencies: 1
Done in 1.53s.
```

In order to upgrade to the latest version of `yo`, we need to upgrade to at least Node.js v12.

### Testing
Changes for #456, #457, #458, #460, #461, and #476 were merged into the same branch and tested together. All tests passed.

#### Unit
```
$ yarn test:jest
...
Test Suites: 23 skipped, 1411 passed, 1411 of 1434 total
Tests:       256 skipped, 9 todo, 10364 passed, 10629 total
Snapshots:   2363 passed, 2363 total
Time:        156.76 s
Ran all test suites.
Done in 159.62s.
```

#### Integration
```
$ yarn test:jest_integration
...
Test Suites: 2 skipped, 48 passed, 48 of 50 total
Tests:       19 skipped, 418 passed, 437 total
Snapshots:   73 passed, 73 total
Time:        222.992 s
Ran all test suites.
Done in 225.23s.
```

#### Functional
![Screen Shot 2021-06-10 at 10 31 39 PM](https://user-images.githubusercontent.com/5437176/121630363-a03df780-ca42-11eb-991d-a3d629341a8e.png)
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 