### PR TITLE
[1.x][Bug] Clean concepts in packages/osd-plugin-generator

### DIFF
--- a/packages/osd-plugin-generator/README.md
+++ b/packages/osd-plugin-generator/README.md
@@ -1,6 +1,6 @@
 # OpenSearch Dashboards Plugin Generator
 
-This package can be used to generate a OpenSearch Dashboards plugin from the OpenSearch Dashboards repo.
+This package can be used to generate an OpenSearch Dashboards plugin from the OpenSearch Dashboards repo.
 
 ## Setup
 
@@ -8,9 +8,7 @@ Before you can use this plugin generator you must setup your [OpenSearch Dashboa
 
 ## Compatibility
 
-The plugin generator became a part of the OpenSearch Dashboards project as of OpenSearch Dashboards 6.3. If you are targeting versions **before OpenSearch Dashboards 6.3** then use the [Kibana plugin sao template](https://github.com/elastic/template-kibana-plugin).
-
-If you are targeting **OpenSearch Dashboards 6.3 or greater** then checkout the corresponding OpenSearch Dashboards branch and run the plugin generator.
+The plugin generator became a part of the OpenSearch Dashboards project as of OpenSearch Dashboards 1.0. 
 
 ## Quick Start
 
@@ -21,13 +19,13 @@ node scripts/generate_plugin --name my_plugin_name -y
 # generates a plugin in `plugins/my_plugin_name`
 ```
 
-To target 6.8, use the `6.8` branch.
+To target 1.0, use the `1.0` branch.
 
 ```sh
-git checkout 6.x
+git checkout 1.x
 yarn osd bootstrap # always bootstrap when switching branches
 node scripts/generate_plugin --name my_plugin_name -y
-# generates a plugin for OpenSearch Dashboards 6.8 in `../opensearch-dashboards-extra/my_plugin_name`
+# generates a plugin for OpenSearch Dashboards 1.0 in `../opensearch-dashboards-extra/my_plugin_name`
 ```
 
 The generate script supports a few flags; run it with the `--help` flag to learn more.
@@ -49,7 +47,7 @@ yarn osd bootstrap
 
 ## Plugin Development Scripts
 
-Generated plugins receive a handful of scripts that can be used during development. Those scripts are detailed in the [README.md](template/README.md) file in each newly generated plugin, and expose the scripts provided by the [OpenSearch Dashboards plugin helpers](../osd-plugin-helpers), but here is a quick reference in case you need it:
+Generated plugins receive a handful of scripts that can be used during development. Those scripts are detailed in the README.md file in each newly generated plugin, and expose the scripts provided by the [OpenSearch Dashboards plugin helpers](../osd-plugin-helpers), but here is a quick reference in case you need it:
 
 > ***NOTE:*** All of these scripts should be run from the generated plugin.
 
@@ -59,6 +57,12 @@ Generated plugins receive a handful of scripts that can be used during developme
 
     > ***IMPORTANT:*** Use this script instead of `yarn` to install dependencies when switching branches, and re-run it whenever your dependencies change.
 
+  - `yarn build`
+
+    Build a distributable archive of your plugin.
+
+To start opensearch dashboards run the following command from OpenSearch Dashboards root.
+
   - `yarn start`
 
     Start OpenSearch Dashboards and have it include this plugin. You can pass any arguments that you would normally send to `bin/opensearch-dashboards`
@@ -66,13 +70,5 @@ Generated plugins receive a handful of scripts that can be used during developme
       ```
       yarn start --opensearch.hosts http://localhost:9220
       ```
-
-  - `yarn build`
-
-    Build a distributable archive of your plugin.
-
-  - `yarn test:mocha`
-
-    Run the server tests using mocha.
 
 For more information about any of these commands run `yarn ${task} --help`. For a full list of tasks run `yarn run` or take a look in the `package.json` file.


### PR DESCRIPTION
### Description
The versions in packages/osd-plugin-generator/README.md are still 6.x
which should be updated to 1.0. Meanwhile, there are some old concepts,
like test using mocha, which should be cleaned. This PR fixes the versions
and cleans out the old concepts.

### Partically Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/592

### Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/609

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 