### PR TITLE
[Test] Enable unit test suite: telemetry_sender.test.ts

### DIFF
--- a/src/plugins/telemetry/public/services/telemetry_sender.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_sender.test.ts
@@ -108,7 +108,6 @@ describe('TelemetrySender', () => {
       const shouldSendRerpot = telemetrySender['shouldSendReport']();
 
       expect(telemetrySender['lastReported']).toBeUndefined();
-      // expect(shouldSendRerpot).toBe(true);
       expect(shouldSendRerpot).toBe(false);
     });
 
@@ -120,7 +119,6 @@ describe('TelemetrySender', () => {
       const telemetrySender = new TelemetrySender(telemetryService);
       telemetrySender['lastReported'] = `${lastReported}`;
       const shouldSendRerpot = telemetrySender['shouldSendReport']();
-      // expect(shouldSendRerpot).toBe(true);
       expect(shouldSendRerpot).toBe(false);
     });
 
@@ -141,7 +139,6 @@ describe('TelemetrySender', () => {
       const telemetrySender = new TelemetrySender(telemetryService);
       telemetrySender['lastReported'] = `random_malformed_string`;
       const shouldSendRerpot = telemetrySender['shouldSendReport']();
-      // expect(shouldSendRerpot).toBe(true);
       expect(shouldSendRerpot).toBe(false);
     });
 
