### PR TITLE
De-Couple Dashboards linux building process

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:ftr:runner": "node scripts/functional_test_runner",
     "test:coverage": "grunt test:coverage",
     "checkLicenses": "node scripts/check_licenses --dev",
+    "build-platform": "node scripts/build",
     "build": "node scripts/build --all-platforms",
     "start": "node scripts/opensearch_dashboards --dev",
     "debug": "node --nolazy --inspect scripts/opensearch_dashboards --dev",

--- a/src/dev/build/args.test.ts
+++ b/src/dev/build/args.test.ts
@@ -50,8 +50,83 @@ it('build dist for current platform, without packages, by default', () => {
         "createDockerPackage": false,
         "createDockerUbiPackage": false,
         "createRpmPackage": false,
+        "darwinX64": false,
         "downloadFreshNode": true,
         "isRelease": false,
+        "linuxArm64": false,
+        "linuxX64": false,
+        "targetAllPlatforms": false,
+        "versionQualifier": "",
+      },
+      "log": <ToolingLog>,
+      "showHelp": false,
+      "unknownFlags": Array [],
+    }
+  `);
+});
+
+it('build dist for linux x64 platform, without packages, if --linux-x64 is passed', () => {
+  expect(readCliArgs(['node', 'scripts/build-platform'])).toMatchInlineSnapshot(`
+    Object {
+      "buildOptions": Object {
+        "createArchives": true,
+        "createDebPackage": false,
+        "createDockerPackage": false,
+        "createDockerUbiPackage": false,
+        "createRpmPackage": false,
+        "darwinX64": false,
+        "downloadFreshNode": true,
+        "isRelease": false,
+        "linuxArm64": false,
+        "linuxX64": false,
+        "targetAllPlatforms": false,
+        "versionQualifier": "",
+      },
+      "log": <ToolingLog>,
+      "showHelp": false,
+      "unknownFlags": Array [],
+    }
+  `);
+});
+
+it('build dist for linux x64 platform, without packages, if --linux-arm64 is passed', () => {
+  expect(readCliArgs(['node', 'scripts/build-platform'])).toMatchInlineSnapshot(`
+    Object {
+      "buildOptions": Object {
+        "createArchives": true,
+        "createDebPackage": false,
+        "createDockerPackage": false,
+        "createDockerUbiPackage": false,
+        "createRpmPackage": false,
+        "darwinX64": false,
+        "downloadFreshNode": true,
+        "isRelease": false,
+        "linuxArm64": false,
+        "linuxX64": false,
+        "targetAllPlatforms": false,
+        "versionQualifier": "",
+      },
+      "log": <ToolingLog>,
+      "showHelp": false,
+      "unknownFlags": Array [],
+    }
+  `);
+});
+
+it('build dist for linux x64 platform, without packages, if --darwin-x64 is passed', () => {
+  expect(readCliArgs(['node', 'scripts/build-platform'])).toMatchInlineSnapshot(`
+    Object {
+      "buildOptions": Object {
+        "createArchives": true,
+        "createDebPackage": false,
+        "createDockerPackage": false,
+        "createDockerUbiPackage": false,
+        "createRpmPackage": false,
+        "darwinX64": false,
+        "downloadFreshNode": true,
+        "isRelease": false,
+        "linuxArm64": false,
+        "linuxX64": false,
         "targetAllPlatforms": false,
         "versionQualifier": "",
       },
@@ -71,8 +146,11 @@ it('builds packages if --all-platforms is passed', () => {
         "createDockerPackage": true,
         "createDockerUbiPackage": true,
         "createRpmPackage": true,
+        "darwinX64": false,
         "downloadFreshNode": true,
         "isRelease": false,
+        "linuxArm64": false,
+        "linuxX64": false,
         "targetAllPlatforms": true,
         "versionQualifier": "",
       },
@@ -92,8 +170,11 @@ it('limits packages if --rpm passed with --all-platforms', () => {
         "createDockerPackage": false,
         "createDockerUbiPackage": false,
         "createRpmPackage": true,
+        "darwinX64": false,
         "downloadFreshNode": true,
         "isRelease": false,
+        "linuxArm64": false,
+        "linuxX64": false,
         "targetAllPlatforms": true,
         "versionQualifier": "",
       },
@@ -113,8 +194,11 @@ it('limits packages if --deb passed with --all-platforms', () => {
         "createDockerPackage": false,
         "createDockerUbiPackage": false,
         "createRpmPackage": false,
+        "darwinX64": false,
         "downloadFreshNode": true,
         "isRelease": false,
+        "linuxArm64": false,
+        "linuxX64": false,
         "targetAllPlatforms": true,
         "versionQualifier": "",
       },
@@ -135,8 +219,11 @@ it('limits packages if --docker passed with --all-platforms', () => {
         "createDockerPackage": true,
         "createDockerUbiPackage": true,
         "createRpmPackage": false,
+        "darwinX64": false,
         "downloadFreshNode": true,
         "isRelease": false,
+        "linuxArm64": false,
+        "linuxX64": false,
         "targetAllPlatforms": true,
         "versionQualifier": "",
       },
@@ -157,8 +244,11 @@ it('limits packages if --docker passed with --skip-docker-ubi and --all-platform
         "createDockerPackage": true,
         "createDockerUbiPackage": false,
         "createRpmPackage": false,
+        "darwinX64": false,
         "downloadFreshNode": true,
         "isRelease": false,
+        "linuxArm64": false,
+        "linuxX64": false,
         "targetAllPlatforms": true,
         "versionQualifier": "",
       },

--- a/src/dev/build/args.ts
+++ b/src/dev/build/args.ts
@@ -45,6 +45,9 @@ export function readCliArgs(argv: string[]) {
       'verbose',
       'debug',
       'all-platforms',
+      'linux-x64',
+      'linux-arm64',
+      'darwin-x64',
       'verbose',
       'quiet',
       'silent',
@@ -111,6 +114,9 @@ export function readCliArgs(argv: string[]) {
     createDebPackage: isOsPackageDesired('deb'),
     createDockerPackage: isOsPackageDesired('docker'),
     createDockerUbiPackage: isOsPackageDesired('docker') && !Boolean(flags['skip-docker-ubi']),
+    darwinX64: Boolean(flags['darwin-x64']),
+    linuxArm64: Boolean(flags['linux-arm64']),
+    linuxX64: Boolean(flags['linux-x64']),
     targetAllPlatforms: Boolean(flags['all-platforms']),
   };
 

--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -40,6 +40,9 @@ export interface BuildOptions {
   createDockerUbiPackage: boolean;
   versionQualifier: string | undefined;
   targetAllPlatforms: boolean;
+  darwinX64: boolean;
+  linuxArm64: boolean;
+  linuxX64: boolean;
 }
 
 export async function buildDistributables(log: ToolingLog, options: BuildOptions) {

--- a/src/dev/build/cli.ts
+++ b/src/dev/build/cli.ts
@@ -55,6 +55,9 @@ if (showHelp) {
         --skip-archives         {dim Don't produce tar/zip archives}
         --skip-os-packages      {dim Don't produce rpm/deb/docker packages}
         --all-platforms         {dim Produce archives for all platforms, not just this one}
+        --linux-x64             {dim Produce archives for only linux x64 platform}
+        --linux-arm64           {dim Produce archives for only linux arm64 platform}
+        --darwin-x64            {dim Produce archives for only darwin x64 platform}
         --rpm                   {dim Only build the rpm package}
         --deb                   {dim Only build the deb package}
         --docker                {dim Only build the docker image}

--- a/src/dev/build/lib/build.test.ts
+++ b/src/dev/build/lib/build.test.ts
@@ -35,8 +35,11 @@ expect.addSnapshotSerializer(createAbsolutePathSerializer());
 
 const config = new Config(
   true,
+  false,
+  false,
+  false,
   {
-    version: '8.0.0',
+    version: '1.0.0',
     engines: {
       node: '*',
     },
@@ -49,7 +52,7 @@ const config = new Config(
   {
     buildNumber: 1234,
     buildSha: 'abcd1234',
-    buildVersion: '8.0.0',
+    buildVersion: '1.0.0',
   },
   true
 );
@@ -93,7 +96,7 @@ describe('#resolvePath()', () => {
 describe('#resolvePathForPlatform()', () => {
   it('uses config.resolveFromRepo(), config.getBuildVersion(), and platform.getBuildName() to create path', () => {
     expect(build.resolvePathForPlatform(linuxPlatform, 'foo', 'bar')).toMatchInlineSnapshot(
-      `<absolute path>/build/opensearch-dashboards-8.0.0-linux-x64/foo/bar`
+      `<absolute path>/build/opensearch-dashboards-1.0.0-linux-x64/foo/bar`
     );
   });
 });
@@ -101,13 +104,13 @@ describe('#resolvePathForPlatform()', () => {
 describe('#getPlatformArchivePath()', () => {
   it('creates correct path for different platforms', () => {
     expect(build.getPlatformArchivePath(linuxPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-8.0.0-linux-x64.tar.gz`
+      `<absolute path>/target/opensearch-dashboards-1.0.0-linux-x64.tar.gz`
     );
     expect(build.getPlatformArchivePath(linuxArmPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-8.0.0-linux-arm64.tar.gz`
+      `<absolute path>/target/opensearch-dashboards-1.0.0-linux-arm64.tar.gz`
     );
     expect(build.getPlatformArchivePath(windowsPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-8.0.0-windows-x64.zip`
+      `<absolute path>/target/opensearch-dashboards-1.0.0-windows-x64.zip`
     );
   });
 });

--- a/src/dev/build/tasks/clean_tasks.ts
+++ b/src/dev/build/tasks/clean_tasks.ts
@@ -183,7 +183,7 @@ export const CleanExtraBinScripts: Task = {
   description: 'Cleaning extra bin/* scripts from platform-specific builds',
 
   async run(config, log, build) {
-    for (const platform of config.getNodePlatforms()) {
+    for (const platform of config.getTargetPlatforms()) {
       if (platform.isWindows()) {
         await deleteAll(
           [

--- a/src/dev/build/tasks/create_archives_sources_task.ts
+++ b/src/dev/build/tasks/create_archives_sources_task.ts
@@ -50,7 +50,6 @@ export const CreateArchivesSources: Task = {
           source: getNodeDownloadInfo(config, platform).extractDir,
           destination: build.resolvePathForPlatform(platform, 'node'),
         });
-
         log.debug('Node.js copied into', platform.getNodeArch(), 'specific build directory');
       })
     );

--- a/src/dev/build/tasks/nodejs/clean_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/clean_node_builds_task.ts
@@ -31,7 +31,7 @@ export const CleanNodeBuilds: Task = {
   description: 'Cleaning npm from node',
 
   async run(config, log, build) {
-    for (const platform of config.getNodePlatforms()) {
+    for (const platform of config.getTargetPlatforms()) {
       await deleteAll(
         [
           build.resolvePathForPlatform(platform, 'node/lib/node_modules'),

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.ts
@@ -35,7 +35,7 @@ export const DownloadNodeBuilds: GlobalTask = {
   async run(config, log) {
     const shasums = await getNodeShasums(log, config.getNodeVersion());
     await Promise.all(
-      config.getNodePlatforms().map(async (platform) => {
+      config.getTargetPlatforms().map(async (platform) => {
         const { url, downloadPath, downloadName } = getNodeDownloadInfo(config, platform);
         await download({
           log,

--- a/src/dev/build/tasks/nodejs/extract_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/extract_node_builds_task.ts
@@ -35,7 +35,7 @@ export const ExtractNodeBuilds: GlobalTask = {
   description: 'Extracting node.js builds for all platforms',
   async run(config) {
     await Promise.all(
-      config.getNodePlatforms().map(async (platform) => {
+      config.getTargetPlatforms().map(async (platform) => {
         const { downloadPath, extractDir } = getNodeDownloadInfo(config, platform);
         if (platform.isWindows()) {
           // windows executable is not extractable, it's just an .exe file

--- a/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.ts
@@ -36,7 +36,7 @@ export const VerifyExistingNodeBuilds: GlobalTask = {
     const shasums = await getNodeShasums(log, config.getNodeVersion());
 
     await Promise.all(
-      config.getNodePlatforms().map(async (platform) => {
+      config.getTargetPlatforms().map(async (platform) => {
         const { downloadPath, downloadName } = getNodeDownloadInfo(config, platform);
 
         const sha256 = await getFileHash(downloadPath, 'sha256');

--- a/src/dev/build/tasks/notice_file_task.ts
+++ b/src/dev/build/tasks/notice_file_task.ts
@@ -53,9 +53,15 @@ export const CreateNoticeFile: Task = {
     });
 
     log.info('Generating build notice');
+
     const { extractDir: nodeDir, version: nodeVersion } = getNodeDownloadInfo(
       config,
-      config.getPlatform('linux', 'x64')
+      config.hasSpecifiedPlatform()
+        ? config.getPlatform(
+            config.getTargetPlatforms()[0].getName(),
+            config.getTargetPlatforms()[0].getArchitecture()
+          )
+        : config.getPlatform('linux', 'x64')
     );
 
     const notice = await generateBuildNoticeText({


### PR DESCRIPTION
### Description
When running yarn build --skip-os-packages it will build 4 tarballs
for Dashboards (2x linux, 1x macOS, 1x windows) and takes 10+min to
do so.

In this PR, we break the building process to allow single linux to
build. If run `yarn build-platform --linux-x64` only linux x64 tarball
is created. Same for linux arm64 and darwin x64. You could run `yarn
build-platform --linux-arm64` and `yarn build-platform darwin-x64`.

### Partially Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/473

Signed-off-by: Anan Zhuang <ananzh@amazon.com>
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 