### PR TITLE
[1.x][Build] build:types and uiFramework run successfully

### DIFF
--- a/packages/osd-ui-framework/doc_site/src/components/guide_nav/_guide_nav.scss
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_nav/_guide_nav.scss
@@ -80,9 +80,10 @@
       font-size: 14px;
     }
 
-    .guideNav__elasticLogo {
+    // TODO: [RENAMEME] replacement background-image might be needed
+    .guideNav__opensearchLogo {
       position: absolute;
-      background-image: url("images/elastic-logo.svg");
+      background-image: url("images/react-logo.svg");
       width: 106px;
       height: 36px;
       background-repeat: no-repeat;

--- a/packages/osd-ui-framework/doc_site/src/components/guide_nav/guide_nav.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_nav/guide_nav.js
@@ -172,8 +172,8 @@ export class GuideNav extends Component {
           </Link>
           <a
             href="http://opensearch.org"
-            className="guideNav__elasticLogo"
-            aria-label="Go to the Elastic website"
+            className="guideNav__opensearchLogo"
+            aria-label="Go to the OpenSearch website"
           />
 
           {this.renderPagination()}

--- a/packages/osd-ui-framework/doc_site/webpack.config.js
+++ b/packages/osd-ui-framework/doc_site/webpack.config.js
@@ -64,7 +64,19 @@ module.exports = {
       },
       {
         test: /\.scss$/,
-        loaders: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader'],
+        loaders: [
+          'style-loader',
+          'css-loader',
+          {
+            loader: 'postcss-loader',
+            options: {
+              config: {
+                path: require.resolve('@osd/optimizer/postcss.config.js'),
+              },
+            },
+          },
+          'sass-loader',
+        ],
         exclude: /node_modules/,
       },
       {

--- a/src/plugins/data/common/field_formats/field_formats_registry.ts
+++ b/src/plugins/data/common/field_formats/field_formats_registry.ts
@@ -182,7 +182,7 @@ export class FieldFormatsRegistry {
 
       return new ConcreteFieldFormat(params, this.getConfig);
     },
-    (formatId: FieldFormatId, params: Record<string, any>) =>
+    (formatId: FieldFormatId, params: Record<string, any> = {}) =>
       JSON.stringify({
         formatId,
         ...params,
@@ -222,7 +222,7 @@ export class FieldFormatsRegistry {
    */
   getDefaultInstanceCacheResolver(
     fieldType: OSD_FIELD_TYPES,
-    esTypes: OPENSEARCH_FIELD_TYPES[]
+    esTypes?: OPENSEARCH_FIELD_TYPES[]
   ): string {
     // @ts-ignore
     return Array.isArray(esTypes) && esTypes.indexOf(fieldType) === -1


### PR DESCRIPTION
Allowing for the following builds to complete successfully:
* `yarn build:types`
* `yarn uiFramework:build`
* `yarn uiFramework:start`

Not positive about the expected results when running uiFramework:start
but it seems to be on par with the legacy 7.10.2 version.

Issue resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/680

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/734

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>