### PR TITLE
[DOCS] Replace settings and help menu links

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -124,9 +124,13 @@ export class DocLinksService {
         },
         indexPatterns: {
           loadingData: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/tutorial-load-dataset.html`,
-          introduction: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/index-patterns.html`,
+          // TODO: [RENAMEME] Need prod urls.
+          // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
+          introduction: `${OPENSEARCH_DASHBOARDS_DOCS}`,
         },
-        addData: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/connect-to-elasticsearch.html`,
+        // TODO: [RENAMEME] Need prod urls.
+        // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
+        addData: `${OPENSEARCH_DASHBOARDS_DOCS}`,
         opensearchDashboards: `${OPENSEARCH_DASHBOARDS_DOCS}`,
         siem: {
           guide: `${OPENSEARCH_WEBSITE_URL}guide/en/security/${DOC_LINK_VERSION}/index.html`,
@@ -147,8 +151,8 @@ export class DocLinksService {
           dashboardSettings: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/advanced-options.html#opensearch-dashboard-settings`,
         },
         visualize: {
-          guide: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/dashboard.html`,
-          timelineDeprecation: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/dashboard.html#timeline-deprecation`,
+          guide: `${OPENSEARCH_DASHBOARDS_DOCS}`,
+          timelineDeprecation: `${OPENSEARCH_DASHBOARDS_DOCS}`,
         },
       },
     });

--- a/src/core/server/ui_settings/settings/date_formats.ts
+++ b/src/core/server/ui_settings/settings/date_formats.ts
@@ -168,7 +168,9 @@ export const getDateFormatSettings = (): Record<string, UiSettingsParams> => {
         defaultMessage: 'Used for the {dateNanosLink} datatype of OpenSearch',
         values: {
           dateNanosLink:
-            '<a href="https://www.opensearch.org/guide/en/elasticsearch/reference/master/date_nanos.html" target="_blank" rel="noopener noreferrer">' +
+            // TODO: [RENAMEME] Need prod urls.
+            // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
+            '<a href="https://docs-beta.opensearch.org/opensearch/units" target="_blank" rel="noopener noreferrer">' +
             i18n.translate('core.ui_settings.params.dateNanosLinkTitle', {
               defaultMessage: 'date_nanos',
             }) +

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/msearch.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/msearch.json
@@ -23,6 +23,6 @@
       "{indices}/_msearch",
       "{indices}/{type}/_msearch"
     ],
-    "documentation": "https://www.opensearch.org/guide/en/elasticsearch/reference/master/search-multi-search.html"
+    "documentation": "https://docs-beta.opensearch.org/opensearch/query-dsl/full-text/#multi-match"
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/msearch_template.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/msearch_template.json
@@ -21,6 +21,6 @@
       "{indices}/_msearch/template",
       "{indices}/{type}/_msearch/template"
     ],
-    "documentation": "https://www.opensearch.org/guide/en/elasticsearch/reference/current/search-multi-search.html"
+    "documentation": "https://docs-beta.opensearch.org/opensearch/query-dsl/full-text/#multi-match"
   }
 }