@@ -192,17 +189,8 @@ describe('TelemetrySender', () => {
         telemetrySender['isSending'] = false;
         await telemetrySender['sendIfDue']();
 
-        // expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
         expect(telemetryService.fetchTelemetry).toBeCalledTimes(0);
-        // expect(mockFetch).toBeCalledTimes(1);
         expect(mockFetch).toBeCalledTimes(0);
-        // expect(mockFetch).toBeCalledWith(mockTelemetryUrl, {
-        //  method: 'POST',
-        //  headers: {
-        //    'Content-Type': 'application/json',
-        //  },
-        //  body: mockTelemetryPayload[0],
-        // });
       });
 
       it('sends report separately for every cluster', async () => {
@@ -217,9 +205,7 @@ describe('TelemetrySender', () => {
         telemetrySender['isSending'] = false;
         await telemetrySender['sendIfDue']();
 
-        // expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
         expect(telemetryService.fetchTelemetry).toBeCalledTimes(0);
-        // expect(mockFetch).toBeCalledTimes(2);
         expect(mockFetch).toBeCalledTimes(0);
       });
 
@@ -236,7 +222,6 @@ describe('TelemetrySender', () => {
 
         await telemetrySender['sendIfDue']();
 
-        // expect(mockFetch).toBeCalledTimes(1);
         expect(mockFetch).toBeCalledTimes(0);
         expect(telemetrySender['lastReported']).toBeDefined();
         expect(telemetrySender['saveToBrowser']).toBeCalledTimes(1);
@@ -251,7 +236,6 @@ describe('TelemetrySender', () => {
           throw Error('Error fetching usage');
         });
         await telemetrySender['sendIfDue']();
-        // expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
         expect(telemetryService.fetchTelemetry).toBeCalledTimes(0);
         expect(telemetrySender['lastReported']).toBeUndefined();
         expect(telemetrySender['isSending']).toBe(false);
@@ -267,9 +251,7 @@ describe('TelemetrySender', () => {
           throw Error('Error sending usage');
         });
         await telemetrySender['sendIfDue']();
-        // expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
         expect(telemetryService.fetchTelemetry).toBeCalledTimes(0);
-        // expect(mockFetch).toBeCalledTimes(2);
         expect(mockFetch).toBeCalledTimes(0);
         expect(telemetrySender['lastReported']).toBeUndefined();
         expect(telemetrySender['isSending']).toBe(false);

--- a/src/plugins/telemetry/public/services/telemetry_sender.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_sender.test.ts
@@ -45,7 +45,7 @@ Object.defineProperty(window, 'localStorage', {
   value: mockLocalStorage,
 });
 
-describe.skip('TelemetrySender', () => {
+describe('TelemetrySender', () => {
   beforeEach(() => {
     mockLocalStorage.getItem.mockClear();
     mockLocalStorage.setItem.mockClear();
@@ -56,7 +56,7 @@ describe.skip('TelemetrySender', () => {
     })
   );
 
-  describe.skip('constructor', () => {
+  describe('constructor', () => {
     it('defaults lastReport if unset', () => {
       const telemetryService = mockTelemetryService();
       const telemetrySender = new TelemetrySender(telemetryService);
@@ -74,7 +74,7 @@ describe.skip('TelemetrySender', () => {
     });
   });
 
-  describe.skip('saveToBrowser', () => {
+  describe('saveToBrowser', () => {
     it('uses lastReport', () => {
       const lastReport = `${Date.now()}`;
       const telemetryService = mockTelemetryService();
@@ -90,7 +90,7 @@ describe.skip('TelemetrySender', () => {
     });
   });
 
-  describe.skip('shouldSendReport', () => {
+  describe('shouldSendReport', () => {
     it('returns false whenever optIn is false', () => {
       const telemetryService = mockTelemetryService();
       telemetryService.getIsOptedIn = jest.fn().mockReturnValue(false);
@@ -108,7 +108,8 @@ describe.skip('TelemetrySender', () => {
       const shouldSendRerpot = telemetrySender['shouldSendReport']();
 
       expect(telemetrySender['lastReported']).toBeUndefined();
-      expect(shouldSendRerpot).toBe(true);
+      // expect(shouldSendRerpot).toBe(true);
+      expect(shouldSendRerpot).toBe(false);
     });
 
     it('returns true if lastReported passed REPORT_INTERVAL_MS', () => {
@@ -119,7 +120,8 @@ describe.skip('TelemetrySender', () => {
       const telemetrySender = new TelemetrySender(telemetryService);
       telemetrySender['lastReported'] = `${lastReported}`;
       const shouldSendRerpot = telemetrySender['shouldSendReport']();
-      expect(shouldSendRerpot).toBe(true);
+      // expect(shouldSendRerpot).toBe(true);
+      expect(shouldSendRerpot).toBe(false);
     });
 
     it('returns false if lastReported is within REPORT_INTERVAL_MS', () => {
@@ -139,10 +141,11 @@ describe.skip('TelemetrySender', () => {
       const telemetrySender = new TelemetrySender(telemetryService);
       telemetrySender['lastReported'] = `random_malformed_string`;
       const shouldSendRerpot = telemetrySender['shouldSendReport']();
-      expect(shouldSendRerpot).toBe(true);
+      // expect(shouldSendRerpot).toBe(true);
+      expect(shouldSendRerpot).toBe(false);
     });
 
-    describe.skip('sendIfDue', () => {
+    describe('sendIfDue', () => {
       let originalFetch: typeof window['fetch'];
       let mockFetch: jest.Mock<typeof window['fetch']>;
 
@@ -189,15 +192,17 @@ describe.skip('TelemetrySender', () => {
         telemetrySender['isSending'] = false;
         await telemetrySender['sendIfDue']();
 
-        expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
-        expect(mockFetch).toBeCalledTimes(1);
-        expect(mockFetch).toBeCalledWith(mockTelemetryUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: mockTelemetryPayload[0],
-        });
+        // expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
+        expect(telemetryService.fetchTelemetry).toBeCalledTimes(0);
+        // expect(mockFetch).toBeCalledTimes(1);
+        expect(mockFetch).toBeCalledTimes(0);
+        // expect(mockFetch).toBeCalledWith(mockTelemetryUrl, {
+        //  method: 'POST',
+        //  headers: {
+        //    'Content-Type': 'application/json',
+        //  },
+        //  body: mockTelemetryPayload[0],
+        // });
       });
 
       it('sends report separately for every cluster', async () => {
@@ -212,8 +217,10 @@ describe.skip('TelemetrySender', () => {
         telemetrySender['isSending'] = false;
         await telemetrySender['sendIfDue']();
 
-        expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
-        expect(mockFetch).toBeCalledTimes(2);
+        // expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
+        expect(telemetryService.fetchTelemetry).toBeCalledTimes(0);
+        // expect(mockFetch).toBeCalledTimes(2);
+        expect(mockFetch).toBeCalledTimes(0);
       });
 
       it('updates last lastReported and calls saveToBrowser', async () => {
@@ -229,7 +236,8 @@ describe.skip('TelemetrySender', () => {
 
         await telemetrySender['sendIfDue']();
 
-        expect(mockFetch).toBeCalledTimes(1);
+        // expect(mockFetch).toBeCalledTimes(1);
+        expect(mockFetch).toBeCalledTimes(0);
         expect(telemetrySender['lastReported']).toBeDefined();
         expect(telemetrySender['saveToBrowser']).toBeCalledTimes(1);
         expect(telemetrySender['isSending']).toBe(false);
@@ -243,7 +251,8 @@ describe.skip('TelemetrySender', () => {
           throw Error('Error fetching usage');
         });
         await telemetrySender['sendIfDue']();
-        expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
+        // expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
+        expect(telemetryService.fetchTelemetry).toBeCalledTimes(0);
         expect(telemetrySender['lastReported']).toBeUndefined();
         expect(telemetrySender['isSending']).toBe(false);
       });
@@ -258,14 +267,16 @@ describe.skip('TelemetrySender', () => {
           throw Error('Error sending usage');
         });
         await telemetrySender['sendIfDue']();
-        expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
-        expect(mockFetch).toBeCalledTimes(2);
+        // expect(telemetryService.fetchTelemetry).toBeCalledTimes(1);
+        expect(telemetryService.fetchTelemetry).toBeCalledTimes(0);
+        // expect(mockFetch).toBeCalledTimes(2);
+        expect(mockFetch).toBeCalledTimes(0);
         expect(telemetrySender['lastReported']).toBeUndefined();
         expect(telemetrySender['isSending']).toBe(false);
       });
     });
   });
-  describe.skip('startChecking', () => {
+  describe('startChecking', () => {
     let originalSetInterval: typeof window['setInterval'];
     let mockSetInterval: jest.Mock<typeof window['setInterval']>;
 


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped at forking. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR modifies and enables
telemetry_sender.test.ts.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Issues Resolved
[#498  ](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/498)

### Test results
unit test for telemetry_sender.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/services/telemetry_sender.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/services/telemetry_sender.test.ts
 PASS  src/plugins/telemetry/public/services/telemetry_sender.test.ts
  TelemetrySender
    constructor
      ✓ defaults lastReport if unset (5 ms)
      ✓ uses lastReport if set (1 ms)
    saveToBrowser
      ✓ uses lastReport
    shouldSendReport
      ✓ returns false whenever optIn is false
      ✓ returns true if lastReported is undefined (1 ms)
      ✓ returns true if lastReported passed REPORT_INTERVAL_MS (1 ms)
      ✓ returns false if lastReported is within REPORT_INTERVAL_MS
      ✓ returns true if lastReported is malformed (1 ms)
      sendIfDue
        ✓ does not send if already sending (1 ms)
        ✓ does not send if shouldSendReport returns false (1 ms)
        ✓ sends report if due (1 ms)
        ✓ sends report separately for every cluster
        ✓ updates last lastReported and calls saveToBrowser (1 ms)
        ✓ catches fetchTelemetry errors and sets isSending to false (1 ms)
        ✓ catches fetch errors and sets isSending to false (1 ms)
    startChecking
      ✓ calls sendIfDue every 60000 ms (1 ms)

Test Suites: 1 passed, 1 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        3.94 s, estimated 4 s
```

Overall test result:
<img width="1628" alt="Screen Shot 2021-06-18 at 12 40 31 PM" src="https://user-images.githubusercontent.com/79961084/122609335-af203d80-d032-11eb-8946-fc35f1aebc9c.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 