### PR TITLE
[Test] Enable unit test suite: get_local_stats.test.ts

### DIFF
--- a/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
@@ -211,28 +211,6 @@ describe('get_local_stats', () => {
       expect(Object.keys(result)).not.toContain('license');
       expect(result.stack_stats).toEqual({ opensearch_dashboards: undefined, data: undefined });
     });
-
-    it('returns expected object with xpack', () => {
-      const result = handleLocalStats(
-        clusterInfo,
-        clusterStatsWithNodesUsage,
-        void 0,
-        void 0,
-        context
-      );
-
-      const { stack_stats: stack, ...cluster } = result;
-      expect(cluster.collection).toBe(combinedStatsResult.collection);
-      expect(cluster.cluster_uuid).toBe(combinedStatsResult.cluster_uuid);
-      expect(cluster.cluster_name).toBe(combinedStatsResult.cluster_name);
-      expect(stack.kibana).toBe(undefined); // not mocked for this test
-      expect(stack.data).toBe(undefined); // not mocked for this test
-
-      expect(cluster.version).toEqual(combinedStatsResult.version);
-      expect(cluster.cluster_stats).toEqual(combinedStatsResult.cluster_stats);
-      expect(Object.keys(cluster).indexOf('license')).toBeLessThan(0);
-      expect(Object.keys(stack).indexOf('xpack')).toBeLessThan(0);
-    });
   });
 
   describe('getLocalStats', () => {

--- a/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
@@ -92,7 +92,7 @@ function mockGetLocalStats(clusterInfo: any, clusterStats: any) {
   return opensearchClient;
 }
 
-describe.skip('get_local_stats', () => {
+describe('get_local_stats', () => {
   const clusterUuid = 'abc123';
   const clusterName = 'my-cool-cluster';
   const version = '2.3.4';
@@ -194,7 +194,7 @@ describe.skip('get_local_stats', () => {
     version: '8.0.0',
   };
 
-  describe.skip('handleLocalStats', () => {
+  describe('handleLocalStats', () => {
     it('returns expected object without OpenSearch Dashboards data', () => {
       const result = handleLocalStats(
         clusterInfo,
@@ -235,7 +235,7 @@ describe.skip('get_local_stats', () => {
     });
   });
 
-  describe.skip('getLocalStats', () => {
+  describe('getLocalStats', () => {
     it('returns expected object with OpenSearch Dashboards data', async () => {
       const callCluster = jest.fn();
       const usageCollection = mockUsageCollection(opensearchDashboards);


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR checks and enables
get_local_stats.test.ts.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Issues Resolved
[#512](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/512)

### Test results
unit test for get_local_stats.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
 PASS  src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
  get_local_stats
    handleLocalStats
      ✓ returns expected object without OpenSearch Dashboards data (21 ms)
      ✓ returns expected object with xpack (6 ms)
    getLocalStats
      ✓ returns expected object with OpenSearch Dashboards data (30 ms)
      ✓ returns an empty array when no cluster uuid is provided (15 ms)

  console.warn
    No OpenSearchDashboards stats returned from usage collectors

      60 | ) {
      61 |   if (!response) {
    > 62 |     logger.warn('No OpenSearchDashboards stats returned from usage collectors');
         |            ^
      63 |     return;
      64 |   }
      65 |   const {

      at handleOpenSearchDashboardsStats (src/plugins/telemetry/server/telemetry_collection/get_opensearch_dashboards.ts:62:12)
      at handleLocalStats (src/plugins/telemetry/server/telemetry_collection/get_local_stats.ts:73:30)
      at Object.it (src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts:199:22)

  console.warn
    No OpenSearchDashboards stats returned from usage collectors

      60 | ) {
      61 |   if (!response) {
    > 62 |     logger.warn('No OpenSearchDashboards stats returned from usage collectors');
         |            ^
      63 |     return;
      64 |   }
      65 |   const {

      at handleOpenSearchDashboardsStats (src/plugins/telemetry/server/telemetry_collection/get_opensearch_dashboards.ts:62:12)
      at handleLocalStats (src/plugins/telemetry/server/telemetry_collection/get_local_stats.ts:73:30)
      at Object.it (src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts:216:22)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        2.618 s
```

Overall test result:
<img width="1626" alt="Screen Shot 2021-06-21 at 9 42 20 PM" src="https://user-images.githubusercontent.com/79961084/122864501-9d13f880-d2d9-11eb-8377-1748687fa27c.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 