### PR TITLE
[1.x] Bump `axios` from 0.21.1 to 0.21.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "resolutions": {
     "**/@types/node": ">=10.17.17 <10.20.0",
+    "**/axios": "^0.21.4",
     "**/ejs": "^3.1.6",
     "**/front-matter": "^4.0.2",
     "**/glob-parent": "^6.0.0",

--- a/packages/osd-dev-utils/package.json
+++ b/packages/osd-dev-utils/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@babel/core": "^7.11.6",
     "@osd/utils": "1.0.0",
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "chalk": "^4.1.0",
     "cheerio": "0.22.0",
     "dedent": "^0.7.0",

--- a/packages/osd-release-notes/package.json
+++ b/packages/osd-release-notes/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@osd/utils": "1.0.0",
     "@osd/dev-utils": "1.0.0",
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "cheerio": "0.22.0",
     "dedent": "^0.7.0",
     "graphql": "^0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5819,12 +5819,12 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.2.tgz#c7cf7378378a51fcd272d3c09668002a4990b1cb"
   integrity sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==
 
-axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+axios@^0.21.1, axios@^0.21.4:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
-    follow-redirects "^1.10.0"
+    follow-redirects "^1.14.0"
 
 axobject-query@^2.0.2:
   version "2.0.2"
@@ -11359,10 +11359,10 @@ follow-redirects@1.12.1:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.12.1.tgz#de54a6205311b93d60398ebc01cf7015682312b6"
   integrity sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
-  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
+follow-redirects@^1.0.0, follow-redirects@^1.14.0:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.3.tgz#6ada78118d8d24caee595595accdc0ac6abd022e"
+  integrity sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==
 
 font-awesome@4.7.0:
   version "4.7.0"


### PR DESCRIPTION
### Issues Resolved 
https://github.com/advisories/GHSA-cph5-m8f7-6c5x
### Backport PR: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/779

### Description
Bumps [axios](https://github.com/axios/axios) from 0.21.1 to 0.21.4
- [Release notes](https://github.com/axios/axios/releases/tag/v0.21.4)
- [Changelog](https://github.com/axios/axios/blob/v0.21.4/CHANGELOG.md)
- [Commits](https://github.com/axios/axios/compare/v0.21.1...v0.21.4)
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 