### PR TITLE
[Test] Enable unit test suite: render_opt_in_banner.test.ts 

### DIFF
--- a/src/plugins/telemetry/public/services/telemetry_notifications/render_opt_in_banner.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_notifications/render_opt_in_banner.test.ts
@@ -34,7 +34,7 @@ import { renderOptInBanner } from './render_opt_in_banner';
 // eslint-disable-next-line @osd/eslint/no-restricted-paths
 import { overlayServiceMock } from '../../../../../core/public/overlays/overlay_service.mock';
 
-describe.skip('renderOptInBanner', () => {
+describe('renderOptInBanner', () => {
   it('adds a banner to banners with priority of 10000', () => {
     const bannerID = 'brucer-wayne';
     const overlays = overlayServiceMock.createStartContract();


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR modifies and enables
render_opt_in_banner.test.ts.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>
 
### Issues Resolved
[#503  ](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/503)

### Test results
unit test for render_opt_in_banner.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/services/telemetry_notifications/render_opt_in_banner.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/services/telemetry_notifications/render_opt_in_banner.test.ts
 PASS  src/plugins/telemetry/public/services/telemetry_notifications/render_opt_in_banner.test.ts
  renderOptInBanner
    ✓ adds a banner to banners with priority of 10000 (4 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        3.882 s
```

Overall test result:
<img width="1632" alt="Screen Shot 2021-06-18 at 5 15 17 PM" src="https://user-images.githubusercontent.com/79961084/122625207-d984f180-d058-11eb-872a-e1eac4b262b9.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 