### PR TITLE
Remove `osd-name` from response headers

### DIFF
--- a/src/core/server/http/integration_tests/lifecycle_handlers.test.ts
+++ b/src/core/server/http/integration_tests/lifecycle_handlers.test.ts
@@ -48,7 +48,6 @@ const pkg = require('../../../../../package.json');
 const actualVersion = pkg.version;
 const versionHeader = 'osd-version';
 const xsrfHeader = 'osd-xsrf';
-const nameHeader = 'osd-name';
 const whitelistedTestPath = '/xsrf/test/route/whitelisted';
 const xsrfDisabledTestPath = '/xsrf/test/route/disabled';
 const opensearchDashboardsName = 'my-opensearch-dashboards-name';
@@ -137,22 +136,12 @@ describe('core lifecycle handlers', () => {
       await server.start();
     });
 
-    it('adds the osd-name header', async () => {
+    it('does not add the osd-name header', async () => {
       const result = await supertest(innerServer.listener).get(testRoute).expect(200, 'ok');
       const headers = result.header as Record<string, string>;
       expect(headers).toEqual(
-        expect.objectContaining({
-          [nameHeader]: opensearchDashboardsName,
-        })
-      );
-    });
-
-    it('adds the osd-name header in case of error', async () => {
-      const result = await supertest(innerServer.listener).get(testErrorRoute).expect(400);
-      const headers = result.header as Record<string, string>;
-      expect(headers).toEqual(
-        expect.objectContaining({
-          [nameHeader]: opensearchDashboardsName,
+        expect.not.objectContaining({
+          'osd-name': opensearchDashboardsName,
         })
       );
     });

--- a/src/core/server/http/lifecycle_handlers.test.ts
+++ b/src/core/server/http/lifecycle_handlers.test.ts
@@ -259,16 +259,6 @@ describe('customHeaders pre-response handler', () => {
     toolkit = httpServerMock.createToolkit();
   });
 
-  it('adds the osd-name header to the response', () => {
-    const config = createConfig({ name: 'my-server-name' });
-    const handler = createCustomHeadersPreResponseHandler(config as HttpConfig);
-
-    handler({} as any, {} as any, toolkit);
-
-    expect(toolkit.next).toHaveBeenCalledTimes(1);
-    expect(toolkit.next).toHaveBeenCalledWith({ headers: { 'osd-name': 'my-server-name' } });
-  });
-
   it('adds the custom headers defined in the configuration', () => {
     const config = createConfig({
       name: 'my-server-name',
@@ -284,30 +274,6 @@ describe('customHeaders pre-response handler', () => {
     expect(toolkit.next).toHaveBeenCalledTimes(1);
     expect(toolkit.next).toHaveBeenCalledWith({
       headers: {
-        'osd-name': 'my-server-name',
-        headerA: 'value-A',
-        headerB: 'value-B',
-      },
-    });
-  });
-
-  it('preserve the osd-name value from server.name if definied in custom headders ', () => {
-    const config = createConfig({
-      name: 'my-server-name',
-      customResponseHeaders: {
-        'osd-name': 'custom-name',
-        headerA: 'value-A',
-        headerB: 'value-B',
-      },
-    });
-    const handler = createCustomHeadersPreResponseHandler(config as HttpConfig);
-
-    handler({} as any, {} as any, toolkit);
-
-    expect(toolkit.next).toHaveBeenCalledTimes(1);
-    expect(toolkit.next).toHaveBeenCalledWith({
-      headers: {
-        'osd-name': 'my-server-name',
         headerA: 'value-A',
         headerB: 'value-B',
       },

--- a/src/core/server/http/lifecycle_handlers.ts
+++ b/src/core/server/http/lifecycle_handlers.ts
@@ -39,7 +39,6 @@ import { LifecycleRegistrar } from './http_server';
 
 const VERSION_HEADER = 'osd-version';
 const XSRF_HEADER = 'osd-xsrf';
-const OPENSEARCH_DASHBOARDS_NAME_HEADER = 'osd-name';
 
 export const createXsrfPostAuthHandler = (config: HttpConfig): OnPostAuthHandler => {
   const { whitelist, disableProtection } = config.xsrf;
@@ -88,17 +87,7 @@ export const createVersionCheckPostAuthHandler = (
 };
 
 export const createCustomHeadersPreResponseHandler = (config: HttpConfig): OnPreResponseHandler => {
-  const serverName = config.name;
-  const customHeaders = config.customResponseHeaders;
-
-  return (request, response, toolkit) => {
-    const additionalHeaders = {
-      ...customHeaders,
-      [OPENSEARCH_DASHBOARDS_NAME_HEADER]: serverName,
-    };
-
-    return toolkit.next({ headers: additionalHeaders });
-  };
+  return (request, response, toolkit) => toolkit.next({ headers: config.customResponseHeaders });
 };
 
 export const registerCoreHandlers = (


### PR DESCRIPTION
This is a draft PR to gather feedback.

### Description
Addresses a potential security risk where the header could be used for targeted attacks. Depending on the deployment configuration, this header may include the IP address of the host. The header is included even if an error response is returned, meaning that it's possible that anyone could get access to this information, even if they are not authenticated/authorized to access the Dashboards instance.

As for why this header exists in the first place, I dug back through the commit history and found this comment `attach the app name to the server, so we can be sure we are actually talking to kibana` here (which was merged to the main repo): https://github.com/pgayvallet/kibana/blob/ec481861799ed8dcced9cafd8112e5b26e641c54/src/legacy/server/http/index.js#L63

However, there aren't any references that I could find in our code base or for any plugins that require this header. I can keep digging for more information.

### Testing

![Screen Shot 2021-07-06 at 1 28 40 PM](https://user-images.githubusercontent.com/5437176/124649432-1ffe8c80-de5e-11eb-8250-9c3a5c56e877.png)
 
### Issues Resolved
N/A - security risk
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 