### PR TITLE
[DOCS] Replace edit_index_pattern link

### DIFF
--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -231,7 +231,9 @@ export const EditIndexPattern = withRouter(
                 values={{ indexPatternTitle: <strong>{indexPattern.title}</strong> }}
               />{' '}
               <EuiLink
-                href="http://www.opensearch.org/guide/en/elasticsearch/reference/current/mapping.html"
+                // TODO: [RENAMEME] Need prod urls.
+                // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
+                href="https://docs-beta.opensearch.org/opensearch/index-templates"
                 target="_blank"
                 external
               >


### PR DESCRIPTION
### Description
Replacing previous upstream reference within the edit index
pattern page. This does not fully resolve the current issue
due to the link being replaced with a temporary link, and
the link being related to Mappings API documentation but
does not fully replace the content that the original provided.

Will track replacement with:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
Partially: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/482
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 