### PR TITLE
[Test] Enable unit test suite: get_cluster_info.test.ts

### DIFF
--- a/src/plugins/telemetry/server/telemetry_collection/get_cluster_info.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_cluster_info.test.ts
@@ -46,7 +46,7 @@ export function mockGetClusterInfo(clusterInfo: any) {
   return opensearchClient;
 }
 
-describe.skip('get_cluster_info using the opensearch client', () => {
+describe('get_cluster_info using the opensearch client', () => {
   it('uses the opensearchClient to get info API', async () => {
     const clusterInfo = {
       cluster_uuid: '1234',


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR checks and enables
get_cluster_info.test.ts.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Issues Resolved
[#509 ](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/509)

### Test results
unit test for get_cluster_info.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_collection/get_cluster_info.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_collection/get_cluster_info.test.ts
 PASS  src/plugins/telemetry/server/telemetry_collection/get_cluster_info.test.ts
  get_cluster_info using the opensearch client
    ✓ uses the opensearchClient to get info API (24 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        2.249 s
```

Overall test result:
<img width="1623" alt="Screen Shot 2021-06-21 at 8 14 49 PM" src="https://user-images.githubusercontent.com/79961084/122857523-73ed6b00-d2cd-11eb-9b5d-411faa0c37b6.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 