### PR TITLE
Bump `tar` from 6.1.6 to 6.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "**/react-syntax-highlighter/**/highlight.js": "^10.4.1",
     "**/request": "^2.88.2",
     "**/ssri": "^6.0.2",
-    "**/tar": "^6.1.6",
+    "**/tar": "^6.1.11",
     "**/trim": "^0.0.3",
     "**/trim-newlines": "^3.0.1",
     "**/typescript": "4.0.2"
@@ -206,7 +206,7 @@
     "semver": "^5.7.0",
     "source-map-support": "^0.5.19",
     "symbol-observable": "^1.2.0",
-    "tar": "^6.1.6",
+    "tar": "^6.1.11",
     "tinygradient": "0.4.3",
     "tinymath": "1.2.1",
     "tslib": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22900,10 +22900,10 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@6.0.2, tar@^6.0.1, tar@^6.0.2, tar@^6.1.6:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
-  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
+tar@6.0.2, tar@^6.0.1, tar@^6.0.2, tar@^6.1.11:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"


### PR DESCRIPTION
### Description
Addresses https://github.com/advisories/GHSA-5955-9wpr-37jh

Bumps [tar](https://github.com/npm/node-tar) from 6.1.6 to 6.1.11.
- [Release notes](https://github.com/npm/node-tar/releases)
- [Changelog](https://github.com/npm/node-tar/blob/main/CHANGELOG.md)
- [Commits](https://github.com/npm/node-tar/compare/v6.1.6...v6.1.11)

Signed-off-by: Tommy Markley <markleyt@amazon.com>

### Testing

![Screen Shot 2021-09-02 at 11 19 56 AM](https://user-images.githubusercontent.com/5437176/131880620-d02128a4-32c8-4b69-86c2-b080b4ad68a5.png)
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 