### PR TITLE
[Test] Enable unit test suites in telemetry_management_section

### DIFF
--- a/src/plugins/telemetry_management_section/public/components/__snapshots__/opt_in_security_example_flyout.test.tsx.snap
+++ b/src/plugins/telemetry_management_section/public/components/__snapshots__/opt_in_security_example_flyout.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`security flyout renders as expected renders as expected 1`] = `
         color="subdued"
       >
         <EuiText>
-          This is a representative sample of the endpoint security alert event that we collect. Endpoint security data is collected only when the Elastic Endpoint is enabled. It includes information about the endpoint configuration and detection events.
+          This is a representative sample of the endpoint security alert event that we collect. Endpoint security data is collected only when the OpenSearch Endpoint is enabled. It includes information about the endpoint configuration and detection events.
         </EuiText>
       </EuiTextColor>
     </EuiFlyoutHeader>
@@ -76,7 +76,7 @@ exports[`security flyout renders as expected renders as expected 1`] = `
   "ecs": {
     "version": "1.5.0"
   },
-  "elastic": {
+  "opensearch": {
     "agent": {
       "id": "b2e88aea-2671-402a-828a-957526bac315"
     }
@@ -125,7 +125,7 @@ exports[`security flyout renders as expected renders as expected 1`] = `
     "kind": "alert"
   },
   "cluster_uuid": "kLbKvSMcRiiFAR0t8LebDA",
-  "cluster_name": "elasticsearch"
+  "cluster_name": "opensearch"
 }
       </EuiCodeBlock>
     </EuiFlyoutBody>

--- a/src/plugins/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
+++ b/src/plugins/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TelemetryManagementSectionComponent does not show the endpoint link whe
       values={
         Object {
           "privacyStatementLink": <EuiLink
-            href="https://www.opensearch.org/legal/privacy-statement"
+            href=""
             target="_blank"
           >
             <FormattedMessage
@@ -74,14 +74,14 @@ exports[`TelemetryManagementSectionComponent renders as expected 1`] = `
         title={
           <p>
             <FormattedMessage
-              defaultMessage="Changes to this setting apply to {allOfKibanaText} and are saved automatically."
+              defaultMessage="Changes to this setting apply to {allOfOpenSearchDashboardsText} and are saved automatically."
               id="telemetry.callout.appliesSettingTitle"
               values={
                 Object {
-                  "allOfKibanaText": <strong>
+                  "allOfOpenSearchDashboardsText": <strong>
                     <FormattedMessage
-                      defaultMessage="all of Kibana"
-                      id="telemetry.callout.appliesSettingTitle.allOfKibanaText"
+                      defaultMessage="all of OpenSearchDashboards"
+                      id="telemetry.callout.appliesSettingTitle.allOfOpenSearchDashboardsText"
                       values={Object {}}
                     />
                   </strong>,
@@ -111,7 +111,7 @@ exports[`TelemetryManagementSectionComponent renders as expected 1`] = `
                   values={
                     Object {
                       "privacyStatementLink": <EuiLink
-                        href="https://www.opensearch.org/legal/privacy-statement"
+                        href=""
                         target="_blank"
                       >
                         <FormattedMessage
@@ -158,7 +158,7 @@ exports[`TelemetryManagementSectionComponent renders as expected 1`] = `
             "displayName": "Provide usage statistics",
             "name": "telemetry:enabled",
             "type": "boolean",
-            "value": true,
+            "value": false,
           }
         }
         toasts={null}

--- a/src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.test.tsx
+++ b/src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.test.tsx
@@ -33,7 +33,7 @@ import React from 'react';
 import { shallowWithIntl } from 'test_utils/enzyme_helpers';
 import { OptInExampleFlyout } from './opt_in_example_flyout';
 
-describe.skip('OptInDetailsComponent', () => {
+describe('OptInDetailsComponent', () => {
   it('renders as expected', () => {
     expect(
       shallowWithIntl(

--- a/src/plugins/telemetry_management_section/public/components/opt_in_security_example_flyout.test.tsx
+++ b/src/plugins/telemetry_management_section/public/components/opt_in_security_example_flyout.test.tsx
@@ -33,7 +33,7 @@ import React from 'react';
 import { shallowWithIntl } from 'test_utils/enzyme_helpers';
 import { OptInSecurityExampleFlyout } from './opt_in_security_example_flyout';
 
-describe.skip('security flyout renders as expected', () => {
+describe('security flyout renders as expected', () => {
   it('renders as expected', () => {
     expect(shallowWithIntl(<OptInSecurityExampleFlyout onClose={jest.fn()} />)).toMatchSnapshot();
   });

--- a/src/plugins/telemetry_management_section/public/components/telemetry_management_section.test.tsx
+++ b/src/plugins/telemetry_management_section/public/components/telemetry_management_section.test.tsx
@@ -36,7 +36,7 @@ import { TelemetryService } from '../../../telemetry/public/services';
 import { coreMock } from '../../../../core/public/mocks';
 import { render } from '@testing-library/react';
 
-describe.skip('TelemetryManagementSectionComponent', () => {
+describe('TelemetryManagementSectionComponent', () => {
   const coreStart = coreMock.createStart();
   const coreSetup = coreMock.createSetup();
 


### PR DESCRIPTION
### Description

All the unit tests related to unused telemetry are temporarily skipped after the fork. Unit tests of the disabled telemetry functions should also be modified correspondingly. To build a clean unit test, we decide to modify and enable all the working unit tests. This PR checks and enables three test suites in src/plugins/telemetry_management_section including: 1) opt_in_example_flyout.test.tsx, 2) opt_in_security_example_flyout.test.tsx, and 3) telemetry_management_section.test.tsx.

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

### Issues Resolved
[#519](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/519)
[#520](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/520)
[#521](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/521)

### Test results
unit test for opt_in_example_flyout.test.tsx
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.test.tsx -u
yarn run v1.22.5
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.test.tsx -u
 PASS  src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.test.tsx
  OptInDetailsComponent
    ✓ renders as expected (9 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        2.985 s
```

unit test for opt_in_security_example_flyout.test.tsx
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry_management_section/public/components/opt_in_security_example_flyout.test.tsx -u
yarn run v1.22.5
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry_management_section/public/components/opt_in_security_example_flyout.test.tsx -u
 PASS  src/plugins/telemetry_management_section/public/components/opt_in_security_example_flyout.test.tsx
  security flyout renders as expected
    ✓ renders as expected (9 ms)

 › 1 snapshot updated.
Snapshot Summary
 › 1 snapshot updated from 1 test suite.

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 updated, 1 total
Time:        2.996 s
```

unit test for telemetry_management_section.test.tsx 
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry_management_section/public/components/telemetry_management_section.test.tsx -u
yarn run v1.22.5
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/telemetry_management_section/public/components/telemetry_management_section.test.tsx -u
 PASS  src/plugins/telemetry_management_section/public/components/telemetry_management_section.test.tsx
  TelemetryManagementSectionComponent
    ✓ renders as expected (9 ms)
    ✓ renders null because query does not match the SEARCH_TERMS (301 ms)
    ✓ renders because query matches the SEARCH_TERMS (30 ms)
    ✓ renders null because allowChangingOptInStatus is false (4 ms)
    ✓ shows the OptInExampleFlyout (38 ms)
    ✓ shows the OptInSecurityExampleFlyout (23 ms)
    ✓ does not show the endpoint link when isSecurityExampleEnabled returns false (9 ms)
    ✓ toggles the OptIn button (31 ms)
    ✓ test the wrapper (for coverage purposes) (1 ms)

 › 2 snapshots updated.
  console.error
    [React Intl] Could not find required `intl` object. <IntlProvider> needs to exist in the component ancestry. Using default message as fallback.

      at defaultFormatMessage (node_modules/react-intl/lib/index.js:1533:13)
      at FormattedMessage.render (node_modules/react-intl/lib/index.js:1638:30)
      at finishClassComponent (node_modules/react-dom/cjs/react-dom.development.js:18470:31)
      at updateClassComponent (node_modules/react-dom/cjs/react-dom.development.js:18423:24)
      at beginWork$1 (node_modules/react-dom/cjs/react-dom.development.js:20186:16)
      at beginWork$$1 (node_modules/react-dom/cjs/react-dom.development.js:25756:14)
      at performUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:24698:12)
      at workLoopSync (node_modules/react-dom/cjs/react-dom.development.js:24671:22)
      at performSyncWorkOnRoot (node_modules/react-dom/cjs/react-dom.development.js:24270:11)
      at scheduleUpdateOnFiber (node_modules/react-dom/cjs/react-dom.development.js:23698:7)
      at updateContainer (node_modules/react-dom/cjs/react-dom.development.js:27103:3)
      at node_modules/react-dom/cjs/react-dom.development.js:27528:7
      at unbatchedUpdates (node_modules/react-dom/cjs/react-dom.development.js:24433:12)

  console.error
    Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
        in OptInExampleFlyout (created by TelemetryManagementSection)
        in TelemetryManagementSection (created by WrapperComponent)
        in WrapperComponent

      75 |       const { fetchExample } = this.props;
      76 |       const clusters = await fetchExample();
    > 77 |       this.setState({
         |            ^
      78 |         data: Array.isArray(clusters) ? clusters : null,
      79 |         isLoading: false,
      80 |         hasPrivilegeToRead: true,

      at warningWithoutStack (node_modules/react-dom/cjs/react-dom.development.js:530:32)
      at warnAboutUpdateOnUnmountedFiberInDEV (node_modules/react-dom/cjs/react-dom.development.js:25738:5)
      at scheduleUpdateOnFiber (node_modules/react-dom/cjs/react-dom.development.js:23679:5)
      at Object.enqueueSetState (node_modules/react-dom/cjs/react-dom.development.js:13994:5)
      at OptInExampleFlyout.setState (node_modules/react/cjs/react.development.js:325:16)
      at OptInExampleFlyout.componentDidMount (src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.tsx:77:12)

Snapshot Summary
 › 2 snapshots updated from 1 test suite.

Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Snapshots:   2 updated, 2 passed, 4 total
Time:        4.473 s
```

Overall test result:
<img width="1562" alt="Screen Shot 2021-06-22 at 11 51 36 PM" src="https://user-images.githubusercontent.com/79961084/123050178-44b22900-d3b5-11eb-930f-ad41e02caefe.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 