### PR TITLE
[Build] Dashboards working with legacy engines 7.10.2

### DIFF
--- a/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.test.ts
+++ b/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.test.ts
@@ -46,6 +46,18 @@ describe('plugins/opensearch', () => {
       it('when majors are equal, but OpenSearch minor is less than OpenSearch Dashboards minor', () => {
         expect(opensearchVersionCompatibleWithOpenSearchDashboards('1.0.0', '1.1.0')).toBe(false);
       });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 6.10.3 and OpenSearch Dashboards is on 1.0.0', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('6.10.3', '1.0.0')).toBe(false);
+      });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 7.10.3 and OpenSearch Dashboards is on 1.0.0', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('7.10.3', '1.0.0')).toBe(false);
+      });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 8.0.0 and OpenSearch Dashboards is on 1.0.0', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('8.0.0', '1.0.0')).toBe(false);
+      });
     });
 
     describe('returns true', () => {
@@ -63,6 +75,18 @@ describe('plugins/opensearch', () => {
 
       it('when majors and minors are equal, but OpenSearch patch is less than OpenSearch Dashboards patch', () => {
         expect(opensearchVersionCompatibleWithOpenSearchDashboards('1.1.0', '1.1.1')).toBe(true);
+      });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 7.10.2 and OpenSearch Dashboards is on 1.0.0', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('7.10.2', '1.0.0')).toBe(true);
+      });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 7.10.2 and OpenSearch Dashboards is on 1.0.1', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('7.10.2', '1.0.1')).toBe(true);
+      });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 7.10.2 and OpenSearch Dashboards is on 1.1.0', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('7.10.2', '1.1.0')).toBe(true);
       });
     });
   });

--- a/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.ts
+++ b/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.ts
@@ -32,6 +32,13 @@
 
 import semver, { coerce } from 'semver';
 
+/** @private */
+interface VersionNumbers {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
 /**
  * Checks for the compatibilitiy between OpenSearch and OpenSearchDashboards versions
  * 1. Major version differences will never work together.
@@ -41,17 +48,26 @@ export function opensearchVersionCompatibleWithOpenSearchDashboards(
   opensearchVersion: string,
   opensearchDashboardsVersion: string
 ) {
-  const opensearchVersionNumbers = {
+  const opensearchVersionNumbers: VersionNumbers = {
     major: semver.major(opensearchVersion),
     minor: semver.minor(opensearchVersion),
     patch: semver.patch(opensearchVersion),
   };
 
-  const opensearchDashboardsVersionNumbers = {
+  const opensearchDashboardsVersionNumbers: VersionNumbers = {
     major: semver.major(opensearchDashboardsVersion),
     minor: semver.minor(opensearchDashboardsVersion),
     patch: semver.patch(opensearchDashboardsVersion),
   };
+
+  if (
+    legacyVersionCompatibleWithOpenSearchDashboards(
+      opensearchVersionNumbers,
+      opensearchDashboardsVersionNumbers
+    )
+  ) {
+    return true;
+  }
 
   // Reject mismatching major version numbers.
   if (opensearchVersionNumbers.major !== opensearchDashboardsVersionNumbers.major) {
@@ -76,5 +92,26 @@ export function opensearchVersionEqualsOpenSearchDashboards(
     nodeSemVer &&
     opensearchDashboardsSemver &&
     nodeSemVer.version === opensearchDashboardsSemver.version
+  );
+}
+
+/**
+ * Verify legacy version of engines is compatible with current version
+ * of OpenSearch Dashboards if OpenSearch Dashboards is 1.x.
+ *
+ * @private
+ * @param legacyVersionNumbers semantic version of legacy engine
+ * @param opensearchDashboardsVersionNumbers semantic version of application
+ * @returns {boolean}
+ */
+function legacyVersionCompatibleWithOpenSearchDashboards(
+  legacyVersionNumbers: VersionNumbers,
+  opensearchDashboardsVersionNumbers: VersionNumbers
+) {
+  return (
+    legacyVersionNumbers.major === 7 &&
+    legacyVersionNumbers.minor === 10 &&
+    legacyVersionNumbers.patch === 2 &&
+    opensearchDashboardsVersionNumbers.major === 1
   );
 }


### PR DESCRIPTION
### Description
Enables the version check to work specifically in the case of OSD 1.X and
legacy 7.10.2. This will avoid conflicts in future versions of the application
where Dashboards is not compatible with the Engines on version differences.

Testing for verifying compatible legacy version.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/720
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 