### PR TITLE
Temporarily remove Tutorials from "Add Data" page

### DIFF
--- a/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -25,26 +25,6 @@ exports[`AddData render 1`] = `
         </h2>
       </EuiTitle>
     </EuiFlexItem>
-    <EuiFlexItem
-      className="homDataAdd__actions"
-      grow={false}
-    >
-      <div>
-        <EuiButtonEmpty
-          className="homDataAdd__actionButton"
-          flush="left"
-          href="#/tutorial_directory/sampleData"
-          iconType="visTable"
-          size="xs"
-        >
-          <FormattedMessage
-            defaultMessage="Try our sample data"
-            id="home.addData.sampleDataButtonLabel"
-            values={Object {}}
-          />
-        </EuiButtonEmpty>
-      </div>
-    </EuiFlexItem>
   </EuiFlexGroup>
   <EuiSpacer
     size="m"
@@ -56,7 +36,7 @@ exports[`AddData render 1`] = `
       key="home_tutorial_directory"
     >
       <Synopsis
-        description="Ingest data from popular apps and services."
+        description="Try our sample data."
         iconType="indexOpen"
         id="home_tutorial_directory"
         isBeta={false}

--- a/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`AddData render 1`] = `
       key="home_tutorial_directory"
     >
       <Synopsis
-        description="Try our sample data."
+        description="Get started with sample data, visualizations, and dashboards."
         iconType="indexOpen"
         id="home_tutorial_directory"
         isBeta={false}

--- a/src/plugins/home/public/application/components/add_data/add_data.test.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.test.tsx
@@ -49,7 +49,7 @@ const addBasePathMock = jest.fn((path: string) => (path ? path : 'path'));
 const mockFeatures = [
   {
     category: 'data',
-    description: 'Try our sample data.',
+    description: 'Get started with sample data, visualizations, and dashboards.',
     showOnHomePage: true,
     icon: 'indexOpen',
     id: 'home_tutorial_directory',

--- a/src/plugins/home/public/application/components/add_data/add_data.test.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.test.tsx
@@ -49,7 +49,7 @@ const addBasePathMock = jest.fn((path: string) => (path ? path : 'path'));
 const mockFeatures = [
   {
     category: 'data',
-    description: 'Ingest data from popular apps and services.',
+    description: 'Try our sample data.',
     showOnHomePage: true,
     icon: 'indexOpen',
     id: 'home_tutorial_directory',

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -32,7 +32,7 @@
 
 import React, { FC } from 'react';
 import PropTypes from 'prop-types';
-import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 // @ts-expect-error untyped service
 import { FeatureCatalogueEntry } from '../../services';
@@ -54,23 +54,6 @@ export const AddData: FC<Props> = ({ addBasePath, features }) => (
             <FormattedMessage id="home.addData.sectionTitle" defaultMessage="Ingest your data" />
           </h2>
         </EuiTitle>
-      </EuiFlexItem>
-
-      <EuiFlexItem className="homDataAdd__actions" grow={false}>
-        <div>
-          <EuiButtonEmpty
-            className="homDataAdd__actionButton"
-            flush="left"
-            href="#/tutorial_directory/sampleData"
-            iconType="visTable"
-            size="xs"
-          >
-            <FormattedMessage
-              id="home.addData.sampleDataButtonLabel"
-              defaultMessage="Try our sample data"
-            />
-          </EuiButtonEmpty>
-        </div>
       </EuiFlexItem>
     </EuiFlexGroup>
 

--- a/src/plugins/home/public/application/components/tutorial_directory.js
+++ b/src/plugins/home/public/application/components/tutorial_directory.js
@@ -66,9 +66,8 @@ class TutorialDirectoryUi extends React.Component {
   constructor(props) {
     super(props);
 
-    // temporarily set tabs to empty due to no available data instructions
-    // to users. this part will be added back once we have instructions
-    // and sample code snippets that can instruct users to add data
+    // TODO: Enable the tabs once we have instructions
+    // and sample code snippets to instruct users to add data
     this.tabs = [
       //{
       //  id: ALL_TAB_ID,

--- a/src/plugins/home/public/application/components/tutorial_directory.js
+++ b/src/plugins/home/public/application/components/tutorial_directory.js
@@ -68,43 +68,7 @@ class TutorialDirectoryUi extends React.Component {
 
     // TODO: Enable the tabs once we have instructions
     // and sample code snippets to instruct users to add data
-    this.tabs = [
-      //{
-      //  id: ALL_TAB_ID,
-      //  name: this.props.intl.formatMessage({
-      //    id: 'home.tutorial.tabs.allTitle',
-      //    defaultMessage: 'All',
-      //  }),
-      //},
-      //{
-      //  id: 'logging',
-      //  name: this.props.intl.formatMessage({
-      //    id: 'home.tutorial.tabs.loggingTitle',
-      //    defaultMessage: 'Logs',
-      //  }),
-      //},
-      //{
-      //  id: 'metrics',
-      //  name: this.props.intl.formatMessage({
-      //    id: 'home.tutorial.tabs.metricsTitle',
-      //    defaultMessage: 'Metrics',
-      //  }),
-      //},
-      //{
-      //  id: 'security',
-      //  name: this.props.intl.formatMessage({
-      //    id: 'home.tutorial.tabs.securitySolutionTitle',
-      //    defaultMessage: 'Security',
-      //  }),
-      //},
-      //{
-      //  id: SAMPLE_DATA_TAB_ID,
-      //  name: this.props.intl.formatMessage({
-      //    id: 'home.tutorial.tabs.sampleDataTitle',
-      //    defaultMessage: 'Sample data',
-      // }),
-      //},
-    ];
+    this.tabs = [];
 
     let openTab = SAMPLE_DATA_TAB_ID;
     if (

--- a/src/plugins/home/public/application/components/tutorial_directory.js
+++ b/src/plugins/home/public/application/components/tutorial_directory.js
@@ -66,45 +66,48 @@ class TutorialDirectoryUi extends React.Component {
   constructor(props) {
     super(props);
 
+    // temporarily set tabs to empty due to no available data instructions
+    // to users. this part will be added back once we have instructions
+    // and sample code snippets that can instruct users to add data
     this.tabs = [
-      {
-        id: ALL_TAB_ID,
-        name: this.props.intl.formatMessage({
-          id: 'home.tutorial.tabs.allTitle',
-          defaultMessage: 'All',
-        }),
-      },
-      {
-        id: 'logging',
-        name: this.props.intl.formatMessage({
-          id: 'home.tutorial.tabs.loggingTitle',
-          defaultMessage: 'Logs',
-        }),
-      },
-      {
-        id: 'metrics',
-        name: this.props.intl.formatMessage({
-          id: 'home.tutorial.tabs.metricsTitle',
-          defaultMessage: 'Metrics',
-        }),
-      },
-      {
-        id: 'security',
-        name: this.props.intl.formatMessage({
-          id: 'home.tutorial.tabs.securitySolutionTitle',
-          defaultMessage: 'Security',
-        }),
-      },
-      {
-        id: SAMPLE_DATA_TAB_ID,
-        name: this.props.intl.formatMessage({
-          id: 'home.tutorial.tabs.sampleDataTitle',
-          defaultMessage: 'Sample data',
-        }),
-      },
+      //{
+      //  id: ALL_TAB_ID,
+      //  name: this.props.intl.formatMessage({
+      //    id: 'home.tutorial.tabs.allTitle',
+      //    defaultMessage: 'All',
+      //  }),
+      //},
+      //{
+      //  id: 'logging',
+      //  name: this.props.intl.formatMessage({
+      //    id: 'home.tutorial.tabs.loggingTitle',
+      //    defaultMessage: 'Logs',
+      //  }),
+      //},
+      //{
+      //  id: 'metrics',
+      //  name: this.props.intl.formatMessage({
+      //    id: 'home.tutorial.tabs.metricsTitle',
+      //    defaultMessage: 'Metrics',
+      //  }),
+      //},
+      //{
+      //  id: 'security',
+      //  name: this.props.intl.formatMessage({
+      //    id: 'home.tutorial.tabs.securitySolutionTitle',
+      //    defaultMessage: 'Security',
+      //  }),
+      //},
+      //{
+      //  id: SAMPLE_DATA_TAB_ID,
+      //  name: this.props.intl.formatMessage({
+      //    id: 'home.tutorial.tabs.sampleDataTitle',
+      //    defaultMessage: 'Sample data',
+      // }),
+      //},
     ];
 
-    let openTab = ALL_TAB_ID;
+    let openTab = SAMPLE_DATA_TAB_ID;
     if (
       props.openTab &&
       this.tabs.some((tab) => {
@@ -284,7 +287,7 @@ class TutorialDirectoryUi extends React.Component {
               <h1>
                 <FormattedMessage
                   id="home.tutorial.addDataToOpenSearchDashboardsTitle"
-                  defaultMessage="Add data"
+                  defaultMessage="Add sample data"
                 />
               </h1>
             </EuiTitle>

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -137,7 +137,7 @@ export class HomePublicPlugin
         defaultMessage: 'Add sample data',
       }),
       description: i18n.translate('home.tutorialDirectory.featureCatalogueDescription', {
-        defaultMessage: 'Try our sample data.',
+        defaultMessage: 'Get started with sample data, visualizations, and dashboards.',
       }),
       icon: 'indexOpen',
       showOnHomePage: true,

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -134,10 +134,10 @@ export class HomePublicPlugin
     featureCatalogue.register({
       id: 'home_tutorial_directory',
       title: i18n.translate('home.tutorialDirectory.featureCatalogueTitle', {
-        defaultMessage: 'Add data',
+        defaultMessage: 'Add sample data',
       }),
       description: i18n.translate('home.tutorialDirectory.featureCatalogueDescription', {
-        defaultMessage: 'Ingest data from popular apps and services.',
+        defaultMessage: 'Try our sample data.',
       }),
       icon: 'indexOpen',
       showOnHomePage: true,

--- a/src/plugins/opensearch_dashboards_overview/public/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/opensearch_dashboards_overview/public/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -25,28 +25,6 @@ exports[`AddData render 1`] = `
         </h2>
       </EuiTitle>
     </EuiFlexItem>
