### PR TITLE
[Test]Enable unit test suite: render_opted_in_notice_banner.test.ts

### DIFF
--- a/src/plugins/telemetry/public/services/telemetry_notifications/render_opted_in_notice_banner.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_notifications/render_opted_in_notice_banner.test.ts
@@ -34,7 +34,7 @@ import { renderOptedInNoticeBanner } from './render_opted_in_notice_banner';
 // eslint-disable-next-line @osd/eslint/no-restricted-paths
 import { overlayServiceMock } from '../../../../../core/public/overlays/overlay_service.mock';
 
-describe.skip('renderOptedInNoticeBanner', () => {
+describe('renderOptedInNoticeBanner', () => {
   it('adds a banner to banners with priority of 10000', () => {
     const bannerID = 'brucer-wayne';
     const overlays = overlayServiceMock.createStartContract();


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR modifies and enables
render_opted_in_notice_banner.test.ts.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>
 
### Issues Resolved
[#504](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/504)

### Test results
unit test for render_opted_in_notice_banner.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/services/telemetry_notifications/render_opted_in_notice_banner.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/services/telemetry_notifications/render_opted_in_notice_banner.test.ts
 PASS  src/plugins/telemetry/public/services/telemetry_notifications/render_opted_in_notice_banner.test.ts
  renderOptedInNoticeBanner
    ✓ adds a banner to banners with priority of 10000 (4 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        3.892 s
```

Overall test result:
<img width="1623" alt="Screen Shot 2021-06-18 at 6 07 32 PM" src="https://user-images.githubusercontent.com/79961084/122626558-16081b80-d060-11eb-8393-842523addb8b.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 