### PR TITLE
[1.x] Correct the mime-type of exported CSVs (#792)

### DIFF
--- a/src/plugins/inspector/public/views/data/lib/export_csv.ts
+++ b/src/plugins/inspector/public/views/data/lib/export_csv.ts
@@ -86,7 +86,7 @@ export function exportAsCsv({
   csvSeparator,
   quoteValues,
 }: any) {
-  const type = 'text/plain;charset=utf-8';
+  const type = 'text/csv;charset=utf-8';
 
   const csv = new Blob([buildCsv(columns, rows, csvSeparator, quoteValues, valueFormatter)], {
     type,

--- a/src/plugins/vis_type_table/public/agg_table/agg_table.js
+++ b/src/plugins/vis_type_table/public/agg_table/agg_table.js
@@ -66,7 +66,7 @@ export function OsdAggTable(config, RecursionHelper) {
       };
 
       self.exportAsCsv = function (formatted) {
-        const csv = new Blob([self.toCsv(formatted)], { type: 'text/plain;charset=utf-8' });
+        const csv = new Blob([self.toCsv(formatted)], { type: 'text/csv;charset=utf-8' });
         self._saveAs(csv, self.csv.filename);
       };
 

--- a/src/plugins/vis_type_table/public/agg_table/agg_table.test.js
+++ b/src/plugins/vis_type_table/public/agg_table/agg_table.test.js
@@ -487,7 +487,7 @@ describe('Table Vis - AggTable Directive', function () {
         'one,two,"with double-quotes("")"' + '\r\n' + '1,2,"""foobar"""' + '\r\n',
       ]);
       expect(call.args[0].opts).toEqual({
-        type: 'text/plain;charset=utf-8',
+        type: 'text/csv;charset=utf-8',
       });
       expect(call.args[1]).toBe('somefilename.csv');
     });


### PR DESCRIPTION
### Description
Blobs representing CSV content are generated on the browser which are then exported as downloadables. The mime-types were incorrectly set to text/plain in a few places. This commit changes the mime-type to be text/csv.

Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/640

Signed-off-by: Miki <mehranb@amazon.com>
 
### Issues Resolved
Backport of #792 to 1.x.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 