### PR TITLE
[1.0][Bug] remove incorrect reference in testing.md

### DIFF
--- a/src/core/TESTING.md
+++ b/src/core/TESTING.md
@@ -271,10 +271,6 @@ The tests cover:
 
 - authenticated / non-authenticated user access (when applicable)
 
-```typescript
-// TODO after https://github.com/elastic/kibana/pull/53208/
-```
-
 - request validation
 
 ```typescript


### PR DESCRIPTION
### Description
There is a kibana closed issue reference under test
"authenticated / non-authenticated user access".
We removed the reference in this PR.

### Partially Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/592

### Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/597

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 
