### PR TITLE
Make main page primary dashboard card logo and title configurable

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -157,6 +157,9 @@
 # smaller version customized logo URL
 # opensearchDashboards.branding.smallLogoUrl: ""
 
+# customized loading logo URL
+# opensearchDashboards.branding.loadingLogoUrl: ""
+
 # custom application title
 # opensearchDashboards.branding.title: ""
 

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -59,6 +59,9 @@ export const config = {
       smallLogoUrl: schema.string({
         defaultValue: '/',
       }),
+      loadingLogoUrl: schema.string({
+        defaultValue: '/',
+      }),
       title: schema.string({ defaultValue: 'OpenSearch Dashboards' }),
     }),
   }),

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -62,7 +62,7 @@ export const config = {
       loadingLogoUrl: schema.string({
         defaultValue: '/',
       }),
-      title: schema.string({ defaultValue: 'OpenSearch Dashboards' }),
+      title: schema.string({ defaultValue: '' }),
     }),
   }),
   deprecations,

--- a/src/core/server/rendering/__mocks__/rendering_service.ts
+++ b/src/core/server/rendering/__mocks__/rendering_service.ts
@@ -42,10 +42,12 @@ export const setupMock: jest.Mocked<InternalRenderingServiceSetup> = {
 export const mockSetup = jest.fn().mockResolvedValue(setupMock);
 export const mockStop = jest.fn();
 export const mockCheckUrlValid = jest.fn();
+export const mockCheckTitleValid = jest.fn();
 export const mockRenderingService: jest.Mocked<IRenderingService> = {
   setup: mockSetup,
   stop: mockStop,
   checkUrlValid: mockCheckUrlValid,
+  checkTitleValid: mockCheckTitleValid,
 };
 export const RenderingService = jest.fn<IRenderingService, [typeof mockRenderingServiceParams]>(
   () => mockRenderingService

--- a/src/core/server/rendering/rendering_service.test.ts
+++ b/src/core/server/rendering/rendering_service.test.ts
@@ -136,6 +136,7 @@ describe('RenderingService', () => {
       });
     });
   });
