### PR TITLE
[Test] Enable unit test suite: get_cluster_stats.test.ts 

### DIFF
--- a/src/plugins/telemetry/server/telemetry_collection/get_cluster_stats.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_cluster_stats.test.ts
@@ -40,7 +40,7 @@ export function mockGetClusterStats(clusterStats: any) {
   return opensearchClient;
 }
 
-describe.skip('get_cluster_stats', () => {
+describe('get_cluster_stats', () => {
   it('uses the opensearchClient to get the response from the `cluster.stats` API', async () => {
     const response = Promise.resolve({ body: { cluster_uuid: '1234' } });
     const opensearchClient = opensearchServiceMock.createClusterClient().asInternalUser;


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR checks and enables
get_cluster_stats.test.ts.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Issues Resolved
[#510](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/510)

### Test results
unit test for get_cluster_stats.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_collection/get_cluster_stats.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_collection/get_cluster_stats.test.ts
 PASS  src/plugins/telemetry/server/telemetry_collection/get_cluster_stats.test.ts
  get_cluster_stats
    ✓ uses the opensearchClient to get the response from the `cluster.stats` API (27 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        2.676 s
```

Overall test result:
<img width="1630" alt="Screen Shot 2021-06-21 at 8 59 05 PM" src="https://user-images.githubusercontent.com/79961084/122861057-a4d09e80-d2d3-11eb-9090-819deebe2eed.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 