### PR TITLE
[Test] Enable schema_error.test.ts

### DIFF
--- a/packages/osd-config-schema/src/errors/__snapshots__/schema_error.test.ts.snap
+++ b/packages/osd-config-schema/src/errors/__snapshots__/schema_error.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`includes stack 1`] = `
+"Error: test
+    at Object.<anonymous>.it (packages/osd-config-schema/src/errors/schema_error.test.ts:57:11)
+    at new Promise (<anonymous>)"
+`;

--- a/packages/osd-config-schema/src/errors/schema_error.test.ts
+++ b/packages/osd-config-schema/src/errors/schema_error.test.ts
@@ -52,11 +52,7 @@ export const cleanStack = (stack: string) =>
     })
     .join('\n');
 
-// TODO This is skipped because it fails depending on Node version. That might
-// not be a problem, but I think we should wait with including this test until
-// we've made a proper decision around error handling in the new platform, see
-// https://github.com/elastic/kibana/issues/12947
-test.skip('includes stack', () => {
+it('includes stack', () => {
   try {
     throw new SchemaError('test');
   } catch (e) {


### PR DESCRIPTION
Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Description
This is skipped because in 2017 there is no decision around error handling in the new platform. We can enable the unit test for error handling. 

The error message is:
```
    { Error: test
        at Object.<anonymous>.it (/home/anan/work/OpenSearch-Dashboards/packages/osd-config-schema/src/errors/schema_error.test.ts:61:11)
        at Object.asyncJestTest (/home/anan/work/OpenSearch-Dashboards/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:106:37)
        at resolve (/home/anan/work/OpenSearch-Dashboards/node_modules/jest-jasmine2/build/queueRunner.js:45:12)
        at new Promise (<anonymous>)
        at mapper (/home/anan/work/OpenSearch-Dashboards/node_modules/jest-jasmine2/build/queueRunner.js:28:19)
        at promise.then (/home/anan/work/OpenSearch-Dashboards/node_modules/jest-jasmine2/build/queueRunner.js:75:41)
        at process._tickCallback (internal/process/next_tick.js:68:7) cause: undefined }

      at Object.<anonymous>.it (packages/osd-config-schema/src/errors/schema_error.test.ts:63:13)
```

After clean and select, following message will be compare to snapshot
```
    Error: test
        at Object.<anonymous>.it (packages/osd-config-schema/src/errors/schema_error.test.ts:61:11)
        at new Promise (<anonymous>)
```

 
### Issues Resolved
[#486 ](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/486)

### Test results
unit test for schema_error.test.ts
```
$ node scripts/jest /packages/osd-config-schema/src/errors/schema_error.test.ts
 PASS  packages/osd-config-schema/src/errors/schema_error.test.ts
  ✓ includes stack (5 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        1.659 s
```

overall unit test:
```
Test Suites: 22 skipped, 1412 passed, 1412 of 1434 total
Tests:       257 skipped, 9 todo, 10358 passed, 10624 total
Snapshots:   2364 passed, 2364 total
Time:        44.997 s
```
integration test:
```
Test Suites: 50 passed, 50 total
Tests:       3 skipped, 434 passed, 437 total
Snapshots:   73 passed, 73 total
Time:        314.149 s
```

functional test: see below image
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 