-    <EuiFlexItem
-      className="osdOverviewDataAdd__actions"
-      grow={false}
-    >
-      <RedirectAppLinks>
-        <div>
-          <EuiButtonEmpty
-            className="osdOverviewDataAdd__actionButton"
-            flush="left"
-            href="/app/home#/tutorial_directory/sampleData"
-            iconType="visTable"
-            size="xs"
-          >
-            <FormattedMessage
-              defaultMessage="Try our sample data"
-              id="opensearchDashboardsOverview.addData.sampleDataButtonLabel"
-              values={Object {}}
-            />
-          </EuiButtonEmpty>
-        </div>
-      </RedirectAppLinks>
-    </EuiFlexItem>
   </EuiFlexGroup>
   <EuiSpacer
     size="m"
@@ -59,7 +37,7 @@ exports[`AddData render 1`] = `
     >
       <RedirectAppLinks>
         <Synopsis
-          description="Ingest data from popular apps and services."
+          description="Try our sample data."
           iconType="indexOpen"
           id="home_tutorial_directory"
           isBeta={false}

--- a/src/plugins/opensearch_dashboards_overview/public/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/opensearch_dashboards_overview/public/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`AddData render 1`] = `
     >
       <RedirectAppLinks>
         <Synopsis
-          description="Try our sample data."
+          description="Get started with sample data, visualizations, and dashboards."
           iconType="indexOpen"
           id="home_tutorial_directory"
           isBeta={false}

