### PR TITLE
[Test] Fix console warning in field_editor.test.tsx

### DIFF
--- a/src/plugins/index_pattern_management/public/components/field_editor/field_editor.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/field_editor.test.tsx
@@ -45,6 +45,7 @@ jest.mock('@elastic/eui', () => ({
   EuiButtonEmpty: 'eui-button-empty',
   EuiCallOut: 'eui-call-out',
   EuiCode: 'eui-code',
+  EuiCodeEditor: 'eui-code-editor',
   EuiConfirmModal: 'eui-confirm-modal',
   EuiFieldNumber: 'eui-field-number',
   EuiFieldText: 'eui-field-text',


### PR DESCRIPTION
### Description
Currently, unit test field_editor.test.tsx shows a console warning:

```
React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined. 
```

This warning is because EuiCodeEditor is missing in the mock of elastic/eui, which causes undefined EuiCodeEditor in the test.

### PR Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/673

### Test results
unit test for field_editor.test.tsx
```
yarn test:jest src/plugins/index_pattern_management/public/components/field_editor/field_editor.test.tsx -u
yarn run v1.22.5
$ node scripts/jest src/plugins/index_pattern_management/public/components/field_editor/field_editor.test.tsx -u
 PASS  src/plugins/index_pattern_management/public/components/field_editor/field_editor.test.tsx
  FieldEditor
    ✓ should render create new scripted field correctly (15 ms)
    ✓ should render edit scripted field correctly (5 ms)
    ✓ should show deprecated lang warning (4 ms)
    ✓ should show conflict field warning (4 ms)
    ✓ should show multiple type field warning with a table containing indices (4 ms)

 › 5 snapshots updated.
Snapshot Summary
 › 5 snapshots updated from 1 test suite.

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   5 updated, 5 total
Time:        3.688 s, estimated 4 s

```

Overall test result:

<img width="1635" alt="Screen Shot 2021-07-27 at 1 42 42 PM" src="https://user-images.githubusercontent.com/79961084/127224692-240e63cc-d1e1-4b3c-b5fe-4fa587c89a4e.png">

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 