### PR TITLE
[Test] Enable unit test suite: api.test.ts

### DIFF
--- a/src/plugins/newsfeed/public/lib/api.test.ts
+++ b/src/plugins/newsfeed/public/lib/api.test.ts
@@ -64,7 +64,7 @@ jest.mock('uuid', () => ({
   v4: () => 'NEW_UUID',
 }));
 
-describe.skip('NewsfeedApiDriver', () => {
+describe('NewsfeedApiDriver', () => {
   const opensearchDashboardsVersion = '99.999.9-test_version'; // It'll remove the `-test_version` bit
   const userLanguage = 'en';
   const fetchInterval = 2000;
@@ -75,7 +75,7 @@ describe.skip('NewsfeedApiDriver', () => {
     sinon.reset();
   });
 
-  describe.skip('shouldFetch', () => {
+  describe('shouldFetch', () => {
     it('defaults to true', () => {
       const driver = getDriver();
       expect(driver.shouldFetch()).toBe(true);
@@ -100,7 +100,7 @@ describe.skip('NewsfeedApiDriver', () => {
     });
   });
 
-  describe.skip('updateHashes', () => {
+  describe('updateHashes', () => {
     it('returns previous and current storage', () => {
       const driver = getDriver();
       const items: NewsfeedItem[] = [
@@ -192,7 +192,7 @@ describe.skip('NewsfeedApiDriver', () => {
     ).toBe(false);
   });
 
-  describe.skip('modelItems', () => {
+  describe('modelItems', () => {
     it('Models empty set with defaults', () => {
       const driver = getDriver();
       const apiItems: ApiItem[] = [];
@@ -465,7 +465,7 @@ describe.skip('NewsfeedApiDriver', () => {
   });
 });
 
-describe.skip('getApi', () => {
+describe('getApi', () => {
   const mockHttpGet = jest.fn();
   let httpMock = ({
     fetch: mockHttpGet,
@@ -630,7 +630,7 @@ describe.skip('getApi', () => {
     });
   });
 
-  describe.skip('Retry fetching', () => {
+  describe('Retry fetching', () => {
     const successItems: ApiItem[] = [
       {
         title: { en: 'hasNew test' },


### PR DESCRIPTION
### Description

All the unit tests related to unused newsfeed are temporarily
skipped at forking. To build a clean unit test, we decide to
check and enable all the working unit tests. This PR checks
and enables api.test.ts.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>
 
### Issues Resolved
[#490 ](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/490)

### Test results
unit test for api.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/newsfeed/public/lib/api.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/newsfeed/public/lib/api.test.ts
  console.error
    sorry, try again later!

      217 |       driver.fetchNewsfeedItems(http, config.service).pipe(
      218 |         catchError((err) => {
    > 219 |           window.console.error(err);
          |                          ^
      220 |           return Rx.of({
      221 |             error: err,
      222 |             opensearchDashboardsVersion,

      at CatchSubscriber.driver.fetchNewsfeedItems.pipe.err [as selector] (src/plugins/newsfeed/public/lib/api.ts:219:26)
      at CatchSubscriber.Object.<anonymous>.CatchSubscriber.error (node_modules/rxjs/src/internal/operators/catchError.ts:130:23)
      at node_modules/rxjs/src/internal/util/subscribeToPromise.ts:12:30

  console.error
    Sorry, try again later!

      217 |       driver.fetchNewsfeedItems(http, config.service).pipe(
      218 |         catchError((err) => {
    > 219 |           window.console.error(err);
          |                          ^
      220 |           return Rx.of({
      221 |             error: err,
      222 |             opensearchDashboardsVersion,

      at CatchSubscriber.driver.fetchNewsfeedItems.pipe.err [as selector] (src/plugins/newsfeed/public/lib/api.ts:219:26)
      at CatchSubscriber.Object.<anonymous>.CatchSubscriber.error (node_modules/rxjs/src/internal/operators/catchError.ts:130:23)
      at node_modules/rxjs/src/internal/util/subscribeToPromise.ts:12:30

  console.error
    Sorry, internal server error!

      217 |       driver.fetchNewsfeedItems(http, config.service).pipe(
      218 |         catchError((err) => {
    > 219 |           window.console.error(err);
          |                          ^
      220 |           return Rx.of({
      221 |             error: err,
      222 |             opensearchDashboardsVersion,

      at CatchSubscriber.driver.fetchNewsfeedItems.pipe.err [as selector] (src/plugins/newsfeed/public/lib/api.ts:219:26)
      at CatchSubscriber.Object.<anonymous>.CatchSubscriber.error (node_modules/rxjs/src/internal/operators/catchError.ts:130:23)
      at node_modules/rxjs/src/internal/util/subscribeToPromise.ts:12:30

  console.error
    Sorry, it's too cold to go outside!

      217 |       driver.fetchNewsfeedItems(http, config.service).pipe(
      218 |         catchError((err) => {
    > 219 |           window.console.error(err);
          |                          ^
      220 |           return Rx.of({
      221 |             error: err,
      222 |             opensearchDashboardsVersion,

      at CatchSubscriber.driver.fetchNewsfeedItems.pipe.err [as selector] (src/plugins/newsfeed/public/lib/api.ts:219:26)
      at CatchSubscriber.Object.<anonymous>.CatchSubscriber.error (node_modules/rxjs/src/internal/operators/catchError.ts:130:23)
      at node_modules/rxjs/src/internal/util/subscribeToPromise.ts:12:30

 PASS  src/plugins/newsfeed/public/lib/api.test.ts
  NewsfeedApiDriver
    ✓ Validates items for required fields (1 ms)
    shouldFetch
      ✓ defaults to true (4 ms)
      ✓ returns true if last fetch time precedes page load time (3 ms)
      ✓ returns false if last fetch time is recent enough (1 ms)
    updateHashes
      ✓ returns previous and current storage (3 ms)
      ✓ concatenates the previous hashes with the current (1 ms)
    modelItems
      ✓ Models empty set with defaults (1 ms)
      ✓ Selects default language (2 ms)
      ✓ Falls back to English when user language isn't present (1 ms)
      ✓ Models multiple items into an API FetchResult (1 ms)
      ✓ Filters expired (1 ms)
      ✓ Filters pre-published
  getApi
    ✓ creates a result (6 ms)
    ✓ hasNew is true when the service returns hashes not in the cache (26 ms)
    ✓ hasNew is false when service returns hashes that are all stored (3 ms)
    ✓ forwards an error (65 ms)
    Retry fetching
      ✓ retries until fetch doesn't error (50 ms)
      ✓ doesn't retry if fetch succeeds (3 ms)

Test Suites: 1 passed, 1 total
Tests:       18 passed, 18 total
Snapshots:   10 passed, 10 total
Time:        2.235 s
```

Overall test result:
<img width="1562" alt="Screen Shot 2021-06-18 at 10 14 24 AM" src="https://user-images.githubusercontent.com/79961084/122595984-1384d200-d01e-11eb-8de1-56df1c57964b.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 