### PR TITLE
[1.x][Bug] fix timeline icon in Visualize list

### DIFF
--- a/src/plugins/vis_type_timeline/public/timeline_vis_type.tsx
+++ b/src/plugins/vis_type_timeline/public/timeline_vis_type.tsx
@@ -53,7 +53,7 @@ export function getTimelineVisDefinition(dependencies: TimelineVisDependencies) 
   return {
     name: TIMELINE_VIS_NAME,
     title: 'Timeline',
-    icon: 'visTimeline',
+    icon: 'visTimelion',
     description: i18n.translate('timeline.timelineDescription', {
       defaultMessage: 'Build time-series using functional expressions',
     }),


### PR DESCRIPTION
### Description
Icon was not loading in the Visualize list because it was
referencing a non-existant icon. Other parts of the code
loads the icon correctly, so updated the icon to an existing
icon.

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/659

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/658
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 