--- a/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.test.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.test.tsx
@@ -38,7 +38,7 @@ import { FeatureCatalogueCategory } from 'src/plugins/home/public';
 const mockFeatures = [
   {
     category: FeatureCatalogueCategory.DATA,
-    description: 'Try our sample data.',
+    description: 'Get started with sample data, visualizations, and dashboards.',
     showOnHomePage: true,
     icon: 'indexOpen',
     id: 'home_tutorial_directory',

--- a/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.test.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.test.tsx
@@ -38,7 +38,7 @@ import { FeatureCatalogueCategory } from 'src/plugins/home/public';
 const mockFeatures = [
   {
     category: FeatureCatalogueCategory.DATA,
-    description: 'Ingest data from popular apps and services.',
+    description: 'Try our sample data.',
     showOnHomePage: true,
     icon: 'indexOpen',
     id: 'home_tutorial_directory',

--- a/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.tsx
@@ -32,7 +32,7 @@
 
 import React, { FC } from 'react';
 import PropTypes from 'prop-types';
-import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { CoreStart } from 'opensearch-dashboards/public';
 import {
@@ -65,25 +65,6 @@ export const AddData: FC<Props> = ({ addBasePath, features }) => {
               />
             </h2>
           </EuiTitle>
-        </EuiFlexItem>
-
-        <EuiFlexItem className="osdOverviewDataAdd__actions" grow={false}>
-          <RedirectAppLinks application={application}>
-            <div>
-              <EuiButtonEmpty
-                className="osdOverviewDataAdd__actionButton"
-                flush="left"
-                href={addBasePath('/app/home#/tutorial_directory/sampleData')}
-                iconType="visTable"
-                size="xs"
-              >
-                <FormattedMessage
-                  id="opensearchDashboardsOverview.addData.sampleDataButtonLabel"
-                  defaultMessage="Try our sample data"
-                />
-              </EuiButtonEmpty>
-            </div>
-          </RedirectAppLinks>
         </EuiFlexItem>
       </EuiFlexGroup>
 

--- a/test/functional/apps/home/_add_data.js
+++ b/test/functional/apps/home/_add_data.js
@@ -37,12 +37,12 @@ export default function ({ getService, getPageObjects }) {
   const PageObjects = getPageObjects(['common', 'header', 'home', 'dashboard']);
 
   describe('add data tutorials', function describeIndexTests() {
-    it('directory should display registered tutorials', async () => {
+    it('directory should not display registered tutorials', async () => {
       await PageObjects.common.navigateToUrl('home', 'tutorial_directory', { useActualUrl: true });
       await PageObjects.header.waitUntilLoadingHasFinished();
       await retry.try(async () => {
         const tutorialExists = await PageObjects.home.doesSynopsisExist('netflowlogs');
-        expect(tutorialExists).to.be(true);
+        expect(tutorialExists).to.be(false);
       });
     });
   });


### PR DESCRIPTION
Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Description
Currently we don't have instructions/code samples/docs  that instruct users to use apps to add data or download agents from `artifacts.opensearch.org`. Therefore, we decide to temporarily remove tutorials from `add data` page.

There are 3 places cx can enter into `add data` page. 2 of them is on home page (upper left and `Ingest your data` section) and 1 on overview page. This PR remove the `add data` page and only keep `try sample data`. Now the home page, overview page and add data page look like below:

1) Home page:
<img width="1121" alt="Screen Shot 2021-06-08 at 5 11 17 PM" src="https://user-images.githubusercontent.com/79961084/121273517-4cce7c80-c87d-11eb-82d0-6f4b10aea13f.png">


2)Overview page:
<img width="1090" alt="Screen Shot 2021-06-08 at 5 09 53 PM" src="https://user-images.githubusercontent.com/79961084/121273886-1fce9980-c87e-11eb-8fff-a75b644dd318.png">


3)When click `add data` or `Add sample data `, all goes to add data page:
<img width="1128" alt="Screen Shot 2021-06-08 at 5 11 41 PM" src="https://user-images.githubusercontent.com/79961084/121273906-28bf6b00-c87e-11eb-8f4b-df47a23c5bc7.png">



 
### Issues Resolved
[#426 ](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/426)


### Tests
1)Unit
<img width="538" alt="Screen Shot 2021-06-08 at 4 25 13 PM" src="https://user-images.githubusercontent.com/79961084/121274121-a7b4a380-c87e-11eb-8044-0041fcd30983.png">
2)Integration
<img width="495" alt="Screen Shot 2021-06-08 at 4 42 11 PM" src="https://user-images.githubusercontent.com/79961084/121274107-9d92a500-c87e-11eb-93cb-08226416282b.png">
3)Functional
<img width="1765" alt="Screen Shot 2021-06-08 at 7 38 58 PM" src="https://user-images.githubusercontent.com/79961084/121284361-9759f400-c891-11eb-91bb-86acc2159bd4.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 