### PR TITLE
[Bug] Fix broken links in package.json in opensearch-eslint-config-opensearch-dashboards

### DIFF
--- a/packages/opensearch-eslint-config-opensearch-dashboards/README.md
+++ b/packages/opensearch-eslint-config-opensearch-dashboards/README.md
@@ -1,6 +1,6 @@
-# elastic-eslint-config-kibana
+# opensearch-eslint-config-opensearch-dashboards
 
-The eslint config used by the kibana team
+The eslint config used by the opensearch dashboards team
 
 ## Usage
 

--- a/packages/opensearch-eslint-config-opensearch-dashboards/package.json
+++ b/packages/opensearch-eslint-config-opensearch-dashboards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/eslint-config-kibana",
   "version": "0.15.0",
-  "description": "The eslint config used by the kibana team",
+  "description": "The eslint config used by the opensearch dashboards team",
   "main": ".eslintrc.js",
   "repository": {
     "type": "git",
@@ -14,9 +14,9 @@
   "author": "Spencer Alger <email@spalger.com>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/opensearch-project/OpenSearch-Dashboards/tree/master/packages/elastic-eslint-config-kibana"
+    "url": "https://github.com/opensearch-project/OpenSearch-Dashboards/issues"
   },
-  "homepage": "https://github.com/opensearch-project/OpenSearch-Dashboards/tree/master/packages/elastic-eslint-config-kibana",
+  "homepage": "https://github.com/opensearch-project/OpenSearch-Dashboards/tree/main/packages/opensearch-eslint-config-opensearch-dashboards",
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.10.0",
     "@typescript-eslint/parser": "^3.10.0",


### PR DESCRIPTION
### Description
/packages/opensearch-eslint-config-opensearch-dashboards/package.json
has broken homepage and bug report links. This PR fixes these two links.

### Partically Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/592

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 