### PR TITLE
[Test] Enable unit test suite: telemetry_service.test.ts

### DIFF
--- a/src/plugins/telemetry/public/services/telemetry_service.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_service.test.ts
@@ -57,7 +57,8 @@ jest.mock('moment', () => {
   });
 });
 
-describe.skip('TelemetryService', () => {
+describe('TelemetryService', () => {
+  // TODO: enable this unit test when fetchTelemtry function is restored
   describe.skip('fetchTelemetry', () => {
     it('calls expected URL with 20 minutes - now', async () => {
       const telemetryService = mockTelemetryService();
@@ -70,7 +71,7 @@ describe.skip('TelemetryService', () => {
     });
   });
 
-  describe.skip('fetchExample', () => {
+  describe('fetchExample', () => {
     it('calls fetchTelemetry with unencrupted: true', async () => {
       const telemetryService = mockTelemetryService();
       telemetryService.fetchTelemetry = jest.fn();
@@ -79,7 +80,7 @@ describe.skip('TelemetryService', () => {
     });
   });
 
-  describe.skip('setOptIn', () => {
+  describe('setOptIn', () => {
     it('does not call the api if canChangeOptInStatus==false', async () => {
       const telemetryService = mockTelemetryService({
         reportOptInStatusChange: false,
@@ -183,7 +184,7 @@ describe.skip('TelemetryService', () => {
     });
   });
 
-  describe.skip('getTelemetryUrl', () => {
+  describe('getTelemetryUrl', () => {
     it('should return the config.url parameter', async () => {
       const url = 'http://test.com';
       const telemetryService = mockTelemetryService({
@@ -194,7 +195,7 @@ describe.skip('TelemetryService', () => {
     });
   });
 
-  describe.skip('setUserHasSeenNotice', () => {
+  describe('setUserHasSeenNotice', () => {
     it('should hit the API and change the config', async () => {
       const telemetryService = mockTelemetryService({
         config: { telemetryNotifyUserAboutOptInDefault: undefined, userCanChangeSettings: true },
@@ -229,7 +230,7 @@ describe.skip('TelemetryService', () => {
     });
   });
 
-  describe.skip('getUserShouldSeeOptInNotice', () => {
+  describe('getUserShouldSeeOptInNotice', () => {
     it('returns whether the user can update the telemetry config (has SavedObjects access)', () => {
       const telemetryService = mockTelemetryService({
         config: { userCanChangeSettings: undefined },


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR modifies and enables
telemetry_service.test.ts

Signed-off-by: Anan Zhuang <ananzh@amazon.com>
 
### Issues Resolved
[#499](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/499) (1 test case is skipped)

### Test results
unit test for telemetry_service.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/services/telemetry_service.test.ts
yarn run v1.22.5
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/services/telemetry_service.test.ts
 PASS  src/plugins/telemetry/public/services/telemetry_service.test.ts
  TelemetryService
    fetchTelemetry
      ○ skipped calls expected URL with 20 minutes - now
    fetchExample
      ✓ calls fetchTelemetry with unencrupted: true (4 ms)
    setOptIn
      ✓ does not call the api if canChangeOptInStatus==false (1 ms)
      ✓ calls api if canChangeOptInStatus
      ✓ sends enabled true if optedIn: true (1 ms)
      ✓ sends enabled false if optedIn: false (1 ms)
      ✓ does not call reportOptInStatus if reportOptInStatusChange is false
      ✓ calls reportOptInStatus if reportOptInStatusChange is true (70 ms)
      ✓ adds an error toast on api error (2 ms)
      ✓ adds an error toast on reportOptInStatus error (1 ms)
    getTelemetryUrl
      ✓ should return the config.url parameter
    setUserHasSeenNotice
      ✓ should hit the API and change the config (1 ms)
      ✓ should show a toast notification if the request fail (1 ms)
    getUserShouldSeeOptInNotice
      ✓ returns whether the user can update the telemetry config (has SavedObjects access) (2 ms)

  console.error
    Error: Error: connect ECONNREFUSED 127.0.0.1:80
        at Object.dispatchError (/home/anan/work/OpenSearch-Dashboards/node_modules/jsdom/lib/jsdom/living/xhr-utils.js:60:19)
        at Request.client.on.err (/home/anan/work/OpenSearch-Dashboards/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:674:20)
        at Request.emit (events.js:203:15)
        at Request.onRequestError (/home/anan/work/OpenSearch-Dashboards/node_modules/request/request.js:877:8)
        at ClientRequest.emit (events.js:198:13)
        at Socket.socketErrorListener (_http_client.js:401:9)
        at Socket.emit (events.js:198:13)
        at emitErrorNT (internal/streams/destroy.js:91:8)
        at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
        at process._tickCallback (internal/process/next_tick.js:63:19) undefined

      at VirtualConsole.on.e (node_modules/jsdom/lib/jsdom/virtual-console.js:29:45)
      at Object.dispatchError (node_modules/jsdom/lib/jsdom/living/xhr-utils.js:63:53)
      at Request.client.on.err (node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:674:20)
      at Request.onRequestError (node_modules/request/request.js:877:8)

Test Suites: 1 passed, 1 total
Tests:       1 skipped, 13 passed, 14 total
Snapshots:   0 total
Time:        3.627 s
```

Overall test result:
<img width="1625" alt="Screen Shot 2021-06-18 at 4 01 45 PM" src="https://user-images.githubusercontent.com/79961084/122622738-87d76980-d04e-11eb-8991-ea5a4142ed0e.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 