### PR TITLE
[Test] Enable unit test suite: get_nodes_usage.test.ts

### DIFF
--- a/src/plugins/telemetry/server/telemetry_collection/get_nodes_usage.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_nodes_usage.test.ts
@@ -59,7 +59,7 @@ const mockedNodesFetchResponse = {
   },
 };
 
-describe.skip('get_nodes_usage', () => {
+describe('get_nodes_usage', () => {
   it('returns a modified array of nodes usage data', async () => {
     const response = Promise.resolve({ body: mockedNodesFetchResponse });
     const opensearchClient = opensearchServiceMock.createClusterClient().asInternalUser;


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR checks and enables
get_nodes_usage.test.ts.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Issues Resolved
[#513](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/513)

### Test results
unit test for get_nodes_usage.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_collection/get_nodes_usage.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_collection/get_nodes_usage.test.ts
 PASS  src/plugins/telemetry/server/telemetry_collection/get_nodes_usage.test.ts
  get_nodes_usage
    ✓ returns a modified array of nodes usage data (25 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        2.482 s
```

Overall test result:
<img width="1629" alt="Screen Shot 2021-06-21 at 10 42 24 PM" src="https://user-images.githubusercontent.com/79961084/122871678-3a742a00-d2e4-11eb-8184-dda2c017bd67.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 