### PR TITLE
[Purify] Remove deprecation message in batchSearches settings

### DIFF
--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -291,13 +291,6 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
            away or update the query. When enabled, dashboard panels will load together when all of the data is loaded, and
            searches will not terminate.`,
       }),
-      deprecation: {
-        message: i18n.translate('data.advancedSettings.courier.batchSearchesTextDeprecation', {
-          defaultMessage:
-            'This setting is deprecated and will be removed in OpenSearch Dashboards 8.0.',
-        }),
-        docLinksKey: 'opensearchDashboardsSearchSettings',
-      },
       category: ['search'],
       schema: schema.boolean(),
     },


### PR DESCRIPTION
### Description
Remove deprecation message from batchSearches in advanced settings.
It referenced OpenSearch Dashboards 8.0, which is just from the legacy
application.

No plan to deprecate yet.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/363
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 