### PR TITLE
[Tests] updated artifact script

### DIFF
--- a/packages/osd-opensearch-archiver/src/lib/docs/__tests__/generate_doc_records_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/docs/__tests__/generate_doc_records_stream.ts
@@ -104,7 +104,7 @@ describe('opensearchArchiver: createGenerateDocRecordsStream()', () => {
         await delay(200);
         return {
           _scroll_id: 'index1ScrollId',
-          hits: { total: 2, hits: [{ _id: 1, _index: '.opensearch_dashboards_foo' }] },
+          hits: { total: 2, hits: [{ _id: 1, _index: '.opensearch_dashboards_1' }] },
         };
       },
       async (name, params) => {

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/integration_tests/create_or_upgrade.test.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/integration_tests/create_or_upgrade.test.ts
@@ -95,8 +95,7 @@ describe('createOrUpgradeSavedConfig()', () => {
     await osd.stop();
   }, 30000);
 
-  // TODO: [RENAMEME] Test can be enabled once there is a valid snapshot URL
-  xit('upgrades the previous version on each increment', async function () {
+  it('upgrades the previous version on each increment', async function () {
     // ------------------------------------
     // upgrade to 5.4.0
     await createOrUpgradeSavedConfig({

--- a/src/core/server/ui_settings/integration_tests/index.test.ts
+++ b/src/core/server/ui_settings/integration_tests/index.test.ts
@@ -36,8 +36,7 @@ import { docExistsSuite } from './doc_exists';
 import { docMissingSuite } from './doc_missing';
 import { docMissingAndIndexReadOnlySuite } from './doc_missing_and_index_read_only';
 
-// TODO: [RENAMEME] Test can be enabled once there is a valid snapshot URL
-xdescribe('uiSettings/routes', function () {
+describe('uiSettings/routes', function () {
   jest.setTimeout(10000);
 
   beforeAll(startServers);


### PR DESCRIPTION
### Description
Updating artifact to enable running integration tests and functional
tests to pull an artifact from the current hosted distributions.

At the time of this commit, there is not manifest hosted but there are
static links which can have an unknown amount of RC versions if the
GA snapshot does not exist for that version. But the assumption
is that it will not be too high.

Deprecating the previous implementation but we can remove that in a
future iteration. Wanted to leave that available incase others use
that for custom manifests.

Enable tests that depended on snapshots as well.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/242
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/19
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 