### PR TITLE
Branding config structure change and renaming

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -151,16 +151,15 @@
 # ]
 #vis_type_timeline.graphiteBlockedIPs: []
 
-# full version customized logo URL
-# opensearchDashboards.branding.fullLogoUrl: ""
-
-# smaller version customized logo URL
-# opensearchDashboards.branding.logoUrl: ""
-
-# customized loading logo URL
-# opensearchDashboards.branding.loadingLogoUrl: ""
-
-# custom application title
-# opensearchDashboards.branding.title: ""
-
-
+# opensearchDashboards.branding:
+  # logo:
+    # defaultUrl: ""
+    # darkModeUrl: ""
+  # mark:
+    # defaultUrl: ""
+    # darkModeUrl: ""
+  # loadingLogo: 
+    # defaultUrl: ""
+    # darkModeUrl: ""
+  # favicon: ""
+  # applicationTitle: ""

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -249,9 +249,13 @@ exports[`Header renders 1`] = `
   }
   branding={
     Object {
-      "fullLogoUrl": "/",
-      "logoUrl": "/",
-      "title": "OpenSearch Dashboards",
+      "applicationTitle": "OpenSearch Dashboards",
+      "logo": Object {
+        "defaultUrl": "/",
+      },
+      "mark": Object {
+        "defaultUrl": "/",
+      },
     }
   }
   breadcrumbs$={
@@ -1674,9 +1678,13 @@ exports[`Header renders 1`] = `
                 <HeaderLogo
                   branding={
                     Object {
-                      "fullLogoUrl": "/",
-                      "logoUrl": "/",
-                      "title": "OpenSearch Dashboards",
+                      "applicationTitle": "OpenSearch Dashboards",
+                      "logo": Object {
+                        "defaultUrl": "/",
+                      },
+                      "mark": Object {
+                        "defaultUrl": "/",
+                      },
                     }
                   }
                   forceNavigation$={
@@ -2787,9 +2795,13 @@ exports[`Header renders 1`] = `
                   <HeaderLogo
                     branding={
                       Object {
-                        "fullLogoUrl": "/",
-                        "logoUrl": "/",
-                        "title": "OpenSearch Dashboards",
+                        "applicationTitle": "OpenSearch Dashboards",
+                        "logo": Object {
+                          "defaultUrl": "/",
+                        },
+                        "mark": Object {
+                          "defaultUrl": "/",
+                        },
                       }
                     }
                     forceNavigation$={
@@ -2945,18 +2957,30 @@ exports[`Header renders 1`] = `
                       onClick={[Function]}
                     >
                       <CustomLogo
-                        fullLogoUrl="/"
-                        logoUrl="/"
-                        title="OpenSearch Dashboards"
+                        applicationTitle="OpenSearch Dashboards"
+                        logo={
+                          Object {
+                            "defaultUrl": "/",
+                          }
+                        }
+                        mark={
+                          Object {
+                            "defaultUrl": "/",
+                          }
+                        }
                       >
-                        <img
-                          alt="OpenSearch Dashboards logo"
-                          className="logoImage"
-                          data-test-image-url="/"
-                          data-test-subj="customLogo"
-                          loading="lazy"
-                          src="/"
-                        />
+                        <div
+                          className="logoContainer"
+                        >
+                          <img
+                            alt="OpenSearch Dashboards logo"
+                            className="logoImage"
+                            data-test-image-url="/"
+                            data-test-subj="customLogo"
+                            loading="lazy"
+                            src="/"
+                          />
+                        </div>
                       </CustomLogo>
                     </a>
                   </HeaderLogo>

--- a/src/core/public/chrome/ui/header/branding/__snapshots__/opensearch_dashboards_custom_logo.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/branding/__snapshots__/opensearch_dashboards_custom_logo.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Custom Logo Take in a normal full logo URL string 1`] = `
 <CustomLogo
-  fullLogoUrl="/custom"
+  applicationTitle="title"
   intl={
     Object {
       "defaultFormats": Object {},
@@ -105,21 +105,31 @@ exports[`Custom Logo Take in a normal full logo URL string 1`] = `
       "timeZone": null,
     }
   }
-  title="title"
+  logo={
+    Object {
+      "defaultUrl": "/",
+    }
+  }
+  mark={Object {}}
 >
-  <img
-    alt="title logo"
-    className="logoImage"
-    data-test-image-url="/custom"
-    data-test-subj="customLogo"
-    loading="lazy"
-    src="/custom"
-  />
+  <div
+    className="logoContainer"
+  >
+    <img
+      alt="title logo"
+      className="logoImage"
+      data-test-image-url="/"
+      data-test-subj="customLogo"
+      loading="lazy"
+      src="/"
+    />
+  </div>
 </CustomLogo>
 `;
 
 exports[`Custom Logo Take in an invalid full logo URL string and a valid logo URL string 1`] = `
 <CustomLogo
+  applicationTitle="title"
   intl={
     Object {
       "defaultFormats": Object {},
@@ -222,22 +232,31 @@ exports[`Custom Logo Take in an invalid full logo URL string and a valid logo UR
       "timeZone": null,
     }
   }
-  logoUrl="/custom"
-  title="title"
+  logo={Object {}}
+  mark={
+    Object {
+      "defaultUrl": "/",
+    }
+  }
 >
-  <img
-    alt="title logo"
-    className="logoImage"
-    data-test-image-url="/custom"
-    data-test-subj="customLogo"
-    loading="lazy"
-    src="/custom"
-  />
+  <div
+    className="logoContainer"
+  >
+    <img
+      alt="title logo"
+      className="logoImage"
+      data-test-image-url="/"
+      data-test-subj="customLogo"
+      loading="lazy"
+      src="/"
+    />
+  </div>
 </CustomLogo>
 `;
 
 exports[`Custom Logo Take in invalid full logo URL and logo URL 1`] = `
 <CustomLogo
+  applicationTitle="title"
   intl={
     Object {
       "defaultFormats": Object {},
@@ -340,7 +359,8 @@ exports[`Custom Logo Take in invalid full logo URL and logo URL 1`] = `
       "timeZone": null,
     }
   }
-  title="title"
+  logo={Object {}}
+  mark={Object {}}
 >
   <svg
     fill="none"

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.test.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.test.tsx
@@ -12,19 +12,31 @@ import { CustomLogo } from './opensearch_dashboards_custom_logo';
 
 describe('Custom Logo', () => {
   it('Take in a normal full logo URL string', () => {
-    const branding = { fullLogoUrl: '/custom', title: 'title' };
+    const branding = {
+      logo: { defaultUrl: '/' },
+      mark: {},
+      applicationTitle: 'title',
+    };
     const component = mountWithIntl(<CustomLogo {...branding} />);
     expect(component).toMatchSnapshot();
   });
 
   it('Take in an invalid full logo URL string and a valid logo URL string', () => {
-    const branding = { logoUrl: '/custom', title: 'title' };
+    const branding = {
+      logo: {},
+      mark: { defaultUrl: '/' },
+      applicationTitle: 'title',
+    };
     const component = mountWithIntl(<CustomLogo {...branding} />);
     expect(component).toMatchSnapshot();
   });
 
   it('Take in invalid full logo URL and logo URL', () => {
-    const branding = { title: 'title' };
+    const branding = {
+      logo: {},
+      mark: {},
+      applicationTitle: 'title',
+    };
     const component = mountWithIntl(<CustomLogo {...branding} />);
     expect(component).toMatchSnapshot();
   });

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.tsx
@@ -35,35 +35,45 @@ import '../header_logo.scss';
 import { OpenSearchDashboardsLogoDarkMode } from './opensearch_dashboards_logo_darkmode';
 
 /**
- * @param {string} fullLogoUrl - custom URL for the top left logo of the main screen
- * @param {string} logoUrl - custom URL for the logo icon
- * @param {string} title - custom title for the application
+ * @param {object} logo - full logo on main screen: defaultUrl will be used in default mode; darkModeUrl will be used in dark mode
+ * @param {object} mark - thumbnail logo: defaultUrl will be used in default mode; darkModeUrl will be used in dark mode
+ * @param {string} applicationTitle - custom title for the application
  */
 export interface CustomLogoType {
-  fullLogoUrl?: string;
-  logoUrl?: string;
-  title: string;
+  logo: {
+    defaultUrl?: string;
+    darkModeUrl?: string;
+  };
+  mark: {
+    defaultUrl?: string;
+    darkModeUrl?: string;
+  };
+  applicationTitle?: string;
 }
 /**
  *
- * @param {CustomLogoType} - branding object consist of fullLogoUrl, logoUrl and title
+ * @param {CustomLogoType} - branding object consist of logo, mark and title
  * @returns A image component which is going to be rendered on the main page header bar.
- *          If fullLogoUrl is valid, the full logo by fullLogoUrl config will be rendered;
- *          if not, the logo icon by logoUrl config will be rendered; if both are not found,
+ *          If logo default is valid, the full logo by logo default config will be rendered;
+ *          if not, the logo icon by mark default config will be rendered; if both are not found,
  *          the default opensearch logo will be rendered.
  */
 export const CustomLogo = ({ ...branding }: CustomLogoType) => {
-  const headerLogoUrl = !branding.fullLogoUrl ? branding.logoUrl : branding.fullLogoUrl;
-  return !branding.fullLogoUrl && !branding.logoUrl ? (
+  const headerLogoUrl = !branding.logo.defaultUrl
+    ? branding.mark.defaultUrl
+    : branding.logo.defaultUrl;
+  return !branding.logo.defaultUrl && !branding.mark.defaultUrl ? (
     OpenSearchDashboardsLogoDarkMode()
   ) : (
-    <img
-      data-test-subj="customLogo"
-      data-test-image-url={headerLogoUrl}
-      src={headerLogoUrl}
-      alt={branding.title + ' logo'}
-      loading="lazy"
-      className="logoImage"
-    />
+    <div className="logoContainer">
+      <img
+        data-test-subj="customLogo"
+        data-test-image-url={headerLogoUrl}
+        src={headerLogoUrl}
+        alt={branding.applicationTitle + ' logo'}
+        loading="lazy"
+        className="logoImage"
+      />
+    </div>
   );
 };

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -69,7 +69,11 @@ function mockProps() {
     isLocked$: new BehaviorSubject(false),
     loadingCount$: new BehaviorSubject(0),
     onIsLockedUpdate: () => {},
-    branding: { fullLogoUrl: '/', logoUrl: '/', title: 'OpenSearch Dashboards' },
+    branding: {
+      logo: { defaultUrl: '/' },
+      mark: { defaultUrl: '/' },
+      applicationTitle: 'OpenSearch Dashboards',
+    },
   };
 }
 

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -87,7 +87,17 @@ export interface HeaderProps {
   isLocked$: Observable<boolean>;
   loadingCount$: ReturnType<HttpStart['getLoadingCount$']>;
   onIsLockedUpdate: OnIsLockedUpdate;
-  branding: { fullLogoUrl?: string; logoUrl?: string; title: string };
+  branding: {
+    logo: {
+      defaultUrl?: string;
+      darkModeUrl?: string;
+    };
+    mark: {
+      defaultUrl?: string;
+      darkModeUrl?: string;
+    };
+    applicationTitle?: string;
+  };
 }
 
 export function Header({

--- a/src/core/public/chrome/ui/header/header_logo.scss
+++ b/src/core/public/chrome/ui/header/header_logo.scss
@@ -3,7 +3,7 @@
     padding: 3px 3px 3px 10px;
 }
 
-.logoImage{
+.logoImage {
     height: 100%;
     max-width: 100%;
 }

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -237,9 +237,11 @@ export interface CoreSetup<TPluginsStart extends object = object, TStart = unkno
   injectedMetadata: {
     getInjectedVar: (name: string, defaultValue?: any) => unknown;
     getBranding: () => {
-      fullLogoUrl?: string;
-      logoUrl?: string;
-      title: string;
+      mark: {
+        defaultUrl?: string;
+        darkModeUrl?: string;
+      };
+      title?: string;
     };
   };
   /** {@link StartServicesAccessor} */
@@ -297,9 +299,11 @@ export interface CoreStart {
   injectedMetadata: {
     getInjectedVar: (name: string, defaultValue?: any) => unknown;
     getBranding: () => {
-      fullLogoUrl?: string;
-      logoUrl?: string;
-      title: string;
+      mark: {
+        defaultUrl?: string;
+        darkModeUrl?: string;
+      };
+      applicationTitle?: string;
     };
   };
 }

--- a/src/core/public/injected_metadata/injected_metadata_service.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.ts
@@ -77,9 +77,20 @@ export interface InjectedMetadataParams {
       };
     };
     branding: {
-      fullLogoUrl?: string;
-      logoUrl?: string;
-      title: string;
+      logo: {
+        defaultUrl?: string;
+        darkModeUrl?: string;
+      };
+      mark: {
+        defaultUrl?: string;
+        darkModeUrl?: string;
+      };
+      loadingLogo: {
+        defaultUrl?: string;
+        darkModeUrl?: string;
+      };
+      favicon?: string;
+      applicationTitle?: string;
     };
   };
 }
@@ -186,9 +197,20 @@ export interface InjectedMetadataSetup {
     [key: string]: unknown;
   };
   getBranding: () => {
-    fullLogoUrl?: string;
-    logoUrl?: string;
-    title: string;
+    logo: {
+      defaultUrl?: string;
+      darkModeUrl?: string;
+    };
+    mark: {
+      defaultUrl?: string;
+      darkModeUrl?: string;
+    };
+    loadingLogo: {
+      defaultUrl?: string;
+      darkModeUrl?: string;
+    };
+    favicon?: string;
+    applicationTitle?: string;
   };
 }
 

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -53,16 +53,36 @@ export const config = {
     autocompleteTerminateAfter: schema.duration({ defaultValue: 100000 }),
     autocompleteTimeout: schema.duration({ defaultValue: 1000 }),
     branding: schema.object({
-      fullLogoUrl: schema.string({
+      logo: schema.object({
+        defaultUrl: schema.string({
+          defaultValue: '/',
+        }),
+        darkModeUrl: schema.string({
+          defaultValue: '/',
+        }),
+      }),
+      mark: schema.object({
+        defaultUrl: schema.string({
+          defaultValue: '/',
+        }),
+        darkModeUrl: schema.string({
+          defaultValue: '/',
+        }),
+      }),
+      loadingLogo: schema.object({
+        defaultUrl: schema.string({
+          defaultValue: '/',
+        }),
+        darkModeUrl: schema.string({
+          defaultValue: '/',
+        }),
+      }),
+      favicon: schema.string({
         defaultValue: '/',
       }),
-      logoUrl: schema.string({
-        defaultValue: '/',
+      applicationTitle: schema.string({
+        defaultValue: '',
       }),
-      loadingLogoUrl: schema.string({
-        defaultValue: '/',
-      }),
-      title: schema.string({ defaultValue: '' }),
     }),
   }),
   deprecations,

--- a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
@@ -6,7 +6,17 @@ Object {
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
   "branding": Object {
-    "title": "OpenSearch Dashboards",
+    "applicationTitle": "OpenSearch Dashboards",
+    "favicon": "",
+    "loadingLogo": Object {
+      "darkModeUrl": "",
+    },
+    "logo": Object {
+      "darkModeUrl": "",
+    },
+    "mark": Object {
+      "darkModeUrl": "",
+    },
   },
   "buildNumber": Any<Number>,
   "csp": Object {
@@ -52,7 +62,17 @@ Object {
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
   "branding": Object {
-    "title": "OpenSearch Dashboards",
+    "applicationTitle": "OpenSearch Dashboards",
+    "favicon": "",
+    "loadingLogo": Object {
+      "darkModeUrl": "",
+    },
+    "logo": Object {
+      "darkModeUrl": "",
+    },
+    "mark": Object {
+      "darkModeUrl": "",
+    },
   },
   "buildNumber": Any<Number>,
   "csp": Object {
@@ -98,7 +118,17 @@ Object {
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
   "branding": Object {
-    "title": "OpenSearch Dashboards",
+    "applicationTitle": "OpenSearch Dashboards",
+    "favicon": "",
+    "loadingLogo": Object {
+      "darkModeUrl": "",
+    },
+    "logo": Object {
+      "darkModeUrl": "",
+    },
+    "mark": Object {
+      "darkModeUrl": "",
+    },
   },
   "buildNumber": Any<Number>,
   "csp": Object {
@@ -148,7 +178,17 @@ Object {
   "basePath": "",
   "branch": Any<String>,
   "branding": Object {
-    "title": "OpenSearch Dashboards",
+    "applicationTitle": "OpenSearch Dashboards",
+    "favicon": "",
+    "loadingLogo": Object {
+      "darkModeUrl": "",
+    },
+    "logo": Object {
+      "darkModeUrl": "",
+    },
+    "mark": Object {
+      "darkModeUrl": "",
+    },
   },
   "buildNumber": Any<Number>,
   "csp": Object {
@@ -194,7 +234,17 @@ Object {
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
   "branding": Object {
-    "title": "OpenSearch Dashboards",
+    "applicationTitle": "OpenSearch Dashboards",
+    "favicon": "",
+    "loadingLogo": Object {
+      "darkModeUrl": "",
+    },
+    "logo": Object {
+      "darkModeUrl": "",
+    },
+    "mark": Object {
+      "darkModeUrl": "",
+    },
   },
   "buildNumber": Any<Number>,
   "csp": Object {

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -65,19 +65,22 @@ export class RenderingService {
       .pipe(first())
       .toPromise();
 
-    const isFullLogoUrlValid = await this.checkUrlValid(
-      opensearchDashboardsConfig.branding.fullLogoUrl,
-      'fullLogoUrl'
+    const isLogoDefaultValid = await this.checkUrlValid(
+      opensearchDashboardsConfig.branding.logo.defaultUrl,
+      'logo default'
     );
-    const isLogoUrlValid = await this.checkUrlValid(
-      opensearchDashboardsConfig.branding.logoUrl,
-      'logoUrl'
+    const isMarkDefaultValid = await this.checkUrlValid(
+      opensearchDashboardsConfig.branding.mark.defaultUrl,
+      'mark default'
     );
-    const isLoadingLogoUrlValid = await this.checkUrlValid(
-      opensearchDashboardsConfig.branding.loadingLogoUrl,
-      'loadingLogoUrl'
+    const isLoadingLogoDefaultValid = await this.checkUrlValid(
+      opensearchDashboardsConfig.branding.loadingLogo.defaultUrl,
+      'loadingLogo default'
     );
-    const isTitleValid = this.checkTitleValid(opensearchDashboardsConfig.branding.title, 'title');
+    const isTitleValid = this.checkTitleValid(
+      opensearchDashboardsConfig.branding.applicationTitle,
+      'applicationTitle'
+    );
 
     return {
       render: async (
@@ -128,14 +131,28 @@ export class RenderingService {
               uiSettings: settings,
             },
             branding: {
-              fullLogoUrl: isFullLogoUrlValid
-                ? opensearchDashboardsConfig.branding.fullLogoUrl
-                : undefined,
-              logoUrl: isLogoUrlValid ? opensearchDashboardsConfig.branding.logoUrl : undefined,
-              loadingLogoUrl: isLoadingLogoUrlValid
-                ? opensearchDashboardsConfig.branding.loadingLogoUrl
-                : undefined,
-              title: isTitleValid ? opensearchDashboardsConfig.branding.title : DEFAULT_TITLE,
+              logo: {
+                defaultUrl: isLogoDefaultValid
+                  ? opensearchDashboardsConfig.branding.logo.defaultUrl
+                  : undefined,
+                darkModeUrl: '',
+              },
+              mark: {
+                defaultUrl: isMarkDefaultValid
+                  ? opensearchDashboardsConfig.branding.mark.defaultUrl
+                  : undefined,
+                darkModeUrl: '',
+              },
+              loadingLogo: {
+                defaultUrl: isLoadingLogoDefaultValid
+                  ? opensearchDashboardsConfig.branding.loadingLogo.defaultUrl
+                  : undefined,
+                darkModeUrl: '',
+              },
+              favicon: '',
+              applicationTitle: isTitleValid
+                ? opensearchDashboardsConfig.branding.applicationTitle
+                : DEFAULT_TITLE,
             },
           },
         };

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -75,10 +75,20 @@ export interface RenderingMetadata {
       };
     };
     branding: {
-      fullLogoUrl?: string;
-      logoUrl?: string;
-      loadingLogoUrl?: string;
-      title: string;
+      logo: {
+        defaultUrl?: string;
+        darkModeUrl?: string;
+      };
+      mark: {
+        defaultUrl?: string;
+        darkModeUrl?: string;
+      };
+      loadingLogo: {
+        defaultUrl?: string;
+        darkModeUrl?: string;
+      };
+      favicon?: string;
+      applicationTitle?: string;
     };
   };
 }

--- a/src/core/server/rendering/views/__snapshots__/template.test.tsx.snap
+++ b/src/core/server/rendering/views/__snapshots__/template.test.tsx.snap
@@ -66,7 +66,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"logoUrl\\":\\"/\\",\\"loadingLogoUrl\\":\\"/\\",\\"title\\":\\"\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/\\"},\\"loadingLogo\\":{\\"defaultUrl\\":\\"/\\"},\\"applicationTitle\\":\\"\\"}}"
   />,
   <div
     class="osdWelcomeView"
@@ -206,7 +206,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"title\\":\\"\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"applicationTitle\\":\\"\\"}}"
   />,
   <div
     class="osdWelcomeView"
@@ -367,7 +367,7 @@ Array [
     data="{\\"strictCsp\\":true}"
   />,
   <osd-injected-metadata
-    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"logoUrl\\":\\"/\\",\\"title\\":\\"\\"}}"
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/\\"},\\"loadingLogo\\":{},\\"applicationTitle\\":\\"\\"}}"
   />,
   <div
     class="osdWelcomeView"

--- a/src/core/server/rendering/views/template.test.tsx
+++ b/src/core/server/rendering/views/template.test.tsx
@@ -86,7 +86,10 @@ function mockProps() {
 describe('Template', () => {
   it('renders with default OpenSearch loading logo', () => {
     const branding = {
-      title: '',
+      logo: {},
+      mark: {},
+      loadingLogo: {},
+      applicationTitle: '',
     };
     injectedMetadata.getBranding.mockReturnValue(branding);
     const component = renderWithIntl(<Template metadata={mockProps()} />);
@@ -95,8 +98,10 @@ describe('Template', () => {
 
   it('renders with static logo with horizontal loading bar', () => {
     const branding = {
-      logoUrl: '/',
-      title: '',
+      logo: {},
+      mark: { defaultUrl: '/' },
+      loadingLogo: {},
+      applicationTitle: '',
     };
     injectedMetadata.getBranding.mockReturnValue(branding);
     const component = renderWithIntl(<Template metadata={mockProps()} />);
@@ -105,9 +110,10 @@ describe('Template', () => {
 
   it('renders with customized loading logo', () => {
     const branding = {
-      logoUrl: '/',
-      loadingLogoUrl: '/',
-      title: '',
+      logo: {},
+      mark: { defaultUrl: '/' },
+      loadingLogo: { defaultUrl: '/' },
+      applicationTitle: '',
     };
     injectedMetadata.getBranding.mockReturnValue(branding);
     const component = renderWithIntl(<Template metadata={mockProps()} />);

--- a/src/core/server/rendering/views/template.tsx
+++ b/src/core/server/rendering/views/template.tsx
@@ -97,13 +97,19 @@ export const Template: FunctionComponent<Props> = ({
   );
 
   const renderBrandingEnabledOrDisabledLoadingBar = () => {
-    if (!injectedMetadata.branding.loadingLogoUrl && injectedMetadata.branding.logoUrl) {
+    if (
+      !injectedMetadata.branding.loadingLogo.defaultUrl &&
+      injectedMetadata.branding.mark.defaultUrl
+    ) {
       return <div className="osdProgress" />;
     }
   };
 
   const renderBrandingEnabledOrDisabledLoadingLogo = () => {
-    if (!injectedMetadata.branding.loadingLogoUrl && !injectedMetadata.branding.logoUrl) {
+    if (
+      !injectedMetadata.branding.loadingLogo.defaultUrl &&
+      !injectedMetadata.branding.mark.defaultUrl
+    ) {
       return openSearchLogoSpinner;
     } else {
       return (
@@ -111,11 +117,11 @@ export const Template: FunctionComponent<Props> = ({
           <img
             className="loadingLogo"
             src={
-              !injectedMetadata.branding.loadingLogoUrl
-                ? injectedMetadata.branding.logoUrl
-                : injectedMetadata.branding.loadingLogoUrl
+              !injectedMetadata.branding.loadingLogo.defaultUrl
+                ? injectedMetadata.branding.mark.defaultUrl
+                : injectedMetadata.branding.loadingLogo.defaultUrl
             }
-            alt={injectedMetadata.branding.title + ' logo'}
+            alt={injectedMetadata.branding.applicationTitle + ' logo'}
           />
         </div>
       );
@@ -179,11 +185,11 @@ export const Template: FunctionComponent<Props> = ({
             <div
               className="osdWelcomeText"
               data-error-message={i18n('core.ui.welcomeErrorMessage', {
-                defaultMessage: `${injectedMetadata.branding.title} did not load properly. Check the server output for more information.`,
+                defaultMessage: `${injectedMetadata.branding.applicationTitle} did not load properly. Check the server output for more information.`,
               })}
             >
               {i18n('core.ui.welcomeMessage', {
-                defaultMessage: `Loading ${injectedMetadata.branding.title}`,
+                defaultMessage: `Loading ${injectedMetadata.branding.applicationTitle}`,
               })}
             </div>
             {renderBrandingEnabledOrDisabledLoadingBar()}

--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -234,10 +234,20 @@ export default () =>
       // TODO Also allow units here like in opensearch config once this is moved to the new platform
       autocompleteTimeout: Joi.number().integer().min(1).default(1000),
       branding: Joi.object({
-        fullLogoUrl: Joi.any().default('/'),
-        logoUrl: Joi.any().default('/'),
-        loadingLogoUrl: Joi.any().default('/'),
-        title: Joi.any().default(''),
+        logo: Joi.object({
+          defaultUrl: Joi.any().default('/'),
+          darkModeUrl: Joi.any().default('/'),
+        }),
+        mark: Joi.object({
+          defaultUrl: Joi.any().default('/'),
+          darkModeUrl: Joi.any().default('/'),
+        }),
+        loadingLogo: Joi.object({
+          defaultUrl: Joi.any().default('/'),
+          darkModeUrl: Joi.any().default('/'),
+        }),
+        favicon: Joi.any().default('/'),
+        applicationTitle: Joi.any().default(''),
       }),
     }).default(),
 

--- a/src/plugins/home/public/application/components/welcome.test.tsx
+++ b/src/plugins/home/public/application/components/welcome.test.tsx
@@ -51,8 +51,10 @@ test('should render a Welcome screen with the telemetry disclaimer', () => {
 */
 
 const branding = {
-  logoUrl: '/',
-  title: 'OpenSearch Dashboards',
+  mark: {
+    defaultUrl: '/',
+  },
+  applicationTitle: 'OpenSearch Dashboards',
 };
 
 test('should render a Welcome screen with the telemetry disclaimer when optIn is true', () => {
@@ -92,7 +94,8 @@ test('fires opt-in seen when mounted', () => {
 
 test('should render a Welcome screen with the default OpenSearch Dashboards branding', () => {
   const defaultBranding = {
-    title: 'OpenSearch Dashboards',
+    mark: {},
+    applicationTitle: 'OpenSearch Dashboards',
   };
   const component = shallow(
     <Welcome urlBasePath="/" onSkip={() => {}} branding={defaultBranding} />
@@ -102,8 +105,10 @@ test('should render a Welcome screen with the default OpenSearch Dashboards bran
 
 test('should render a Welcome screen with customized branding', () => {
   const customBranding = {
-    logoUrl: '/custom',
-    title: 'custom title',
+    mark: {
+      defaultUrl: '/custom',
+    },
+    applicationTitle: 'custom title',
   };
   const component = shallow(
     <Welcome urlBasePath="/" onSkip={() => {}} branding={customBranding} />

--- a/src/plugins/home/public/application/components/welcome.tsx
+++ b/src/plugins/home/public/application/components/welcome.tsx
@@ -59,8 +59,11 @@ interface Props {
   onSkip: () => void;
   telemetry?: TelemetryPluginStart;
   branding: {
-    logoUrl?: string;
-    title: string;
+    mark: {
+      defaultUrl?: string;
+      darkModeUrl?: string;
+    };
+    applicationTitle?: string;
   };
 }
 
@@ -145,7 +148,8 @@ export class Welcome extends React.Component<Props> {
   };
 
   private renderBrandingEnabledOrDisabledLogo = () => {
-    if (!this.props.branding.logoUrl) {
+    const mark = this.props.branding.mark.defaultUrl;
+    if (!mark) {
       return (
         <span className="homWelcome__logo">
           <EuiIcon type={OpenSearchMarkCentered} size="original" />
@@ -157,9 +161,9 @@ export class Welcome extends React.Component<Props> {
           <img
             className="homWelcome__customLogo"
             data-test-subj="welcomeCustomLogo"
-            data-test-image-url={this.props.branding.logoUrl}
-            alt={this.props.branding.title + ' logo'}
-            src={this.props.branding.logoUrl}
+            data-test-image-url={mark}
+            alt={this.props.branding.applicationTitle + ' logo'}
+            src={mark}
           />
         </div>
       );
@@ -179,12 +183,12 @@ export class Welcome extends React.Component<Props> {
                 size="l"
                 className="homWelcome__title"
                 data-test-subj="welcomeCustomTitle"
-                data-test-title-message={`Welcome to ${branding.title}`}
+                data-test-title-message={`Welcome to ${branding.applicationTitle}`}
               >
                 <h1>
                   <FormattedMessage
                     id="home.welcomeTitle"
-                    defaultMessage={`Welcome to ${branding.title}`}
+                    defaultMessage={`Welcome to ${branding.applicationTitle}`}
                   />
                 </h1>
               </EuiTitle>

--- a/src/plugins/home/public/application/opensearch_dashboards_services.ts
+++ b/src/plugins/home/public/application/opensearch_dashboards_services.ts
@@ -71,9 +71,11 @@ export interface HomeOpenSearchDashboardsServices {
   injectedMetadata: {
     getInjectedVar: (name: string, defaultValue?: any) => unknown;
     getBranding: () => {
-      fullLogoUrl?: string;
-      logoUrl?: string;
-      title: string;
+      mark: {
+        defaultUrl?: string;
+        darkModeUrl?: string;
+      };
+      applicationTitle?: string;
     };
   };
 }

--- a/test/common/config.js
+++ b/test/common/config.js
@@ -75,9 +75,9 @@ export default function () {
         // `--newsfeed.service.urlRoot=${servers.opensearchDashboards.protocol}://${servers.opensearchDashboards.hostname}:${servers.opensearchDashboards.port}`,
         // `--newsfeed.service.pathTemplate=/api/_newsfeed-FTS-external-service-simulators/opensearch-dashboards/v{VERSION}.json`,
         // Custom branding config
-        `--opensearchDashboards.branding.fullLogoUrl=https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg`,
-        `--opensearchDashboards.branding.logoUrl=https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg`,
-        `--opensearchDashboards.branding.title=OpenSearch`,
+        `--opensearchDashboards.branding.logo.defaultUrl=https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg`,
+        `--opensearchDashboards.branding.mark.defaultUrl=https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg`,
+        `--opensearchDashboards.branding.applicationTitle=OpenSearch`,
       ],
     },
     services,


### PR DESCRIPTION
### Description
This PR changes the branding related config to a map structure in the opensearch_dashboards.yml file.
It also renames the configs according to the official branding guidelines. The full logo on the main page header will be called logo, and it has two modes: default and dark mode; the small logo icon will be called mark, and it has two modes: default and dark mode; the loading logo will be called loadingLogo, and has two modes: default and dark mode. The logic is the same as the previous PR.
 
Signed-off-by: Abby Hu <abigailhu2000@gmail.com>

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 