### PR TITLE
[Test] Enable help.test.ts

### DIFF
--- a/packages/osd-dev-utils/src/run/help.test.ts
+++ b/packages/osd-dev-utils/src/run/help.test.ts
@@ -70,7 +70,7 @@ const barCommand: Command<any> = {
   usage: 'bar [...names]',
 };
 
-describe.skip('getHelp()', () => {
+describe('getHelp()', () => {
   it('returns the expected output', () => {
     expect(
       getHelp({
@@ -108,13 +108,16 @@ describe.skip('getHelp()', () => {
   });
 });
 
-describe.skip('getCommandLevelHelp()', () => {
+describe('getCommandLevelHelp()', () => {
   it('returns the expected output', () => {
     expect(
       getCommandLevelHelp({
         command: fooCommand,
         globalFlagHelp: `
           --global-flag      some flag that applies to all commands
+        `,
+        usage: `
+          node node_modules/jest-worker/build/workers/processChild.js
         `,
       })
     ).toMatchInlineSnapshot(`
@@ -154,7 +157,7 @@ describe.skip('getCommandLevelHelp()', () => {
   });
 });
 
-describe.skip('getHelpForAllCommands()', () => {
+describe('getHelpForAllCommands()', () => {
   it('returns the expected output', () => {
     expect(
       getHelpForAllCommands({


### PR DESCRIPTION
Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Description
Don't find any specific reasons to skip this unit test. Unit test for `getCommandLevelHelp` function passes no `usage `parameters. We can either 1) change the inline snapshot:
`node node_modules/jest-worker/build/workers/processChild.js foo [...names]` ---> `node scripts/jest foo [...names]`
 or 2) pass a `usage` parameter to match inline snapshot. No specific pros and cons between these two options.

This PR uses option 2) and passes a `usage` parameter to match inline snapshot.
 
### Issues Resolved
[#487  ](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/487)

### Test results
unit test for help.test.ts
```
$ node scripts/jest /packages/osd-dev-utils/src/run/help.test.ts
 PASS  packages/osd-dev-utils/src/run/help.test.ts
  getHelp()
    ✓ returns the expected output (5 ms)
  getCommandLevelHelp()
    ✓ returns the expected output (1 ms)
  getHelpForAllCommands()
    ✓ returns the expected output (1 ms)
```

overall unit test:
```
Test Suites: 22 skipped, 1412 passed, 1412 of 1434 total
Tests:       255 skipped, 9 todo, 10360 passed, 10624 total
Snapshots:   2366 passed, 2366 total
Time:        44.748 s
```
integration test:
```
Test Suites: 50 passed, 50 total
Tests:       3 skipped, 434 passed, 437 total
Snapshots:   73 passed, 73 total
Time:        327.176 s
```

functional test:
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 