### PR TITLE
[Test] Enable unit test suite: get_data_telemetry.test.ts

### DIFF
--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
@@ -34,10 +34,10 @@ import { buildDataTelemetryPayload, getDataTelemetry } from './get_data_telemetr
 import { DATA_DATASETS_INDEX_PATTERNS, DATA_DATASETS_INDEX_PATTERNS_UNIQUE } from './constants';
 import { opensearchServiceMock } from '../../../../../../src/core/server/mocks';
 
-describe.skip('get_data_telemetry', () => {
-  describe.skip('DATA_DATASETS_INDEX_PATTERNS', () => {
+describe('get_data_telemetry', () => {
+  describe('DATA_DATASETS_INDEX_PATTERNS', () => {
     DATA_DATASETS_INDEX_PATTERNS.forEach((entry, index, array) => {
-      describe.skip(`Pattern ${entry.pattern}`, () => {
+      describe(`Pattern ${entry.pattern}`, () => {
         test('there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE', () => {
           expect(
             DATA_DATASETS_INDEX_PATTERNS_UNIQUE.filter(({ pattern }) => pattern === entry.pattern)
@@ -56,7 +56,7 @@ describe.skip('get_data_telemetry', () => {
     });
   });
 
-  describe.skip('buildDataTelemetryPayload', () => {
+  describe('buildDataTelemetryPayload', () => {
     test('return the base object when no indices provided', () => {
       expect(buildDataTelemetryPayload([])).toStrictEqual([]);
     });
@@ -207,7 +207,7 @@ describe.skip('get_data_telemetry', () => {
     });
   });
 
-  describe.skip('getDataTelemetry', () => {
+  describe('getDataTelemetry', () => {
     test('it returns the base payload (all 0s) because no indices are found', async () => {
       const opensearchClient = mockOpenSearchClient();
       await expect(getDataTelemetry(opensearchClient)).resolves.toStrictEqual([]);


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR checks and enables
get_data_telemetry.test.ts.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Issues Resolved
[#514](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/514)

### Test results
unit test for get_data_telemetry.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
 PASS  src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
  get_data_telemetry
    DATA_DATASETS_INDEX_PATTERNS
      Pattern .ent-search-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (2 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern .app-search-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *magento2*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *magento*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *shopify*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *wordpress*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (1 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *drupal*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *joomla*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *search*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (2 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *sharepoint*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *squarespace*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (1 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *sitecore*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *weebly*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical (1 ms)
      Pattern *acquia*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern filebeat-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical (1 ms)
      Pattern metricbeat-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (1 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern apm-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern functionbeat-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern heartbeat-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (1 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern logstash-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical (1 ms)
      Pattern fluentd*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (1 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern telegraf*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern prometheusbeat*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern fluentbit*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical (1 ms)
      Pattern *nginx*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *apache*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern endgame-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (1 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern logs-endpoint.*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern metrics-endpoint.*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern .siem-signals-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern auditbeat-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern winlogbeat-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern packetbeat-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *tomcat*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *artifactory*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *aruba*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *barracuda*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *bluecoat*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern arcsight-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical (1 ms)
      Pattern *checkpoint*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *cisco*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *citrix*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *cyberark*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical (1 ms)
      Pattern *cylance*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *fireeye*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *fortinet*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *infoblox*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *kaspersky*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *mcafee*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *paloaltonetworks*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern pan-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern pan_*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (1 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern pan.*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern rsa.*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern rsa-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern rsa_*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (1 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern snort-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern logstash-snort*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *sonicwall*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *sophos*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (1 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern squid-*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern squid_*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern squid.*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *symantec*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (1 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *tippingpoint*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *trendmicro*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *tripwire*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *zscaler*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE (1 ms)
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *zeek*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *sigma_doc*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern ecs-corelight*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *suricata*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical (1 ms)
      Pattern *wazuh*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
      Pattern *meow*
        ✓ there should only be one in DATA_DATASETS_INDEX_PATTERNS_UNIQUE
        ✓ when a document is duplicated, the duplicates should be identical
    buildDataTelemetryPayload
      ✓ return the base object when no indices provided (1 ms)
      ✓ return the base object when no matching indices provided (2 ms)
      ✓ matches some indices and puts them in their own category (2 ms)
    getDataTelemetry
      ✓ it returns the base payload (all 0s) because no indices are found (27 ms)
      ✓ can only see the index mappings, but not the stats (16 ms)
      ✓ can see the mappings and the stats (14 ms)
      ✓ find an index that does not match any index pattern but has mappings metadata (41 ms)
      ✓ return empty array when there is an error (17 ms)

Test Suites: 1 passed, 1 total
Tests:       162 passed, 162 total
Snapshots:   0 total
Time:        2.583 s
```

Overall test result:
<img width="1626" alt="Screen Shot 2021-06-21 at 10 42 42 PM" src="https://user-images.githubusercontent.com/79961084/122871709-4233ce80-d2e4-11eb-815d-c41b2ac0ae7b.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 