### PR TITLE
Updating MAINTAINERS.md with correct links

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,3 +9,5 @@
 | Rocky | [kavilla](https://github.com/kavilla) | Amazon |
 | Sean Neumann | [seanneumann](https://github.com/seanneumann) | Amazon | 
 | Tommy Markley | [tmarkley](https://github.com/tmarkley) | Amazon | 
+
+[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
### Description
* Add path to .github maintainer doc. 
* Add path to CONTRIBUTING.md
 
### Issues Resolved
Partially Resolve: Issue #592 