### PR TITLE
[Test] Enable unit test suite: empty_news.test.tsx

### DIFF
--- a/src/plugins/newsfeed/public/components/__snapshots__/empty_news.test.tsx.snap
+++ b/src/plugins/newsfeed/public/components/__snapshots__/empty_news.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`empty_news rendering renders the default Empty News 1`] = `
   body={
     <p>
       <FormattedMessage
-        defaultMessage="If your Kibana instance doesn’t have internet access, ask your administrator to disable this feature. Otherwise, we’ll keep trying to fetch the news."
+        defaultMessage="If your OpenSearch Dashboards instance doesn’t have internet access, ask your administrator to disable this feature. Otherwise, we’ll keep trying to fetch the news."
         id="newsfeed.emptyPrompt.noNewsText"
         values={Object {}}
       />

--- a/src/plugins/newsfeed/public/components/empty_news.test.tsx
+++ b/src/plugins/newsfeed/public/components/empty_news.test.tsx
@@ -35,8 +35,8 @@ import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { NewsEmptyPrompt } from './empty_news';
 
-describe.skip('empty_news', () => {
-  describe.skip('rendering', () => {
+describe('empty_news', () => {
+  describe('rendering', () => {
     it('renders the default Empty News', () => {
       const wrapper = shallow(<NewsEmptyPrompt />);
       expect(toJson(wrapper)).toMatchSnapshot();


### PR DESCRIPTION
### Description
All the unit tests related to unused newsfeed are temporarily
skipped at forking. To build a clean unit test, we decide to
check and enable all the working unit tests. This PR checks
and enables empty_news.test.tsx.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>
 
### Issues Resolved
[#491 ](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/491)

### Test results
unit test for empty_news.test.tsx
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/newsfeed/public/components/empty_news.test.tsx
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/newsfeed/public/components/empty_news.test.tsx
 PASS  src/plugins/newsfeed/public/components/empty_news.test.tsx
  empty_news
    rendering
      ✓ renders the default Empty News (9 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        3.188 s, estimated 4 s
```

Overall test result:
<img width="1622" alt="Screen Shot 2021-06-18 at 11 45 59 AM" src="https://user-images.githubusercontent.com/79961084/122604531-f0acea80-d02a-11eb-902c-d60a1848d8c0.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 