### PR TITLE
Remove Beta label from bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -2,7 +2,7 @@
 name: 🐛 Bug report
 about: Create a report to help us improve
 title: "[BUG]"
-labels: 'bug, untriaged, Beta'
+labels: 'bug, untriaged'
 assignees: ''
 ---
 


### PR DESCRIPTION
Signed-off-by: Tommy Markley <markleyt@amazon.com>

### Description
`Beta` is no longer relevant.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 