### PR TITLE
[Test] Fix console error in search_service.test.ts 

### DIFF
--- a/src/plugins/data/server/search/search_service.ts
+++ b/src/plugins/data/server/search/search_service.ts
@@ -140,7 +140,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
       .pipe(first())
       .toPromise()
       .then((value) => {
-        if (value.search.aggs.shardDelay.enabled) {
+        if (value?.search?.aggs?.shardDelay?.enabled) {
           aggs.types.registerBucket(SHARD_DELAY_AGG_NAME, getShardDelayBucketAgg);
           registerFunction(aggShardDelay);
         }


### PR DESCRIPTION
### Description
Run unit test suite search_service.test.ts has a console error:
```
UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'aggs' of undefined
```

This is caused by a missing promise result check in the setup fun
in search_service.ts. If the promise result is empty (or null/undefined),
then any properties of the empty result is undefined. In our case,
`aggs` in `if (value.search.aggs.shardDelay.enabled)` is undefined.
In this PR, we fixed this issue by adding a value check in setup fun.


Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/594
 
### Test results
```
yarn test:jest /home/anan/work/OpenSearch-Dashboards/src/plugins/data/server/search/search_service.test.ts
yarn run v1.22.5
$ node scripts/jest /home/anan/work/OpenSearch-Dashboards/src/plugins/data/server/search/search_service.test.ts
 PASS  src/plugins/data/server/search/search_service.test.ts
  Search service
    setup()
      ✓ exposes proper contract (43 ms)
    start()
      ✓ exposes proper contract (25 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        2.961 s
Ran all test suites matching /\/home\/anan\/work\/OpenSearch-Dashboards\/src\/plugins\/data\/server\/search\/search_service.test.ts/i.
Done in 5.36s.
```

Overall test result:
<img width="1562" alt="Screen Shot 2021-07-08 at 10 53 42 AM" src="https://user-images.githubusercontent.com/79961084/124968848-dbe4c680-dfda-11eb-83a0-e427721a8538.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 