--- a/src/plugins/dashboard/public/application/help_menu/help_menu_util.ts
+++ b/src/plugins/dashboard/public/application/help_menu/help_menu_util.ts
@@ -44,7 +44,9 @@ export function addHelpMenuToAppChrome(
     links: [
       {
         linkType: 'documentation',
-        href: `${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/dashboard.html`,
+        // TODO: [RENAMEME] Need prod urls.
+        // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
+        href: `${docLinks.links.opensearchDashboards}`,
       },
     ],
   });

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -106,7 +106,9 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'data.advancedSettings.query.queryStringOptionsText',
         values: {
           optionsLink:
-            '<a href="https://www.opensearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html" target="_blank" rel="noopener">' +
+            // TODO: [RENAMEME] Need prod urls.
+            // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
+            '<a href="https://docs-beta.opensearch.org/opensearch/query-dsl/index" target="_blank" rel="noopener">' +
             i18n.translate('data.advancedSettings.query.queryStringOptions.optionsLinkText', {
               defaultMessage: 'Options',
             }) +
@@ -165,7 +167,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'data.advancedSettings.sortOptionsText',
         values: {
           optionsLink:
-            '<a href="https://www.opensearch.org/guide/en/elasticsearch/reference/current/search-request-sort.html" target="_blank" rel="noopener">' +
+            '<a href="https://docs-beta.opensearch.org/opensearch/ux/#sort-results" target="_blank" rel="noopener">' +
             i18n.translate('data.advancedSettings.sortOptions.optionsLinkText', {
               defaultMessage: 'Options',
             }) +
@@ -247,7 +249,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           setRequestReferenceSetting: `<strong>${UI_SETTINGS.COURIER_SET_REQUEST_PREFERENCE}</strong>`,
           customSettingValue: '"custom"',
           requestPreferenceLink:
-            '<a href="https://www.opensearch.org/guide/en/elasticsearch/reference/current/search-request-preference.html" target="_blank" rel="noopener">' +
+            '<a href="https://docs-beta.opensearch.org/opensearch/popular-api" target="_blank" rel="noopener">' +
             i18n.translate(
               'data.advancedSettings.courier.customRequestPreference.requestPreferenceLinkText',
               {
@@ -271,7 +273,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'Controls the {maxRequestsLink} setting used for _msearch requests sent by OpenSearch Dashboards. ' +
           'Set to 0 to disable this config and use the OpenSearch default.',
         values: {
-          maxRequestsLink: `<a href="https://www.opensearch.org/guide/en/elasticsearch/reference/current/search-multi-search.html"
+          maxRequestsLink: `<a href="https://docs-beta.opensearch.org/opensearch/query-dsl/full-text/#multi-match"
             target="_blank" rel="noopener" >max_concurrent_shard_requests</a>`,
         },
       }),
@@ -301,7 +303,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
     },
     [UI_SETTINGS.SEARCH_INCLUDE_FROZEN]: {
       name: 'Search in frozen indices',
-      description: `Will include <a href="https://www.opensearch.org/guide/en/elasticsearch/reference/current/frozen-indices.html"
+      description: `Will include <a href="https://docs-beta.opensearch.org/opensearch/index-data"
         target="_blank" rel="noopener">frozen indices</a> in results if enabled. Searching through frozen indices
         might increase the search time.`,
       value: false,
@@ -650,7 +652,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'data.advancedSettings.timepicker.quickRanges.acceptedFormatsLinkText',
         values: {
           acceptedFormatsLink:
-            `<a href="https://www.opensearch.org/guide/en/elasticsearch/reference/current/common-options.html#date-math"
+            `<a href="https://docs-beta.opensearch.org/opensearch/units"
             target="_blank" rel="noopener">` +
             i18n.translate('data.advancedSettings.timepicker.quickRanges.acceptedFormatsLinkText', {
               defaultMessage: 'accepted formats',

--- a/src/plugins/discover/public/application/angular/context/api/utils/get_opensearch_query_sort.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/get_opensearch_query_sort.ts
@@ -37,7 +37,7 @@ import {
 
 /**
  * Returns `OpenSearchQuerySort` which is used to sort records in the OpenSearch query
- * https://www.opensearch.org/guide/en/elasticsearch/reference/current/search-request-sort.html
+ * https://docs-beta.opensearch.org/opensearch/ux/#sort-results
  * @param timeField
  * @param tieBreakerField
  * @param sortDir

--- a/src/plugins/discover/public/application/components/help_menu/help_menu_util.js
+++ b/src/plugins/discover/public/application/components/help_menu/help_menu_util.js
@@ -42,7 +42,9 @@ export function addHelpMenuToAppChrome(chrome) {
     links: [
       {
         linkType: 'documentation',
-        href: `${docLinks.OPENSEARCH_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/discover.html`,
+        // TODO: [RENAMEME] Need prod urls.
+        // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
+        href: `${docLinks.links.opensearchDashboards}`,
       },
     ],
   });

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/__snapshots__/empty_state.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/__snapshots__/empty_state.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`EmptyState should render normally 1`] = `
                   Object {
                     "description": <EuiLink
                       external={true}
-                      href="https://www.opensearch.org/guide/en/opensearch/mocked-test-branch/connect-to-elasticsearch.html"
+                      href="https://docs-beta.opensearch.org/docs/opensearch-dashboards/"
                       target="_blank"
                     >
                       <FormattedMessage

--- a/src/plugins/maps_legacy/server/ui_settings.ts
+++ b/src/plugins/maps_legacy/server/ui_settings.ts
@@ -51,7 +51,9 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
             'maps_legacy.advancedSettings.visualization.tileMap.maxPrecision.cellDimensionsLinkText',
           values: {
             cellDimensionsLink:
-              `<a href="http://www.opensearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html#_cell_dimensions_at_the_equator"
+              // TODO: [RENAMEME] Need prod urls.
+              // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
+              `<a href="https://docs-beta.opensearch.org/dashboards/maptiles"
             target="_blank" rel="noopener">` +
               i18n.translate(
                 'maps_legacy.advancedSettings.visualization.tileMap.maxPrecision.cellDimensionsLinkText',

--- a/src/plugins/vis_type_vega/public/components/vega_help_menu.tsx
+++ b/src/plugins/vis_type_vega/public/components/vega_help_menu.tsx
@@ -54,7 +54,9 @@ function VegaHelpMenu() {
   const items = [
     <EuiContextMenuItem
       key="vegaHelp"
-      href="https://www.opensearch.org/guide/en/kibana/master/vega-graph.html"
+      // TODO: [RENAMEME] Need prod urls.
+      // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
+      href="https://docs-beta.opensearch.org/docs/opensearch-dashboards"
       target="_blank"
       onClick={closePopover}
     >


### PR DESCRIPTION
### Description
Replacing previous upstream references with working links.
This does not fully resolve the current issue due to the link
being replaced with a temporary link, and the link directing
to related documentation if it exists but some do not so it
sends it to the basic OpenSearch Dashboards documentation which
is a bad experience but better than a 404.

Will track replacement with:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
Partial: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 