### PR TITLE
Upgrade merge from 1.2.1 to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "**/istanbul-instrumenter-loader/schema-utils": "^1.0.0",
     "**/load-grunt-config/lodash": "^4.17.20",
     "**/locutus": "^2.0.14",
+    "**/merge": "^2.1.1",
     "**/minimist": "^1.2.5",
     "**/node-jose/node-forge": "^0.10.0",
     "**/prismjs": "^1.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16887,10 +16887,10 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-merge@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
+merge@^1.2.0, merge@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-2.1.1.tgz#59ef4bf7e0b3e879186436e8481c06a6c162ca98"
+  integrity sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==
 
 methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
### Description
Addresses https://github.com/advisories/GHSA-7wpw-2hjm-89gp

Bumps [merge](https://github.com/yeikos/js.merge) from 1.2.1 to 2.1.1
- [Release notes](https://github.com/yeikos/js.merge/releases)
- [Commits](https://github.com/yeikos/js.merge/compare/v1.2.1...v2.1.1)

Merge 1.2.1 is a downstream dependency of `sass-lint` which is an unmaintained repo without any newer versions. I've opened #551 to address this as a longer-term solution.

**Before**
```
$ yarn why merge
yarn why v1.22.10
[1/4] Why do we have the module "merge"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "merge@1.2.1"
info Reasons this module exists
   - "_project_#sass-lint" depends on it
   - Hoisted from "_project_#sass-lint#merge"
info Disk size without dependencies: "28KB"
info Disk size with unique dependencies: "28KB"
info Disk size with transitive dependencies: "28KB"
info Number of shared dependencies: 0
Done in 1.35s.
```

### Testing

<img width="1444" alt="Screen Shot 2021-06-25 at 4 35 41 PM" src="https://user-images.githubusercontent.com/5437176/123487368-67ba2400-d5d3-11eb-9978-f5f7794b9e3d.png">
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 