### PR TITLE
Make loading page logo and title configurable 

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -157,6 +157,9 @@
 # smaller version customized logo URL
 # opensearchDashboards.branding.smallLogoUrl: ""
 
+# customized loading logo URL
+# opensearchDashboards.branding.loadingLogoUrl: ""
+
 # custom application title
 # opensearchDashboards.branding.title: ""
 

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -59,6 +59,9 @@ export const config = {
       smallLogoUrl: schema.string({
         defaultValue: '/',
       }),
+      loadingLogoUrl: schema.string({
+        defaultValue: '/',
+      }),
       title: schema.string({ defaultValue: 'OpenSearch Dashboards' }),
     }),
   }),

--- a/src/core/server/rendering/rendering_service.test.ts
+++ b/src/core/server/rendering/rendering_service.test.ts
@@ -136,6 +136,7 @@ describe('RenderingService', () => {
       });
     });
   });
+
   describe('checkUrlValid()', () => {
     it('SVG URL is valid', async () => {
       const result = await service.checkUrlValid(
@@ -144,6 +145,7 @@ describe('RenderingService', () => {
       );
       expect(result).toEqual(true);
     });
+
     it('PNG URL is valid', async () => {
       const result = await service.checkUrlValid(
         'https://opensearch.org/assets/brand/PNG/Mark/opensearch_mark_default.png',
@@ -151,10 +153,12 @@ describe('RenderingService', () => {
       );
       expect(result).toEqual(true);
     });
-    it('URL does not contain svg, or png', async () => {
+
+    it('URL does not contain svg, png or gif', async () => {
       const result = await service.checkUrlValid('https://validUrl', 'config');
       expect(result).toEqual(false);
     });
+
     it('URL is invalid', async () => {
       const result = await service.checkUrlValid('http://notfound.svg', 'config');
       expect(result).toEqual(false);

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -71,6 +71,10 @@ export class RenderingService {
       opensearchDashboardsConfig.branding.smallLogoUrl,
       'smallLogoUrl'
     );
+    const isLoadingLogoUrlValid = await this.checkUrlValid(
+      opensearchDashboardsConfig.branding.loadingLogoUrl,
+      'loadingLogoUrl'
+    );
 
     return {
       render: async (
@@ -125,6 +129,9 @@ export class RenderingService {
               smallLogoUrl: isSmallLogoUrlValid
                 ? opensearchDashboardsConfig.branding.smallLogoUrl
                 : undefined,
+              loadingLogoUrl: isLoadingLogoUrlValid
+                ? opensearchDashboardsConfig.branding.loadingLogoUrl
+                : undefined,
               title: opensearchDashboardsConfig.branding.title,
             },
           },
@@ -144,7 +151,7 @@ export class RenderingService {
   }
 
   public checkUrlValid = async (url: string, configName?: string): Promise<boolean> => {
-    if (url.match(/\.(png|svg)$/) === null) {
+    if (url.match(/\.(png|svg|gif)$/) === null) {
       this.logger.get('branding').warn(configName + ' config is not found or invalid.');
       return false;
     }

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -77,6 +77,7 @@ export interface RenderingMetadata {
     branding: {
       logoUrl?: string;
       smallLogoUrl?: string;
+      loadingLogoUrl?: string;
       title: string;
     };
   };

--- a/src/core/server/rendering/views/__snapshots__/template.test.tsx.snap
+++ b/src/core/server/rendering/views/__snapshots__/template.test.tsx.snap
@@ -1,0 +1,445 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Template renders with customized loading logo 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title>
+    OpenSearch
+  </title>,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"smallLogoUrl\\":\\"/\\",\\"loadingLogoUrl\\":\\"/\\",\\"title\\":\\"\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <div
+        class="loadingLogoContainer"
+      >
+        <img
+          alt="loadingLogo"
+          class="loadingLogo"
+          src="/"
+        />
+      </div>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Template renders with default OpenSearch loading logo 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title>
+    OpenSearch
+  </title>,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"title\\":\\"\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 90 90"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M75.7374 37.5C74.4878 37.5 73.4748 38.513 73.4748 39.7626C73.4748 58.3813 58.3813 73.4748 39.7626 73.4748C38.513 73.4748 37.5 74.4878 37.5 75.7374C37.5 76.987 38.513 78 39.7626 78C60.8805 78 78 60.8805 78 39.7626C78 38.513 76.987 37.5 75.7374 37.5Z"
+            fill="#005EB8"
+          />
+          <animateTransform
+            attributeName="transform"
+            dur="1.5s"
+            from="0 40 40"
+            keyTimes="0; .3; .7; 1"
+            repeatCount="indefinite"
+            to="359.9 40 40"
+            type="rotate"
+            values="0 40 40; 15 40 40; 340 40 40; 359.9 40 40"
+          />
+        </g>
+        <path
+          d="M62.0814 52C64.2572 48.4505 66.3615 43.7178 65.9475 37.0921C65.0899 23.3673 52.6589 12.9554 40.9206 14.0837C36.3253 14.5255 31.6068 18.2712 32.026 24.9805C32.2082 27.8961 33.6352 29.6169 35.9544 30.9399C38.1618 32.1992 40.9978 32.9969 44.2128 33.9011C48.0962 34.9934 52.6009 36.2203 56.0631 38.7717C60.2125 41.8296 63.0491 45.3743 62.0814 52Z"
+          fill="#003B5C"
+        />
+        <path
+          d="M17.9186 28C15.7428 31.5495 13.6385 36.2822 14.0525 42.9079C14.9101 56.6327 27.3411 67.0446 39.0794 65.9163C43.6747 65.4745 48.3932 61.7288 47.974 55.0195C47.7918 52.1039 46.3647 50.3831 44.0456 49.0601C41.8382 47.8008 39.0022 47.0031 35.7872 46.0989C31.9038 45.0066 27.3991 43.7797 23.9369 41.2283C19.7875 38.1704 16.9509 34.6257 17.9186 28Z"
+          fill="#005EB8"
+        />
+      </svg>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Template renders with static logo with horizontal loading bar 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title>
+    OpenSearch
+  </title>,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"smallLogoUrl\\":\\"/\\",\\"title\\":\\"\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <div
+        class="loadingLogoContainer"
+      >
+        <img
+          alt="staticLoadingLogo"
+          class="loadingLogo"
+          src="/"
+        />
+      </div>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+      <div
+        class="osdProgress"
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;

--- a/src/core/server/rendering/views/styles.tsx
+++ b/src/core/server/rendering/views/styles.tsx
@@ -159,6 +159,16 @@ export const Styles: FunctionComponent<Props> = ({ darkMode }) => {
             background-color: ${darkMode ? '#1BA9F5' : '#006DE4'};
           }
 
+          .loadingLogoContainer {
+            height: 60px;
+            padding: 10px 10px 10px 10px;
+          }
+          
+          .loadingLogo {
+            height: 100%;
+            max-width: 100%;
+          }
+
           @keyframes osdProgress {
             0% {
               transform: scaleX(1) translateX(-100%);

--- a/src/core/server/rendering/views/template.test.tsx
+++ b/src/core/server/rendering/views/template.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from 'react';
+import { injectedMetadataServiceMock } from '../../../public/mocks';
+import { httpServiceMock } from '../../http/http_service.mock';
+import { Template } from './template';
+import { renderWithIntl } from 'test_utils/enzyme_helpers';
+
+const http = httpServiceMock.createStartContract();
+const injectedMetadata = injectedMetadataServiceMock.createSetupContract();
+
+function mockProps() {
+  return {
+    uiPublicUrl: `${http.basePath}/ui`,
+    locale: '',
+    darkMode: true,
+    i18n: () => '',
+    bootstrapScriptUrl: `${http.basePath}/bootstrap.js`,
+    strictCsp: true,
+    injectedMetadata: {
+      version: injectedMetadata.getOpenSearchDashboardsVersion(),
+      buildNumber: 1,
+      branch: injectedMetadata.getBasePath(),
+      basePath: '',
+      serverBasePath: '',
+      env: {
+        packageInfo: {
+          version: '',
+          branch: '',
+          buildNum: 1,
+          buildSha: '',
+          dist: true,
+        },
+        mode: {
+          name: 'production' as 'development' | 'production',
+          dev: true,
+          prod: false,
+        },
+      },
+      anonymousStatusPage: injectedMetadata.getAnonymousStatusPage(),
+      i18n: { translationsUrl: '' },
+      csp: injectedMetadata.getCspConfig(),
+      vars: injectedMetadata.getInjectedVars(),
+      uiPlugins: injectedMetadata.getPlugins(),
+      legacyMetadata: {
+        uiSettings: {
+          defaults: { legacyInjectedUiSettingDefaults: true },
+          user: {},
+        },
+      },
+      branding: injectedMetadata.getBranding(),
+    },
+  };
+}
+
+describe('Template', () => {
+  it('renders with default OpenSearch loading logo', () => {
+    const branding = {
+      title: '',
+    };
+    injectedMetadata.getBranding.mockReturnValue(branding);
+    const component = renderWithIntl(<Template metadata={mockProps()} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders with static logo with horizontal loading bar', () => {
+    const branding = {
+      smallLogoUrl: '/',
+      title: '',
+    };
+    injectedMetadata.getBranding.mockReturnValue(branding);
+    const component = renderWithIntl(<Template metadata={mockProps()} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders with customized loading logo', () => {
+    const branding = {
+      smallLogoUrl: '/',
+      loadingLogoUrl: '/',
+      title: '',
+    };
+    injectedMetadata.getBranding.mockReturnValue(branding);
+    const component = renderWithIntl(<Template metadata={mockProps()} />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/core/server/rendering/views/template.tsx
+++ b/src/core/server/rendering/views/template.tsx
@@ -95,6 +95,33 @@ export const Template: FunctionComponent<Props> = ({
       />
     </svg>
   );
+
+  const renderBrandingEnabledOrDisabledLoadingBar = () => {
+    if (!injectedMetadata.branding.loadingLogoUrl && injectedMetadata.branding.smallLogoUrl) {
+      return <div className="osdProgress" />;
+    }
+  };
+
+  const renderBrandingEnabledOrDisabledLoadingLogo = () => {
+    if (!injectedMetadata.branding.loadingLogoUrl && !injectedMetadata.branding.smallLogoUrl) {
+      return openSearchLogoSpinner;
+    } else {
+      return (
+        <div className="loadingLogoContainer">
+          <img
+            className="loadingLogo"
+            src={
+              !injectedMetadata.branding.loadingLogoUrl
+                ? injectedMetadata.branding.smallLogoUrl
+                : injectedMetadata.branding.loadingLogoUrl
+            }
+            alt={injectedMetadata.branding.title + ' logo'}
+          />
+        </div>
+      );
+    }
+  };
+
   return (
     <html lang={locale}>
       <head>
@@ -147,17 +174,19 @@ export const Template: FunctionComponent<Props> = ({
           style={{ display: 'none' }}
           data-test-subj="osdLoadingMessage"
         >
-          <div className="osdLoaderWrap">
-            {openSearchLogoSpinner}
+          <div className="osdLoaderWrap" data-test-subj="loadingLogo">
+            {renderBrandingEnabledOrDisabledLoadingLogo()}
             <div
               className="osdWelcomeText"
               data-error-message={i18n('core.ui.welcomeErrorMessage', {
-                defaultMessage:
-                  'OpenSearch did not load properly. Check the server output for more information.',
+                defaultMessage: `${injectedMetadata.branding.title} did not load properly. Check the server output for more information.`,
               })}
             >
-              {i18n('core.ui.welcomeMessage', { defaultMessage: 'Loading OpenSearch' })}
+              {i18n('core.ui.welcomeMessage', {
+                defaultMessage: `Loading ${injectedMetadata.branding.title}`,
+              })}
             </div>
+            {renderBrandingEnabledOrDisabledLoadingBar()}
           </div>
         </div>
 

--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -236,6 +236,7 @@ export default () =>
       branding: Joi.object({
         logoUrl: Joi.string().default('/'),
         smallLogoUrl: Joi.string().default('/'),
+        loadingLogoUrl: Joi.string().default('/'),
         title: Joi.string().default('OpenSearch Dashboards'),
       }),
     }).default(),


### PR DESCRIPTION
### Description:
US3: User can set animated version of logo and title in the opensearch_dashboards.yml and see it in the application at run time for the loading page.

### Requirement:
User need to input a valid URL for opensearchDashboards.branding.loadingLogoUrl and a valid string for opensearchDashboards.branding.title in the opensearch_dashboards.yml file.
![image](https://user-images.githubusercontent.com/43937633/131294469-be04c4b5-e796-4029-b4de-305c2b3597b5.png)

### Details: 
* If the URL is invalid or does not end with gif or svg, the default OpenSearch Dashboard logo will be shown. An application error log will be shown.
* If no loadingLogoUrl is not provided, the static logoUrl with a horizontal loading bar will be shown. If logoUrl is not provided, the default OpenSearch spinner will be displayed.
* User can input URL with image of any size, and the image will be formatted to a fixed size.
* User needs to be responsible for the content of the URL.
* This is a local setting; user needs to set this config in all data nodes in OpenSearch Dashboards if a global setting is wanted.

### Related Project Card:
https://github.com/abbyhu2000/OpenSearch-Dashboards/projects/1#card-67598784

Signed-off-by: Abby Hu abigailhu2000@gmail.com

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 