### PR TITLE
[1.x][Bug] remove tutorials from router temporarily

### DIFF
--- a/src/plugins/home/server/services/tutorials/tutorials_registry.ts
+++ b/src/plugins/home/server/services/tutorials/tutorials_registry.ts
@@ -98,7 +98,9 @@ export class TutorialsRegistry {
 
   public start() {
     // pre-populate with built in tutorials
-    this.tutorialProviders.push(...builtInTutorials);
+    // TODO: [RENAMEME] Need prod urls.
+    // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335
+    // this.tutorialProviders.push(...builtInTutorials);
     return {};
   }
 }


### PR DESCRIPTION
### Description
We removed the ability to access the tutorials page because we do
not have replacement for the links provided by the tutorials.

However, users could directly navigate to those pages if they typed
into the browser or had a bookmark.

This removes those routes from the router.

Issues resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/647

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/675

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>