### PR TITLE
Require `trim-newlines` v3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "**/request": "^2.88.2",
     "**/ssri": "^6.0.2",
     "**/trim": "^0.0.3",
+    "**/trim-newlines": "^3.0.1",
     "**/typescript": "4.0.2"
   },
   "workspaces": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23429,20 +23429,10 @@ trim-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.3.tgz#839514be82428fd9e7ec89e35081afe8f6f93115"
   integrity sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
-
-trim-newlines@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
-  integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
-
-trim-newlines@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
-  integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
+trim-newlines@^1.0.0, trim-newlines@^2.0.0, trim-newlines@^3.0.0, trim-newlines@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Description
Addresses https://github.com/advisories/GHSA-7p7h-4mm5-852v

Older versions of `trim-newlines` are downstream dependencies of `yo` and `node-sass` which do not have newer versions available/compatible.

```
$ yarn why trim-newlines
yarn why v1.22.10
[1/4] Why do we have the module "trim-newlines"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
[3/4] Finding dependency...
[4/4] Calculating file sizes...

=> Found "trim-newlines@3.0.0"
info Has been hoisted to "trim-newlines"
info Reasons this module exists
   - "workspace-aggregator-02cb94b9-b0be-47c0-838d-cf7b24fa9781" depends on it
   - Hoisted from "_project_#@osd#config-schema#tsd#meow#trim-newlines"
   - Hoisted from "_project_#@osd#utility-types#del-cli#meow#trim-newlines"
info Disk size without dependencies: "20KB"
info Disk size with unique dependencies: "20KB"
info Disk size with transitive dependencies: "20KB"
info Number of shared dependencies: 0

=> Found "meow#trim-newlines@1.0.0"
info This module exists because "_project_#@osd#ui-framework#yo#meow" depends on it.

=> Found "node-sass#trim-newlines@2.0.0"
info Reasons this module exists
   - "_project_#@osd#ui-framework#node-sass#meow" depends on it
   - Hoisted from "_project_#@osd#ui-framework#node-sass#meow#trim-newlines"
Done in 1.35s.
```

### Testing

![Screen Shot 2021-06-30 at 9 41 22 AM](https://user-images.githubusercontent.com/5437176/123980833-79ab1680-d987-11eb-81d7-c51be8b403cb.png)
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 