### PR TITLE
Upgrade chromedriver, match version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,14 @@ RUN apt-get update && \
       libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget openjdk-8-jre && \
     rm -rf /var/lib/apt/lists/*
 
+# Specify the version of Chrome that matches the version of chromedriver in the package.json.
+# A list of Chrome versions can be found here: 
+# https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
+ARG CHROME_VERSION=91.0.4472.114-1
 RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+  && wget -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
   && apt-get update \
-  && apt-get install -y rsync jq bsdtar google-chrome-stable \
-  --no-install-recommends python-pip \
+  && apt-get install -y rsync jq bsdtar /tmp/chrome.deb --no-install-recommends python-pip \
   && pip install awscli \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/package.json
+++ b/package.json
@@ -357,7 +357,7 @@
     "chai": "3.5.0",
     "chance": "1.0.18",
     "cheerio": "0.22.0",
-    "chromedriver": "^88.0.0",
+    "chromedriver": "^91.0.1",
     "classnames": "2.2.6",
     "compare-versions": "3.5.1",
     "d3": "3.5.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7375,17 +7375,16 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^88.0.0:
-  version "88.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-88.0.0.tgz#6833fffd516db23c811eeafa1ee1069b5a12fd2f"
-  integrity sha512-EE8rXh7mikxk3VWKjUsz0KCUX8d3HkQ4HgMNJhWrWjzju12dKPPVHO9MY+YaAI5ryXrXGNf0Y4HcNKgW36P/CA==
+chromedriver@^91.0.1:
+  version "91.0.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-91.0.1.tgz#4d70a569901e356c978a41de3019c464f2a8ebd0"
+  integrity sha512-9LktpHiUxM4UWUsr+jI1K1YKx2GENt6BKKJ2mibPj1Wc6ODzX/3fFIlr8CZ4Ftuyga+dHTTbAyPWKwKvybEbKA==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.1"
     del "^6.0.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.0"
-    mkdirp "^1.0.4"
     proxy-from-env "^1.1.0"
     tcp-port-used "^1.0.1"
 


### PR DESCRIPTION
### Description
Functional tests were failing in Jenkins pipelines because Docker was pulling the latest version of Chrome instead of using the same version that is defined for `chromedriver`. This changes fixes that bug by fetching a specific version of Chrome.

Upgrades [chromedriver](https://github.com/giggio/node-chromedriver) from 88.0.0 to 91.0.1
- [Release notes](https://github.com/giggio/node-chromedriver/releases)

### Testing

![Screen Shot 2021-06-29 at 5 14 35 PM](https://user-images.githubusercontent.com/5437176/123874272-81be7400-d8fd-11eb-9ba0-46c9dc5c12e6.png)
 
### Issues Resolved
Resolves #546 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 