### PR TITLE
feat(module-alias): added support for module-alias with webpack

### DIFF
--- a/packages/osd-optimizer/src/common/bundle.test.ts
+++ b/packages/osd-optimizer/src/common/bundle.test.ts
@@ -39,6 +39,7 @@ const SPEC: BundleSpec = {
   publicDirNames: ['public'],
   id: 'bar',
   outputDir: '/foo/bar/target',
+  moduleAliases: undefined,
   sourceRoot: '/foo',
   type: 'plugin',
 };
@@ -65,6 +66,7 @@ it('creates cache keys', () => {
         "contextDir": "/foo/bar",
         "id": "bar",
         "manifestPath": undefined,
+        "moduleAliases": undefined,
         "outputDir": "/foo/bar/target",
         "publicDirNames": Array [
           "public",
@@ -102,6 +104,7 @@ it('parses bundles from JSON specs', () => {
         "contextDir": "/foo/bar",
         "id": "bar",
         "manifestPath": undefined,
+        "moduleAliases": undefined,
         "outputDir": "/foo/bar/target",
         "publicDirNames": Array [
           "public",

--- a/packages/osd-optimizer/src/integration_tests/__snapshots__/basic_optimization.test.ts.snap
+++ b/packages/osd-optimizer/src/integration_tests/__snapshots__/basic_optimization.test.ts.snap
@@ -12,6 +12,7 @@ OptimizerConfig {
       "contextDir": <absolute path>/packages/osd-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/bar,
       "id": "bar",
       "manifestPath": <absolute path>/packages/osd-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/bar/opensearch_dashboards.json,
+      "moduleAliases": undefined,
       "outputDir": <absolute path>/packages/osd-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/bar/target/public,
       "publicDirNames": Array [
         "public",
@@ -28,6 +29,7 @@ OptimizerConfig {
       "contextDir": <absolute path>/packages/osd-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/foo,
       "id": "foo",
       "manifestPath": <absolute path>/packages/osd-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/foo/opensearch_dashboards.json,
+      "moduleAliases": undefined,
       "outputDir": <absolute path>/packages/osd-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/foo/target/public,
       "publicDirNames": Array [
         "public",

--- a/packages/osd-optimizer/src/optimizer/get_plugin_bundles.test.ts
+++ b/packages/osd-optimizer/src/optimizer/get_plugin_bundles.test.ts
@@ -74,6 +74,7 @@ it('returns a bundle for core and each plugin', () => {
         "contextDir": <repoRoot>/plugins/foo,
         "id": "foo",
         "manifestPath": <repoRoot>/plugins/foo/opensearch_dashboards.json,
+        "moduleAliases": undefined,
         "outputDir": <outputRoot>/plugins/foo/target/public,
         "publicDirNames": Array [
           "public",
@@ -86,6 +87,7 @@ it('returns a bundle for core and each plugin', () => {
         "contextDir": <outsideOfRepo>/plugins/baz,
         "id": "baz",
         "manifestPath": <outsideOfRepo>/plugins/baz/opensearch_dashboards.json,
+        "moduleAliases": undefined,
         "outputDir": <outsideOfRepo>/plugins/baz/target/public,
         "publicDirNames": Array [
           "public",

--- a/packages/osd-optimizer/src/optimizer/get_plugin_bundles.ts
+++ b/packages/osd-optimizer/src/optimizer/get_plugin_bundles.ts
@@ -30,6 +30,7 @@
  * GitHub history for details.
  */
 
+import Fs from 'fs';
 import Path from 'path';
 
 import { Bundle } from '../common';
@@ -56,8 +57,18 @@ export function getPluginBundles(
             Path.relative(repoRoot, p.directory),
             'target/public'
           ),
+          moduleAliases: getBundleAliases(p.directory),
           manifestPath: p.manifestPath,
           banner: undefined,
         })
     );
 }
+
+const getBundleAliases = (contextDir: string): Record<string, string> | undefined => {
+  const pathPackage = `${contextDir}/package.json`;
+  if (Fs.existsSync(pathPackage)) {
+    const pluginPackage = JSON.parse(Fs.readFileSync(pathPackage, 'utf8'));
+    const aliases = pluginPackage?._moduleAliases as Record<string, string>;
+    if (aliases !== undefined) return aliases;
+  }
+};

--- a/packages/osd-optimizer/src/optimizer/optimizer_config.ts
+++ b/packages/osd-optimizer/src/optimizer/optimizer_config.ts
@@ -244,6 +244,7 @@ export class OptimizerConfig {
               sourceRoot: options.repoRoot,
               contextDir: Path.resolve(options.repoRoot, 'src/core'),
               outputDir: Path.resolve(options.outputRoot, 'src/core/target/public'),
+              moduleAliases: undefined,
             }),
           ]
         : []),

--- a/packages/osd-optimizer/src/worker/webpack.config.ts
+++ b/packages/osd-optimizer/src/worker/webpack.config.ts
@@ -50,6 +50,14 @@ const BABEL_PRESET_PATH = require.resolve('@osd/babel-preset/webpack_preset');
 export function getWebpackConfig(bundle: Bundle, bundleRefs: BundleRefs, worker: WorkerConfig) {
   const ENTRY_CREATOR = require.resolve('./entry_point_creator');
 
+  const webpackAliases: Record<string, string> = {};
+  if (bundle.moduleAliases !== undefined) {
+    const aliases = bundle.moduleAliases;
+    Object.keys(aliases).forEach(
+      (key) => (webpackAliases[key] = `${bundle.contextDir}/${aliases[key]}`)
+    );
+  }
+
   const commonConfig: webpack.Configuration = {
     node: { fs: 'empty' },
     context: bundle.contextDir,
@@ -229,6 +237,7 @@ export function getWebpackConfig(bundle: Bundle, bundleRefs: BundleRefs, worker:
       extensions: ['.js', '.ts', '.tsx', '.json'],
       mainFields: ['browser', 'main'],
       alias: {
+        ...webpackAliases,
         tinymath: require.resolve('tinymath/lib/tinymath.es5.js'),
         core_app_image_assets: Path.resolve(worker.repoRoot, 'src/core/public/core_app/images'),
       },


### PR DESCRIPTION
- corrected bundle properties and spec parsing
- added new method to get module aliases from package.json
- corrected webpack.config.ts to accept new aliases as native accepts

Signed-off-by: Felipe Rios <felipe.rios.silva@outlook.com>

### Description
To avoid relative imports like "../../../../" on the "public" folder of a plugin, I made some modifications to receive module-alias with Bundle public interface already provided. It'll possibility to work with an alias on import, at least on the frontend plugin, on React part. We can import things like this: `import { Something } from '@my-weird-alias'` without placing a relative path to the `Something` object.
 
### Issues Resolved
1. https://github.com/opensearch-project/OpenSearch-Dashboards/issues/760
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 