### PR TITLE
[Test] Enable unit test suites in telemetry/public/components

### DIFF
--- a/src/plugins/telemetry/public/components/__snapshots__/opt_in_banner.test.tsx.snap
+++ b/src/plugins/telemetry/public/components/__snapshots__/opt_in_banner.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OptInDetailsComponent renders as expected 1`] = `
   iconType="questionInCircle"
   title={
     <FormattedMessage
-      defaultMessage="Help us improve the Elastic Stack"
+      defaultMessage="Help us improve the OpenSearch Stack"
       id="telemetry.welcomeBanner.title"
       values={Object {}}
     />

--- a/src/plugins/telemetry/public/components/__snapshots__/opt_in_message.test.tsx.snap
+++ b/src/plugins/telemetry/public/components/__snapshots__/opt_in_message.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`OptInMessage renders as expected 1`] = `
 <Fragment>
   <FormattedMessage
-    defaultMessage="Want to help us improve the Elastic Stack? Data usage collection is currently disabled. Enabling data usage collection helps us manage and improve our products and services. See our {privacyStatementLink} for more details."
+    defaultMessage="Want to help us improve the OpenSearch Stack? Data usage collection is currently disabled. Enabling data usage collection helps us manage and improve our products and services. See our {privacyStatementLink} for more details."
     id="telemetry.telemetryBannerDescription"
     values={
       Object {
         "privacyStatementLink": <EuiLink
-          href="https://www.opensearch.org/legal/privacy-statement"
+          href=""
           rel="noopener"
           target="_blank"
         >

--- a/src/plugins/telemetry/public/components/__snapshots__/opted_in_notice_banner.test.tsx.snap
+++ b/src/plugins/telemetry/public/components/__snapshots__/opted_in_notice_banner.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OptInDetailsComponent renders as expected 1`] = `
 <EuiCallOut
-  title="Help us improve the Elastic Stack"
+  title="Help us improve the OpenSearch Stack"
 >
   <FormattedMessage
     defaultMessage="To learn about how usage data helps us manage and improve our products and services, see our {privacyStatementLink}. To stop collection, {disableLink}."
@@ -10,7 +10,7 @@ exports[`OptInDetailsComponent renders as expected 1`] = `
     values={
       Object {
         "disableLink": <EuiLink
-          href="management/kibana/settings"
+          href="management/opensearch-dashboards/settings"
           onClick={[Function]}
         >
           <FormattedMessage
@@ -20,7 +20,7 @@ exports[`OptInDetailsComponent renders as expected 1`] = `
           />
         </EuiLink>,
         "privacyStatementLink": <EuiLink
-          href="https://www.opensearch.org/legal/privacy-statement"
+          href=""
           onClick={[Function]}
           rel="noopener"
           target="_blank"

--- a/src/plugins/telemetry/public/components/opt_in_banner.test.tsx
+++ b/src/plugins/telemetry/public/components/opt_in_banner.test.tsx
@@ -34,7 +34,7 @@ import { EuiButton } from '@elastic/eui';
 import { shallowWithIntl } from 'test_utils/enzyme_helpers';
 import { OptInBanner } from './opt_in_banner';
 
-describe.skip('OptInDetailsComponent', () => {
+describe('OptInDetailsComponent', () => {
   it('renders as expected', () => {
     expect(shallowWithIntl(<OptInBanner onChangeOptInClick={() => {}} />)).toMatchSnapshot();
   });

--- a/src/plugins/telemetry/public/components/opt_in_message.test.tsx
+++ b/src/plugins/telemetry/public/components/opt_in_message.test.tsx
@@ -33,7 +33,7 @@ import React from 'react';
 import { shallowWithIntl } from 'test_utils/enzyme_helpers';
 import { OptInMessage } from './opt_in_message';
 
-describe.skip('OptInMessage', () => {
+describe('OptInMessage', () => {
   it('renders as expected', () => {
     expect(shallowWithIntl(<OptInMessage />)).toMatchSnapshot();
   });

--- a/src/plugins/telemetry/public/components/opted_in_notice_banner.test.tsx
+++ b/src/plugins/telemetry/public/components/opted_in_notice_banner.test.tsx
@@ -34,7 +34,7 @@ import { EuiButton } from '@elastic/eui';
 import { shallowWithIntl } from 'test_utils/enzyme_helpers';
 import { OptedInNoticeBanner } from './opted_in_notice_banner';
 
-describe.skip('OptInDetailsComponent', () => {
+describe('OptInDetailsComponent', () => {
   it('renders as expected', () => {
     expect(shallowWithIntl(<OptedInNoticeBanner onSeenBanner={() => {}} />)).toMatchSnapshot();
   });


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily
skipped after the fork. Unit tests of the disabled telemetry
functions should also be modified correspondingly. To build
a clean unit test, we decide to modify and enable all the
working unit tests. This PR enables three test suites in dir
src/plugins/telemetry/public/components, which includes:
1) opt_in_banner.test.tsx,
2) opt_in_message.test.tsx,
3) opted_in_notice_banner.test.tsx

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Issues Resolved
[#516](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/516)
[#517](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/517)
[#518](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/518)

### Test results
unit test for opt_in_banner.test.tsx

```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/components/opt_in_banner.test.tsx -u
yarn run v1.22.10
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/components/opt_in_banner.test.tsx -u
 PASS  src/plugins/telemetry/public/components/opt_in_banner.test.tsx
  OptInDetailsComponent
    ✓ renders as expected (8 ms)
    ✓ fires the "onChangeOptInClick" prop with true when a enable is clicked (4 ms)
    ✓ fires the "onChangeOptInClick" with false when a disable is clicked (1 ms)

 › 1 snapshot updated.
Snapshot Summary
 › 1 snapshot updated from 1 test suite.

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   1 updated, 1 total
Time:        3.141 s

```

unit test for opt_in_message.test.tsx

```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/components/opt_in_message.test.tsx -u
yarn run v1.22.5
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/components/opt_in_message.test.tsx -u
 PASS  src/plugins/telemetry/public/components/opt_in_message.test.tsx
  OptInMessage
    ✓ renders as expected (7 ms)

 › 1 snapshot updated.
Snapshot Summary
 › 1 snapshot updated from 1 test suite.

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 updated, 1 total
Time:        3.001 s

```

unit test for opted_in_notice_banner.test.tsx

```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/components/opted_in_notice_banner.test.tsx -u
yarn run v1.22.5
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry/public/components/opted_in_notice_banner.test.tsx -u
 PASS  src/plugins/telemetry/public/components/opted_in_notice_banner.test.tsx
  OptInDetailsComponent
    ✓ renders as expected (9 ms)
    ✓ fires the "onSeenBanner" prop when a link is clicked (2 ms)

 › 1 snapshot updated.
Snapshot Summary
 › 1 snapshot updated from 1 test suite.

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   1 updated, 1 total
Time:        3.025 s

```


Overall test result:
<img width="1624" alt="Screen Shot 2021-06-21 at 11 40 29 PM" src="https://user-images.githubusercontent.com/79961084/122876225-1c112d00-d2ea-11eb-956b-977f07d75fff.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 