### PR TITLE
[Test] Enable unit test suite: loading_news.test.tsx

### DIFF
--- a/src/plugins/newsfeed/public/components/loading_news.test.tsx
+++ b/src/plugins/newsfeed/public/components/loading_news.test.tsx
@@ -35,8 +35,8 @@ import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { NewsLoadingPrompt } from './loading_news';
 
-describe.skip('news_loading', () => {
-  describe.skip('rendering', () => {
+describe('news_loading', () => {
+  describe('rendering', () => {
     it('renders the default News Loading', () => {
       const wrapper = shallow(<NewsLoadingPrompt />);
       expect(toJson(wrapper)).toMatchSnapshot();


### PR DESCRIPTION
### Description
All the unit tests related to unused newsfeed are temporarily
skipped at forking. To build a clean unit test, we decide to
check and enable all the working unit tests. This PR checks
and enables loading_news.test.tsx.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>
 
### Issues Resolved
[#492 ](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/492)

### Test results
unit test for empty_news.test.tsx
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/newsfeed/public/components/loading_news.test.tsx
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/newsfeed/public/components/loading_news.test.tsx
 PASS  src/plugins/newsfeed/public/components/loading_news.test.tsx
  news_loading
    rendering
      ✓ renders the default News Loading (8 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        3.333 s
```

Overall test result:
<img width="1567" alt="Screen Shot 2021-06-18 at 11 00 49 AM" src="https://user-images.githubusercontent.com/79961084/122600339-78dbc180-d024-11eb-8df3-4db61ce2811c.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 