### PR TITLE
[1.x][Test] Fix console warning in field_editor.test.tsx

### DIFF
--- a/src/plugins/index_pattern_management/public/components/field_editor/field_editor.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/field_editor.test.tsx
@@ -45,6 +45,7 @@ jest.mock('@elastic/eui', () => ({
   EuiButtonEmpty: 'eui-button-empty',
   EuiCallOut: 'eui-call-out',
   EuiCode: 'eui-code',
+  EuiCodeEditor: 'eui-code-editor',
   EuiConfirmModal: 'eui-confirm-modal',
   EuiFieldNumber: 'eui-field-number',
   EuiFieldText: 'eui-field-text',


### PR DESCRIPTION
### Description
Currently, unit test field_editor.test.tsx shows a console warning:

```
React.createElement: type is invalid -- expected a string
(for built-in components) or a class/function (for composite components)
but got: undefined. 

```

This warning is because EuiCodeEditor is missing in the mock of elastic/eui,
which causes undefined EuiCodeEditor in the test.

### PR Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/673

### Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/674

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 