+
   describe('checkUrlValid()', () => {
     it('SVG URL is valid', async () => {
       const result = await service.checkUrlValid(
@@ -144,6 +145,7 @@ describe('RenderingService', () => {
       );
       expect(result).toEqual(true);
     });
+
     it('PNG URL is valid', async () => {
       const result = await service.checkUrlValid(
         'https://opensearch.org/assets/brand/PNG/Mark/opensearch_mark_default.png',
@@ -151,10 +153,12 @@ describe('RenderingService', () => {
       );
       expect(result).toEqual(true);
     });
-    it('URL does not contain svg, or png', async () => {
+
+    it('URL does not contain svg, png or gif', async () => {
       const result = await service.checkUrlValid('https://validUrl', 'config');
       expect(result).toEqual(false);
     });
+
     it('URL is invalid', async () => {
       const result = await service.checkUrlValid('http://notfound.svg', 'config');
       expect(result).toEqual(false);

--- a/src/core/server/rendering/rendering_service.test.ts
+++ b/src/core/server/rendering/rendering_service.test.ts
@@ -138,7 +138,7 @@ describe('RenderingService', () => {
   });
 
   describe('checkUrlValid()', () => {
-    it('SVG URL is valid', async () => {
+    it('checks valid SVG URL', async () => {
       const result = await service.checkUrlValid(
         'https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg',
         'config'
@@ -146,7 +146,7 @@ describe('RenderingService', () => {
       expect(result).toEqual(true);
     });
 
-    it('PNG URL is valid', async () => {
+    it('checks valid PNG URL', async () => {
       const result = await service.checkUrlValid(
         'https://opensearch.org/assets/brand/PNG/Mark/opensearch_mark_default.png',
         'config'
@@ -154,13 +154,33 @@ describe('RenderingService', () => {
       expect(result).toEqual(true);
     });
 
-    it('URL does not contain svg, png or gif', async () => {
+    it('checks invalid URL that does not contain svg, png or gif', async () => {
       const result = await service.checkUrlValid('https://validUrl', 'config');
       expect(result).toEqual(false);
     });
 
-    it('URL is invalid', async () => {
+    it('checks invalid URL', async () => {
       const result = await service.checkUrlValid('http://notfound.svg', 'config');
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('checkTitleValid()', () => {
+    it('checks valid title', () => {
+      const result = service.checkTitleValid('OpenSearch Dashboards', 'config');
+      expect(result).toEqual(true);
+    });
+
+    it('checks invalid title with empty string', () => {
+      const result = service.checkTitleValid('', 'config');
+      expect(result).toEqual(false);
+    });
+
+    it('checks invalid title with length > 36 character', () => {
+      const result = service.checkTitleValid(
+        'OpenSearch Dashboardssssssssssssssssssssss',
+        'config'
+      );
       expect(result).toEqual(false);
     });
   });

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -75,6 +75,8 @@ export class RenderingService {
       opensearchDashboardsConfig.branding.loadingLogoUrl,
       'loadingLogoUrl'
     );
+    const isTitleValid = this.checkTitleValid(opensearchDashboardsConfig.branding.title, 'title');
+    const defaultTitle = 'OpenSearch Dashboards';
 
     return {
       render: async (
@@ -132,7 +134,7 @@ export class RenderingService {
               loadingLogoUrl: isLoadingLogoUrlValid
                 ? opensearchDashboardsConfig.branding.loadingLogoUrl
                 : undefined,
-              title: opensearchDashboardsConfig.branding.title,
+              title: isTitleValid ? opensearchDashboardsConfig.branding.title : defaultTitle,
             },
           },
         };
@@ -151,7 +153,7 @@ export class RenderingService {
   }
 
   public checkUrlValid = async (url: string, configName?: string): Promise<boolean> => {
-    if (url.match(/\.(png|svg|gif)$/) === null) {
+    if (url.match(/\.(png|svg|gif|PNG|SVG|GIF)$/) === null) {
       this.logger.get('branding').warn(configName + ' config is not found or invalid.');
       return false;
     }
@@ -163,5 +165,13 @@ export class RenderingService {
         this.logger.get('branding').warn(configName + ' config is not found or invalid');
         return false;
       });
+  };
+
+  public checkTitleValid = (title: string, configName?: string): boolean => {
+    if (!title || title.length > 36) {
+      this.logger.get('branding').warn(configName + ' config is not found or invalid');
+      return false;
+    }
+    return true;
   };
 }

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -71,6 +71,10 @@ export class RenderingService {
       opensearchDashboardsConfig.branding.smallLogoUrl,
       'smallLogoUrl'
     );
+    const isLoadingLogoUrlValid = await this.checkUrlValid(
+      opensearchDashboardsConfig.branding.loadingLogoUrl,
+      'loadingLogoUrl'
+    );
 
     return {
       render: async (
@@ -125,6 +129,9 @@ export class RenderingService {
               smallLogoUrl: isSmallLogoUrlValid
                 ? opensearchDashboardsConfig.branding.smallLogoUrl
                 : undefined,
+              loadingLogoUrl: isLoadingLogoUrlValid
+                ? opensearchDashboardsConfig.branding.loadingLogoUrl
+                : undefined,
               title: opensearchDashboardsConfig.branding.title,
             },
           },
@@ -144,7 +151,7 @@ export class RenderingService {
   }
 
   public checkUrlValid = async (url: string, configName?: string): Promise<boolean> => {
-    if (url.match(/\.(png|svg)$/) === null) {
+    if (url.match(/\.(png|svg|gif)$/) === null) {
       this.logger.get('branding').warn(configName + ' config is not found or invalid.');
       return false;
     }

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -77,6 +77,7 @@ export interface RenderingMetadata {
     branding: {
       logoUrl?: string;
       smallLogoUrl?: string;
+      loadingLogoUrl?: string;
       title: string;
     };
   };

--- a/src/core/server/rendering/views/__snapshots__/template.test.tsx.snap
+++ b/src/core/server/rendering/views/__snapshots__/template.test.tsx.snap
@@ -1,0 +1,445 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Template renders with customized loading logo 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title>
+    OpenSearch
+  </title>,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"smallLogoUrl\\":\\"/\\",\\"loadingLogoUrl\\":\\"/\\",\\"title\\":\\"\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <div
+        class="loadingLogoContainer"
+      >
+        <img
+          alt="loadingLogo"
+          class="loadingLogo"
+          src="/"
+        />
+      </div>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Template renders with default OpenSearch loading logo 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title>
+    OpenSearch
+  </title>,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"title\\":\\"\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 90 90"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M75.7374 37.5C74.4878 37.5 73.4748 38.513 73.4748 39.7626C73.4748 58.3813 58.3813 73.4748 39.7626 73.4748C38.513 73.4748 37.5 74.4878 37.5 75.7374C37.5 76.987 38.513 78 39.7626 78C60.8805 78 78 60.8805 78 39.7626C78 38.513 76.987 37.5 75.7374 37.5Z"
+            fill="#005EB8"
+          />
+          <animateTransform
+            attributeName="transform"
+            dur="1.5s"
+            from="0 40 40"
+            keyTimes="0; .3; .7; 1"
+            repeatCount="indefinite"
+            to="359.9 40 40"
+            type="rotate"
+            values="0 40 40; 15 40 40; 340 40 40; 359.9 40 40"
+          />
+        </g>
+        <path
+          d="M62.0814 52C64.2572 48.4505 66.3615 43.7178 65.9475 37.0921C65.0899 23.3673 52.6589 12.9554 40.9206 14.0837C36.3253 14.5255 31.6068 18.2712 32.026 24.9805C32.2082 27.8961 33.6352 29.6169 35.9544 30.9399C38.1618 32.1992 40.9978 32.9969 44.2128 33.9011C48.0962 34.9934 52.6009 36.2203 56.0631 38.7717C60.2125 41.8296 63.0491 45.3743 62.0814 52Z"
+          fill="#003B5C"
+        />
+        <path
+          d="M17.9186 28C15.7428 31.5495 13.6385 36.2822 14.0525 42.9079C14.9101 56.6327 27.3411 67.0446 39.0794 65.9163C43.6747 65.4745 48.3932 61.7288 47.974 55.0195C47.7918 52.1039 46.3647 50.3831 44.0456 49.0601C41.8382 47.8008 39.0022 47.0031 35.7872 46.0989C31.9038 45.0066 27.3991 43.7797 23.9369 41.2283C19.7875 38.1704 16.9509 34.6257 17.9186 28Z"
+          fill="#005EB8"
+        />
+      </svg>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Template renders with static logo with horizontal loading bar 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title>
+    OpenSearch
+  </title>,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"smallLogoUrl\\":\\"/\\",\\"title\\":\\"\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <div
+        class="loadingLogoContainer"
+      >
+        <img
+          alt="staticLoadingLogo"
+          class="loadingLogo"
+          src="/"
+        />
+      </div>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+      <div
+        class="osdProgress"
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;

--- a/src/core/server/rendering/views/styles.tsx
+++ b/src/core/server/rendering/views/styles.tsx
@@ -159,6 +159,16 @@ export const Styles: FunctionComponent<Props> = ({ darkMode }) => {
             background-color: ${darkMode ? '#1BA9F5' : '#006DE4'};
           }
 
+          .loadingLogoContainer {
+            height: 60px;
+            padding: 10px 10px 10px 10px;
+          }
+          
+          .loadingLogo {
+            height: 100%;
+            max-width: 100%;
+          }
+
           @keyframes osdProgress {
             0% {
               transform: scaleX(1) translateX(-100%);

--- a/src/core/server/rendering/views/template.test.tsx
+++ b/src/core/server/rendering/views/template.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from 'react';
+import { injectedMetadataServiceMock } from '../../../public/mocks';
+import { httpServiceMock } from '../../http/http_service.mock';
+import { Template } from './template';
+import { renderWithIntl } from 'test_utils/enzyme_helpers';
+
+const http = httpServiceMock.createStartContract();
+const injectedMetadata = injectedMetadataServiceMock.createSetupContract();
+
+function mockProps() {
+  return {
+    uiPublicUrl: `${http.basePath}/ui`,
+    locale: '',
+    darkMode: true,
+    i18n: () => '',
+    bootstrapScriptUrl: `${http.basePath}/bootstrap.js`,
+    strictCsp: true,
+    injectedMetadata: {
+      version: injectedMetadata.getOpenSearchDashboardsVersion(),
+      buildNumber: 1,
+      branch: injectedMetadata.getBasePath(),
+      basePath: '',
+      serverBasePath: '',
+      env: {
+        packageInfo: {
+          version: '',
+          branch: '',
+          buildNum: 1,
+          buildSha: '',
+          dist: true,
+        },
+        mode: {
+          name: 'production' as 'development' | 'production',
+          dev: true,
+          prod: false,
+        },
+      },
+      anonymousStatusPage: injectedMetadata.getAnonymousStatusPage(),
+      i18n: { translationsUrl: '' },
+      csp: injectedMetadata.getCspConfig(),
+      vars: injectedMetadata.getInjectedVars(),
+      uiPlugins: injectedMetadata.getPlugins(),
+      legacyMetadata: {
+        uiSettings: {
+          defaults: { legacyInjectedUiSettingDefaults: true },
+          user: {},
+        },
+      },
+      branding: injectedMetadata.getBranding(),
+    },
+  };
+}
+
+describe('Template', () => {
+  it('renders with default OpenSearch loading logo', () => {
+    const branding = {
+      title: '',
+    };
+    injectedMetadata.getBranding.mockReturnValue(branding);
+    const component = renderWithIntl(<Template metadata={mockProps()} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders with static logo with horizontal loading bar', () => {
+    const branding = {
+      smallLogoUrl: '/',
+      title: '',
+    };
+    injectedMetadata.getBranding.mockReturnValue(branding);
+    const component = renderWithIntl(<Template metadata={mockProps()} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders with customized loading logo', () => {
+    const branding = {
+      smallLogoUrl: '/',
+      loadingLogoUrl: '/',
+      title: '',
+    };
+    injectedMetadata.getBranding.mockReturnValue(branding);
+    const component = renderWithIntl(<Template metadata={mockProps()} />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/core/server/rendering/views/template.tsx
+++ b/src/core/server/rendering/views/template.tsx
@@ -95,6 +95,33 @@ export const Template: FunctionComponent<Props> = ({
       />
     </svg>
   );
+
+  const renderEnabledOrDisabledLoadingBar = () => {
+    if (!injectedMetadata.branding.loadingLogoUrl && injectedMetadata.branding.smallLogoUrl) {
+      return <div className="osdProgress" />;
+    }
+  };
+
+  const renderBrandingEnabledOrDisabledLoadingLogo = () => {
+    if (!injectedMetadata.branding.loadingLogoUrl && !injectedMetadata.branding.smallLogoUrl) {
+      return openSearchLogoSpinner;
+    } else {
+      return (
+        <div className="loadingLogoContainer">
+          <img
+            className="loadingLogo"
+            src={
+              !injectedMetadata.branding.loadingLogoUrl
+                ? injectedMetadata.branding.smallLogoUrl
+                : injectedMetadata.branding.loadingLogoUrl
+            }
+            alt={injectedMetadata.branding.title + ' logo'}
+          />
+        </div>
+      );
+    }
+  };
+
   return (
     <html lang={locale}>
       <head>
@@ -147,17 +174,19 @@ export const Template: FunctionComponent<Props> = ({
           style={{ display: 'none' }}
           data-test-subj="osdLoadingMessage"
         >
-          <div className="osdLoaderWrap">
-            {openSearchLogoSpinner}
+          <div className="osdLoaderWrap" data-test-subj="loadingLogo">
+            {renderBrandingEnabledOrDisabledLoadingLogo()}
             <div
               className="osdWelcomeText"
               data-error-message={i18n('core.ui.welcomeErrorMessage', {
-                defaultMessage:
-                  'OpenSearch did not load properly. Check the server output for more information.',
+                defaultMessage: `${injectedMetadata.branding.title} did not load properly. Check the server output for more information.`,
               })}
             >
-              {i18n('core.ui.welcomeMessage', { defaultMessage: 'Loading OpenSearch' })}
+              {i18n('core.ui.welcomeMessage', {
+                defaultMessage: `Loading ${injectedMetadata.branding.title}`,
+              })}
             </div>
+            {renderEnabledOrDisabledLoadingBar()}
           </div>
         </div>
 

--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -236,6 +236,7 @@ export default () =>
       branding: Joi.object({
         logoUrl: Joi.string().default('/'),
         smallLogoUrl: Joi.string().default('/'),
+        loadingLogoUrl: Joi.string().default('/'),
         title: Joi.string().default('OpenSearch Dashboards'),
       }),
     }).default(),

--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -234,10 +234,10 @@ export default () =>
       // TODO Also allow units here like in opensearch config once this is moved to the new platform
       autocompleteTimeout: Joi.number().integer().min(1).default(1000),
       branding: Joi.object({
-        logoUrl: Joi.string().default('/'),
-        smallLogoUrl: Joi.string().default('/'),
-        loadingLogoUrl: Joi.string().default('/'),
-        title: Joi.string().default('OpenSearch Dashboards'),
+        logoUrl: Joi.any().default('/'),
+        smallLogoUrl: Joi.any().default('/'),
+        loadingLogoUrl: Joi.any().default('/'),
+        title: Joi.any().default(''),
       }),
     }).default(),
 

--- a/src/plugins/home/public/application/components/__snapshots__/home.test.js.snap
+++ b/src/plugins/home/public/application/components/__snapshots__/home.test.js.snap
@@ -248,6 +248,7 @@ exports[`home directories should render solutions in the "solution section" 1`] 
   >
     <SolutionsSection
       addBasePath={[Function]}
+      branding={Object {}}
       directories={Array []}
       solutions={
         Array [

--- a/src/plugins/home/public/application/components/_solutions_section.scss
+++ b/src/plugins/home/public/application/components/_solutions_section.scss
@@ -91,6 +91,16 @@
   padding: $euiSizeS;
 }
 
+.homSolutionPanel__customIconContainer {
+  height: 50px;
+  padding: 5px 5px 5px 5px;
+}
+
+.homSolutionPanel__customIcon {
+  height: 100%;
+  max-width: 100%;
+}
+
 .homSolutionPanel__subtitle {
   margin-top: $euiSizeXS;
 }

--- a/src/plugins/home/public/application/components/home.js
+++ b/src/plugins/home/public/application/components/home.js
@@ -163,6 +163,7 @@ export class Home extends Component {
               addBasePath={addBasePath}
               solutions={solutions}
               directories={directories}
+              branding={getServices().injectedMetadata.getBranding()}
             />
           ) : null}
 

--- a/src/plugins/home/public/application/components/solutions_section/__snapshots__/solution_panel.test.tsx.snap
+++ b/src/plugins/home/public/application/components/solutions_section/__snapshots__/solution_panel.test.tsx.snap
@@ -24,9 +24,14 @@ exports[`SolutionPanel renders the solution panel for the given solution 1`] = `
           grow={1}
         >
           <SolutionTitle
+            branding={
+              Object {
+                "smallLogoUrl": "/",
+                "title": "OpenSearch Dashboards",
+              }
+            }
             iconType="inputOutput"
             subtitle="Visualize & analyze"
-            title="OpenSearch Dashboards"
           />
         </EuiFlexItem>
         <EuiFlexItem

--- a/src/plugins/home/public/application/components/solutions_section/__snapshots__/solution_title.test.tsx.snap
+++ b/src/plugins/home/public/application/components/solutions_section/__snapshots__/solution_title.test.tsx.snap
@@ -1,6 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SolutionTitle renders the title section of the solution panel 1`] = `
+exports[`SolutionTitle renders the title section of the solution panel with custom branding 1`] = `
+<EuiFlexGroup
+  alignItems="center"
+  gutterSize="none"
+>
+  <EuiFlexItem
+    className="eui-textCenter"
+  >
+    <EuiToken
+      className="homSolutionPanel__icon"
+      fill="light"
+      iconType="inputOutput"
+      shape="circle"
+      size="l"
+    />
+    <EuiTitle
+      className="homSolutionPanel__title eui-textInheritColor"
+      size="s"
+    >
+      <h3>
+        OpenSearch Dashboards
+      </h3>
+    </EuiTitle>
+    <EuiText
+      size="s"
+    >
+      <p
+        className="homSolutionPanel__subtitle"
+      >
+        Visualize & analyze
+         
+        <EuiIcon
+          type="sortRight"
+        />
+      </p>
+    </EuiText>
+  </EuiFlexItem>
+</EuiFlexGroup>
+`;
+
+exports[`SolutionTitle renders the title section of the solution panel with default branding 1`] = `
 <EuiFlexGroup
   alignItems="center"
   gutterSize="none"

--- a/src/plugins/home/public/application/components/solutions_section/__snapshots__/solutions_section.test.tsx.snap
+++ b/src/plugins/home/public/application/components/solutions_section/__snapshots__/solutions_section.test.tsx.snap
@@ -52,6 +52,12 @@ exports[`SolutionsSection renders a single solution 1`] = `
     >
       <SolutionPanel
         addBasePath={[Function]}
+        branding={
+          Object {
+            "smallLogoUrl": "/",
+            "title": "OpenSearch Dashboards",
+          }
+        }
         solution={
           Object {
             "appDescriptions": Array [
@@ -105,6 +111,12 @@ exports[`SolutionsSection renders multiple solutions in a single column when Ope
         >
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "smallLogoUrl": "/",
+                "title": "OpenSearch Dashboards",
+              }
+            }
             key="solution-2"
             solution={
               Object {
@@ -123,6 +135,12 @@ exports[`SolutionsSection renders multiple solutions in a single column when Ope
           />
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "smallLogoUrl": "/",
+                "title": "OpenSearch Dashboards",
+              }
+            }
             key="solution-3"
             solution={
               Object {
@@ -141,6 +159,12 @@ exports[`SolutionsSection renders multiple solutions in a single column when Ope
           />
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "smallLogoUrl": "/",
+                "title": "OpenSearch Dashboards",
+              }
+            }
             key="solution-4"
             solution={
               Object {
@@ -198,6 +222,12 @@ exports[`SolutionsSection renders multiple solutions in two columns with OpenSea
         >
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "smallLogoUrl": "/",
+                "title": "OpenSearch Dashboards",
+              }
+            }
             key="solution-2"
             solution={
               Object {
@@ -216,6 +246,12 @@ exports[`SolutionsSection renders multiple solutions in two columns with OpenSea
           />
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "smallLogoUrl": "/",
+                "title": "OpenSearch Dashboards",
+              }
+            }
             key="solution-3"
             solution={
               Object {
@@ -234,6 +270,12 @@ exports[`SolutionsSection renders multiple solutions in two columns with OpenSea
           />
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "smallLogoUrl": "/",
+                "title": "OpenSearch Dashboards",
+              }
+            }
             key="solution-4"
             solution={
               Object {
@@ -254,6 +296,12 @@ exports[`SolutionsSection renders multiple solutions in two columns with OpenSea
       </EuiFlexItem>
       <SolutionPanel
         addBasePath={[Function]}
+        branding={
+          Object {
+            "smallLogoUrl": "/",
+            "title": "OpenSearch Dashboards",
+          }
+        }
         solution={
           Object {
             "appDescriptions": Array [

--- a/src/plugins/home/public/application/components/solutions_section/solution_panel.test.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_panel.test.tsx
@@ -47,10 +47,15 @@ const solutionEntry = {
 
 const addBasePathMock = (path: string) => (path ? path : 'path');
 
+const branding = {
+  smallLogoUrl: '/',
+  title: 'OpenSearch Dashboards',
+};
+
 describe('SolutionPanel', () => {
   test('renders the solution panel for the given solution', () => {
     const component = shallow(
-      <SolutionPanel addBasePath={addBasePathMock} solution={solutionEntry} />
+      <SolutionPanel addBasePath={addBasePathMock} solution={solutionEntry} branding={branding} />
     );
     expect(component).toMatchSnapshot();
   });

--- a/src/plugins/home/public/application/components/solutions_section/solution_panel.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_panel.tsx
@@ -64,9 +64,13 @@ interface Props {
   addBasePath: (path: string) => string;
   solution: FeatureCatalogueSolution;
   apps?: FeatureCatalogueEntry[];
+  branding: {
+    smallLogoUrl?: string;
+    title: string;
+  };
 }
 
-export const SolutionPanel: FC<Props> = ({ addBasePath, solution, apps = [] }) => (
+export const SolutionPanel: FC<Props> = ({ addBasePath, solution, apps = [], branding }) => (
   <EuiFlexItem
     key={solution.id}
     data-test-subj={`homSolutionPanel homSolutionPanel_${solution.id}`}
@@ -87,8 +91,8 @@ export const SolutionPanel: FC<Props> = ({ addBasePath, solution, apps = [] }) =
           <EuiFlexItem grow={1} className={`homSolutionPanel__header`}>
             <SolutionTitle
               iconType={solution.icon}
-              title={solution.title}
               subtitle={solution.subtitle}
+              branding={branding}
             />
           </EuiFlexItem>
 

--- a/src/plugins/home/public/application/components/solutions_section/solution_title.test.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_title.test.tsx
@@ -36,7 +36,6 @@ import { SolutionTitle } from './solution_title';
 
 const solutionEntry = {
   id: 'opensearchDashboards',
-  title: 'OpenSearch Dashboards',
   subtitle: 'Visualize & analyze',
   descriptions: ['Analyze data in dashboards'],
   icon: 'inputOutput',
@@ -45,12 +44,30 @@ const solutionEntry = {
 };
 
 describe('SolutionTitle', () => {
-  test('renders the title section of the solution panel', () => {
+  test('renders the title section of the solution panel with default branding', () => {
+    const branding = {
+      title: 'OpenSearch Dashboards',
+    };
     const component = shallow(
       <SolutionTitle
-        title={solutionEntry.title}
         subtitle={solutionEntry.subtitle}
         iconType={solutionEntry.icon}
+        branding={branding}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  test('renders the title section of the solution panel with custom branding', () => {
+    const branding = {
+      smallLogoUrl: '/',
+      title: 'OpenSearch Dashboards',
+    };
+    const component = shallow(
+      <SolutionTitle
+        subtitle={solutionEntry.subtitle}
+        iconType={solutionEntry.icon}
+        branding={branding}
       />
     );
     expect(component).toMatchSnapshot();

--- a/src/plugins/home/public/application/components/solutions_section/solution_title.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_title.tsx
@@ -42,14 +42,20 @@ import {
 } from '@elastic/eui';
 
 interface Props {
-  title: string;
   subtitle: string;
   iconType: IconType;
+  branding: {
+    smallLogoUrl?: string;
+    title: string;
+  };
 }
 
-export const SolutionTitle: FC<Props> = ({ title, subtitle, iconType }) => (
-  <EuiFlexGroup gutterSize="none" alignItems="center">
-    <EuiFlexItem className="eui-textCenter">
+const renderBrandingEnabledOrDisabledCardLogo = (
+  iconType: IconType,
+  branding: { smallLogoUrl?: string; title: string }
+) => {
+  if (!branding.smallLogoUrl) {
+    return (
       <EuiToken
         iconType={iconType}
         shape="circle"
@@ -57,9 +63,34 @@ export const SolutionTitle: FC<Props> = ({ title, subtitle, iconType }) => (
         size="l"
         className="homSolutionPanel__icon"
       />
+    );
+  } else {
+    return (
+      <div className="homSolutionPanel__customIcon">
+        <img
+          className="homSolutionPanel__customIconContainer"
+          data-test-subj="dashboardCustomLogo"
+          data-test-image-url={branding.smallLogoUrl}
+          alt={branding.title + ' logo'}
+          src={branding.smallLogoUrl}
+        />
+      </div>
+    );
+  }
+};
 
-      <EuiTitle className="homSolutionPanel__title eui-textInheritColor" size="s">
-        <h3>{title}</h3>
+export const SolutionTitle: FC<Props> = ({ subtitle, iconType, branding }) => (
+  <EuiFlexGroup gutterSize="none" alignItems="center">
+    <EuiFlexItem className="eui-textCenter">
+      {renderBrandingEnabledOrDisabledCardLogo(iconType, branding)}
+
+      <EuiTitle
+        className="homSolutionPanel__title eui-textInheritColor"
+        size="s"
+        data-test-subj="dashboardCustomTitle"
+        data-test-title={branding.title}
+      >
+        <h3>{branding.title}</h3>
       </EuiTitle>
 
       <EuiText size="s">

--- a/src/plugins/home/public/application/components/solutions_section/solutions_section.test.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solutions_section.test.tsx
@@ -107,6 +107,11 @@ const mockDirectories = [
 
 const addBasePathMock = (path: string) => (path ? path : 'path');
 
+const branding = {
+  smallLogoUrl: '/',
+  title: 'OpenSearch Dashboards',
+};
+
 describe('SolutionsSection', () => {
   test('only renders a spacer if no solutions are available', () => {
     const component = shallow(
@@ -114,6 +119,7 @@ describe('SolutionsSection', () => {
         addBasePath={addBasePathMock}
         solutions={[]}
         directories={mockDirectories}
+        branding={branding}
       />
     );
     expect(component).toMatchSnapshot();
@@ -125,6 +131,7 @@ describe('SolutionsSection', () => {
         addBasePath={addBasePathMock}
         solutions={[solutionEntry1]}
         directories={mockDirectories}
+        branding={branding}
       />
     );
     expect(component).toMatchSnapshot();
@@ -136,6 +143,7 @@ describe('SolutionsSection', () => {
         addBasePath={addBasePathMock}
         solutions={[solutionEntry1, solutionEntry2, solutionEntry3, solutionEntry4]}
         directories={mockDirectories}
+        branding={branding}
       />
     );
     expect(component).toMatchSnapshot();
@@ -146,6 +154,7 @@ describe('SolutionsSection', () => {
         addBasePath={addBasePathMock}
         solutions={[solutionEntry2, solutionEntry3, solutionEntry4]}
         directories={mockDirectories}
+        branding={branding}
       />
     );
     expect(component).toMatchSnapshot();

--- a/src/plugins/home/public/application/components/solutions_section/solutions_section.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solutions_section.tsx
@@ -46,9 +46,13 @@ interface Props {
   addBasePath: (path: string) => string;
   solutions: FeatureCatalogueSolution[];
   directories: FeatureCatalogueEntry[];
+  branding: {
+    smallLogoUrl?: string;
+    title: string;
+  };
 }
 
-export const SolutionsSection: FC<Props> = ({ addBasePath, solutions, directories }) => {
+export const SolutionsSection: FC<Props> = ({ addBasePath, solutions, directories, branding }) => {
   // Separate OpenSearch Dashboards from other solutions
   const opensearchDashboards = solutions.find(({ id }) => id === 'opensearchDashboards');
   const opensearchDashboardsApps = directories
@@ -73,7 +77,12 @@ export const SolutionsSection: FC<Props> = ({ addBasePath, solutions, directorie
             <EuiFlexItem grow={1} className="homSolutions__group homSolutions__group--multiple">
               <EuiFlexGroup direction="column">
                 {solutions.map((solution) => (
-                  <SolutionPanel key={solution.id} solution={solution} addBasePath={addBasePath} />
+                  <SolutionPanel
+                    key={solution.id}
+                    solution={solution}
+                    addBasePath={addBasePath}
+                    branding={branding}
+                  />
                 ))}
               </EuiFlexGroup>
             </EuiFlexItem>
@@ -83,6 +92,7 @@ export const SolutionsSection: FC<Props> = ({ addBasePath, solutions, directorie
               solution={opensearchDashboards}
               addBasePath={addBasePath}
               apps={opensearchDashboardsApps.length ? opensearchDashboardsApps : undefined}
+              branding={branding}
             />
           ) : null}
         </EuiFlexGroup>

--- a/test/functional/apps/visualize/_custom_branding.js
+++ b/test/functional/apps/visualize/_custom_branding.js
@@ -43,7 +43,7 @@ export default function ({ getService, getPageObjects }) {
   describe('OpenSearch Dashboards branding configuration', function customHomeBranding() {
     describe('should render welcome page', async () => {
       this.tags('includeFirefox');
-      const expectedWelcomeLogo =
+      const expectedWelcomeLogoUrl =
         'https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_darkmode.svg';
       const expectedWelcomeMessage = 'Welcome to OpenSearch';
 
@@ -73,7 +73,7 @@ export default function ({ getService, getPageObjects }) {
           'welcomeCustomLogo',
           'data-test-image-url'
         );
-        expect(actualLabel.toUpperCase()).to.equal(expectedWelcomeLogo.toUpperCase());
+        expect(actualLabel.toUpperCase()).to.equal(expectedWelcomeLogoUrl.toUpperCase());
       });
 
       it('with customized title', async () => {
@@ -90,6 +90,7 @@ export default function ({ getService, getPageObjects }) {
       this.tags('includeFirefox');
       const expectedUrl =
         'https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_darkmode.svg';
+      const title = 'OpenSearch';
 
       before(async function () {
         await PageObjects.common.navigateToApp('home');
@@ -97,6 +98,24 @@ export default function ({ getService, getPageObjects }) {
 
       it('with customized logo in Navbar', async () => {
         await globalNav.logoExistsOrFail(expectedUrl);
+      });
+
+      it('with customized logo in primary dashboards card', async () => {
+        await testSubjects.existOrFail('dashboardCustomLogo');
+        const actualLabel = await testSubjects.getAttribute(
+          'dashboardCustomLogo',
+          'data-test-image-url'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedUrl.toUpperCase());
+      });
+
+      it('with customized title in primary dashboards card', async () => {
+        await testSubjects.existOrFail('dashboardCustomTitle');
+        const actualLabel = await testSubjects.getAttribute(
+          'dashboardCustomTitle',
+          'data-test-title'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(title.toUpperCase());
       });
 
       it('with customized logo that can take back to home page', async () => {


### PR DESCRIPTION
### Description
US4: User can configure logo and title in the opensearch_dashboards.yml and see it in the application at run time for the primary dashboard card on the main page.
 
<img width="1245" alt="Screen Shot 2021-09-02 at 5 01 59 PM" src="https://user-images.githubusercontent.com/43937633/131930829-b134d911-eb2c-4f51-bc9b-9e4f72a2910b.png">

### Requirement:
User need to input a valid URL for opensearchDashboards.branding.smallLogoUrl and a valid string for opensearchDashboards.branding.title in the opensearch_dashboards.yml file.

### Details:
* If the URL is invalid or does not end with gif or svg, the default OpenSearch Dashboard logo will be shown. An application error log will be shown.
* User can input URL with image of any size, and the image will be formatted to a fixed size.
* User needs to be responsible for the content of the URL.
* This is a local setting; user needs to set this config in all data nodes in OpenSearch Dashboards if a global setting is wanted.

### Related Project Card:
https://github.com/abbyhu2000/OpenSearch-Dashboards/projects/1#card-68050198

Signed-off-by: Abby Hu abigailhu2000@gmail.com

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 