### PR TITLE
Require `ejs` v3.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "**/@types/node": ">=10.17.17 <10.20.0",
     "**/cross-fetch/node-fetch": "^2.6.1",
     "**/dns-packet": "^1.3.4",
+    "**/ejs": "^3.1.6",
     "**/fast-deep-equal": "^3.1.1",
     "**/graphql-toolkit/lodash": "^4.17.15",
     "**/hoist-non-react-statics": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9600,15 +9600,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-ejs@^2.3.1:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
-  integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
-
-ejs@^3.1.2, ejs@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.5.tgz#aed723844dc20acb4b170cd9ab1017e476a0d93b"
-  integrity sha512-dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==
+ejs@^2.3.1, ejs@^3.1.2, ejs@^3.1.5, ejs@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.6.tgz#5bfd0a0689743bb5268b3550cceeebbc1702822a"
+  integrity sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==
   dependencies:
     jake "^10.6.1"
 


### PR DESCRIPTION
### Description
Addresses [WS-2021-0153](https://github.com/mde/ejs/commit/abaee2be937236b1b8da9a1f55096c17dda905fd)

`ejs` is a downstream dependency of `yeoman-generator`, and the newest version of that package still depends on the older version of `ejs`.

Bumps [ejs](https://github.com/mde/ejs) from 2.7.4/3.1.5 to 3.1.6
- [Release notes](https://github.com/mde/ejs/releases)
- [Changelog](https://github.com/mde/ejs/blob/v3.1.6/CHANGELOG.md)
- [Commits](https://github.com/mde/ejs/compare/v2.7.4...v3.1.6)
 
### Testing

<img width="1442" alt="Screen Shot 2021-06-25 at 6 12 36 PM" src="https://user-images.githubusercontent.com/5437176/123493053-f1bcb980-d5e0-11eb-912f-b43d43992a78.png">

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 