### PR TITLE
[1.x][Bug] Remove appKey in github-checks-reporter

### DIFF
--- a/github_checks_reporter.json
+++ b/github_checks_reporter.json
@@ -1,6 +1,6 @@
 {
   "appId": 26774,
   "envVars": {
-    "appKey": "KIBANA_CI_REPORTER_KEY"
+    "appKey": ""
   }
 }


### PR DESCRIPTION
### Description
github-checks-reporter is a task wrapper that provides expressive
CI feedback via GitHub checks. Currently, we don’t have our own
appKey. To avoid any confusions, this PR removed the old key.

### Partically Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/592

### Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/603

Signed-off-by: Anan Zhuang <ananzh@amazon.com>


### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 