### PR TITLE
[1.x] Bump `ws` from 7.3.1 to 7.5.3 (#699)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25447,9 +25447,9 @@ ws@^6.1.2, ws@^6.2.1:
     async-limiter "~1.0.0"
 
 ws@^7.2.3:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
-  integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
+  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
 
 x-is-function@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
### Description

Signed-off-by: Tommy Markley <markleyt@amazon.com>
 
### Issues Resolved
Backport of #699 to 1.x.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 