### PR TITLE
[1.x][Test] Fix console error in search_service.test.ts 

### DIFF
--- a/src/plugins/data/server/search/search_service.ts
+++ b/src/plugins/data/server/search/search_service.ts
@@ -140,7 +140,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
       .pipe(first())
       .toPromise()
       .then((value) => {
-        if (value.search.aggs.shardDelay.enabled) {
+        if (value?.search?.aggs?.shardDelay?.enabled) {
           aggs.types.registerBucket(SHARD_DELAY_AGG_NAME, getShardDelayBucketAgg);
           registerFunction(aggShardDelay);
         }


### PR DESCRIPTION
### Description
Run unit test suite search_service.test.ts has a console error:
```
UnhandledPromiseRejectionWarning: TypeError: Cannot read
property 'aggs' of undefined
```

This is caused by a missing promise result check in the setup fun
in search_service.ts. If the promise result is empty (or null/undefined),
then any properties of the empty result is undefined. In our case,
`aggs` in `if (value.search.aggs.shardDelay.enabled)` is undefined.
In this PR, we fixed this issue by adding a value check in setup fun.

Issues resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/594

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/595

Signed-off-by: Anan Zhuang <ananzh@amazon.com>


 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 