### PR TITLE
[1.x][Tests] ARM64 artifacts for testing

### DIFF
--- a/packages/osd-opensearch/src/artifact.js
+++ b/packages/osd-opensearch/src/artifact.js
@@ -182,8 +182,8 @@ async function getArtifactSpecForSnapshotFromUrl(urlVersion, log) {
   // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/475
   const platform = process.platform === 'win32' ? 'windows' : process.platform;
   const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
-  if (platform !== 'linux' || arch !== 'x64') {
-    throw createCliError(`Snapshots are only available for Linux x64`);
+  if (platform !== 'linux') {
+    throw createCliError(`Snapshots are only available for Linux`);
   }
 
   const latestUrl = `${DAILY_SNAPSHOTS_BASE_URL}/${desiredVersion}`;


### PR DESCRIPTION
### Description
Removing the graceful failures for ARM64 snapshot testing and
updating tests.

Previously, snapshots for ARM64 were not available but now they are
so this allows developers to run tests for that arch out of the box
whereas before they had to set the snapshot manually.

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/641

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/475 [Partially]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 