### PR TITLE
Add proper dependency resolution for immer

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "**/fast-deep-equal": "^3.1.1",
     "**/graphql-toolkit/lodash": "^4.17.15",
     "**/hoist-non-react-statics": "^3.3.2",
+    "**/immer": "^8.0.1",
     "**/isomorphic-fetch/node-fetch": "^2.6.1",
     "**/istanbul-instrumenter-loader/schema-utils": "^1.0.0",
     "**/load-grunt-config/lodash": "^4.17.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13181,12 +13181,7 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immer@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
-  integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
-
-immer@^8.0.1:
+immer@1.10.0, immer@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==


### PR DESCRIPTION
### Description
Dependabot bumped immer from 1.10.0 to 8.0.1 in #433, but it did not add a resolution to prevent older versions from remaining in the lockfile.

Signed-off-by: Tommy Markley <markleyt@amazon.com>

```
$ yarn why immer
yarn why v1.22.10
[1/4] Why do we have the module "immer"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "immer@8.0.1"
info Has been hoisted to "immer"
info Reasons this module exists
   - "workspace-aggregator-62005fd5-e986-4599-9851-789db848ca40" depends on it
   - Specified in "devDependencies"
   - Hoisted from "_project_#immer"
info Disk size without dependencies: "1.02MB"
info Disk size with unique dependencies: "1.02MB"
info Disk size with transitive dependencies: "1.02MB"
info Number of shared dependencies: 0
=> Found "react-dev-utils#immer@1.10.0"
info This module exists because "_project_#@osd#storybook#@storybook#react#react-dev-utils" depends on it.
info Disk size without dependencies: "268KB"
info Disk size with unique dependencies: "268KB"
info Disk size with transitive dependencies: "268KB"
info Number of shared dependencies: 0
Done in 1.51s.
```

The longer-term solution is to bump the storybook dependencies.

### Testing
Changes for #456, #457, #458, #460, #461, and #476 were merged into the same branch and tested together. All tests passed.

#### Unit
```
$ yarn test:jest
...
Test Suites: 23 skipped, 1411 passed, 1411 of 1434 total
Tests:       256 skipped, 9 todo, 10364 passed, 10629 total
Snapshots:   2363 passed, 2363 total
Time:        156.76 s
Ran all test suites.
Done in 159.62s.
```

#### Integration
```
$ yarn test:jest_integration
...
Test Suites: 2 skipped, 48 passed, 48 of 50 total
Tests:       19 skipped, 418 passed, 437 total
Snapshots:   73 passed, 73 total
Time:        222.992 s
Ran all test suites.
Done in 225.23s.
```

#### Functional
![Screen Shot 2021-06-10 at 10 31 39 PM](https://user-images.githubusercontent.com/5437176/121630363-a03df780-ca42-11eb-991d-a3d629341a8e.png)
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 