### PR TITLE
[Test] Enable unit test suite:telemetry_notifications

### DIFF
--- a/src/plugins/telemetry/public/services/telemetry_notifications/telemetry_notifications.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_notifications/telemetry_notifications.test.ts
@@ -33,7 +33,7 @@
 /* eslint-disable dot-notation */
 import { mockTelemetryNotifications, mockTelemetryService } from '../../mocks';
 
-describe.skip('onSetOptInClick', () => {
+describe('onSetOptInClick', () => {
   it('sets setting successfully and removes banner', async () => {
     const optIn = true;
     const bannerId = 'bruce-banner';
@@ -51,7 +51,7 @@ describe.skip('onSetOptInClick', () => {
   });
 });
 
-describe.skip('setOptedInNoticeSeen', () => {
+describe('setOptedInNoticeSeen', () => {
   it('sets setting successfully and removes banner', async () => {
     const bannerId = 'bruce-banner';
 
@@ -67,7 +67,7 @@ describe.skip('setOptedInNoticeSeen', () => {
   });
 });
 
-describe.skip('shouldShowOptedInNoticeBanner', () => {
+describe('shouldShowOptedInNoticeBanner', () => {
   it("should return true because a banner hasn't been shown, the notice hasn't been seen and the user has privileges to edit saved objects", () => {
     const telemetryService = mockTelemetryService();
     telemetryService.getUserShouldSeeOptInNotice = jest.fn().mockReturnValue(true);


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR checks and enables
telemetry_notifications.test.ts.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Issues Resolved
[#507](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/507)

### Test results
unit test for telemetry_notifications.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/services/telemetry_notifications/telemetry_notifications.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/services/telemetry_notifications/telemetry_notifications.test.ts
 PASS  src/plugins/telemetry/public/services/telemetry_notifications/telemetry_notifications.test.ts
  onSetOptInClick
    ✓ sets setting successfully and removes banner (6 ms)
  setOptedInNoticeSeen
    ✓ sets setting successfully and removes banner (1 ms)
  shouldShowOptedInNoticeBanner
    ✓ should return true because a banner hasn't been shown, the notice hasn't been seen and the user has privileges to edit saved objects (1 ms)
    ✓ should return false because the banner is already on screen (1 ms)
    ✓ should return false because the banner has already been seen or the user doesn't have privileges to change saved objects

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        3.844 s
```

Overall test result:
<img width="1624" alt="Screen Shot 2021-06-21 at 9 32 24 AM" src="https://user-images.githubusercontent.com/79961084/122850302-d80a3200-d2c1-11eb-84f9-722a0f13f4ff.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 