### PR TITLE
Correct copyright notices to reflect Copyright OpenSearch Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ This project is licensed under the [Apache v2.0 License](LICENSE.txt).
 
 ## Copyright
 
-Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.


### PR DESCRIPTION
### Description
Removed Amazon copyright, the correct copyright for OpenSearch projects is "Copyright OpenSearch Contributors".

Signed-off-by: Tommy Markley <markleyt@amazon.com>
 
### Issues Resolved
Resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/711
 
### Check List
- [x] Commits are signed per the DCO using --signoff 