### PR TITLE
[1.x] De-Couple Dashboards linux building process

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -64,6 +64,22 @@ $ yarn start
 When the server is up and ready, click on the link displayed in your terminal to
 access it.
 
+### Building the artifacts
+
+To build the archives for each platform,  run the following:
+
+```
+yarn build --skip-os-packages
+```
+
+If you want to build a specific platform, pass the platform flag after `yarn build-platform`. For example, to build darwin x64, run the following:
+
+```
+yarn build-platform --darwin
+```
+
+You could pass one or multiple flags. If you don't pass any flag, `yarn build-platform` will use your local environment. Currenly we only support `darwin` (darwin x64), `linux` (linux x64) and `linux-arm` (linux arm64).  
+
 ### Building the Docker Image
 
 To build the Docker image, run the following:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:ftr:runner": "node scripts/functional_test_runner",
     "test:coverage": "grunt test:coverage",
     "checkLicenses": "node scripts/check_licenses --dev",
+    "build-platform": "node scripts/build",
     "build": "node scripts/build --all-platforms",
     "start": "node scripts/opensearch_dashboards --dev",
     "debug": "node --nolazy --inspect scripts/opensearch_dashboards --dev",

--- a/src/dev/build/args.test.ts
+++ b/src/dev/build/args.test.ts
@@ -53,6 +53,89 @@ it('build dist for current platform, without packages, by default', () => {
         "downloadFreshNode": true,
         "isRelease": false,
         "targetAllPlatforms": false,
+        "targetPlatforms": Object {
+          "darwin": false,
+          "linux": false,
+          "linuxArm": false,
+        },
+        "versionQualifier": "",
+      },
+      "log": <ToolingLog>,
+      "showHelp": false,
+      "unknownFlags": Array [],
+    }
+  `);
+});
+
+it('build dist for linux x64 platform, without packages, if --linux-x64 is passed', () => {
+  expect(readCliArgs(['node', 'scripts/build-platform'])).toMatchInlineSnapshot(`
+    Object {
+      "buildOptions": Object {
+        "createArchives": true,
+        "createDebPackage": false,
+        "createDockerPackage": false,
+        "createDockerUbiPackage": false,
+        "createRpmPackage": false,
+        "downloadFreshNode": true,
+        "isRelease": false,
+        "targetAllPlatforms": false,
+        "targetPlatforms": Object {
+          "darwin": false,
+          "linux": false,
+          "linuxArm": false,
+        },
+        "versionQualifier": "",
+      },
+      "log": <ToolingLog>,
+      "showHelp": false,
+      "unknownFlags": Array [],
+    }
+  `);
+});
+
+it('build dist for linux x64 platform, without packages, if --linux-arm64 is passed', () => {
+  expect(readCliArgs(['node', 'scripts/build-platform'])).toMatchInlineSnapshot(`
+    Object {
+      "buildOptions": Object {
+        "createArchives": true,
+        "createDebPackage": false,
+        "createDockerPackage": false,
+        "createDockerUbiPackage": false,
+        "createRpmPackage": false,
+        "downloadFreshNode": true,
+        "isRelease": false,
+        "targetAllPlatforms": false,
+        "targetPlatforms": Object {
+          "darwin": false,
+          "linux": false,
+          "linuxArm": false,
+        },
+        "versionQualifier": "",
+      },
+      "log": <ToolingLog>,
+      "showHelp": false,
+      "unknownFlags": Array [],
+    }
+  `);
+});
+
+it('build dist for linux x64 platform, without packages, if --darwin-x64 is passed', () => {
+  expect(readCliArgs(['node', 'scripts/build-platform'])).toMatchInlineSnapshot(`
+    Object {
+      "buildOptions": Object {
+        "createArchives": true,
+        "createDebPackage": false,
+        "createDockerPackage": false,
+        "createDockerUbiPackage": false,
+        "createRpmPackage": false,
+        "downloadFreshNode": true,
+        "isRelease": false,
+        "targetAllPlatforms": false,
+        "targetPlatforms": Object {
+          "darwin": false,
+          "linux": false,
+          "linuxArm": false,
+        },
         "versionQualifier": "",
       },
       "log": <ToolingLog>,
@@ -74,6 +157,11 @@ it('builds packages if --all-platforms is passed', () => {
         "downloadFreshNode": true,
         "isRelease": false,
         "targetAllPlatforms": true,
+        "targetPlatforms": Object {
+          "darwin": false,
+          "linux": false,
+          "linuxArm": false,
+        },
         "versionQualifier": "",
       },
       "log": <ToolingLog>,
@@ -95,6 +183,11 @@ it('limits packages if --rpm passed with --all-platforms', () => {
         "downloadFreshNode": true,
         "isRelease": false,
         "targetAllPlatforms": true,
+        "targetPlatforms": Object {
+          "darwin": false,
+          "linux": false,
+          "linuxArm": false,
+        },
         "versionQualifier": "",
       },
       "log": <ToolingLog>,
@@ -116,6 +209,11 @@ it('limits packages if --deb passed with --all-platforms', () => {
         "downloadFreshNode": true,
         "isRelease": false,
         "targetAllPlatforms": true,
+        "targetPlatforms": Object {
+          "darwin": false,
+          "linux": false,
+          "linuxArm": false,
+        },
         "versionQualifier": "",
       },
       "log": <ToolingLog>,
@@ -138,6 +236,11 @@ it('limits packages if --docker passed with --all-platforms', () => {
         "downloadFreshNode": true,
         "isRelease": false,
         "targetAllPlatforms": true,
+        "targetPlatforms": Object {
+          "darwin": false,
+          "linux": false,
+          "linuxArm": false,
+        },
         "versionQualifier": "",
       },
       "log": <ToolingLog>,
@@ -160,6 +263,11 @@ it('limits packages if --docker passed with --skip-docker-ubi and --all-platform
         "downloadFreshNode": true,
         "isRelease": false,
         "targetAllPlatforms": true,
+        "targetPlatforms": Object {
+          "darwin": false,
+          "linux": false,
+          "linuxArm": false,
+        },
         "versionQualifier": "",
       },
       "log": <ToolingLog>,

--- a/src/dev/build/args.ts
+++ b/src/dev/build/args.ts
@@ -45,6 +45,9 @@ export function readCliArgs(argv: string[]) {
       'verbose',
       'debug',
       'all-platforms',
+      'darwin',
+      'linux',
+      'linux-arm',
       'verbose',
       'quiet',
       'silent',
@@ -111,6 +114,11 @@ export function readCliArgs(argv: string[]) {
     createDebPackage: isOsPackageDesired('deb'),
     createDockerPackage: isOsPackageDesired('docker'),
     createDockerUbiPackage: isOsPackageDesired('docker') && !Boolean(flags['skip-docker-ubi']),
+    targetPlatforms: {
+      darwin: Boolean(flags.darwin),
+      linux: Boolean(flags.linux),
+      linuxArm: Boolean(flags['linux-arm']),
+    },
     targetAllPlatforms: Boolean(flags['all-platforms']),
   };
 

--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -27,7 +27,7 @@
 
 import { ToolingLog } from '@osd/dev-utils';
 
-import { Config, createRunner } from './lib';
+import { Config, createRunner, TargetPlatforms } from './lib';
 import * as Tasks from './tasks';
 
 export interface BuildOptions {
@@ -40,6 +40,7 @@ export interface BuildOptions {
   createDockerUbiPackage: boolean;
   versionQualifier: string | undefined;
   targetAllPlatforms: boolean;
+  targetPlatforms: TargetPlatforms;
 }
 
 export async function buildDistributables(log: ToolingLog, options: BuildOptions) {

--- a/src/dev/build/cli.ts
+++ b/src/dev/build/cli.ts
@@ -55,6 +55,9 @@ if (showHelp) {
         --skip-archives         {dim Don't produce tar/zip archives}
         --skip-os-packages      {dim Don't produce rpm/deb/docker packages}
         --all-platforms         {dim Produce archives for all platforms, not just this one}
+        --linux-x64             {dim Produce archives for only linux x64 platform}
+        --linux-arm64           {dim Produce archives for only linux arm64 platform}
+        --darwin-x64            {dim Produce archives for only darwin x64 platform}
         --rpm                   {dim Only build the rpm package}
         --deb                   {dim Only build the deb package}
         --docker                {dim Only build the docker image}

--- a/src/dev/build/lib/build.test.ts
+++ b/src/dev/build/lib/build.test.ts
@@ -36,7 +36,12 @@ expect.addSnapshotSerializer(createAbsolutePathSerializer());
 const config = new Config(
   true,
   {
-    version: '8.0.0',
+    darwin: false,
+    linux: false,
+    linuxArm: false,
+  },
+  {
+    version: '1.0.0',
     engines: {
       node: '*',
     },
@@ -49,7 +54,7 @@ const config = new Config(
   {
     buildNumber: 1234,
     buildSha: 'abcd1234',
-    buildVersion: '8.0.0',
+    buildVersion: '1.0.0',
   },
   true
 );
@@ -93,7 +98,7 @@ describe('#resolvePath()', () => {
 describe('#resolvePathForPlatform()', () => {
   it('uses config.resolveFromRepo(), config.getBuildVersion(), and platform.getBuildName() to create path', () => {
     expect(build.resolvePathForPlatform(linuxPlatform, 'foo', 'bar')).toMatchInlineSnapshot(
-      `<absolute path>/build/opensearch-dashboards-8.0.0-linux-x64/foo/bar`
+      `<absolute path>/build/opensearch-dashboards-1.0.0-linux-x64/foo/bar`
     );
   });
 });
@@ -101,13 +106,13 @@ describe('#resolvePathForPlatform()', () => {
 describe('#getPlatformArchivePath()', () => {
   it('creates correct path for different platforms', () => {
     expect(build.getPlatformArchivePath(linuxPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-8.0.0-linux-x64.tar.gz`
+      `<absolute path>/target/opensearch-dashboards-1.0.0-linux-x64.tar.gz`
     );
     expect(build.getPlatformArchivePath(linuxArmPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-8.0.0-linux-arm64.tar.gz`
+      `<absolute path>/target/opensearch-dashboards-1.0.0-linux-arm64.tar.gz`
     );
     expect(build.getPlatformArchivePath(windowsPlatform)).toMatchInlineSnapshot(
-      `<absolute path>/target/opensearch-dashboards-8.0.0-windows-x64.zip`
+      `<absolute path>/target/opensearch-dashboards-1.0.0-windows-x64.zip`
     );
   });
 });

--- a/src/dev/build/lib/platform.ts
+++ b/src/dev/build/lib/platform.ts
@@ -28,6 +28,12 @@
 export type PlatformName = 'win32' | 'darwin' | 'linux';
 export type PlatformArchitecture = 'x64' | 'arm64';
 
+export interface TargetPlatforms {
+  darwin: boolean;
+  linuxArm: boolean;
+  linux: boolean;
+}
+
 export class Platform {
   constructor(
     private name: PlatformName,

--- a/src/dev/build/tasks/clean_tasks.ts
+++ b/src/dev/build/tasks/clean_tasks.ts
@@ -183,7 +183,7 @@ export const CleanExtraBinScripts: Task = {
   description: 'Cleaning extra bin/* scripts from platform-specific builds',
 
   async run(config, log, build) {
-    for (const platform of config.getNodePlatforms()) {
+    for (const platform of config.getTargetPlatforms()) {
       if (platform.isWindows()) {
         await deleteAll(
           [

--- a/src/dev/build/tasks/create_archives_task.ts
+++ b/src/dev/build/tasks/create_archives_task.ts
@@ -40,7 +40,6 @@ export const CreateArchives: Task = {
 
   async run(config, log, build) {
     const archives = [];
-
     // archive one at a time, parallel causes OOM sometimes
     for (const platform of config.getTargetPlatforms()) {
       const source = build.resolvePathForPlatform(platform, '.');

--- a/src/dev/build/tasks/nodejs/clean_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/clean_node_builds_task.ts
@@ -31,7 +31,7 @@ export const CleanNodeBuilds: Task = {
   description: 'Cleaning npm from node',
 
   async run(config, log, build) {
-    for (const platform of config.getNodePlatforms()) {
+    for (const platform of config.getTargetPlatforms()) {
       await deleteAll(
         [
           build.resolvePathForPlatform(platform, 'node/lib/node_modules'),

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.ts
@@ -35,7 +35,7 @@ export const DownloadNodeBuilds: GlobalTask = {
   async run(config, log) {
     const shasums = await getNodeShasums(log, config.getNodeVersion());
     await Promise.all(
-      config.getNodePlatforms().map(async (platform) => {
+      config.getTargetPlatforms().map(async (platform) => {
         const { url, downloadPath, downloadName } = getNodeDownloadInfo(config, platform);
         await download({
           log,

--- a/src/dev/build/tasks/nodejs/extract_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/extract_node_builds_task.ts
@@ -35,7 +35,7 @@ export const ExtractNodeBuilds: GlobalTask = {
   description: 'Extracting node.js builds for all platforms',
   async run(config) {
     await Promise.all(
-      config.getNodePlatforms().map(async (platform) => {
+      config.getTargetPlatforms().map(async (platform) => {
         const { downloadPath, extractDir } = getNodeDownloadInfo(config, platform);
         if (platform.isWindows()) {
           // windows executable is not extractable, it's just an .exe file

--- a/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.ts
@@ -36,7 +36,7 @@ export const VerifyExistingNodeBuilds: GlobalTask = {
     const shasums = await getNodeShasums(log, config.getNodeVersion());
 
     await Promise.all(
-      config.getNodePlatforms().map(async (platform) => {
+      config.getTargetPlatforms().map(async (platform) => {
         const { downloadPath, downloadName } = getNodeDownloadInfo(config, platform);
 
         const sha256 = await getFileHash(downloadPath, 'sha256');

--- a/src/dev/build/tasks/notice_file_task.ts
+++ b/src/dev/build/tasks/notice_file_task.ts
@@ -53,9 +53,15 @@ export const CreateNoticeFile: Task = {
     });
 
     log.info('Generating build notice');
+
     const { extractDir: nodeDir, version: nodeVersion } = getNodeDownloadInfo(
       config,
-      config.getPlatform('linux', 'x64')
+      config.hasSpecifiedPlatform()
+        ? config.getPlatform(
+            config.getTargetPlatforms()[0].getName(),
+            config.getTargetPlatforms()[0].getArchitecture()
+          )
+        : config.getPlatform('linux', 'x64')
     );
 
     const notice = await generateBuildNoticeText({


### PR DESCRIPTION
### Description
When running yarn build --skip-os-packages it will build 4 tarballs
for Dashboards (2x linux, 1x macOS, 1x windows) and takes 10+min to
do so.

In this PR, we break the building process to allow single linux to
build. If run `yarn build-platform --linux-x64` only linux x64 tarball
is created. Same for linux arm64 and darwin x64. You could run `yarn
build-platform --linux-arm64` and `yarn build-platform darwin-x64`.

### Partially solved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/473

### Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/795
Signed-off-by: Anan Zhuang <ananzh@amazon.com>

support multiple CLI options and fix comments

Signed-off-by: AnanZ <ananzh@amazon.com>

fix wording to artifacts

Signed-off-by: AnanZ <ananzh@amazon.com>

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 