### PR TITLE
[1.0][Bug] Fix links in packages/opensearch-safter-lodash-set

### DIFF
--- a/packages/opensearch-safer-lodash-set/LICENSE
+++ b/packages/opensearch-safer-lodash-set/LICENSE
@@ -12,7 +12,7 @@ individuals. For exact contribution history, see the revision history
 available at the following locations:
  - https://github.com/lodash/lodash
  - https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/lodash
- - https://github.com/elastic/kibana/tree/master/packages/elastic-safer-lodash-set
+ - https://github.com/opensearch-project/OpenSearch-Dashboards/tree/main/packages/opensearch-safer-lodash-set
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/packages/opensearch-safer-lodash-set/package.json
+++ b/packages/opensearch-safer-lodash-set/package.json
@@ -37,7 +37,7 @@
   "bugs": {
     "url": "https://github.com/opensearch-project/OpenSearch-Dashboards/issues"
   },
-  "homepage": "https://github.com/opensearch-project/OpenSearch-Dashboards/tree/master/packages/safer-lodash-set#readme",
+  "homepage": "https://github.com/opensearch-project/OpenSearch-Dashboards/tree/main/packages/opensearch-safer-lodash-set",
   "standard": {
     "ignore": [
       "/lodash/"


### PR DESCRIPTION
### Description
Both LICENSE and package.json in packages/opensearch-safter-lodash-set
have broken links. This PR fixes links in these two files.

### Partically Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/592

### Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/607

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 