### PR TITLE
[Test] Enable unit test suite: fetcher.test.ts

### DIFF
--- a/src/plugins/telemetry/server/fetcher.test.ts
+++ b/src/plugins/telemetry/server/fetcher.test.ts
@@ -34,8 +34,8 @@
 import { FetcherTask } from './fetcher';
 import { coreMock } from '../../../core/server/mocks';
 
-describe.skip('FetcherTask', () => {
-  describe.skip('sendIfDue', () => {
+describe('FetcherTask', () => {
+  describe('sendIfDue', () => {
     it('stops when it fails to get telemetry configs', async () => {
       const initializerContext = coreMock.createPluginInitializerContext({});
       const fetcherTask = new FetcherTask(initializerContext);
@@ -104,6 +104,7 @@ describe.skip('FetcherTask', () => {
 
       const fetchTelemetry = jest.fn().mockResolvedValue(mockClusters);
       const sendTelemetry = jest.fn();
+      const updateLastReported = jest.fn();
       const updateReportFailure = jest.fn();
 
       Object.assign(fetcherTask, {
@@ -111,6 +112,7 @@ describe.skip('FetcherTask', () => {
         areAllCollectorsReady,
         shouldSendReport,
         fetchTelemetry,
+        updateLastReported,
         updateReportFailure,
         sendTelemetry,
       });


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build a clean unit test, we decide to modify and enable all the
working unit tests. This PR checks and enables fetcher.test.ts.

The unit test 'fetches usage and send telemetry' checks function [sendIfDue](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4293f92190a98b16ea82a06caafe80394376b6b5/src/plugins/telemetry/server/fetcher.ts#L116) in [FetcherTask class](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4293f92190a98b16ea82a06caafe80394376b6b5/src/plugins/telemetry/server/fetcher.ts#L71). The mocked FetcherTask object calls function [updateLastReported](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4293f92190a98b16ea82a06caafe80394376b6b5/src/plugins/telemetry/server/fetcher.ts#L154) which calls another function [updateTelemetrySavedObject](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4293f92190a98b16ea82a06caafe80394376b6b5/src/plugins/telemetry/server/fetcher.ts#L194). However, there is no parameter passed as requested [here](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4293f92190a98b16ea82a06caafe80394376b6b5/src/plugins/telemetry/server/telemetry_repository/update_telemetry_saved_object.ts#L37). 

```
export async function updateTelemetrySavedObject(
  savedObjectsClient: SavedObjectsClientContract,
  savedObjectAttributes: TelemetrySavedObjectAttributes
)
```

Therefore, this unit test shows a TypeError due to undefined parameter:

```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/fetcher.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/fetcher.test.ts
(node:1847311) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'update' of undefined
Node.js process-warning detected:

UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'update' of undefined
    at emitWarning (internal/process/promises.js:99:15)
    at emitPromiseRejectionWarnings (internal/process/promises.js:143:7)
    at process._tickCallback (internal/process/next_tick.js:69:34)

Terminating process...

 RUNS  src/plugins/telemetry/server/fetcher.test.ts
error Command failed with exit code 1.
```


We have two options 1)mock updateTelemetrySavedObject because the purpose of this test suite is to test FetcherTask class 2)mock a SavedObjectsClientContract parameter and pass it to functionupdateTelemetrySavedObject. This PR uses option 1. There are some reasons for choosing option 1: this unit test is designed for sendIfDue function and updateTelemetrySavedObject has been tested in other unit test suites.  For the reference purpose, for the second option, we can use `savedObjectsClientMock` to mock the missing parameter:

```
import { coreMock, savedObjectsClientMock } from '../../../core/server/mocks';

it('fetches usage and send telemetry', async () => {
      const initializerContext = coreMock.createPluginInitializerContext({});
      const fetcherTask = new FetcherTask(initializerContext);
      fetcherTask['internalRepository'] = savedObjectsClientMock.create();
      const mockTelemetryUrl = 'mock_telemetry_url';
      const mockClusters = ['cluster_1', 'cluster_2'];
      const getCurrentConfigs = jest.fn().mockResolvedValue({
        telemetryUrl: mockTelemetryUrl,
      });
      const areAllCollectorsReady = jest.fn().mockResolvedValue(true);
      const shouldSendReport = jest.fn().mockReturnValue(true);

      const fetchTelemetry = jest.fn().mockResolvedValue(mockClusters);
      const sendTelemetry = jest.fn();
      const updateReportFailure = jest.fn();

      Object.assign(fetcherTask, {
        getCurrentConfigs,
        areAllCollectorsReady,
        shouldSendReport,
        fetchTelemetry,
        updateReportFailure,
        sendTelemetry,
      });

      await fetcherTask['sendIfDue']();

      expect(areAllCollectorsReady).toBeCalledTimes(1);
      expect(fetchTelemetry).toBeCalledTimes(1);
      expect(sendTelemetry).toBeCalledTimes(2);
      expect(sendTelemetry).toHaveBeenNthCalledWith(1, mockTelemetryUrl, mockClusters[0]);
      expect(sendTelemetry).toHaveBeenNthCalledWith(2, mockTelemetryUrl, mockClusters[1]);
      expect(updateReportFailure).toBeCalledTimes(0);
    });
```

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Issues Resolved
[#508 ](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/508)

### Test results
unit test for fetcher.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/fetcher.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/fetcher.test.ts
 PASS  src/plugins/telemetry/server/fetcher.test.ts
  FetcherTask
    sendIfDue
      ✓ stops when it fails to get telemetry configs (7 ms)
      ✓ stops when all collectors are not ready (2 ms)
      ✓ fetches usage and send telemetry (3 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        4.648 s, estimated 5 s
```

Overall test result:
<img width="1620" alt="Screen Shot 2021-06-21 at 7 24 45 PM" src="https://user-images.githubusercontent.com/79961084/122853056-7b5d4600-d2c6-11eb-9b42-88a4bf6d4cc7.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 