### PR TITLE
[1.x][Test] Wrap FunComponent in unit test with IntlProvider

### DIFF
--- a/src/core/public/application/ui/app_container.test.tsx
+++ b/src/core/public/application/ui/app_container.test.tsx
@@ -33,6 +33,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
 
 import { AppContainer } from './app_container';
 import { Mounter, AppMountParameters, AppStatus } from '../types';
@@ -82,7 +83,7 @@ describe('AppContainer', () => {
     const [waitPromise, resolvePromise] = createResolver();
     const mounter = createMounter(waitPromise);
 
-    const wrapper = mount(
+    const wrapper = mountWithIntl(
       <AppContainer
         appPath={`/app/${appId}`}
         appId={appId}

--- a/src/core/public/core_app/status/components/server_status.test.tsx
+++ b/src/core/public/core_app/status/components/server_status.test.tsx
@@ -31,9 +31,9 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
 import { ServerStatus } from './server_status';
 import { FormattedStatus } from '../lib';
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
 
 const getStatus = (parts: Partial<FormattedStatus['state']> = {}): FormattedStatus['state'] => ({
   id: 'green',
@@ -46,7 +46,7 @@ const getStatus = (parts: Partial<FormattedStatus['state']> = {}): FormattedStat
 describe('ServerStatus', () => {
   it('renders correctly for green state', () => {
     const status = getStatus();
-    const component = mount(<ServerStatus serverState={status} name="My Computer" />);
+    const component = mountWithIntl(<ServerStatus serverState={status} name="My Computer" />);
     expect(component.find('EuiTitle').text()).toMatchInlineSnapshot(
       `"OpenSearch Dashboards status is Green"`
     );
@@ -58,7 +58,7 @@ describe('ServerStatus', () => {
       id: 'red',
       title: 'Red',
     });
-    const component = mount(<ServerStatus serverState={status} name="My Computer" />);
+    const component = mountWithIntl(<ServerStatus serverState={status} name="My Computer" />);
     expect(component.find('EuiTitle').text()).toMatchInlineSnapshot(
       `"OpenSearch Dashboards status is Red"`
     );
@@ -66,10 +66,12 @@ describe('ServerStatus', () => {
   });
 
   it('displays the correct `name`', () => {
-    let component = mount(<ServerStatus serverState={getStatus()} name="Localhost" />);
+    let component = mountWithIntl(<ServerStatus serverState={getStatus()} name="Localhost" />);
     expect(component.find('EuiText').text()).toMatchInlineSnapshot(`"Localhost"`);
 
-    component = mount(<ServerStatus serverState={getStatus()} name="OpenSearchDashboards" />);
+    component = mountWithIntl(
+      <ServerStatus serverState={getStatus()} name="OpenSearchDashboards" />
+    );
     expect(component.find('EuiText').text()).toMatchInlineSnapshot(`"OpenSearchDashboards"`);
   });
 });

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/__snapshots__/header.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/__snapshots__/header.test.tsx.snap
@@ -1,352 +1,364 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Header should render a different name, prompt, and beta tag if provided 1`] = `
-<Header
-  docLinks={
-    Object {
-      "links": Object {
-        "indexPatterns": Object {},
-      },
-    }
-  }
-  indexPatternName="test index pattern"
-  isBeta={true}
-  prompt={
-    <div>
-      Test prompt
-    </div>
-  }
+<IntlProvider
+  locale="en"
 >
-  <div>
-    <EuiTitle>
-      <h1
-        className="euiTitle euiTitle--medium"
-      >
-        Create test index pattern
-         
-        <EuiBetaBadge
-          label="Beta"
-        >
-          <span
-            className="euiBetaBadge"
-            title="Beta"
-          >
-            Beta
-          </span>
-        </EuiBetaBadge>
-      </h1>
-    </EuiTitle>
-    <EuiSpacer
-      size="s"
-    >
-      <div
-        className="euiSpacer euiSpacer--s"
-      />
-    </EuiSpacer>
-    <EuiText>
-      <div
-        className="euiText euiText--medium"
-      >
-        <p>
-          <FormattedMessage
-            defaultMessage="An index pattern can match a single source, for example, {single}, or {multiple} data sources, {star}."
-            id="indexPatternManagement.createIndexPattern.description"
-            values={
-              Object {
-                "multiple": <strong>
-                  multiple
-                </strong>,
-                "single": <EuiCode>
-                  filebeat-4-3-22
-                </EuiCode>,
-                "star": <EuiCode>
-                  filebeat-*
-                </EuiCode>,
-              }
-            }
-          >
-            <span>
-              An index pattern can match a single source, for example, 
-              <EuiCode>
-                <EuiCodeBlockImpl
-                  inline={true}
-                >
-                  <span>
-                    <code>
-                      filebeat-4-3-22
-                    </code>
-                  </span>
-                </EuiCodeBlockImpl>
-              </EuiCode>
-              , or 
-              <strong>
-                multiple
-              </strong>
-               data sources, 
-              <EuiCode>
-                <EuiCodeBlockImpl
-                  inline={true}
-                >
-                  <span>
-                    <code>
-                      filebeat-*
-                    </code>
-                  </span>
-                </EuiCodeBlockImpl>
-              </EuiCode>
-              .
-            </span>
-          </FormattedMessage>
-          <br />
-          <EuiLink
-            external={true}
-            target="_blank"
-          >
-            <button
-              className="euiLink euiLink--primary"
-              disabled={false}
-              type="button"
-            >
-              <FormattedMessage
-                defaultMessage="Read documentation"
-                id="indexPatternManagement.createIndexPattern.documentation"
-                values={Object {}}
-              >
-                <span>
-                  Read documentation
-                </span>
-              </FormattedMessage>
-            </button>
-          </EuiLink>
-        </p>
+  <Header
+    docLinks={
+      Object {
+        "links": Object {
+          "indexPatterns": Object {},
+        },
+      }
+    }
+    indexPatternName="test index pattern"
+    isBeta={true}
+    prompt={
+      <div>
+        Test prompt
       </div>
-    </EuiText>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
+    }
+  >
     <div>
-      Test prompt
+      <EuiTitle>
+        <h1
+          className="euiTitle euiTitle--medium"
+        >
+          Create test index pattern
+           
+          <EuiBetaBadge
+            label="Beta"
+          >
+            <span
+              className="euiBetaBadge"
+              title="Beta"
+            >
+              Beta
+            </span>
+          </EuiBetaBadge>
+        </h1>
+      </EuiTitle>
+      <EuiSpacer
+        size="s"
+      >
+        <div
+          className="euiSpacer euiSpacer--s"
+        />
+      </EuiSpacer>
+      <EuiText>
+        <div
+          className="euiText euiText--medium"
+        >
+          <p>
+            <FormattedMessage
+              defaultMessage="An index pattern can match a single source, for example, {single}, or {multiple} data sources, {star}."
+              id="indexPatternManagement.createIndexPattern.description"
+              values={
+                Object {
+                  "multiple": <strong>
+                    multiple
+                  </strong>,
+                  "single": <EuiCode>
+                    filebeat-4-3-22
+                  </EuiCode>,
+                  "star": <EuiCode>
+                    filebeat-*
+                  </EuiCode>,
+                }
+              }
+            >
+              <span>
+                An index pattern can match a single source, for example, 
+                <EuiCode>
+                  <EuiCodeBlockImpl
+                    inline={true}
+                  >
+                    <span>
+                      <code>
+                        filebeat-4-3-22
+                      </code>
+                    </span>
+                  </EuiCodeBlockImpl>
+                </EuiCode>
+                , or 
+                <strong>
+                  multiple
+                </strong>
+                 data sources, 
+                <EuiCode>
+                  <EuiCodeBlockImpl
+                    inline={true}
+                  >
+                    <span>
+                      <code>
+                        filebeat-*
+                      </code>
+                    </span>
+                  </EuiCodeBlockImpl>
+                </EuiCode>
+                .
+              </span>
+            </FormattedMessage>
+            <br />
+            <EuiLink
+              external={true}
+              target="_blank"
+            >
+              <button
+                className="euiLink euiLink--primary"
+                disabled={false}
+                type="button"
+              >
+                <FormattedMessage
+                  defaultMessage="Read documentation"
+                  id="indexPatternManagement.createIndexPattern.documentation"
+                  values={Object {}}
+                >
+                  <span>
+                    Read documentation
+                  </span>
+                </FormattedMessage>
+              </button>
+            </EuiLink>
+          </p>
+        </div>
+      </EuiText>
+      <EuiSpacer
+        size="m"
+      >
+        <div
+          className="euiSpacer euiSpacer--m"
+        />
+      </EuiSpacer>
+      <div>
+        Test prompt
+      </div>
     </div>
-  </div>
-</Header>
+  </Header>
+</IntlProvider>
 `;
 
 exports[`Header should render normally 1`] = `
-<Header
-  docLinks={
-    Object {
-      "links": Object {
-        "indexPatterns": Object {},
-      },
-    }
-  }
-  indexPatternName="test index pattern"
+<IntlProvider
+  locale="en"
 >
-  <div>
-    <EuiTitle>
-      <h1
-        className="euiTitle euiTitle--medium"
+  <Header
+    docLinks={
+      Object {
+        "links": Object {
+          "indexPatterns": Object {},
+        },
+      }
+    }
+    indexPatternName="test index pattern"
+  >
+    <div>
+      <EuiTitle>
+        <h1
+          className="euiTitle euiTitle--medium"
+        >
+          Create test index pattern
+        </h1>
+      </EuiTitle>
+      <EuiSpacer
+        size="s"
       >
-        Create test index pattern
-      </h1>
-    </EuiTitle>
-    <EuiSpacer
-      size="s"
-    >
-      <div
-        className="euiSpacer euiSpacer--s"
-      />
-    </EuiSpacer>
-    <EuiText>
-      <div
-        className="euiText euiText--medium"
-      >
-        <p>
-          <FormattedMessage
-            defaultMessage="An index pattern can match a single source, for example, {single}, or {multiple} data sources, {star}."
-            id="indexPatternManagement.createIndexPattern.description"
-            values={
-              Object {
-                "multiple": <strong>
-                  multiple
-                </strong>,
-                "single": <EuiCode>
-                  filebeat-4-3-22
-                </EuiCode>,
-                "star": <EuiCode>
-                  filebeat-*
-                </EuiCode>,
+        <div
+          className="euiSpacer euiSpacer--s"
+        />
+      </EuiSpacer>
+      <EuiText>
+        <div
+          className="euiText euiText--medium"
+        >
+          <p>
+            <FormattedMessage
+              defaultMessage="An index pattern can match a single source, for example, {single}, or {multiple} data sources, {star}."
+              id="indexPatternManagement.createIndexPattern.description"
+              values={
+                Object {
+                  "multiple": <strong>
+                    multiple
+                  </strong>,
+                  "single": <EuiCode>
+                    filebeat-4-3-22
+                  </EuiCode>,
+                  "star": <EuiCode>
+                    filebeat-*
+                  </EuiCode>,
+                }
               }
-            }
-          >
-            <span>
-              An index pattern can match a single source, for example, 
-              <EuiCode>
-                <EuiCodeBlockImpl
-                  inline={true}
-                >
-                  <span>
-                    <code>
-                      filebeat-4-3-22
-                    </code>
-                  </span>
-                </EuiCodeBlockImpl>
-              </EuiCode>
-              , or 
-              <strong>
-                multiple
-              </strong>
-               data sources, 
-              <EuiCode>
-                <EuiCodeBlockImpl
-                  inline={true}
-                >
-                  <span>
-                    <code>
-                      filebeat-*
-                    </code>
-                  </span>
-                </EuiCodeBlockImpl>
-              </EuiCode>
-              .
-            </span>
-          </FormattedMessage>
-          <br />
-          <EuiLink
-            external={true}
-            target="_blank"
-          >
-            <button
-              className="euiLink euiLink--primary"
-              disabled={false}
-              type="button"
             >
-              <FormattedMessage
-                defaultMessage="Read documentation"
-                id="indexPatternManagement.createIndexPattern.documentation"
-                values={Object {}}
+              <span>
+                An index pattern can match a single source, for example, 
+                <EuiCode>
+                  <EuiCodeBlockImpl
+                    inline={true}
+                  >
+                    <span>
+                      <code>
+                        filebeat-4-3-22
+                      </code>
+                    </span>
+                  </EuiCodeBlockImpl>
+                </EuiCode>
+                , or 
+                <strong>
+                  multiple
+                </strong>
+                 data sources, 
+                <EuiCode>
+                  <EuiCodeBlockImpl
+                    inline={true}
+                  >
+                    <span>
+                      <code>
+                        filebeat-*
+                      </code>
+                    </span>
+                  </EuiCodeBlockImpl>
+                </EuiCode>
+                .
+              </span>
+            </FormattedMessage>
+            <br />
+            <EuiLink
+              external={true}
+              target="_blank"
+            >
+              <button
+                className="euiLink euiLink--primary"
+                disabled={false}
+                type="button"
               >
-                <span>
-                  Read documentation
-                </span>
-              </FormattedMessage>
-            </button>
-          </EuiLink>
-        </p>
-      </div>
-    </EuiText>
-  </div>
-</Header>
+                <FormattedMessage
+                  defaultMessage="Read documentation"
+                  id="indexPatternManagement.createIndexPattern.documentation"
+                  values={Object {}}
+                >
+                  <span>
+                    Read documentation
+                  </span>
+                </FormattedMessage>
+              </button>
+            </EuiLink>
+          </p>
+        </div>
+      </EuiText>
+    </div>
+  </Header>
+</IntlProvider>
 `;
 
 exports[`Header should render without including system indices 1`] = `
-<Header
-  docLinks={
-    Object {
-      "links": Object {
-        "indexPatterns": Object {},
-      },
-    }
-  }
-  indexPatternName="test index pattern"
+<IntlProvider
+  locale="en"
 >
-  <div>
-    <EuiTitle>
-      <h1
-        className="euiTitle euiTitle--medium"
+  <Header
+    docLinks={
+      Object {
+        "links": Object {
+          "indexPatterns": Object {},
+        },
+      }
+    }
+    indexPatternName="test index pattern"
+  >
+    <div>
+      <EuiTitle>
+        <h1
+          className="euiTitle euiTitle--medium"
+        >
+          Create test index pattern
+        </h1>
+      </EuiTitle>
+      <EuiSpacer
+        size="s"
       >
-        Create test index pattern
-      </h1>
-    </EuiTitle>
-    <EuiSpacer
-      size="s"
-    >
-      <div
-        className="euiSpacer euiSpacer--s"
-      />
-    </EuiSpacer>
-    <EuiText>
-      <div
-        className="euiText euiText--medium"
-      >
-        <p>
-          <FormattedMessage
-            defaultMessage="An index pattern can match a single source, for example, {single}, or {multiple} data sources, {star}."
-            id="indexPatternManagement.createIndexPattern.description"
-            values={
-              Object {
-                "multiple": <strong>
-                  multiple
-                </strong>,
-                "single": <EuiCode>
-                  filebeat-4-3-22
-                </EuiCode>,
-                "star": <EuiCode>
-                  filebeat-*
-                </EuiCode>,
+        <div
+          className="euiSpacer euiSpacer--s"
+        />
+      </EuiSpacer>
+      <EuiText>
+        <div
+          className="euiText euiText--medium"
+        >
+          <p>
+            <FormattedMessage
+              defaultMessage="An index pattern can match a single source, for example, {single}, or {multiple} data sources, {star}."
+              id="indexPatternManagement.createIndexPattern.description"
+              values={
+                Object {
+                  "multiple": <strong>
+                    multiple
+                  </strong>,
+                  "single": <EuiCode>
+                    filebeat-4-3-22
+                  </EuiCode>,
+                  "star": <EuiCode>
+                    filebeat-*
+                  </EuiCode>,
+                }
               }
-            }
-          >
-            <span>
-              An index pattern can match a single source, for example, 
-              <EuiCode>
-                <EuiCodeBlockImpl
-                  inline={true}
-                >
-                  <span>
-                    <code>
-                      filebeat-4-3-22
-                    </code>
-                  </span>
-                </EuiCodeBlockImpl>
-              </EuiCode>
-              , or 
-              <strong>
-                multiple
-              </strong>
-               data sources, 
-              <EuiCode>
-                <EuiCodeBlockImpl
-                  inline={true}
-                >
-                  <span>
-                    <code>
-                      filebeat-*
-                    </code>
-                  </span>
-                </EuiCodeBlockImpl>
-              </EuiCode>
-              .
-            </span>
-          </FormattedMessage>
-          <br />
-          <EuiLink
-            external={true}
-            target="_blank"
-          >
-            <button
-              className="euiLink euiLink--primary"
-              disabled={false}
-              type="button"
             >
-              <FormattedMessage
-                defaultMessage="Read documentation"
-                id="indexPatternManagement.createIndexPattern.documentation"
-                values={Object {}}
+              <span>
+                An index pattern can match a single source, for example, 
+                <EuiCode>
+                  <EuiCodeBlockImpl
+                    inline={true}
+                  >
+                    <span>
+                      <code>
+                        filebeat-4-3-22
+                      </code>
+                    </span>
+                  </EuiCodeBlockImpl>
+                </EuiCode>
+                , or 
+                <strong>
+                  multiple
+                </strong>
+                 data sources, 
+                <EuiCode>
+                  <EuiCodeBlockImpl
+                    inline={true}
+                  >
+                    <span>
+                      <code>
+                        filebeat-*
+                      </code>
+                    </span>
+                  </EuiCodeBlockImpl>
+                </EuiCode>
+                .
+              </span>
+            </FormattedMessage>
+            <br />
+            <EuiLink
+              external={true}
+              target="_blank"
+            >
+              <button
+                className="euiLink euiLink--primary"
+                disabled={false}
+                type="button"
               >
-                <span>
-                  Read documentation
-                </span>
-              </FormattedMessage>
-            </button>
-          </EuiLink>
-        </p>
-      </div>
-    </EuiText>
-  </div>
-</Header>
+                <FormattedMessage
+                  defaultMessage="Read documentation"
+                  id="indexPatternManagement.createIndexPattern.documentation"
+                  values={Object {}}
+                >
+                  <span>
+                    Read documentation
+                  </span>
+                </FormattedMessage>
+              </button>
+            </EuiLink>
+          </p>
+        </div>
+      </EuiText>
+    </div>
+  </Header>
+</IntlProvider>
 `;

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.test.tsx
@@ -33,6 +33,7 @@
 import React from 'react';
 import { Header } from '../header';
 import { mount } from 'enzyme';
+import { wrapWithIntl } from 'test_utils/enzyme_helpers';
 import { OpenSearchDashboardsContextProvider } from 'src/plugins/opensearch_dashboards_react/public';
 import { mockManagementPlugin } from '../../../../mocks';
 import { DocLinksStart } from 'opensearch-dashboards/public';
@@ -48,7 +49,7 @@ describe('Header', () => {
 
   it('should render normally', () => {
     const component = mount(
-      <Header indexPatternName={indexPatternName} docLinks={mockedDocLinks} />,
+      wrapWithIntl(<Header indexPatternName={indexPatternName} docLinks={mockedDocLinks} />),
       {
         wrappingComponent: OpenSearchDashboardsContextProvider,
         wrappingComponentProps: {
@@ -62,7 +63,7 @@ describe('Header', () => {
 
   it('should render without including system indices', () => {
     const component = mount(
-      <Header indexPatternName={indexPatternName} docLinks={mockedDocLinks} />,
+      wrapWithIntl(<Header indexPatternName={indexPatternName} docLinks={mockedDocLinks} />),
       {
         wrappingComponent: OpenSearchDashboardsContextProvider,
         wrappingComponentProps: {
@@ -76,12 +77,14 @@ describe('Header', () => {
 
   it('should render a different name, prompt, and beta tag if provided', () => {
     const component = mount(
-      <Header
-        prompt={<div>Test prompt</div>}
-        indexPatternName={indexPatternName}
-        isBeta={true}
-        docLinks={mockedDocLinks}
-      />,
+      wrapWithIntl(
+        <Header
+          prompt={<div>Test prompt</div>}
+          indexPatternName={indexPatternName}
+          isBeta={true}
+          docLinks={mockedDocLinks}
+        />
+      ),
       {
         wrappingComponent: OpenSearchDashboardsContextProvider,
         wrappingComponentProps: {

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/__snapshots__/header.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/__snapshots__/header.test.tsx.snap
@@ -10,17 +10,13 @@ exports[`Header should render normally 1`] = `
     <h3
       class="euiTitle euiTitle--small"
     >
-      <span>
-        Scripted fields
-      </span>
+      Scripted fields
     </h3>
     <div
       class="euiText euiText--medium"
     >
       <p>
-        <span>
-          You can use scripted fields in visualizations and display them in your documents. However, you cannot search scripted fields.
-        </span>
+        You can use scripted fields in visualizations and display them in your documents. However, you cannot search scripted fields.
       </p>
     </div>
   </div>
@@ -38,9 +34,7 @@ exports[`Header should render normally 1`] = `
         <span
           class="euiButton__text"
         >
-          <span>
-            Add scripted field
-          </span>
+          Add scripted field
         </span>
       </span>
     </button>

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/header.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/header.test.tsx
@@ -31,16 +31,15 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { renderWithIntl } from 'test_utils/enzyme_helpers';
 import { RouteComponentProps } from 'react-router-dom';
 import { ScopedHistory } from 'opensearch-dashboards/public';
 import { scopedHistoryMock } from '../../../../../../../../core/public/mocks';
-
 import { Header } from './header';
 
 describe('Header', () => {
   test('should render normally', () => {
-    const component = render(
+    const component = renderWithIntl(
       <Header.WrappedComponent
         indexPatternId="test"
         history={(scopedHistoryMock.create() as unknown) as ScopedHistory}

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/__snapshots__/warning_call_out.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/__snapshots__/warning_call_out.test.tsx.snap
@@ -1,182 +1,190 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ScriptingWarningCallOut should render normally 1`] = `
-<ScriptingWarningCallOut
-  isVisible={true}
+<IntlProvider
+  locale="en"
 >
-  <EuiCallOut
-    color="warning"
-    iconType="alert"
-    title={
-      <FormattedMessage
-        defaultMessage="Proceed with caution"
-        id="indexPatternManagement.warningCallOutHeader"
-        values={Object {}}
-      />
-    }
+  <ScriptingWarningCallOut
+    isVisible={true}
   >
-    <div
-      className="euiCallOut euiCallOut--warning"
+    <EuiCallOut
+      color="warning"
+      iconType="alert"
+      title={
+        <FormattedMessage
+          defaultMessage="Proceed with caution"
+          id="indexPatternManagement.warningCallOutHeader"
+          values={Object {}}
+        />
+      }
     >
       <div
-        className="euiCallOutHeader"
-      >
-        <EuiIcon
-          aria-hidden="true"
-          className="euiCallOutHeader__icon"
-          size="m"
-          type="alert"
-        >
-          <div
-            aria-hidden="true"
-            className="euiCallOutHeader__icon"
-            data-euiicon-type="alert"
-            size="m"
-          />
-        </EuiIcon>
-        <span
-          className="euiCallOutHeader__title"
-        >
-          <FormattedMessage
-            defaultMessage="Proceed with caution"
-            id="indexPatternManagement.warningCallOutHeader"
-            values={Object {}}
-          >
-            <span>
-              Proceed with caution
-            </span>
-          </FormattedMessage>
-        </span>
-      </div>
-      <EuiText
-        size="s"
+        className="euiCallOut euiCallOut--warning"
       >
         <div
-          className="euiText euiText--small"
+          className="euiCallOutHeader"
         >
-          <p>
+          <EuiIcon
+            aria-hidden="true"
+            className="euiCallOutHeader__icon"
+            size="m"
+            type="alert"
+          >
+            <div
+              aria-hidden="true"
+              className="euiCallOutHeader__icon"
+              data-euiicon-type="alert"
+              size="m"
+            />
+          </EuiIcon>
+          <span
+            className="euiCallOutHeader__title"
+          >
             <FormattedMessage
-              defaultMessage="Please familiarize yourself with {scripFields} and with {scriptsInAggregation} before using scripted fields."
-              id="indexPatternManagement.warningCallOutLabel.callOutDetail"
-              values={
-                Object {
-                  "scripFields": <EuiLink
-                    target="_blank"
-                  >
-                    <FormattedMessage
-                      defaultMessage="script fields"
-                      id="indexPatternManagement.warningCallOutLabel.scripFieldsLink"
-                      values={Object {}}
-                    />
-                     
-                    <EuiIcon
-                      type="link"
-                    />
-                  </EuiLink>,
-                  "scriptsInAggregation": <EuiLink
-                    target="_blank"
-                  >
-                    <FormattedMessage
-                      defaultMessage="scripts in aggregations"
-                      id="indexPatternManagement.warningCallOutLabel.scriptsInAggregationLink"
-                      values={Object {}}
-                    />
-                     
-                    <EuiIcon
-                      type="link"
-                    />
-                  </EuiLink>,
-                }
-              }
-            >
-              <span>
-                Please familiarize yourself with 
-                <EuiLink
-                  target="_blank"
-                >
-                  <button
-                    className="euiLink euiLink--primary"
-                    disabled={false}
-                    type="button"
-                  >
-                    <FormattedMessage
-                      defaultMessage="script fields"
-                      id="indexPatternManagement.warningCallOutLabel.scripFieldsLink"
-                      values={Object {}}
-                    >
-                      <span>
-                        script fields
-                      </span>
-                    </FormattedMessage>
-                     
-                    <EuiIcon
-                      type="link"
-                    >
-                      <div
-                        data-euiicon-type="link"
-                      />
-                    </EuiIcon>
-                  </button>
-                </EuiLink>
-                 and with 
-                <EuiLink
-                  target="_blank"
-                >
-                  <button
-                    className="euiLink euiLink--primary"
-                    disabled={false}
-                    type="button"
-                  >
-                    <FormattedMessage
-                      defaultMessage="scripts in aggregations"
-                      id="indexPatternManagement.warningCallOutLabel.scriptsInAggregationLink"
-                      values={Object {}}
-                    >
-                      <span>
-                        scripts in aggregations
-                      </span>
-                    </FormattedMessage>
-                     
-                    <EuiIcon
-                      type="link"
-                    >
-                      <div
-                        data-euiicon-type="link"
-                      />
-                    </EuiIcon>
-                  </button>
-                </EuiLink>
-                 before using scripted fields.
-              </span>
-            </FormattedMessage>
-          </p>
-          <p>
-            <FormattedMessage
-              defaultMessage="Scripted fields can be used to display and aggregate calculated values. As such, they can be very slow, and if done incorrectly, can cause OpenSearch Dashboards to be unusable. There's no safety net here. If you make a typo, unexpected exceptions will be thrown all over the place!"
-              id="indexPatternManagement.warningCallOut.descriptionLabel"
+              defaultMessage="Proceed with caution"
+              id="indexPatternManagement.warningCallOutHeader"
               values={Object {}}
             >
               <span>
-                Scripted fields can be used to display and aggregate calculated values. As such, they can be very slow, and if done incorrectly, can cause OpenSearch Dashboards to be unusable. There's no safety net here. If you make a typo, unexpected exceptions will be thrown all over the place!
+                Proceed with caution
               </span>
             </FormattedMessage>
-          </p>
+          </span>
         </div>
-      </EuiText>
-    </div>
-  </EuiCallOut>
-  <EuiSpacer
-    size="m"
-  >
-    <div
-      className="euiSpacer euiSpacer--m"
-    />
-  </EuiSpacer>
-</ScriptingWarningCallOut>
+        <EuiText
+          size="s"
+        >
+          <div
+            className="euiText euiText--small"
+          >
+            <p>
+              <FormattedMessage
+                defaultMessage="Please familiarize yourself with {scripFields} and with {scriptsInAggregation} before using scripted fields."
+                id="indexPatternManagement.warningCallOutLabel.callOutDetail"
+                values={
+                  Object {
+                    "scripFields": <EuiLink
+                      target="_blank"
+                    >
+                      <FormattedMessage
+                        defaultMessage="script fields"
+                        id="indexPatternManagement.warningCallOutLabel.scripFieldsLink"
+                        values={Object {}}
+                      />
+                       
+                      <EuiIcon
+                        type="link"
+                      />
+                    </EuiLink>,
+                    "scriptsInAggregation": <EuiLink
+                      target="_blank"
+                    >
+                      <FormattedMessage
+                        defaultMessage="scripts in aggregations"
+                        id="indexPatternManagement.warningCallOutLabel.scriptsInAggregationLink"
+                        values={Object {}}
+                      />
+                       
+                      <EuiIcon
+                        type="link"
+                      />
+                    </EuiLink>,
+                  }
+                }
+              >
+                <span>
+                  Please familiarize yourself with 
+                  <EuiLink
+                    target="_blank"
+                  >
+                    <button
+                      className="euiLink euiLink--primary"
+                      disabled={false}
+                      type="button"
+                    >
+                      <FormattedMessage
+                        defaultMessage="script fields"
+                        id="indexPatternManagement.warningCallOutLabel.scripFieldsLink"
+                        values={Object {}}
+                      >
+                        <span>
+                          script fields
+                        </span>
+                      </FormattedMessage>
+                       
+                      <EuiIcon
+                        type="link"
+                      >
+                        <div
+                          data-euiicon-type="link"
+                        />
+                      </EuiIcon>
+                    </button>
+                  </EuiLink>
+                   and with 
+                  <EuiLink
+                    target="_blank"
+                  >
+                    <button
+                      className="euiLink euiLink--primary"
+                      disabled={false}
+                      type="button"
+                    >
+                      <FormattedMessage
+                        defaultMessage="scripts in aggregations"
+                        id="indexPatternManagement.warningCallOutLabel.scriptsInAggregationLink"
+                        values={Object {}}
+                      >
+                        <span>
+                          scripts in aggregations
+                        </span>
+                      </FormattedMessage>
+                       
+                      <EuiIcon
+                        type="link"
+                      >
+                        <div
+                          data-euiicon-type="link"
+                        />
+                      </EuiIcon>
+                    </button>
+                  </EuiLink>
+                   before using scripted fields.
+                </span>
+              </FormattedMessage>
+            </p>
+            <p>
+              <FormattedMessage
+                defaultMessage="Scripted fields can be used to display and aggregate calculated values. As such, they can be very slow, and if done incorrectly, can cause OpenSearch Dashboards to be unusable. There's no safety net here. If you make a typo, unexpected exceptions will be thrown all over the place!"
+                id="indexPatternManagement.warningCallOut.descriptionLabel"
+                values={Object {}}
+              >
+                <span>
+                  Scripted fields can be used to display and aggregate calculated values. As such, they can be very slow, and if done incorrectly, can cause OpenSearch Dashboards to be unusable. There's no safety net here. If you make a typo, unexpected exceptions will be thrown all over the place!
+                </span>
+              </FormattedMessage>
+            </p>
+          </div>
+        </EuiText>
+      </div>
+    </EuiCallOut>
+    <EuiSpacer
+      size="m"
+    >
+      <div
+        className="euiSpacer euiSpacer--m"
+      />
+    </EuiSpacer>
+  </ScriptingWarningCallOut>
+</IntlProvider>
 `;
 
 exports[`ScriptingWarningCallOut should render nothing if not visible 1`] = `
-<ScriptingWarningCallOut
-  isVisible={false}
-/>
+<IntlProvider
+  locale="en"
+>
+  <ScriptingWarningCallOut
+    isVisible={false}
+  />
+</IntlProvider>
 `;

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.test.tsx
@@ -32,6 +32,7 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
+import { wrapWithIntl } from 'test_utils/enzyme_helpers';
 import { OpenSearchDashboardsContextProvider } from 'src/plugins/opensearch_dashboards_react/public';
 import { mockManagementPlugin } from '../../../../mocks';
 import { ScriptingWarningCallOut } from './warning_call_out';
@@ -40,7 +41,7 @@ describe('ScriptingWarningCallOut', () => {
   const mockedContext = mockManagementPlugin.createIndexPatternManagmentContext();
 
   it('should render normally', async () => {
-    const component = mount(<ScriptingWarningCallOut isVisible={true} />, {
+    const component = mount(wrapWithIntl(<ScriptingWarningCallOut isVisible={true} />), {
       wrappingComponent: OpenSearchDashboardsContextProvider,
       wrappingComponentProps: {
         services: mockedContext,
@@ -51,7 +52,7 @@ describe('ScriptingWarningCallOut', () => {
   });
 
   it('should render nothing if not visible', async () => {
-    const component = mount(<ScriptingWarningCallOut isVisible={false} />, {
+    const component = mount(wrapWithIntl(<ScriptingWarningCallOut isVisible={false} />), {
       wrappingComponent: OpenSearchDashboardsContextProvider,
       wrappingComponentProps: {
         services: mockedContext,

--- a/src/plugins/telemetry_management_section/public/components/telemetry_management_section.test.tsx
+++ b/src/plugins/telemetry_management_section/public/components/telemetry_management_section.test.tsx
@@ -30,7 +30,7 @@
  * GitHub history for details.
  */
 import React from 'react';
-import { mountWithIntl, shallowWithIntl } from 'test_utils/enzyme_helpers';
+import { mountWithIntl, shallowWithIntl, wrapWithIntl } from 'test_utils/enzyme_helpers';
 import TelemetryManagementSection from './telemetry_management_section';
 import { TelemetryService } from '../../../telemetry/public/services';
 import { coreMock } from '../../../../core/public/mocks';
@@ -91,31 +91,35 @@ describe('TelemetryManagementSectionComponent', () => {
     });
 
     const component = render(
-      <React.Suspense fallback={<span>Fallback</span>}>
-        <TelemetryManagementSection
-          telemetryService={telemetryService}
-          onQueryMatchChange={onQueryMatchChange}
-          showAppliesSettingMessage={false}
-          enableSaving={true}
-          isSecurityExampleEnabled={isSecurityExampleEnabled}
-          toasts={coreStart.notifications.toasts}
-        />
-      </React.Suspense>
-    );
-
-    try {
-      component.rerender(
+      wrapWithIntl(
         <React.Suspense fallback={<span>Fallback</span>}>
           <TelemetryManagementSection
-            query={{ text: 'asdasdasd' }}
             telemetryService={telemetryService}
             onQueryMatchChange={onQueryMatchChange}
             showAppliesSettingMessage={false}
             enableSaving={true}
-            toasts={coreStart.notifications.toasts}
             isSecurityExampleEnabled={isSecurityExampleEnabled}
+            toasts={coreStart.notifications.toasts}
           />
         </React.Suspense>
+      )
+    );
+
+    try {
+      component.rerender(
+        wrapWithIntl(
+          <React.Suspense fallback={<span>Fallback</span>}>
+            <TelemetryManagementSection
+              query={{ text: 'asdasdasd' }}
+              telemetryService={telemetryService}
+              onQueryMatchChange={onQueryMatchChange}
+              showAppliesSettingMessage={false}
+              enableSaving={true}
+              toasts={coreStart.notifications.toasts}
+              isSecurityExampleEnabled={isSecurityExampleEnabled}
+            />
+          </React.Suspense>
+        )
       );
       expect(onQueryMatchChange).toHaveBeenCalledWith(false);
       expect(onQueryMatchChange).toHaveBeenCalledTimes(1);

--- a/src/plugins/vis_default_editor/public/components/controls/percentiles.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/percentiles.test.tsx
@@ -34,6 +34,7 @@ import React from 'react';
 import { AggParamEditorProps } from '../agg_param_props';
 import { IAggConfig } from 'src/plugins/data/public';
 import { mount } from 'enzyme';
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
 import { PercentilesEditor } from './percentiles';
 import { EditorVisState } from '../sidebar/state/reducers';
 
@@ -66,13 +67,13 @@ describe('PercentilesEditor component', () => {
 
   it('should set valid state to true after adding a unique percentile', () => {
     defaultProps.value = [1, 5, 25, 50, 70];
-    mount(<PercentilesEditor {...defaultProps} />);
+    mountWithIntl(<PercentilesEditor {...defaultProps} />);
     expect(setValidity).lastCalledWith(true);
   });
 
   it('should set valid state to false after adding a duplicate percentile', () => {
     defaultProps.value = [1, 5, 25, 50, 50];
-    mount(<PercentilesEditor {...defaultProps} />);
+    mountWithIntl(<PercentilesEditor {...defaultProps} />);
     expect(setValidity).lastCalledWith(false);
   });
 });

--- a/src/test_utils/public/enzyme_helpers.tsx
+++ b/src/test_utils/public/enzyme_helpers.tsx
@@ -40,6 +40,7 @@
 import { I18nProvider, InjectedIntl, intlShape, __IntlProvider } from '@osd/i18n/react';
 import { mount, ReactWrapper, render, shallow } from 'enzyme';
 import React, { ReactElement, ValidationMap } from 'react';
+import { IntlProvider } from 'react-intl';
 
 // Use fake component to extract `intl` property to use in tests.
 const { intl } = (mount(
@@ -67,8 +68,20 @@ function getOptions(context = {}, childContextTypes: ValidationMap<any> = {}, pr
 /**
  * When using @osd/i18n `injectI18n` on components, props.intl is required.
  */
-function nodeWithIntlProp<T>(node: ReactElement<T>): ReactElement<T & { intl: InjectedIntl }> {
+export function nodeWithIntlProp<T>(
+  node: ReactElement<T>
+): ReactElement<T & { intl: InjectedIntl }> {
   return React.cloneElement<any>(node, { intl });
+}
+
+/**
+ *  Creates the wrapped IntlProvider instance
+ *
+ *  @param node The React element or cheerio wrapper
+ *  @return The wrapped IntlProvider instance
+ */
+export function wrapWithIntl<T>(node: ReactElement<T>) {
+  return <IntlProvider locale="en">{node}</IntlProvider>;
 }
 
 /**


### PR DESCRIPTION
### Description
In the FunctionComponent unit tests, we see many console errors:
`Could not find required intl object. <IntlProvider> needs to
exist in the component ancestry. `

This is because for some unit tests, we mount the FunctionComponent
(with Enzyme's mount()) , which access to the react-intl context by
FormattedMessage without their <IntlProvider /> parent wrapper.

This PR solves 7 out of 8 unit tests with this issue by wrapping the
<IntlProvider /> either through original enzyme_helper functions or
a simple wrapper wrapWithIntl.

### Partically Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/593

### Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/654

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 