### PR TITLE
[Build] deprecate renamed configurations

### DIFF
--- a/src/core/server/opensearch/opensearch_config.test.ts
+++ b/src/core/server/opensearch/opensearch_config.test.ts
@@ -39,18 +39,22 @@ import {
 import { applyDeprecations, configDeprecationFactory } from '@osd/config';
 import { OpenSearchConfig, config } from './opensearch_config';
 
-const CONFIG_PATH = 'opensearch';
+const DEFAULT_CONFIG_PATH = 'opensearch';
+const LEGACY_CONFIG_PATH = 'elasticsearch';
 
-const applyOpenSearchDeprecations = (settings: Record<string, any> = {}) => {
+const applyOpenSearchDeprecations = (
+  settings: Record<string, any> = {},
+  path = DEFAULT_CONFIG_PATH
+) => {
   const deprecations = config.deprecations!(configDeprecationFactory);
   const deprecationMessages: string[] = [];
   const _config: any = {};
-  _config[CONFIG_PATH] = settings;
+  _config[path] = settings;
   const migrated = applyDeprecations(
     _config,
     deprecations.map((deprecation) => ({
       deprecation,
-      path: CONFIG_PATH,
+      path,
     })),
     (msg) => deprecationMessages.push(msg)
   );
@@ -58,6 +62,10 @@ const applyOpenSearchDeprecations = (settings: Record<string, any> = {}) => {
     messages: deprecationMessages,
     migrated,
   };
+};
+
+const applyLegacyDeprecations = (settings: Record<string, any> = {}) => {
+  return applyOpenSearchDeprecations(settings, LEGACY_CONFIG_PATH);
 };
 
 test('set correct defaults', () => {
@@ -370,6 +378,168 @@ describe('deprecations', () => {
   it('does not log a warning if both ssl.key and ssl.certificate are set', () => {
     const { messages } = applyOpenSearchDeprecations({ ssl: { key: '', certificate: '' } });
     expect(messages).toEqual([]);
+  });
+
+  it('logs a warning if elasticsearch.sniffOnStart is set and opensearch.sniffOnStart is not', () => {
+    const { messages } = applyLegacyDeprecations({ sniffOnStart: true });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.sniffOnStart\\" is deprecated and has been replaced by \\"opensearch.sniffOnStart\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.sniffInterval is set and opensearch.sniffInterval is not', () => {
+    const { messages } = applyLegacyDeprecations({ sniffInterval: true });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.sniffInterval\\" is deprecated and has been replaced by \\"opensearch.sniffInterval\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.sniffOnConnectionFault is set and opensearch.sniffOnConnectionFault is not', () => {
+    const { messages } = applyLegacyDeprecations({ sniffOnConnectionFault: true });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.sniffOnConnectionFault\\" is deprecated and has been replaced by \\"opensearch.sniffOnConnectionFault\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.hosts is set and opensearch.hosts is not', () => {
+    const { messages } = applyLegacyDeprecations({ hosts: [''] });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.hosts\\" is deprecated and has been replaced by \\"opensearch.hosts\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.username is set and opensearch.username is not', () => {
+    const { messages } = applyLegacyDeprecations({ username: '' });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.username\\" is deprecated and has been replaced by \\"opensearch.username\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.password is set and opensearch.password is not', () => {
+    const { messages } = applyLegacyDeprecations({ password: '' });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.password\\" is deprecated and has been replaced by \\"opensearch.password\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.requestHeadersWhitelist is set and opensearch.requestHeadersWhitelist is not', () => {
+    const { messages } = applyLegacyDeprecations({ requestHeadersWhitelist: [''] });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.requestHeadersWhitelist\\" is deprecated and has been replaced by \\"opensearch.requestHeadersWhitelist\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.customHeaders is set and opensearch.customHeaders is not', () => {
+    const { messages } = applyLegacyDeprecations({ customHeaders: [''] });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.customHeaders\\" is deprecated and has been replaced by \\"opensearch.customHeaders\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.shardTimeout is set and opensearch.shardTimeout is not', () => {
+    const { messages } = applyLegacyDeprecations({ shardTimeout: 100 });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.shardTimeout\\" is deprecated and has been replaced by \\"opensearch.shardTimeout\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.requestTimeout is set and opensearch.requestTimeout is not', () => {
+    const { messages } = applyLegacyDeprecations({ requestTimeout: 100 });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.requestTimeout\\" is deprecated and has been replaced by \\"opensearch.requestTimeout\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.pingTimeout is set and opensearch.pingTimeout is not', () => {
+    const { messages } = applyLegacyDeprecations({ pingTimeout: 100 });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.pingTimeout\\" is deprecated and has been replaced by \\"opensearch.pingTimeout\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.logQueries is set and opensearch.logQueries is not', () => {
+    const { messages } = applyLegacyDeprecations({ logQueries: true });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.logQueries\\" is deprecated and has been replaced by \\"opensearch.logQueries\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.optimizedHealthcheckId is set and opensearch.optimizedHealthcheckId is not', () => {
+    const { messages } = applyLegacyDeprecations({ optimizedHealthcheckId: '' });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.optimizedHealthcheckId\\" is deprecated and has been replaced by \\"opensearch.optimizedHealthcheckId\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.ssl is set and opensearch.ssl is not', () => {
+    const { messages } = applyLegacyDeprecations({ ssl: true });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.ssl\\" is deprecated and has been replaced by \\"opensearch.ssl\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.ssl.certificate is set and opensearch.ssl.certificate is not', () => {
+    const { messages } = applyLegacyDeprecations({ ssl: { certificate: '' } });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.ssl\\" is deprecated and has been replaced by \\"opensearch.ssl\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.apiVersion is set and opensearch.apiVersion is not', () => {
+    const { messages } = applyLegacyDeprecations({ apiVersion: '' });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.apiVersion\\" is deprecated and has been replaced by \\"opensearch.apiVersion\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.healthCheck is set and opensearch.healthCheck is not', () => {
+    const { messages } = applyLegacyDeprecations({ healthCheck: true });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.healthCheck\\" is deprecated and has been replaced by \\"opensearch.healthCheck\\"",
+      ]
+    `);
+  });
+
+  it('logs a warning if elasticsearch.ignoreVersionMismatch is set and opensearch.ignoreVersionMismatch is not', () => {
+    const { messages } = applyLegacyDeprecations({ ignoreVersionMismatch: true });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"elasticsearch.ignoreVersionMismatch\\" is deprecated and has been replaced by \\"opensearch.ignoreVersionMismatch\\"",
+      ]
+    `);
   });
 });
 

--- a/src/core/server/opensearch/opensearch_config.ts
+++ b/src/core/server/opensearch/opensearch_config.ts
@@ -135,7 +135,24 @@ export const configSchema = schema.object({
   ),
 });
 
-const deprecations: ConfigDeprecationProvider = () => [
+const deprecations: ConfigDeprecationProvider = ({ renameFromRoot }) => [
+  renameFromRoot('elasticsearch.sniffOnStart', 'opensearch.sniffOnStart'),
+  renameFromRoot('elasticsearch.sniffInterval', 'opensearch.sniffInterval'),
+  renameFromRoot('elasticsearch.sniffOnConnectionFault', 'opensearch.sniffOnConnectionFault'),
+  renameFromRoot('elasticsearch.hosts', 'opensearch.hosts'),
+  renameFromRoot('elasticsearch.username', 'opensearch.username'),
+  renameFromRoot('elasticsearch.password', 'opensearch.password'),
+  renameFromRoot('elasticsearch.requestHeadersWhitelist', 'opensearch.requestHeadersWhitelist'),
+  renameFromRoot('elasticsearch.customHeaders', 'opensearch.customHeaders'),
+  renameFromRoot('elasticsearch.shardTimeout', 'opensearch.shardTimeout'),
+  renameFromRoot('elasticsearch.requestTimeout', 'opensearch.requestTimeout'),
+  renameFromRoot('elasticsearch.pingTimeout', 'opensearch.pingTimeout'),
+  renameFromRoot('elasticsearch.logQueries', 'opensearch.logQueries'),
+  renameFromRoot('elasticsearch.optimizedHealthcheckId', 'opensearch.optimizedHealthcheckId'),
+  renameFromRoot('elasticsearch.ssl', 'opensearch.ssl'),
+  renameFromRoot('elasticsearch.apiVersion', 'opensearch.apiVersion'),
+  renameFromRoot('elasticsearch.healthCheck', 'opensearch.healthCheck'),
+  renameFromRoot('elasticsearch.ignoreVersionMismatch', 'opensearch.ignoreVersionMismatch'),
   (settings, fromPath, log) => {
     const opensearch = settings[fromPath];
     if (!opensearch) {

--- a/src/core/server/opensearch_dashboards_config.test.ts
+++ b/src/core/server/opensearch_dashboards_config.test.ts
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { applyDeprecations, configDeprecationFactory } from '@osd/config';
+import { config } from './opensearch_dashboards_config';
+
+const DEFAULT_CONFIG_PATH = 'opensearchDashboards';
+const LEGACY_CONFIG_PATH = 'kibana';
+
+const applyOpenSearchDashboardsDeprecations = (
+  settings: Record<string, any> = {},
+  path = DEFAULT_CONFIG_PATH
+) => {
+  const deprecations = config.deprecations!(configDeprecationFactory);
+  const deprecationMessages: string[] = [];
+  const _config: any = {};
+  _config[path] = settings;
+  const migrated = applyDeprecations(
+    _config,
+    deprecations.map((deprecation) => ({
+      deprecation,
+      path,
+    })),
+    (msg) => deprecationMessages.push(msg)
+  );
+  return {
+    messages: deprecationMessages,
+    migrated,
+  };
+};
+
+const applyLegacyDeprecations = (settings: Record<string, any> = {}) => {
+  return applyOpenSearchDashboardsDeprecations(settings, LEGACY_CONFIG_PATH);
+};
+
+describe('deprecations', () => {
+  it('logs a warning if kibana.enabled is set and opensearchDashboards.enabled is not', () => {
+    const { messages } = applyLegacyDeprecations({ enabled: true });
+    expect(messages).toMatchInlineSnapshot(`
+        Array [
+          "\\"kibana.enabled\\" is deprecated and has been replaced by \\"opensearchDashboards.enabled\\"",
+        ]
+      `);
+  });
+
+  it('logs a warning if kibana.index is set and opensearchDashboards.index is not', () => {
+    const { messages } = applyLegacyDeprecations({ index: '' });
+    expect(messages).toMatchInlineSnapshot(`
+        Array [
+          "\\"kibana.index\\" is deprecated and has been replaced by \\"opensearchDashboards.index\\"",
+        ]
+      `);
+  });
+
+  it('logs a warning if kibana.autocompleteTerminateAfter is set and opensearchDashboards.autocompleteTerminateAfter is not', () => {
+    const { messages } = applyLegacyDeprecations({ autocompleteTerminateAfter: 100 });
+    expect(messages).toMatchInlineSnapshot(`
+        Array [
+          "\\"kibana.autocompleteTerminateAfter\\" is deprecated and has been replaced by \\"opensearchDashboards.autocompleteTerminateAfter\\"",
+        ]
+      `);
+  });
+
+  it('logs a warning if kibana.autocompleteTimeout is set and opensearchDashboards.autocompleteTimeout is not', () => {
+    const { messages } = applyLegacyDeprecations({ autocompleteTimeout: 100 });
+    expect(messages).toMatchInlineSnapshot(`
+        Array [
+          "\\"kibana.autocompleteTimeout\\" is deprecated and has been replaced by \\"opensearchDashboards.autocompleteTimeout\\"",
+        ]
+      `);
+  });
+});

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -31,8 +31,19 @@
  */
 
 import { schema, TypeOf } from '@osd/config-schema';
+import { ConfigDeprecationProvider } from 'packages/osd-config';
 
 export type OpenSearchDashboardsConfigType = TypeOf<typeof config.schema>;
+
+const deprecations: ConfigDeprecationProvider = ({ renameFromRoot }) => [
+  renameFromRoot('kibana.enabled', 'opensearchDashboards.enabled'),
+  renameFromRoot('kibana.index', 'opensearchDashboards.index'),
+  renameFromRoot(
+    'kibana.autocompleteTerminateAfter',
+    'opensearchDashboards.autocompleteTerminateAfter'
+  ),
+  renameFromRoot('kibana.autocompleteTimeout', 'opensearchDashboards.autocompleteTimeout'),
+];
 
 export const config = {
   path: 'opensearchDashboards',
@@ -42,4 +53,5 @@ export const config = {
     autocompleteTerminateAfter: schema.duration({ defaultValue: 100000 }),
     autocompleteTimeout: schema.duration({ defaultValue: 1000 }),
   }),
+  deprecations,
 };

--- a/src/plugins/home/server/index.ts
+++ b/src/plugins/home/server/index.ts
@@ -44,6 +44,7 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
   schema: configSchema,
   deprecations: ({ renameFromRoot }) => [
     renameFromRoot('opensearchDashboards.disableWelcomeScreen', 'home.disableWelcomeScreen'),
+    renameFromRoot('kibana.disableWelcomeScreen', 'home.disableWelcomeScreen'),
   ],
 };
 

--- a/src/plugins/maps_legacy/server/index.ts
+++ b/src/plugins/maps_legacy/server/index.ts
@@ -51,6 +51,14 @@ export const config: PluginConfigDescriptor<MapsLegacyConfig> = {
     emsTileLayerId: true,
   },
   schema: configSchema,
+  deprecations: ({ renameFromRoot }) => [
+    renameFromRoot('map.includeElasticMapsService', 'map.includeOpenSearchMapsService'),
+    renameFromRoot('map.proxyOpenSearchMapsServiceInMaps', 'map.proxyElasticMapsServiceInMaps'),
+    renameFromRoot(
+      'map.regionmap.includeElasticMapsService',
+      'map.regionmap.includeOpenSearchMapsService'
+    ),
+  ],
 };
 
 export interface MapsLegacyPluginSetup {

--- a/src/plugins/opensearch_dashboards_legacy/server/index.ts
+++ b/src/plugins/opensearch_dashboards_legacy/server/index.ts
@@ -52,10 +52,14 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
       'opensearch_dashboards_legacy.defaultAppId',
       true
     ),
+    renameFromRoot('kibana.defaultAppId', 'opensearch_dashboards_legacy.defaultAppId', true),
+    renameFromRoot('kibana_legacy.defaultAppId', 'opensearch_dashboards_legacy.defaultAppId', true),
     (completeConfig: Record<string, any>, rootPath: string, log: ConfigDeprecationLogger) => {
       if (
         get(completeConfig, 'opensearchDashboards.defaultAppId') === undefined &&
-        get(completeConfig, 'opensearch_dashboards_legacy.defaultAppId') === undefined
+        get(completeConfig, 'opensearch_dashboards_legacy.defaultAppId') === undefined &&
+        get(completeConfig, 'kibana.defaultAppId') === undefined &&
+        get(completeConfig, 'kibana_legacy.defaultAppId') === undefined
       ) {
         return completeConfig;
       }

--- a/src/plugins/region_map/server/index.ts
+++ b/src/plugins/region_map/server/index.ts
@@ -41,6 +41,12 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
     layers: true,
   },
   schema: configSchema,
+  deprecations: ({ renameFromRoot }) => [
+    renameFromRoot(
+      'map.regionmap.includeElasticMapsService',
+      'map.regionmap.includeOpenSearchMapsService'
+    ),
+  ],
 };
 
 export const plugin = () => ({

--- a/src/plugins/vis_type_timeline/server/index.ts
+++ b/src/plugins/vis_type_timeline/server/index.ts
@@ -42,10 +42,26 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
     ui: true,
   },
   deprecations: ({ renameFromRoot }) => [
-    renameFromRoot('timeline_vis.enabled', 'vis_type_timeline.enabled'),
+    // timelion.enabled and timelion_vis.enabled deprecation
+    renameFromRoot('timelion.enabled', 'vis_type_timeline.enabled'),
+    renameFromRoot('timelion_vis.enabled', 'vis_type_timeline.enabled'),
+    renameFromRoot('vis_type_timelion.enabled', 'vis_type_timeline.enabled'),
     renameFromRoot('timeline.enabled', 'vis_type_timeline.enabled'),
-    renameFromRoot('timeline.graphiteUrls', 'vis_type_timeline.graphiteUrls'),
+    renameFromRoot('timeline_vis.enabled', 'vis_type_timeline.enabled'),
+
+    // timelion.graphiteUrls deprecation
+    renameFromRoot('timelion.graphiteUrls', 'vis_type_timeline.graphiteAllowedUrls'),
+    renameFromRoot('vis_type_timelion.graphiteUrls', 'vis_type_timeline.graphiteAllowedUrls'),
+    renameFromRoot(
+      'vis_type_timelion.graphiteAllowedUrls',
+      'vis_type_timeline.graphiteAllowedUrls'
+    ),
+    renameFromRoot('timeline.graphiteUrls', 'vis_type_timeline.graphiteAllowedUrls'),
     renameFromRoot('vis_type_timeline.graphiteUrls', 'vis_type_timeline.graphiteAllowedUrls'),
+
+    // timelion.ui.enabled deprecation
+    renameFromRoot('timelion.ui.enabled', 'vis_type_timeline.ui.enabled', true),
+    renameFromRoot('vis_type_timelion.ui.enabled', 'vis_type_timeline.ui.enabled', true),
     renameFromRoot('timeline.ui.enabled', 'vis_type_timeline.ui.enabled', true),
   ],
 };

--- a/src/plugins/vis_type_vega/server/index.ts
+++ b/src/plugins/vis_type_vega/server/index.ts
@@ -30,7 +30,7 @@
  * GitHub history for details.
  */
 
-import { PluginConfigDescriptor, PluginInitializerContext } from 'opensearch_dashboards/server';
+import { PluginConfigDescriptor, PluginInitializerContext } from 'opensearch-dashboards/server';
 
 import { configSchema, ConfigSchema } from '../config';
 import { VisTypeVegaPlugin } from './plugin';


### PR DESCRIPTION
### Description
While renaming after the fork, configurations were renamed
and replaced with keywords related to OpenSearch.

This meant that anyone who migrated to OpenSearch Dashboards
who had configured their YAML file no longer were able to
carry over those changes and run the application. This
prevented the application from starting due to unknown config
keys. Although, this still does not allow the application to
work out of the box because people will need to make sure
then rename their kibana.yml to opensearch_dashboards.yml,
but once they do they do not need to modify the content
of the config.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/440
Partial: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/334
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 