### PR TITLE
Require front-matter v4.0.2, fix resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,17 +75,13 @@
   },
   "resolutions": {
     "**/@types/node": ">=10.17.17 <10.20.0",
-    "**/cross-fetch/node-fetch": "^2.6.1",
-    "**/dns-packet": "^1.3.4",
     "**/ejs": "^3.1.6",
-    "**/fast-deep-equal": "^3.1.1",
+    "**/front-matter": "^4.0.2",
     "**/glob-parent": "^6.0.0",
     "**/hoist-non-react-statics": "^3.3.2",
     "**/immer": "^8.0.1",
-    "**/isomorphic-fetch/node-fetch": "^2.6.1",
     "**/istanbul-instrumenter-loader/schema-utils": "^1.0.0",
     "**/kind-of": ">=6.0.3",
-    "**/locutus": "^2.0.14",
     "**/lodash": "^4.17.21",
     "**/merge": "^2.1.1",
     "**/minimist": "^1.2.5",
@@ -97,8 +93,7 @@
     "**/request": "^2.88.2",
     "**/ssri": "^6.0.2",
     "**/trim": "^0.0.3",
-    "**/typescript": "4.0.2",
-    "**/url-parse": "^1.5.1"
+    "**/typescript": "4.0.2"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -9330,7 +9330,7 @@ dns-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
-dns-packet@^1.3.1, dns-packet@^1.3.4:
+dns-packet@^1.3.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.4.tgz#e3455065824a2507ba886c55a89963bb107dec6f"
   integrity sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==
@@ -10904,9 +10904,9 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
 
 fast-deep-equal@^3.1.1, fast-deep-equal@~3.1.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
-  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-diff@^1.1.2:
   version "1.2.0"
@@ -11528,12 +11528,12 @@ from2@^2.1.0, from2@^2.1.1:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-front-matter@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-2.1.2.tgz#f75983b9f2f413be658c93dfd7bd8ce4078f5cdb"
-  integrity sha1-91mDufL0E75ljJPf172M5AePXNs=
+front-matter@2.1.2, front-matter@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-4.0.2.tgz#b14e54dc745cfd7293484f3210d15ea4edd7f4d5"
+  integrity sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==
   dependencies:
-    js-yaml "^3.4.6"
+    js-yaml "^3.13.1"
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -15307,7 +15307,7 @@ js-yaml@3.13.1, js-yaml@~3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.9.0, js-yaml@~3.14.0:
+js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.9.0, js-yaml@~3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -16031,7 +16031,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-locutus@^2.0.14, locutus@^2.0.5:
+locutus@^2.0.5:
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/locutus/-/locutus-2.0.15.tgz#d75b9100713aaaf30be8b38ed6543910498c0db0"
   integrity sha512-2xWC4RkoAoCVXEb/stzEgG1TNgd+mrkLBj6TuEDNyUoKeQ2XzDTyJUC23sMiqbL6zJmJSP3w59OZo+zc4IBOmA==


### PR DESCRIPTION
### Description
Addresses [WS-2020-0341](https://github.com/jxson/front-matter/commit/f71652cfef6f296f7b5ab495461914ae61d76da2)

Also removes unnecessary resolutions for dependencies that didn't have conflicts.

`front-matter` 2.1.2 is a downstream dependency of `sass-lint` which is an unmaintained repo without any newer versions. I've opened #551 to address this as a longer-term solution.

Upgrades [front-matter](https://github.com/jxson/front-matter) from 2.1.2 to 4.0.2
- [Release notes](https://github.com/jxson/front-matter/releases)
- [Commits](https://github.com/jxson/front-matter/compare/v2.1.2...v4.0.2)

**Before**
```
$ yarn why front-matter
yarn why v1.22.10
[1/4] Why do we have the module "front-matter"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "front-matter@2.1.2"
info Reasons this module exists
   - "_project_#sass-lint" depends on it
   - Hoisted from "_project_#sass-lint#front-matter"
info Disk size without dependencies: "36KB"
info Disk size with unique dependencies: "456KB"
info Disk size with transitive dependencies: "1.07MB"
info Number of shared dependencies: 4
Done in 1.38s.
```

### Testing

![Screen Shot 2021-06-29 at 11 47 53 PM](https://user-images.githubusercontent.com/5437176/123903518-76d30600-d934-11eb-9168-bafcf0b3699d.png)
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 