### PR TITLE
Update FieldEditor test snapshots

### DIFF
--- a/src/plugins/index_pattern_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`FieldEditor should render create new scripted field correctly 1`] = `
       isInvalid={true}
       label="Script"
     >
-      <Component
+      <eui-code-editor
         data-test-subj="editorFieldScript"
         height="300px"
         mode="groovy"
@@ -372,7 +372,7 @@ exports[`FieldEditor should render edit scripted field correctly 1`] = `
       isInvalid={false}
       label="Script"
     >
-      <Component
+      <eui-code-editor
         data-test-subj="editorFieldScript"
         height="300px"
         mode="groovy"
@@ -652,7 +652,7 @@ exports[`FieldEditor should show conflict field warning 1`] = `
       isInvalid={true}
       label="Script"
     >
-      <Component
+      <eui-code-editor
         data-test-subj="editorFieldScript"
         height="300px"
         mode="groovy"
@@ -950,7 +950,7 @@ exports[`FieldEditor should show deprecated lang warning 1`] = `
       isInvalid={false}
       label="Script"
     >
-      <Component
+      <eui-code-editor
         data-test-subj="editorFieldScript"
         height="300px"
         mode="groovy"
@@ -1286,7 +1286,7 @@ exports[`FieldEditor should show multiple type field warning with a table contai
       isInvalid={true}
       label="Script"
     >
-      <Component
+      <eui-code-editor
         data-test-subj="editorFieldScript"
         height="300px"
         mode="groovy"


### PR DESCRIPTION
### Description
Previous PR #674 did not include updated snapshots.

Signed-off-by: Tommy Markley <markleyt@amazon.com>
 
### Issues Resolved
Related to https://github.com/opensearch-project/OpenSearch-Dashboards/issues/673

### Testing

```
$ yarn test:jest
...
Test Suites: 1 skipped, 1434 passed, 1434 of 1435 total
Tests:       24 skipped, 9 todo, 10637 passed, 10670 total
Snapshots:   2410 passed, 2410 total
Time:        47.32 s
Ran all test suites.
Done in 49.23s.

$ yarn test:jest_integration
...
Test Suites: 50 passed, 50 total
Tests:       4 skipped, 433 passed, 437 total
Snapshots:   73 passed, 73 total
Time:        307.323 s
Ran all test suites.
         │ info [opensearch] cleanup complete
Done in 309.62s.
```
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 