### PR TITLE
Revert "Default to converting folder name for cli plugin to kebab-case (#357)"

### DIFF
--- a/src/cli_plugin/install/install.js
+++ b/src/cli_plugin/install/install.js
@@ -41,7 +41,6 @@ import { cleanPrevious, cleanArtifacts } from './cleanup';
 import { extract, getPackData } from './pack';
 import { renamePlugin } from './rename';
 import { existingInstall, assertVersion } from './opensearch_dashboards';
-import { kebabCase } from 'lodash';
 
 const mkdir = promisify(Fs.mkdir);
 
@@ -63,7 +62,7 @@ export async function install(settings, logger) {
 
     assertVersion(settings);
 
-    const targetDir = path.join(settings.pluginDir, kebabCase(settings.plugins[0].id));
+    const targetDir = path.join(settings.pluginDir, settings.plugins[0].id);
     await renamePlugin(settings.workingPath, targetDir);
 
     logger.log('Plugin installation complete');

--- a/src/cli_plugin/install/opensearch_dashboards.js
+++ b/src/cli_plugin/install/opensearch_dashboards.js
@@ -32,13 +32,12 @@
 
 import path from 'path';
 import { statSync } from 'fs';
-import { kebabCase } from 'lodash';
 
 import { versionSatisfies, cleanVersion } from '../../legacy/utils/version';
 
 export function existingInstall(settings, logger) {
   try {
-    statSync(path.join(settings.pluginDir, kebabCase(settings.plugins[0].id)));
+    statSync(path.join(settings.pluginDir, settings.plugins[0].id));
 
     logger.error(
       `Plugin ${settings.plugins[0].id} already exists, please remove before installing a new version`


### PR DESCRIPTION
### Description
This reverts commit 747ef8eb6fc15b62c26a9af832561254b3522c42.

Reverting for now because the full impact is not known and requires
subsequent commits to mitigate some confusion related to CLI output.

Also, it seems like in the code there exists verification on the code
that plugins should explicitly be camelCase. So this merits more
discussion but also could be bundled into a feature branch related to kebab
casing and prioritized for a vNext release.

Will create a new PR to re-enable this casing.

Issues related:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/322

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/465
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/366
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 