### PR TITLE
[Test] Remove unit test case in zip.test.js

### DIFF
--- a/src/cli_plugin/install/zip.test.js
+++ b/src/cli_plugin/install/zip.test.js
@@ -32,14 +32,11 @@
 
 import path from 'path';
 import os from 'os';
-import fs from 'fs';
 
 import del from 'del';
 import glob from 'glob';
 
 import { analyzeArchive, extractArchive } from './zip';
-
-const getMode = (path) => (fs.statSync(path).mode & parseInt('777', 8)).toString(8);
 
 describe('opensearchDashboards cli', function () {
   describe('zip', function () {
@@ -91,25 +88,6 @@ describe('opensearchDashboards cli', function () {
             "public/index.js",
           ]
         `);
-      });
-    });
-
-    describe('checkFilePermission', () => {
-      // TODO:: Verify why zip is not validating correct permission.
-      it.skip('verify consistency of modes of files', async () => {
-        const archivePath = path.resolve(repliesPath, 'test_plugin.zip');
-
-        await extractArchive(archivePath, tempPath, 'opensearch-dashboards/test-plugin/bin');
-
-        expect(glob.sync('**/*', { cwd: tempPath })).toMatchInlineSnapshot(`
-          Array [
-            "executable",
-            "not-executable",
-          ]
-        `);
-
-        expect(getMode(path.resolve(tempPath, 'executable'))).toEqual('755');
-        expect(getMode(path.resolve(tempPath, 'not-executable'))).toEqual('644');
       });
     });
 


### PR DESCRIPTION
### Description

With existing fixture, test verify consistency of modes of files inside zip.test.js fails. This is due to diff file mode in different system when doing same command or operation. For example, in our ubuntu, when create a file using mkdir cmd, the file mode is 775. But local machine, the file mode is 755.

```
local env: drwxr-xr-x  62 ananzh  staff   1.9K Jun 23 19:12 OpenSearch-Dashboards (755)
Ubuntu: drwxrwxr-x 24 anan anan 4096 Jun 24 01:04 OpenSearch-Dashboards (775)
```

After unzip executable has mode 777 and not-executable has mode 644. These two numbers are fixed. They are not dependent on diff system or folder mode where you unzip the files. However, the following two results:
```
getMode(path.resolve(tempPath,'executable'))
getMode(path.resolve(tempPath,’not-executable'))
```
are dependent on tempPath mode because it will use the lower mode. For example (use mode# directly below):
1)If tempPath is 775 then:
```
getMode(path.resolve(775, 777)) —> 775
getMode(path.resolve(775, 644)) —> 644
```
2)If tempPath is 755 then:
```
getMode(path.resolve(755, 777)) —> 755
getMode(path.resolve(755, 644)) —> 644
```
To verify by yourself, you could change `getMode` function and for example pass it a 755:
`getMode = (path) => (fs.statSync(path).mode & parseInt('755’, 8)).toString(8);`
Then in the test case, console log the mode of tempPath and test result:
```
console.log(getMode(tempPath));
console.log(getMode(path.resolve(tempPath, 'executable')));
```

Therefore, this unit test case result is dependent on the mode of tempPath which is affected by your system or system settings.

This PR investigats the issue and remove todo. We have two options: 1) Our Jenkins test env has 755 for tempPath (see below image). So we could enable this test case without any changes. Customer might fail this test locally and can manually skip this test.

<img width="1013" alt="Screen Shot 2021-06-24 at 8 08 23 AM" src="https://user-images.githubusercontent.com/79961084/123287595-aeb8f400-d4c3-11eb-80c7-933c3f7cb18b.png">

Option2: Force the tempPath mode to be 755 by changing:
```
const getMode = (path) => (fs.statSync(path).mode & parseInt('755', 8)).toString(8);
```
However, this assumes customer's env will generate a tempPath either 755 or 775, which does not guaranteed that this test case won't fail again locally.

Option3: Remove this test case and open a new issue to investigate alternative ways to write this test case

This PR uses option 3.  The meaning of this test case is to test whether extractArchive function extract files with same
permission when they archive. However, getMode function in this test suite is system env dependent which doesn’t serve the purpose of this test case.


Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Issues Resolved
[#4](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4)
 
### Test results
unit test for zip.test.js
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/cli_plugin/install/zip.test.js
yarn run v1.22.5
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/cli_plugin/install/zip.test.js
 PASS  src/cli_plugin/install/zip.test.js
  opensearchDashboards cli
    zip
      ✓ handles a corrupt zip archive (2 ms)
      analyzeArchive
        ✓ returns array of plugins (26 ms)
      extractArchive
        ✓ extracts files using the extractPath filter (10 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   3 passed, 3 total
Time:        1.884 s

```

Overall test result:
<img width="1656" alt="Screen Shot 2021-06-24 at 8 41 48 AM" src="https://user-images.githubusercontent.com/79961084/123292647-1a9d5b80-d4c8-11eb-968e-dcfe24fd2a54.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 