### PR TITLE
[1.x][Bug] Fix broken link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "number": 8467,
     "sha": "6cb7fec4e154faa0a4a3fee4b33dfef91b9870d9"
   },
-  "homepage": "https://www.opensearch.org/products/kibana",
+  "homepage": "https://www.opensearch.org",
   "bugs": {
     "url": "http://github.com/opensearch-project/OpenSearch-Dashboards/issues"
   },


### PR DESCRIPTION
### Description
Package.json has a broken homepage link. This PR fixes this link.

### Partically Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/592

### Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/604

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 