### PR TITLE
[1.x][Docs] Update doc refs from beta to prod

### DIFF
--- a/src/core/public/doc_links/doc_links_service.test.ts
+++ b/src/core/public/doc_links/doc_links_service.test.ts
@@ -40,8 +40,6 @@ describe('DocLinksService#start()', () => {
     const service = new DocLinksService();
     const api = service.start({ injectedMetadata });
     expect(api.DOC_LINK_VERSION).toEqual('test-branch');
-    expect(api.links.opensearchDashboards).toEqual(
-      'https://docs-beta.opensearch.org/docs/opensearch-dashboards/'
-    );
+    expect(api.links.opensearchDashboards).toEqual('https://opensearch.org/docs/dashboards/');
   });
 });

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -43,8 +43,8 @@ export class DocLinksService {
   public start({ injectedMetadata }: StartDeps): DocLinksStart {
     const DOC_LINK_VERSION = injectedMetadata.getOpenSearchDashboardsBranch();
     const OPENSEARCH_WEBSITE_URL = 'https://www.opensearch.org/';
-    const OPENSEARCH_DOCS = `https://docs-beta.opensearch.org/docs/opensearch/`;
-    const OPENSEARCH_DASHBOARDS_DOCS = `https://docs-beta.opensearch.org/docs/opensearch-dashboards/`;
+    const OPENSEARCH_DOCS = `https://opensearch.org/docs/opensearch/`;
+    const OPENSEARCH_DASHBOARDS_DOCS = `https://opensearch.org/docs/dashboards/`;
 
     return deepFreeze({
       DOC_LINK_VERSION,

--- a/src/core/server/ui_settings/settings/date_formats.ts
+++ b/src/core/server/ui_settings/settings/date_formats.ts
@@ -170,7 +170,7 @@ export const getDateFormatSettings = (): Record<string, UiSettingsParams> => {
           dateNanosLink:
             // TODO: [RENAMEME] Need prod urls.
             // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-            '<a href="https://docs-beta.opensearch.org/opensearch/units" target="_blank" rel="noopener noreferrer">' +
+            '<a href="https://opensearch.org/docs/opensearch/units" target="_blank" rel="noopener noreferrer">' +
             i18n.translate('core.ui_settings.params.dateNanosLinkTitle', {
               defaultMessage: 'date_nanos',
             }) +

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/msearch.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/msearch.json
@@ -23,6 +23,6 @@
       "{indices}/_msearch",
       "{indices}/{type}/_msearch"
     ],
-    "documentation": "https://docs-beta.opensearch.org/opensearch/query-dsl/full-text/#multi-match"
+    "documentation": "https://opensearch.org/docs/opensearch/query-dsl/full-text/#multi-match"
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/msearch_template.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/msearch_template.json
@@ -21,6 +21,6 @@
       "{indices}/_msearch/template",
       "{indices}/{type}/_msearch/template"
     ],
-    "documentation": "https://docs-beta.opensearch.org/opensearch/query-dsl/full-text/#multi-match"
+    "documentation": "https://opensearch.org/docs/opensearch/query-dsl/full-text/#multi-match"
   }
 }

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -108,7 +108,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           optionsLink:
             // TODO: [RENAMEME] Need prod urls.
             // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-            '<a href="https://docs-beta.opensearch.org/opensearch/query-dsl/index" target="_blank" rel="noopener">' +
+            '<a href="https://opensearch.org/docs/opensearch/query-dsl/index" target="_blank" rel="noopener">' +
             i18n.translate('data.advancedSettings.query.queryStringOptions.optionsLinkText', {
               defaultMessage: 'Options',
             }) +
@@ -167,7 +167,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'data.advancedSettings.sortOptionsText',
         values: {
           optionsLink:
-            '<a href="https://docs-beta.opensearch.org/opensearch/ux/#sort-results" target="_blank" rel="noopener">' +
+            '<a href="https://opensearch.org/docs/opensearch/ux/#sort-results" target="_blank" rel="noopener">' +
             i18n.translate('data.advancedSettings.sortOptions.optionsLinkText', {
               defaultMessage: 'Options',
             }) +
@@ -249,7 +249,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           setRequestReferenceSetting: `<strong>${UI_SETTINGS.COURIER_SET_REQUEST_PREFERENCE}</strong>`,
           customSettingValue: '"custom"',
           requestPreferenceLink:
-            '<a href="https://docs-beta.opensearch.org/opensearch/popular-api" target="_blank" rel="noopener">' +
+            '<a href="https://opensearch.org/docs/opensearch/popular-api" target="_blank" rel="noopener">' +
             i18n.translate(
               'data.advancedSettings.courier.customRequestPreference.requestPreferenceLinkText',
               {
@@ -273,7 +273,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'Controls the {maxRequestsLink} setting used for _msearch requests sent by OpenSearch Dashboards. ' +
           'Set to 0 to disable this config and use the OpenSearch default.',
         values: {
-          maxRequestsLink: `<a href="https://docs-beta.opensearch.org/opensearch/query-dsl/full-text/#multi-match"
+          maxRequestsLink: `<a href="https://opensearch.org/docs/opensearch/query-dsl/full-text/#multi-match"
             target="_blank" rel="noopener" >max_concurrent_shard_requests</a>`,
         },
       }),
@@ -303,7 +303,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
     },
     [UI_SETTINGS.SEARCH_INCLUDE_FROZEN]: {
       name: 'Search in frozen indices',
-      description: `Will include <a href="https://docs-beta.opensearch.org/opensearch/index-data"
+      description: `Will include <a href="https://opensearch.org/docs/opensearch/index-data"
         target="_blank" rel="noopener">frozen indices</a> in results if enabled. Searching through frozen indices
         might increase the search time.`,
       value: false,
@@ -652,7 +652,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'data.advancedSettings.timepicker.quickRanges.acceptedFormatsLinkText',
         values: {
           acceptedFormatsLink:
-            `<a href="https://docs-beta.opensearch.org/opensearch/units"
+            `<a href="https://opensearch.org/docs/opensearch/units"
             target="_blank" rel="noopener">` +
             i18n.translate('data.advancedSettings.timepicker.quickRanges.acceptedFormatsLinkText', {
               defaultMessage: 'accepted formats',

--- a/src/plugins/discover/public/application/angular/context/api/utils/get_opensearch_query_sort.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/get_opensearch_query_sort.ts
@@ -37,7 +37,7 @@ import {
 
 /**
  * Returns `OpenSearchQuerySort` which is used to sort records in the OpenSearch query
- * https://docs-beta.opensearch.org/opensearch/ux/#sort-results
+ * https://opensearch.org/docs/opensearch/ux/#sort-results
  * @param timeField
  * @param tieBreakerField
  * @param sortDir

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -233,7 +233,7 @@ export const EditIndexPattern = withRouter(
               <EuiLink
                 // TODO: [RENAMEME] Need prod urls.
                 // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-                href="https://docs-beta.opensearch.org/opensearch/index-templates"
+                href="https://opensearch.org/docs/opensearch/index-templates"
                 target="_blank"
                 external
               >

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/__snapshots__/empty_state.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/__snapshots__/empty_state.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`EmptyState should render normally 1`] = `
                   Object {
                     "description": <EuiLink
                       external={true}
-                      href="https://docs-beta.opensearch.org/docs/opensearch-dashboards/"
+                      href="https://opensearch.org/docs/dashboards/"
                       target="_blank"
                     >
                       <FormattedMessage

--- a/src/plugins/maps_legacy/public/map/map_messages.js
+++ b/src/plugins/maps_legacy/public/map/map_messages.js
@@ -115,10 +115,7 @@ export const createZoomWarningMsg = (function () {
               // TODO: [RENAMEME] Need prod urls.
               values={{
                 wms: (
-                  <a
-                    target="_blank"
-                    href="https://docs-beta.opensearch.org/docs/opensearch-dashboards/maptiles"
-                  >
+                  <a target="_blank" href="https://opensearch.org/docs/dashboards/maptiles/">
                     {`Custom WMS Configuration`}
                   </a>
                 ),

--- a/src/plugins/maps_legacy/server/ui_settings.ts
+++ b/src/plugins/maps_legacy/server/ui_settings.ts
@@ -53,7 +53,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
             cellDimensionsLink:
               // TODO: [RENAMEME] Need prod urls.
               // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-              `<a href="https://docs-beta.opensearch.org/dashboards/maptiles"
+              `<a href="https://opensearch.org/docs/dashboards/maptiles"
             target="_blank" rel="noopener">` +
               i18n.translate(
                 'maps_legacy.advancedSettings.visualization.tileMap.maxPrecision.cellDimensionsLinkText',

--- a/src/plugins/vis_type_vega/public/components/vega_help_menu.tsx
+++ b/src/plugins/vis_type_vega/public/components/vega_help_menu.tsx
@@ -56,7 +56,7 @@ function VegaHelpMenu() {
       key="vegaHelp"
       // TODO: [RENAMEME] Need prod urls.
       // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-      href="https://docs-beta.opensearch.org/docs/opensearch-dashboards"
+      href="https://opensearch.org/docs/dashboards"
       target="_blank"
       onClick={closePopover}
     >


### PR DESCRIPTION
### Description
Updating references to the doc site from docs-beta.opensearch.org
to the production site of opensearch.org/docs.

Did not remove the TODOs because we do not have replacements for the
content yet.

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/733

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
Partial: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335
