### PR TITLE
[Test] Enable unit test suite: get_telemetry_saved_object.test.ts

### DIFF
--- a/src/plugins/telemetry/server/telemetry_repository/get_telemetry_saved_object.test.ts
+++ b/src/plugins/telemetry/server/telemetry_repository/get_telemetry_saved_object.test.ts
@@ -33,7 +33,7 @@
 import { getTelemetrySavedObject } from './get_telemetry_saved_object';
 import { SavedObjectsErrorHelpers } from '../../../../core/server';
 
-describe.skip('getTelemetrySavedObject', () => {
+describe('getTelemetrySavedObject', () => {
   it('returns null when saved object not found', async () => {
     const params = getCallGetTelemetrySavedObjectParams({
       savedObjectNotFound: true,


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR checks and enables
get_telemetry_saved_object.test.ts.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>
 

### Issues Resolved
[#515](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/515)

### Test results
unit test for get_telemetry_saved_object.test.ts
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_repository/get_telemetry_saved_object.test.ts
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/server/telemetry_repository/get_telemetry_saved_object.test.ts
 PASS  src/plugins/telemetry/server/telemetry_repository/get_telemetry_saved_object.test.ts
  getTelemetrySavedObject
    ✓ returns null when saved object not found (3 ms)
    ✓ returns false when saved object forbidden (1 ms)
    ✓ throws an error on unexpected saved object error

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        4.938 s
```

Overall test result:
<img width="1629" alt="Screen Shot 2021-06-21 at 11 28 57 PM" src="https://user-images.githubusercontent.com/79961084/122874945-7e692e00-d2e8-11eb-83b6-8b736965cbc6.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 