### PR TITLE
Side menu logo and Overview header logo configuration

### DIFF
--- a/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
@@ -60,6 +60,15 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
       "serverBasePath": "/test",
     }
   }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
+    }
+  }
   closeNav={[Function]}
   customNavLink$={
     BehaviorSubject {
@@ -853,8 +862,9 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
               className="euiFlexItem eui-yScroll"
             >
               <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="/defaultModeLogo"
                 data-test-subj="collapsibleNavGroup-opensearchDashboards"
-                iconType="inputOutput"
+                iconType="/defaultModeLogo"
                 initialIsOpen={true}
                 isCollapsible={true}
                 key="opensearchDashboards"
@@ -875,7 +885,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                       >
                         <EuiIcon
                           size="l"
-                          type="inputOutput"
+                          type="/defaultModeLogo"
                         />
                       </EuiFlexItem>
                       <EuiFlexItem>
@@ -893,6 +903,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexGroup>
                   }
                   className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="/defaultModeLogo"
                   data-test-subj="collapsibleNavGroup-opensearchDashboards"
                   id="mockId"
                   initialIsOpen={true}
@@ -903,6 +914,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 >
                   <div
                     className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="/defaultModeLogo"
                     data-test-subj="collapsibleNavGroup-opensearchDashboards"
                     onToggle={[Function]}
                   >
@@ -951,10 +963,10 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                                 >
                                   <EuiIcon
                                     size="l"
-                                    type="inputOutput"
+                                    type="/defaultModeLogo"
                                   >
                                     <div
-                                      data-euiicon-type="inputOutput"
+                                      data-euiicon-type="/defaultModeLogo"
                                       size="l"
                                     />
                                   </EuiIcon>
@@ -1143,6 +1155,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 </EuiAccordion>
               </EuiCollapsibleNavGroup>
               <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
                 data-test-subj="collapsibleNavGroup-observability"
                 iconType="logoObservability"
                 initialIsOpen={true}
@@ -1183,6 +1196,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexGroup>
                   }
                   className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
                   data-test-subj="collapsibleNavGroup-observability"
                   id="mockId"
                   initialIsOpen={true}
@@ -1193,6 +1207,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 >
                   <div
                     className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
                     data-test-subj="collapsibleNavGroup-observability"
                     onToggle={[Function]}
                   >
@@ -1394,6 +1409,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 </EuiAccordion>
               </EuiCollapsibleNavGroup>
               <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoSecurity"
                 data-test-subj="collapsibleNavGroup-securitySolution"
                 iconType="logoSecurity"
                 initialIsOpen={true}
@@ -1434,6 +1450,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexGroup>
                   }
                   className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoSecurity"
                   data-test-subj="collapsibleNavGroup-securitySolution"
                   id="mockId"
                   initialIsOpen={true}
@@ -1444,6 +1461,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 >
                   <div
                     className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoSecurity"
                     data-test-subj="collapsibleNavGroup-securitySolution"
                     onToggle={[Function]}
                   >
@@ -1606,6 +1624,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 </EuiAccordion>
               </EuiCollapsibleNavGroup>
               <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="managementApp"
                 data-test-subj="collapsibleNavGroup-management"
                 iconType="managementApp"
                 initialIsOpen={true}
@@ -1646,6 +1665,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexGroup>
                   }
                   className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="managementApp"
                   data-test-subj="collapsibleNavGroup-management"
                   id="mockId"
                   initialIsOpen={true}
@@ -1656,6 +1676,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 >
                   <div
                     className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="managementApp"
                     data-test-subj="collapsibleNavGroup-management"
                     onToggle={[Function]}
                   >
@@ -2083,6 +2104,15 @@ exports[`CollapsibleNav renders the default nav 1`] = `
       "serverBasePath": "/test",
     }
   }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
+    }
+  }
   closeNav={[Function]}
   customNavLink$={
     BehaviorSubject {
@@ -2316,6 +2346,15 @@ exports[`CollapsibleNav renders the default nav 2`] = `
       "prepend": [Function],
       "remove": [Function],
       "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
     }
   }
   closeNav={[Function]}
@@ -2552,6 +2591,15 @@ exports[`CollapsibleNav renders the default nav 3`] = `
       "prepend": [Function],
       "remove": [Function],
       "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
     }
   }
   closeNav={[Function]}
@@ -3099,6 +3147,6009 @@ exports[`CollapsibleNav renders the default nav 3`] = `
                                   title="Undock navigation"
                                 >
                                   Undock navigation
+                                </span>
+                              </button>
+                            </li>
+                          </EuiListGroupItem>
+                        </ul>
+                      </EuiListGroup>
+                    </div>
+                  </div>
+                </EuiCollapsibleNavGroup>
+              </EuiShowFor>
+            </div>
+          </EuiFlexItem>
+          <EuiScreenReaderOnly
+            showOnFocus={true}
+          >
+            <EuiButtonEmpty
+              className="euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+              iconType="cross"
+              onClick={[Function]}
+              size="xs"
+              textProps={
+                Object {
+                  "className": "euiCollapsibleNav__closeButtonText",
+                }
+              }
+            >
+              <button
+                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <EuiButtonContent
+                  className="euiButtonEmpty__content"
+                  iconSide="left"
+                  iconType="cross"
+                  textProps={
+                    Object {
+                      "className": "euiButtonEmpty__text euiCollapsibleNav__closeButtonText",
+                    }
+                  }
+                >
+                  <span
+                    className="euiButtonContent euiButtonEmpty__content"
+                  >
+                    <EuiIcon
+                      className="euiButtonContent__icon"
+                      size="m"
+                      type="cross"
+                    >
+                      <div
+                        className="euiButtonContent__icon"
+                        data-euiicon-type="cross"
+                        size="m"
+                      />
+                    </EuiIcon>
+                    <span
+                      className="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+                    >
+                      <EuiI18n
+                        default="close"
+                        token="euiCollapsibleNav.closeButtonLabel"
+                      >
+                        close
+                      </EuiI18n>
+                    </span>
+                  </span>
+                </EuiButtonContent>
+              </button>
+            </EuiButtonEmpty>
+          </EuiScreenReaderOnly>
+        </nav>
+      </div>
+    </EuiFocusTrap>
+  </EuiCollapsibleNav>
+</CollapsibleNav>
+`;
+
+exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 1`] = `
+<CollapsibleNav
+  appId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "test",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  basePath={
+    BasePath {
+      "basePath": "/test",
+      "get": [Function],
+      "prepend": [Function],
+      "remove": [Function],
+      "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": true,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
+    }
+  }
+  closeNav={[Function]}
+  customNavLink$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  homeHref="/"
+  id="collapsibe-nav"
+  isLocked={false}
+  isNavOpen={true}
+  navLinks$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "inputOutput",
+            "id": "opensearchDashboards",
+            "label": "OpenSearch Dashboards",
+            "order": 1000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "logoObservability",
+            "id": "observability",
+            "label": "Observability",
+            "order": 3000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navigateToApp={[Function]}
+  navigateToUrl={[Function]}
+  onIsLockedUpdate={[Function]}
+  recentlyAccessed$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "id": "recent",
+          "label": "recent",
+          "link": "recent",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  storage={
+    StubBrowserStorage {
+      "keys": Array [],
+      "size": 0,
+      "sizeLimit": 5000000,
+      "values": Array [],
+    }
+  }
+>
+  <EuiCollapsibleNav
+    aria-label="Primary"
+    data-test-subj="collapsibleNav"
+    id="collapsibe-nav"
+    isDocked={false}
+    isOpen={true}
+    onClose={[Function]}
+  >
+    <EuiWindowEvent
+      event="keydown"
+      handler={[Function]}
+    />
+    <EuiOverlayMask
+      headerZindexLocation="below"
+      onClick={[Function]}
+    >
+      <Portal
+        containerInfo={
+          <div
+            class="euiOverlayMask euiOverlayMask--belowHeader"
+          />
+        }
+      />
+    </EuiOverlayMask>
+    <EuiFocusTrap
+      clickOutsideDisables={true}
+      disabled={false}
+    >
+      <div
+        data-eui="EuiFocusTrap"
+      >
+        <nav
+          aria-label="Primary"
+          className="euiCollapsibleNav"
+          data-test-subj="collapsibleNav"
+          id="collapsibe-nav"
+        >
+          <EuiFlexItem
+            grow={false}
+            style={
+              Object {
+                "flexShrink": 0,
+              }
+            }
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+              style={
+                Object {
+                  "flexShrink": 0,
+                }
+              }
+            >
+              <EuiCollapsibleNavGroup
+                background="light"
+                className="eui-yScroll"
+                style={
+                  Object {
+                    "maxHeight": "40vh",
+                  }
+                }
+              >
+                <div
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light eui-yScroll"
+                  id="mockId"
+                  style={
+                    Object {
+                      "maxHeight": "40vh",
+                    }
+                  }
+                >
+                  <div
+                    className="euiCollapsibleNavGroup__children"
+                  >
+                    <EuiListGroup
+                      aria-label="Pinned links"
+                      color="text"
+                      gutterSize="none"
+                      listItems={
+                        Array [
+                          Object {
+                            "href": "/",
+                            "iconType": "home",
+                            "label": "Home",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      maxWidth="none"
+                      size="s"
+                    >
+                      <ul
+                        aria-label="Pinned links"
+                        className="euiListGroup"
+                        style={
+                          Object {
+                            "maxWidth": "none",
+                          }
+                        }
+                      >
+                        <EuiListGroupItem
+                          color="text"
+                          href="/"
+                          iconType="home"
+                          key="title-0"
+                          label="Home"
+                          onClick={[Function]}
+                          showToolTip={false}
+                          size="s"
+                          wrapText={false}
+                        >
+                          <li
+                            className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          >
+                            <a
+                              className="euiListGroupItem__button"
+                              href="/"
+                              onClick={[Function]}
+                              rel="noreferrer"
+                            >
+                              <EuiIcon
+                                className="euiListGroupItem__icon"
+                                type="home"
+                              >
+                                <div
+                                  className="euiListGroupItem__icon"
+                                  data-euiicon-type="home"
+                                />
+                              </EuiIcon>
+                              <span
+                                className="euiListGroupItem__label"
+                                title="Home"
+                              >
+                                Home
+                              </span>
+                            </a>
+                          </li>
+                        </EuiListGroupItem>
+                      </ul>
+                    </EuiListGroup>
+                  </div>
+                </div>
+              </EuiCollapsibleNavGroup>
+            </div>
+          </EuiFlexItem>
+          <EuiCollapsibleNavGroup
+            background="light"
+            data-test-subj="collapsibleNavGroup-recentlyViewed"
+            initialIsOpen={true}
+            isCollapsible={true}
+            key="recentlyViewed"
+            onToggle={[Function]}
+            title="Recently viewed"
+          >
+            <EuiAccordion
+              arrowDisplay="right"
+              buttonClassName="euiCollapsibleNavGroup__heading"
+              buttonContent={
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="m"
+                  responsive={false}
+                >
+                  <EuiFlexItem>
+                    <EuiTitle
+                      size="xxs"
+                    >
+                      <h3
+                        className="euiCollapsibleNavGroup__title"
+                        id="mockId__title"
+                      >
+                        Recently viewed
+                      </h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
+              className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+              data-test-subj="collapsibleNavGroup-recentlyViewed"
+              id="mockId"
+              initialIsOpen={true}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                data-test-subj="collapsibleNavGroup-recentlyViewed"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="mockId"
+                    aria-expanded={true}
+                    className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                    id="mockId"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon euiAccordion__icon-isOpen"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <div
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          data-euiicon-type="arrowRight"
+                          size="m"
+                        />
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="m"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiTitle
+                                size="xxs"
+                              >
+                                <h3
+                                  className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                  id="mockId__title"
+                                >
+                                  Recently viewed
+                                </h3>
+                              </EuiTitle>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  className="euiAccordion__childWrapper"
+                  id="mockId"
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <div
+                          className="euiCollapsibleNavGroup__children"
+                        >
+                          <EuiListGroup
+                            aria-label="Recently viewed links"
+                            className="osdCollapsibleNav__recentsListGroup"
+                            color="subdued"
+                            gutterSize="none"
+                            listItems={
+                              Array [
+                                Object {
+                                  "aria-label": "recent",
+                                  "data-test-subj": "collapsibleNavAppLink--recent",
+                                  "href": "http://localhost/recent",
+                                  "label": "recent",
+                                  "onClick": [Function],
+                                  "title": "recent",
+                                },
+                              ]
+                            }
+                            maxWidth="none"
+                            size="s"
+                          >
+                            <ul
+                              aria-label="Recently viewed links"
+                              className="euiListGroup osdCollapsibleNav__recentsListGroup"
+                              style={
+                                Object {
+                                  "maxWidth": "none",
+                                }
+                              }
+                            >
+                              <EuiListGroupItem
+                                aria-label="recent"
+                                color="subdued"
+                                data-test-subj="collapsibleNavAppLink--recent"
+                                href="http://localhost/recent"
+                                key="title-0"
+                                label="recent"
+                                onClick={[Function]}
+                                showToolTip={false}
+                                size="s"
+                                title="recent"
+                                wrapText={false}
+                              >
+                                <li
+                                  className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                >
+                                  <a
+                                    aria-label="recent"
+                                    className="euiListGroupItem__button"
+                                    data-test-subj="collapsibleNavAppLink--recent"
+                                    href="http://localhost/recent"
+                                    onClick={[Function]}
+                                    rel="noreferrer"
+                                    title="recent"
+                                  >
+                                    <span
+                                      className="euiListGroupItem__label"
+                                      title="recent"
+                                    >
+                                      recent
+                                    </span>
+                                  </a>
+                                </li>
+                              </EuiListGroupItem>
+                            </ul>
+                          </EuiListGroup>
+                        </div>
+                      </div>
+                    </div>
+                  </EuiResizeObserver>
+                </div>
+              </div>
+            </EuiAccordion>
+          </EuiCollapsibleNavGroup>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiFlexItem
+            className="eui-yScroll"
+          >
+            <div
+              className="euiFlexItem eui-yScroll"
+            >
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="/darkModeLogo"
+                data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                iconType="/darkModeLogo"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="opensearchDashboards"
+                onToggle={[Function]}
+                title="OpenSearch Dashboards"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="/darkModeLogo"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            OpenSearch Dashboards
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="/darkModeLogo"
+                  data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="/darkModeLogo"
+                    data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="/darkModeLogo"
+                                  >
+                                    <div
+                                      data-euiicon-type="/darkModeLogo"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      OpenSearch Dashboards
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, OpenSearch Dashboards"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, OpenSearch Dashboards"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
+                data-test-subj="collapsibleNavGroup-observability"
+                iconType="logoObservability"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="observability"
+                onToggle={[Function]}
+                title="Observability"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="logoObservability"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            Observability
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
+                  data-test-subj="collapsibleNavGroup-observability"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
+                    data-test-subj="collapsibleNavGroup-observability"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="logoObservability"
+                                  >
+                                    <div
+                                      data-euiicon-type="logoObservability"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      Observability
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, Observability"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, Observability"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiShowFor
+                sizes={
+                  Array [
+                    "l",
+                    "xl",
+                  ]
+                }
+              >
+                <EuiCollapsibleNavGroup>
+                  <div
+                    className="euiCollapsibleNavGroup"
+                    id="mockId"
+                  >
+                    <div
+                      className="euiCollapsibleNavGroup__children"
+                    >
+                      <EuiListGroup
+                        flush={true}
+                      >
+                        <ul
+                          className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+                        >
+                          <EuiListGroupItem
+                            aria-label="Dock primary navigation"
+                            buttonRef={
+                              Object {
+                                "current": <button
+                                  aria-label="Dock primary navigation"
+                                  class="euiListGroupItem__button"
+                                  data-test-subj="collapsible-nav-lock"
+                                  type="button"
+                                >
+                                  <div
+                                    class="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                  <span
+                                    class="euiListGroupItem__label"
+                                    title="Dock navigation"
+                                  >
+                                    Dock navigation
+                                  </span>
+                                </button>,
+                              }
+                            }
+                            color="subdued"
+                            data-test-subj="collapsible-nav-lock"
+                            iconType="lockOpen"
+                            label="Dock navigation"
+                            onClick={[Function]}
+                            size="xs"
+                          >
+                            <li
+                              className="euiListGroupItem euiListGroupItem--xSmall euiListGroupItem--subdued euiListGroupItem-isClickable"
+                            >
+                              <button
+                                aria-label="Dock primary navigation"
+                                className="euiListGroupItem__button"
+                                data-test-subj="collapsible-nav-lock"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  className="euiListGroupItem__icon"
+                                  type="lockOpen"
+                                >
+                                  <div
+                                    className="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                </EuiIcon>
+                                <span
+                                  className="euiListGroupItem__label"
+                                  title="Dock navigation"
+                                >
+                                  Dock navigation
+                                </span>
+                              </button>
+                            </li>
+                          </EuiListGroupItem>
+                        </ul>
+                      </EuiListGroup>
+                    </div>
+                  </div>
+                </EuiCollapsibleNavGroup>
+              </EuiShowFor>
+            </div>
+          </EuiFlexItem>
+          <EuiScreenReaderOnly
+            showOnFocus={true}
+          >
+            <EuiButtonEmpty
+              className="euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+              iconType="cross"
+              onClick={[Function]}
+              size="xs"
+              textProps={
+                Object {
+                  "className": "euiCollapsibleNav__closeButtonText",
+                }
+              }
+            >
+              <button
+                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <EuiButtonContent
+                  className="euiButtonEmpty__content"
+                  iconSide="left"
+                  iconType="cross"
+                  textProps={
+                    Object {
+                      "className": "euiButtonEmpty__text euiCollapsibleNav__closeButtonText",
+                    }
+                  }
+                >
+                  <span
+                    className="euiButtonContent euiButtonEmpty__content"
+                  >
+                    <EuiIcon
+                      className="euiButtonContent__icon"
+                      size="m"
+                      type="cross"
+                    >
+                      <div
+                        className="euiButtonContent__icon"
+                        data-euiicon-type="cross"
+                        size="m"
+                      />
+                    </EuiIcon>
+                    <span
+                      className="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+                    >
+                      <EuiI18n
+                        default="close"
+                        token="euiCollapsibleNav.closeButtonLabel"
+                      >
+                        close
+                      </EuiI18n>
+                    </span>
+                  </span>
+                </EuiButtonContent>
+              </button>
+            </EuiButtonEmpty>
+          </EuiScreenReaderOnly>
+        </nav>
+      </div>
+    </EuiFocusTrap>
+  </EuiCollapsibleNav>
+</CollapsibleNav>
+`;
+
+exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 2`] = `
+<CollapsibleNav
+  appId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "test",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  basePath={
+    BasePath {
+      "basePath": "/test",
+      "get": [Function],
+      "prepend": [Function],
+      "remove": [Function],
+      "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": true,
+      "mark": Object {
+        "defaultUrl": "/defaultModeLogo",
+      },
+    }
+  }
+  closeNav={[Function]}
+  customNavLink$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  homeHref="/"
+  id="collapsibe-nav"
+  isLocked={false}
+  isNavOpen={true}
+  navLinks$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "inputOutput",
+            "id": "opensearchDashboards",
+            "label": "OpenSearch Dashboards",
+            "order": 1000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "logoObservability",
+            "id": "observability",
+            "label": "Observability",
+            "order": 3000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navigateToApp={[Function]}
+  navigateToUrl={[Function]}
+  onIsLockedUpdate={[Function]}
+  recentlyAccessed$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "id": "recent",
+          "label": "recent",
+          "link": "recent",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  storage={
+    StubBrowserStorage {
+      "keys": Array [],
+      "size": 0,
+      "sizeLimit": 5000000,
+      "values": Array [],
+    }
+  }
+>
+  <EuiCollapsibleNav
+    aria-label="Primary"
+    data-test-subj="collapsibleNav"
+    id="collapsibe-nav"
+    isDocked={false}
+    isOpen={true}
+    onClose={[Function]}
+  >
+    <EuiWindowEvent
+      event="keydown"
+      handler={[Function]}
+    />
+    <EuiOverlayMask
+      headerZindexLocation="below"
+      onClick={[Function]}
+    >
+      <Portal
+        containerInfo={
+          <div
+            class="euiOverlayMask euiOverlayMask--belowHeader"
+          />
+        }
+      />
+    </EuiOverlayMask>
+    <EuiFocusTrap
+      clickOutsideDisables={true}
+      disabled={false}
+    >
+      <div
+        data-eui="EuiFocusTrap"
+      >
+        <nav
+          aria-label="Primary"
+          className="euiCollapsibleNav"
+          data-test-subj="collapsibleNav"
+          id="collapsibe-nav"
+        >
+          <EuiFlexItem
+            grow={false}
+            style={
+              Object {
+                "flexShrink": 0,
+              }
+            }
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+              style={
+                Object {
+                  "flexShrink": 0,
+                }
+              }
+            >
+              <EuiCollapsibleNavGroup
+                background="light"
+                className="eui-yScroll"
+                style={
+                  Object {
+                    "maxHeight": "40vh",
+                  }
+                }
+              >
+                <div
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light eui-yScroll"
+                  id="mockId"
+                  style={
+                    Object {
+                      "maxHeight": "40vh",
+                    }
+                  }
+                >
+                  <div
+                    className="euiCollapsibleNavGroup__children"
+                  >
+                    <EuiListGroup
+                      aria-label="Pinned links"
+                      color="text"
+                      gutterSize="none"
+                      listItems={
+                        Array [
+                          Object {
+                            "href": "/",
+                            "iconType": "home",
+                            "label": "Home",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      maxWidth="none"
+                      size="s"
+                    >
+                      <ul
+                        aria-label="Pinned links"
+                        className="euiListGroup"
+                        style={
+                          Object {
+                            "maxWidth": "none",
+                          }
+                        }
+                      >
+                        <EuiListGroupItem
+                          color="text"
+                          href="/"
+                          iconType="home"
+                          key="title-0"
+                          label="Home"
+                          onClick={[Function]}
+                          showToolTip={false}
+                          size="s"
+                          wrapText={false}
+                        >
+                          <li
+                            className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          >
+                            <a
+                              className="euiListGroupItem__button"
+                              href="/"
+                              onClick={[Function]}
+                              rel="noreferrer"
+                            >
+                              <EuiIcon
+                                className="euiListGroupItem__icon"
+                                type="home"
+                              >
+                                <div
+                                  className="euiListGroupItem__icon"
+                                  data-euiicon-type="home"
+                                />
+                              </EuiIcon>
+                              <span
+                                className="euiListGroupItem__label"
+                                title="Home"
+                              >
+                                Home
+                              </span>
+                            </a>
+                          </li>
+                        </EuiListGroupItem>
+                      </ul>
+                    </EuiListGroup>
+                  </div>
+                </div>
+              </EuiCollapsibleNavGroup>
+            </div>
+          </EuiFlexItem>
+          <EuiCollapsibleNavGroup
+            background="light"
+            data-test-subj="collapsibleNavGroup-recentlyViewed"
+            initialIsOpen={true}
+            isCollapsible={true}
+            key="recentlyViewed"
+            onToggle={[Function]}
+            title="Recently viewed"
+          >
+            <EuiAccordion
+              arrowDisplay="right"
+              buttonClassName="euiCollapsibleNavGroup__heading"
+              buttonContent={
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="m"
+                  responsive={false}
+                >
+                  <EuiFlexItem>
+                    <EuiTitle
+                      size="xxs"
+                    >
+                      <h3
+                        className="euiCollapsibleNavGroup__title"
+                        id="mockId__title"
+                      >
+                        Recently viewed
+                      </h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
+              className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+              data-test-subj="collapsibleNavGroup-recentlyViewed"
+              id="mockId"
+              initialIsOpen={true}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                data-test-subj="collapsibleNavGroup-recentlyViewed"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="mockId"
+                    aria-expanded={true}
+                    className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                    id="mockId"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon euiAccordion__icon-isOpen"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <div
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          data-euiicon-type="arrowRight"
+                          size="m"
+                        />
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="m"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiTitle
+                                size="xxs"
+                              >
+                                <h3
+                                  className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                  id="mockId__title"
+                                >
+                                  Recently viewed
+                                </h3>
+                              </EuiTitle>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  className="euiAccordion__childWrapper"
+                  id="mockId"
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <div
+                          className="euiCollapsibleNavGroup__children"
+                        >
+                          <EuiListGroup
+                            aria-label="Recently viewed links"
+                            className="osdCollapsibleNav__recentsListGroup"
+                            color="subdued"
+                            gutterSize="none"
+                            listItems={
+                              Array [
+                                Object {
+                                  "aria-label": "recent",
+                                  "data-test-subj": "collapsibleNavAppLink--recent",
+                                  "href": "http://localhost/recent",
+                                  "label": "recent",
+                                  "onClick": [Function],
+                                  "title": "recent",
+                                },
+                              ]
+                            }
+                            maxWidth="none"
+                            size="s"
+                          >
+                            <ul
+                              aria-label="Recently viewed links"
+                              className="euiListGroup osdCollapsibleNav__recentsListGroup"
+                              style={
+                                Object {
+                                  "maxWidth": "none",
+                                }
+                              }
+                            >
+                              <EuiListGroupItem
+                                aria-label="recent"
+                                color="subdued"
+                                data-test-subj="collapsibleNavAppLink--recent"
+                                href="http://localhost/recent"
+                                key="title-0"
+                                label="recent"
+                                onClick={[Function]}
+                                showToolTip={false}
+                                size="s"
+                                title="recent"
+                                wrapText={false}
+                              >
+                                <li
+                                  className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                >
+                                  <a
+                                    aria-label="recent"
+                                    className="euiListGroupItem__button"
+                                    data-test-subj="collapsibleNavAppLink--recent"
+                                    href="http://localhost/recent"
+                                    onClick={[Function]}
+                                    rel="noreferrer"
+                                    title="recent"
+                                  >
+                                    <span
+                                      className="euiListGroupItem__label"
+                                      title="recent"
+                                    >
+                                      recent
+                                    </span>
+                                  </a>
+                                </li>
+                              </EuiListGroupItem>
+                            </ul>
+                          </EuiListGroup>
+                        </div>
+                      </div>
+                    </div>
+                  </EuiResizeObserver>
+                </div>
+              </div>
+            </EuiAccordion>
+          </EuiCollapsibleNavGroup>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiFlexItem
+            className="eui-yScroll"
+          >
+            <div
+              className="euiFlexItem eui-yScroll"
+            >
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="/defaultModeLogo"
+                data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                iconType="/defaultModeLogo"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="opensearchDashboards"
+                onToggle={[Function]}
+                title="OpenSearch Dashboards"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="/defaultModeLogo"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            OpenSearch Dashboards
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="/defaultModeLogo"
+                  data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="/defaultModeLogo"
+                    data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="/defaultModeLogo"
+                                  >
+                                    <div
+                                      data-euiicon-type="/defaultModeLogo"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      OpenSearch Dashboards
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, OpenSearch Dashboards"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, OpenSearch Dashboards"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
+                data-test-subj="collapsibleNavGroup-observability"
+                iconType="logoObservability"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="observability"
+                onToggle={[Function]}
+                title="Observability"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="logoObservability"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            Observability
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
+                  data-test-subj="collapsibleNavGroup-observability"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
+                    data-test-subj="collapsibleNavGroup-observability"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="logoObservability"
+                                  >
+                                    <div
+                                      data-euiicon-type="logoObservability"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      Observability
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, Observability"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, Observability"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiShowFor
+                sizes={
+                  Array [
+                    "l",
+                    "xl",
+                  ]
+                }
+              >
+                <EuiCollapsibleNavGroup>
+                  <div
+                    className="euiCollapsibleNavGroup"
+                    id="mockId"
+                  >
+                    <div
+                      className="euiCollapsibleNavGroup__children"
+                    >
+                      <EuiListGroup
+                        flush={true}
+                      >
+                        <ul
+                          className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+                        >
+                          <EuiListGroupItem
+                            aria-label="Dock primary navigation"
+                            buttonRef={
+                              Object {
+                                "current": <button
+                                  aria-label="Dock primary navigation"
+                                  class="euiListGroupItem__button"
+                                  data-test-subj="collapsible-nav-lock"
+                                  type="button"
+                                >
+                                  <div
+                                    class="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                  <span
+                                    class="euiListGroupItem__label"
+                                    title="Dock navigation"
+                                  >
+                                    Dock navigation
+                                  </span>
+                                </button>,
+                              }
+                            }
+                            color="subdued"
+                            data-test-subj="collapsible-nav-lock"
+                            iconType="lockOpen"
+                            label="Dock navigation"
+                            onClick={[Function]}
+                            size="xs"
+                          >
+                            <li
+                              className="euiListGroupItem euiListGroupItem--xSmall euiListGroupItem--subdued euiListGroupItem-isClickable"
+                            >
+                              <button
+                                aria-label="Dock primary navigation"
+                                className="euiListGroupItem__button"
+                                data-test-subj="collapsible-nav-lock"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  className="euiListGroupItem__icon"
+                                  type="lockOpen"
+                                >
+                                  <div
+                                    className="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                </EuiIcon>
+                                <span
+                                  className="euiListGroupItem__label"
+                                  title="Dock navigation"
+                                >
+                                  Dock navigation
+                                </span>
+                              </button>
+                            </li>
+                          </EuiListGroupItem>
+                        </ul>
+                      </EuiListGroup>
+                    </div>
+                  </div>
+                </EuiCollapsibleNavGroup>
+              </EuiShowFor>
+            </div>
+          </EuiFlexItem>
+          <EuiScreenReaderOnly
+            showOnFocus={true}
+          >
+            <EuiButtonEmpty
+              className="euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+              iconType="cross"
+              onClick={[Function]}
+              size="xs"
+              textProps={
+                Object {
+                  "className": "euiCollapsibleNav__closeButtonText",
+                }
+              }
+            >
+              <button
+                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <EuiButtonContent
+                  className="euiButtonEmpty__content"
+                  iconSide="left"
+                  iconType="cross"
+                  textProps={
+                    Object {
+                      "className": "euiButtonEmpty__text euiCollapsibleNav__closeButtonText",
+                    }
+                  }
+                >
+                  <span
+                    className="euiButtonContent euiButtonEmpty__content"
+                  >
+                    <EuiIcon
+                      className="euiButtonContent__icon"
+                      size="m"
+                      type="cross"
+                    >
+                      <div
+                        className="euiButtonContent__icon"
+                        data-euiicon-type="cross"
+                        size="m"
+                      />
+                    </EuiIcon>
+                    <span
+                      className="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+                    >
+                      <EuiI18n
+                        default="close"
+                        token="euiCollapsibleNav.closeButtonLabel"
+                      >
+                        close
+                      </EuiI18n>
+                    </span>
+                  </span>
+                </EuiButtonContent>
+              </button>
+            </EuiButtonEmpty>
+          </EuiScreenReaderOnly>
+        </nav>
+      </div>
+    </EuiFocusTrap>
+  </EuiCollapsibleNav>
+</CollapsibleNav>
+`;
+
+exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 3`] = `
+<CollapsibleNav
+  appId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "test",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  basePath={
+    BasePath {
+      "basePath": "/test",
+      "get": [Function],
+      "prepend": [Function],
+      "remove": [Function],
+      "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {},
+    }
+  }
+  closeNav={[Function]}
+  customNavLink$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  homeHref="/"
+  id="collapsibe-nav"
+  isLocked={false}
+  isNavOpen={true}
+  navLinks$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "inputOutput",
+            "id": "opensearchDashboards",
+            "label": "OpenSearch Dashboards",
+            "order": 1000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "logoObservability",
+            "id": "observability",
+            "label": "Observability",
+            "order": 3000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navigateToApp={[Function]}
+  navigateToUrl={[Function]}
+  onIsLockedUpdate={[Function]}
+  recentlyAccessed$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "id": "recent",
+          "label": "recent",
+          "link": "recent",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  storage={
+    StubBrowserStorage {
+      "keys": Array [],
+      "size": 0,
+      "sizeLimit": 5000000,
+      "values": Array [],
+    }
+  }
+>
+  <EuiCollapsibleNav
+    aria-label="Primary"
+    data-test-subj="collapsibleNav"
+    id="collapsibe-nav"
+    isDocked={false}
+    isOpen={true}
+    onClose={[Function]}
+  >
+    <EuiWindowEvent
+      event="keydown"
+      handler={[Function]}
+    />
+    <EuiOverlayMask
+      headerZindexLocation="below"
+      onClick={[Function]}
+    >
+      <Portal
+        containerInfo={
+          <div
+            class="euiOverlayMask euiOverlayMask--belowHeader"
+          />
+        }
+      />
+    </EuiOverlayMask>
+    <EuiFocusTrap
+      clickOutsideDisables={true}
+      disabled={false}
+    >
+      <div
+        data-eui="EuiFocusTrap"
+      >
+        <nav
+          aria-label="Primary"
+          className="euiCollapsibleNav"
+          data-test-subj="collapsibleNav"
+          id="collapsibe-nav"
+        >
+          <EuiFlexItem
+            grow={false}
+            style={
+              Object {
+                "flexShrink": 0,
+              }
+            }
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+              style={
+                Object {
+                  "flexShrink": 0,
+                }
+              }
+            >
+              <EuiCollapsibleNavGroup
+                background="light"
+                className="eui-yScroll"
+                style={
+                  Object {
+                    "maxHeight": "40vh",
+                  }
+                }
+              >
+                <div
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light eui-yScroll"
+                  id="mockId"
+                  style={
+                    Object {
+                      "maxHeight": "40vh",
+                    }
+                  }
+                >
+                  <div
+                    className="euiCollapsibleNavGroup__children"
+                  >
+                    <EuiListGroup
+                      aria-label="Pinned links"
+                      color="text"
+                      gutterSize="none"
+                      listItems={
+                        Array [
+                          Object {
+                            "href": "/",
+                            "iconType": "home",
+                            "label": "Home",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      maxWidth="none"
+                      size="s"
+                    >
+                      <ul
+                        aria-label="Pinned links"
+                        className="euiListGroup"
+                        style={
+                          Object {
+                            "maxWidth": "none",
+                          }
+                        }
+                      >
+                        <EuiListGroupItem
+                          color="text"
+                          href="/"
+                          iconType="home"
+                          key="title-0"
+                          label="Home"
+                          onClick={[Function]}
+                          showToolTip={false}
+                          size="s"
+                          wrapText={false}
+                        >
+                          <li
+                            className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          >
+                            <a
+                              className="euiListGroupItem__button"
+                              href="/"
+                              onClick={[Function]}
+                              rel="noreferrer"
+                            >
+                              <EuiIcon
+                                className="euiListGroupItem__icon"
+                                type="home"
+                              >
+                                <div
+                                  className="euiListGroupItem__icon"
+                                  data-euiicon-type="home"
+                                />
+                              </EuiIcon>
+                              <span
+                                className="euiListGroupItem__label"
+                                title="Home"
+                              >
+                                Home
+                              </span>
+                            </a>
+                          </li>
+                        </EuiListGroupItem>
+                      </ul>
+                    </EuiListGroup>
+                  </div>
+                </div>
+              </EuiCollapsibleNavGroup>
+            </div>
+          </EuiFlexItem>
+          <EuiCollapsibleNavGroup
+            background="light"
+            data-test-subj="collapsibleNavGroup-recentlyViewed"
+            initialIsOpen={true}
+            isCollapsible={true}
+            key="recentlyViewed"
+            onToggle={[Function]}
+            title="Recently viewed"
+          >
+            <EuiAccordion
+              arrowDisplay="right"
+              buttonClassName="euiCollapsibleNavGroup__heading"
+              buttonContent={
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="m"
+                  responsive={false}
+                >
+                  <EuiFlexItem>
+                    <EuiTitle
+                      size="xxs"
+                    >
+                      <h3
+                        className="euiCollapsibleNavGroup__title"
+                        id="mockId__title"
+                      >
+                        Recently viewed
+                      </h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
+              className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+              data-test-subj="collapsibleNavGroup-recentlyViewed"
+              id="mockId"
+              initialIsOpen={true}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                data-test-subj="collapsibleNavGroup-recentlyViewed"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="mockId"
+                    aria-expanded={true}
+                    className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                    id="mockId"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon euiAccordion__icon-isOpen"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <div
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          data-euiicon-type="arrowRight"
+                          size="m"
+                        />
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="m"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiTitle
+                                size="xxs"
+                              >
+                                <h3
+                                  className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                  id="mockId__title"
+                                >
+                                  Recently viewed
+                                </h3>
+                              </EuiTitle>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  className="euiAccordion__childWrapper"
+                  id="mockId"
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <div
+                          className="euiCollapsibleNavGroup__children"
+                        >
+                          <EuiListGroup
+                            aria-label="Recently viewed links"
+                            className="osdCollapsibleNav__recentsListGroup"
+                            color="subdued"
+                            gutterSize="none"
+                            listItems={
+                              Array [
+                                Object {
+                                  "aria-label": "recent",
+                                  "data-test-subj": "collapsibleNavAppLink--recent",
+                                  "href": "http://localhost/recent",
+                                  "label": "recent",
+                                  "onClick": [Function],
+                                  "title": "recent",
+                                },
+                              ]
+                            }
+                            maxWidth="none"
+                            size="s"
+                          >
+                            <ul
+                              aria-label="Recently viewed links"
+                              className="euiListGroup osdCollapsibleNav__recentsListGroup"
+                              style={
+                                Object {
+                                  "maxWidth": "none",
+                                }
+                              }
+                            >
+                              <EuiListGroupItem
+                                aria-label="recent"
+                                color="subdued"
+                                data-test-subj="collapsibleNavAppLink--recent"
+                                href="http://localhost/recent"
+                                key="title-0"
+                                label="recent"
+                                onClick={[Function]}
+                                showToolTip={false}
+                                size="s"
+                                title="recent"
+                                wrapText={false}
+                              >
+                                <li
+                                  className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                >
+                                  <a
+                                    aria-label="recent"
+                                    className="euiListGroupItem__button"
+                                    data-test-subj="collapsibleNavAppLink--recent"
+                                    href="http://localhost/recent"
+                                    onClick={[Function]}
+                                    rel="noreferrer"
+                                    title="recent"
+                                  >
+                                    <span
+                                      className="euiListGroupItem__label"
+                                      title="recent"
+                                    >
+                                      recent
+                                    </span>
+                                  </a>
+                                </li>
+                              </EuiListGroupItem>
+                            </ul>
+                          </EuiListGroup>
+                        </div>
+                      </div>
+                    </div>
+                  </EuiResizeObserver>
+                </div>
+              </div>
+            </EuiAccordion>
+          </EuiCollapsibleNavGroup>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiFlexItem
+            className="eui-yScroll"
+          >
+            <div
+              className="euiFlexItem eui-yScroll"
+            >
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                iconType="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="opensearchDashboards"
+                onToggle={[Function]}
+                title="OpenSearch Dashboards"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            OpenSearch Dashboards
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                  data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                    data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                                  >
+                                    <div
+                                      data-euiicon-type="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      OpenSearch Dashboards
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, OpenSearch Dashboards"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, OpenSearch Dashboards"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
+                data-test-subj="collapsibleNavGroup-observability"
+                iconType="logoObservability"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="observability"
+                onToggle={[Function]}
+                title="Observability"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="logoObservability"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            Observability
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
+                  data-test-subj="collapsibleNavGroup-observability"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
+                    data-test-subj="collapsibleNavGroup-observability"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="logoObservability"
+                                  >
+                                    <div
+                                      data-euiicon-type="logoObservability"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      Observability
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, Observability"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, Observability"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiShowFor
+                sizes={
+                  Array [
+                    "l",
+                    "xl",
+                  ]
+                }
+              >
+                <EuiCollapsibleNavGroup>
+                  <div
+                    className="euiCollapsibleNavGroup"
+                    id="mockId"
+                  >
+                    <div
+                      className="euiCollapsibleNavGroup__children"
+                    >
+                      <EuiListGroup
+                        flush={true}
+                      >
+                        <ul
+                          className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+                        >
+                          <EuiListGroupItem
+                            aria-label="Dock primary navigation"
+                            buttonRef={
+                              Object {
+                                "current": <button
+                                  aria-label="Dock primary navigation"
+                                  class="euiListGroupItem__button"
+                                  data-test-subj="collapsible-nav-lock"
+                                  type="button"
+                                >
+                                  <div
+                                    class="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                  <span
+                                    class="euiListGroupItem__label"
+                                    title="Dock navigation"
+                                  >
+                                    Dock navigation
+                                  </span>
+                                </button>,
+                              }
+                            }
+                            color="subdued"
+                            data-test-subj="collapsible-nav-lock"
+                            iconType="lockOpen"
+                            label="Dock navigation"
+                            onClick={[Function]}
+                            size="xs"
+                          >
+                            <li
+                              className="euiListGroupItem euiListGroupItem--xSmall euiListGroupItem--subdued euiListGroupItem-isClickable"
+                            >
+                              <button
+                                aria-label="Dock primary navigation"
+                                className="euiListGroupItem__button"
+                                data-test-subj="collapsible-nav-lock"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  className="euiListGroupItem__icon"
+                                  type="lockOpen"
+                                >
+                                  <div
+                                    className="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                </EuiIcon>
+                                <span
+                                  className="euiListGroupItem__label"
+                                  title="Dock navigation"
+                                >
+                                  Dock navigation
+                                </span>
+                              </button>
+                            </li>
+                          </EuiListGroupItem>
+                        </ul>
+                      </EuiListGroup>
+                    </div>
+                  </div>
+                </EuiCollapsibleNavGroup>
+              </EuiShowFor>
+            </div>
+          </EuiFlexItem>
+          <EuiScreenReaderOnly
+            showOnFocus={true}
+          >
+            <EuiButtonEmpty
+              className="euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+              iconType="cross"
+              onClick={[Function]}
+              size="xs"
+              textProps={
+                Object {
+                  "className": "euiCollapsibleNav__closeButtonText",
+                }
+              }
+            >
+              <button
+                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <EuiButtonContent
+                  className="euiButtonEmpty__content"
+                  iconSide="left"
+                  iconType="cross"
+                  textProps={
+                    Object {
+                      "className": "euiButtonEmpty__text euiCollapsibleNav__closeButtonText",
+                    }
+                  }
+                >
+                  <span
+                    className="euiButtonContent euiButtonEmpty__content"
+                  >
+                    <EuiIcon
+                      className="euiButtonContent__icon"
+                      size="m"
+                      type="cross"
+                    >
+                      <div
+                        className="euiButtonContent__icon"
+                        data-euiicon-type="cross"
+                        size="m"
+                      />
+                    </EuiIcon>
+                    <span
+                      className="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+                    >
+                      <EuiI18n
+                        default="close"
+                        token="euiCollapsibleNav.closeButtonLabel"
+                      >
+                        close
+                      </EuiI18n>
+                    </span>
+                  </span>
+                </EuiButtonContent>
+              </button>
+            </EuiButtonEmpty>
+          </EuiScreenReaderOnly>
+        </nav>
+      </div>
+    </EuiFocusTrap>
+  </EuiCollapsibleNav>
+</CollapsibleNav>
+`;
+
+exports[`CollapsibleNav renders the nav bar with custom logo in default mode 1`] = `
+<CollapsibleNav
+  appId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "test",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  basePath={
+    BasePath {
+      "basePath": "/test",
+      "get": [Function],
+      "prepend": [Function],
+      "remove": [Function],
+      "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
+    }
+  }
+  closeNav={[Function]}
+  customNavLink$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  homeHref="/"
+  id="collapsibe-nav"
+  isLocked={false}
+  isNavOpen={true}
+  navLinks$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "inputOutput",
+            "id": "opensearchDashboards",
+            "label": "OpenSearch Dashboards",
+            "order": 1000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "logoObservability",
+            "id": "observability",
+            "label": "Observability",
+            "order": 3000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navigateToApp={[Function]}
+  navigateToUrl={[Function]}
+  onIsLockedUpdate={[Function]}
+  recentlyAccessed$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "id": "recent",
+          "label": "recent",
+          "link": "recent",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  storage={
+    StubBrowserStorage {
+      "keys": Array [],
+      "size": 0,
+      "sizeLimit": 5000000,
+      "values": Array [],
+    }
+  }
+>
+  <EuiCollapsibleNav
+    aria-label="Primary"
+    data-test-subj="collapsibleNav"
+    id="collapsibe-nav"
+    isDocked={false}
+    isOpen={true}
+    onClose={[Function]}
+  >
+    <EuiWindowEvent
+      event="keydown"
+      handler={[Function]}
+    />
+    <EuiOverlayMask
+      headerZindexLocation="below"
+      onClick={[Function]}
+    >
+      <Portal
+        containerInfo={
+          <div
+            class="euiOverlayMask euiOverlayMask--belowHeader"
+          />
+        }
+      />
+    </EuiOverlayMask>
+    <EuiFocusTrap
+      clickOutsideDisables={true}
+      disabled={false}
+    >
+      <div
+        data-eui="EuiFocusTrap"
+      >
+        <nav
+          aria-label="Primary"
+          className="euiCollapsibleNav"
+          data-test-subj="collapsibleNav"
+          id="collapsibe-nav"
+        >
+          <EuiFlexItem
+            grow={false}
+            style={
+              Object {
+                "flexShrink": 0,
+              }
+            }
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+              style={
+                Object {
+                  "flexShrink": 0,
+                }
+              }
+            >
+              <EuiCollapsibleNavGroup
+                background="light"
+                className="eui-yScroll"
+                style={
+                  Object {
+                    "maxHeight": "40vh",
+                  }
+                }
+              >
+                <div
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light eui-yScroll"
+                  id="mockId"
+                  style={
+                    Object {
+                      "maxHeight": "40vh",
+                    }
+                  }
+                >
+                  <div
+                    className="euiCollapsibleNavGroup__children"
+                  >
+                    <EuiListGroup
+                      aria-label="Pinned links"
+                      color="text"
+                      gutterSize="none"
+                      listItems={
+                        Array [
+                          Object {
+                            "href": "/",
+                            "iconType": "home",
+                            "label": "Home",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      maxWidth="none"
+                      size="s"
+                    >
+                      <ul
+                        aria-label="Pinned links"
+                        className="euiListGroup"
+                        style={
+                          Object {
+                            "maxWidth": "none",
+                          }
+                        }
+                      >
+                        <EuiListGroupItem
+                          color="text"
+                          href="/"
+                          iconType="home"
+                          key="title-0"
+                          label="Home"
+                          onClick={[Function]}
+                          showToolTip={false}
+                          size="s"
+                          wrapText={false}
+                        >
+                          <li
+                            className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          >
+                            <a
+                              className="euiListGroupItem__button"
+                              href="/"
+                              onClick={[Function]}
+                              rel="noreferrer"
+                            >
+                              <EuiIcon
+                                className="euiListGroupItem__icon"
+                                type="home"
+                              >
+                                <div
+                                  className="euiListGroupItem__icon"
+                                  data-euiicon-type="home"
+                                />
+                              </EuiIcon>
+                              <span
+                                className="euiListGroupItem__label"
+                                title="Home"
+                              >
+                                Home
+                              </span>
+                            </a>
+                          </li>
+                        </EuiListGroupItem>
+                      </ul>
+                    </EuiListGroup>
+                  </div>
+                </div>
+              </EuiCollapsibleNavGroup>
+            </div>
+          </EuiFlexItem>
+          <EuiCollapsibleNavGroup
+            background="light"
+            data-test-subj="collapsibleNavGroup-recentlyViewed"
+            initialIsOpen={true}
+            isCollapsible={true}
+            key="recentlyViewed"
+            onToggle={[Function]}
+            title="Recently viewed"
+          >
+            <EuiAccordion
+              arrowDisplay="right"
+              buttonClassName="euiCollapsibleNavGroup__heading"
+              buttonContent={
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="m"
+                  responsive={false}
+                >
+                  <EuiFlexItem>
+                    <EuiTitle
+                      size="xxs"
+                    >
+                      <h3
+                        className="euiCollapsibleNavGroup__title"
+                        id="mockId__title"
+                      >
+                        Recently viewed
+                      </h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
+              className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+              data-test-subj="collapsibleNavGroup-recentlyViewed"
+              id="mockId"
+              initialIsOpen={true}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                data-test-subj="collapsibleNavGroup-recentlyViewed"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="mockId"
+                    aria-expanded={true}
+                    className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                    id="mockId"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon euiAccordion__icon-isOpen"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <div
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          data-euiicon-type="arrowRight"
+                          size="m"
+                        />
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="m"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiTitle
+                                size="xxs"
+                              >
+                                <h3
+                                  className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                  id="mockId__title"
+                                >
+                                  Recently viewed
+                                </h3>
+                              </EuiTitle>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  className="euiAccordion__childWrapper"
+                  id="mockId"
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <div
+                          className="euiCollapsibleNavGroup__children"
+                        >
+                          <EuiListGroup
+                            aria-label="Recently viewed links"
+                            className="osdCollapsibleNav__recentsListGroup"
+                            color="subdued"
+                            gutterSize="none"
+                            listItems={
+                              Array [
+                                Object {
+                                  "aria-label": "recent",
+                                  "data-test-subj": "collapsibleNavAppLink--recent",
+                                  "href": "http://localhost/recent",
+                                  "label": "recent",
+                                  "onClick": [Function],
+                                  "title": "recent",
+                                },
+                              ]
+                            }
+                            maxWidth="none"
+                            size="s"
+                          >
+                            <ul
+                              aria-label="Recently viewed links"
+                              className="euiListGroup osdCollapsibleNav__recentsListGroup"
+                              style={
+                                Object {
+                                  "maxWidth": "none",
+                                }
+                              }
+                            >
+                              <EuiListGroupItem
+                                aria-label="recent"
+                                color="subdued"
+                                data-test-subj="collapsibleNavAppLink--recent"
+                                href="http://localhost/recent"
+                                key="title-0"
+                                label="recent"
+                                onClick={[Function]}
+                                showToolTip={false}
+                                size="s"
+                                title="recent"
+                                wrapText={false}
+                              >
+                                <li
+                                  className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                >
+                                  <a
+                                    aria-label="recent"
+                                    className="euiListGroupItem__button"
+                                    data-test-subj="collapsibleNavAppLink--recent"
+                                    href="http://localhost/recent"
+                                    onClick={[Function]}
+                                    rel="noreferrer"
+                                    title="recent"
+                                  >
+                                    <span
+                                      className="euiListGroupItem__label"
+                                      title="recent"
+                                    >
+                                      recent
+                                    </span>
+                                  </a>
+                                </li>
+                              </EuiListGroupItem>
+                            </ul>
+                          </EuiListGroup>
+                        </div>
+                      </div>
+                    </div>
+                  </EuiResizeObserver>
+                </div>
+              </div>
+            </EuiAccordion>
+          </EuiCollapsibleNavGroup>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiFlexItem
+            className="eui-yScroll"
+          >
+            <div
+              className="euiFlexItem eui-yScroll"
+            >
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="/defaultModeLogo"
+                data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                iconType="/defaultModeLogo"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="opensearchDashboards"
+                onToggle={[Function]}
+                title="OpenSearch Dashboards"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="/defaultModeLogo"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            OpenSearch Dashboards
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="/defaultModeLogo"
+                  data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="/defaultModeLogo"
+                    data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="/defaultModeLogo"
+                                  >
+                                    <div
+                                      data-euiicon-type="/defaultModeLogo"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      OpenSearch Dashboards
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, OpenSearch Dashboards"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, OpenSearch Dashboards"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
+                data-test-subj="collapsibleNavGroup-observability"
+                iconType="logoObservability"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="observability"
+                onToggle={[Function]}
+                title="Observability"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="logoObservability"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            Observability
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
+                  data-test-subj="collapsibleNavGroup-observability"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
+                    data-test-subj="collapsibleNavGroup-observability"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="logoObservability"
+                                  >
+                                    <div
+                                      data-euiicon-type="logoObservability"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      Observability
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, Observability"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, Observability"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiShowFor
+                sizes={
+                  Array [
+                    "l",
+                    "xl",
+                  ]
+                }
+              >
+                <EuiCollapsibleNavGroup>
+                  <div
+                    className="euiCollapsibleNavGroup"
+                    id="mockId"
+                  >
+                    <div
+                      className="euiCollapsibleNavGroup__children"
+                    >
+                      <EuiListGroup
+                        flush={true}
+                      >
+                        <ul
+                          className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+                        >
+                          <EuiListGroupItem
+                            aria-label="Dock primary navigation"
+                            buttonRef={
+                              Object {
+                                "current": <button
+                                  aria-label="Dock primary navigation"
+                                  class="euiListGroupItem__button"
+                                  data-test-subj="collapsible-nav-lock"
+                                  type="button"
+                                >
+                                  <div
+                                    class="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                  <span
+                                    class="euiListGroupItem__label"
+                                    title="Dock navigation"
+                                  >
+                                    Dock navigation
+                                  </span>
+                                </button>,
+                              }
+                            }
+                            color="subdued"
+                            data-test-subj="collapsible-nav-lock"
+                            iconType="lockOpen"
+                            label="Dock navigation"
+                            onClick={[Function]}
+                            size="xs"
+                          >
+                            <li
+                              className="euiListGroupItem euiListGroupItem--xSmall euiListGroupItem--subdued euiListGroupItem-isClickable"
+                            >
+                              <button
+                                aria-label="Dock primary navigation"
+                                className="euiListGroupItem__button"
+                                data-test-subj="collapsible-nav-lock"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  className="euiListGroupItem__icon"
+                                  type="lockOpen"
+                                >
+                                  <div
+                                    className="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                </EuiIcon>
+                                <span
+                                  className="euiListGroupItem__label"
+                                  title="Dock navigation"
+                                >
+                                  Dock navigation
+                                </span>
+                              </button>
+                            </li>
+                          </EuiListGroupItem>
+                        </ul>
+                      </EuiListGroup>
+                    </div>
+                  </div>
+                </EuiCollapsibleNavGroup>
+              </EuiShowFor>
+            </div>
+          </EuiFlexItem>
+          <EuiScreenReaderOnly
+            showOnFocus={true}
+          >
+            <EuiButtonEmpty
+              className="euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+              iconType="cross"
+              onClick={[Function]}
+              size="xs"
+              textProps={
+                Object {
+                  "className": "euiCollapsibleNav__closeButtonText",
+                }
+              }
+            >
+              <button
+                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <EuiButtonContent
+                  className="euiButtonEmpty__content"
+                  iconSide="left"
+                  iconType="cross"
+                  textProps={
+                    Object {
+                      "className": "euiButtonEmpty__text euiCollapsibleNav__closeButtonText",
+                    }
+                  }
+                >
+                  <span
+                    className="euiButtonContent euiButtonEmpty__content"
+                  >
+                    <EuiIcon
+                      className="euiButtonContent__icon"
+                      size="m"
+                      type="cross"
+                    >
+                      <div
+                        className="euiButtonContent__icon"
+                        data-euiicon-type="cross"
+                        size="m"
+                      />
+                    </EuiIcon>
+                    <span
+                      className="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+                    >
+                      <EuiI18n
+                        default="close"
+                        token="euiCollapsibleNav.closeButtonLabel"
+                      >
+                        close
+                      </EuiI18n>
+                    </span>
+                  </span>
+                </EuiButtonContent>
+              </button>
+            </EuiButtonEmpty>
+          </EuiScreenReaderOnly>
+        </nav>
+      </div>
+    </EuiFocusTrap>
+  </EuiCollapsibleNav>
+</CollapsibleNav>
+`;
+
+exports[`CollapsibleNav renders the nav bar with custom logo in default mode 2`] = `
+<CollapsibleNav
+  appId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "test",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  basePath={
+    BasePath {
+      "basePath": "/test",
+      "get": [Function],
+      "prepend": [Function],
+      "remove": [Function],
+      "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {},
+    }
+  }
+  closeNav={[Function]}
+  customNavLink$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  homeHref="/"
+  id="collapsibe-nav"
+  isLocked={false}
+  isNavOpen={true}
+  navLinks$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "inputOutput",
+            "id": "opensearchDashboards",
+            "label": "OpenSearch Dashboards",
+            "order": 1000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "logoObservability",
+            "id": "observability",
+            "label": "Observability",
+            "order": 3000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navigateToApp={[Function]}
+  navigateToUrl={[Function]}
+  onIsLockedUpdate={[Function]}
+  recentlyAccessed$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "id": "recent",
+          "label": "recent",
+          "link": "recent",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  storage={
+    StubBrowserStorage {
+      "keys": Array [],
+      "size": 0,
+      "sizeLimit": 5000000,
+      "values": Array [],
+    }
+  }
+>
+  <EuiCollapsibleNav
+    aria-label="Primary"
+    data-test-subj="collapsibleNav"
+    id="collapsibe-nav"
+    isDocked={false}
+    isOpen={true}
+    onClose={[Function]}
+  >
+    <EuiWindowEvent
+      event="keydown"
+      handler={[Function]}
+    />
+    <EuiOverlayMask
+      headerZindexLocation="below"
+      onClick={[Function]}
+    >
+      <Portal
+        containerInfo={
+          <div
+            class="euiOverlayMask euiOverlayMask--belowHeader"
+          />
+        }
+      />
+    </EuiOverlayMask>
+    <EuiFocusTrap
+      clickOutsideDisables={true}
+      disabled={false}
+    >
+      <div
+        data-eui="EuiFocusTrap"
+      >
+        <nav
+          aria-label="Primary"
+          className="euiCollapsibleNav"
+          data-test-subj="collapsibleNav"
+          id="collapsibe-nav"
+        >
+          <EuiFlexItem
+            grow={false}
+            style={
+              Object {
+                "flexShrink": 0,
+              }
+            }
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+              style={
+                Object {
+                  "flexShrink": 0,
+                }
+              }
+            >
+              <EuiCollapsibleNavGroup
+                background="light"
+                className="eui-yScroll"
+                style={
+                  Object {
+                    "maxHeight": "40vh",
+                  }
+                }
+              >
+                <div
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light eui-yScroll"
+                  id="mockId"
+                  style={
+                    Object {
+                      "maxHeight": "40vh",
+                    }
+                  }
+                >
+                  <div
+                    className="euiCollapsibleNavGroup__children"
+                  >
+                    <EuiListGroup
+                      aria-label="Pinned links"
+                      color="text"
+                      gutterSize="none"
+                      listItems={
+                        Array [
+                          Object {
+                            "href": "/",
+                            "iconType": "home",
+                            "label": "Home",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      maxWidth="none"
+                      size="s"
+                    >
+                      <ul
+                        aria-label="Pinned links"
+                        className="euiListGroup"
+                        style={
+                          Object {
+                            "maxWidth": "none",
+                          }
+                        }
+                      >
+                        <EuiListGroupItem
+                          color="text"
+                          href="/"
+                          iconType="home"
+                          key="title-0"
+                          label="Home"
+                          onClick={[Function]}
+                          showToolTip={false}
+                          size="s"
+                          wrapText={false}
+                        >
+                          <li
+                            className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          >
+                            <a
+                              className="euiListGroupItem__button"
+                              href="/"
+                              onClick={[Function]}
+                              rel="noreferrer"
+                            >
+                              <EuiIcon
+                                className="euiListGroupItem__icon"
+                                type="home"
+                              >
+                                <div
+                                  className="euiListGroupItem__icon"
+                                  data-euiicon-type="home"
+                                />
+                              </EuiIcon>
+                              <span
+                                className="euiListGroupItem__label"
+                                title="Home"
+                              >
+                                Home
+                              </span>
+                            </a>
+                          </li>
+                        </EuiListGroupItem>
+                      </ul>
+                    </EuiListGroup>
+                  </div>
+                </div>
+              </EuiCollapsibleNavGroup>
+            </div>
+          </EuiFlexItem>
+          <EuiCollapsibleNavGroup
+            background="light"
+            data-test-subj="collapsibleNavGroup-recentlyViewed"
+            initialIsOpen={true}
+            isCollapsible={true}
+            key="recentlyViewed"
+            onToggle={[Function]}
+            title="Recently viewed"
+          >
+            <EuiAccordion
+              arrowDisplay="right"
+              buttonClassName="euiCollapsibleNavGroup__heading"
+              buttonContent={
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="m"
+                  responsive={false}
+                >
+                  <EuiFlexItem>
+                    <EuiTitle
+                      size="xxs"
+                    >
+                      <h3
+                        className="euiCollapsibleNavGroup__title"
+                        id="mockId__title"
+                      >
+                        Recently viewed
+                      </h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
+              className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+              data-test-subj="collapsibleNavGroup-recentlyViewed"
+              id="mockId"
+              initialIsOpen={true}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                data-test-subj="collapsibleNavGroup-recentlyViewed"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="mockId"
+                    aria-expanded={true}
+                    className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                    id="mockId"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon euiAccordion__icon-isOpen"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <div
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          data-euiicon-type="arrowRight"
+                          size="m"
+                        />
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="m"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiTitle
+                                size="xxs"
+                              >
+                                <h3
+                                  className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                  id="mockId__title"
+                                >
+                                  Recently viewed
+                                </h3>
+                              </EuiTitle>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  className="euiAccordion__childWrapper"
+                  id="mockId"
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <div
+                          className="euiCollapsibleNavGroup__children"
+                        >
+                          <EuiListGroup
+                            aria-label="Recently viewed links"
+                            className="osdCollapsibleNav__recentsListGroup"
+                            color="subdued"
+                            gutterSize="none"
+                            listItems={
+                              Array [
+                                Object {
+                                  "aria-label": "recent",
+                                  "data-test-subj": "collapsibleNavAppLink--recent",
+                                  "href": "http://localhost/recent",
+                                  "label": "recent",
+                                  "onClick": [Function],
+                                  "title": "recent",
+                                },
+                              ]
+                            }
+                            maxWidth="none"
+                            size="s"
+                          >
+                            <ul
+                              aria-label="Recently viewed links"
+                              className="euiListGroup osdCollapsibleNav__recentsListGroup"
+                              style={
+                                Object {
+                                  "maxWidth": "none",
+                                }
+                              }
+                            >
+                              <EuiListGroupItem
+                                aria-label="recent"
+                                color="subdued"
+                                data-test-subj="collapsibleNavAppLink--recent"
+                                href="http://localhost/recent"
+                                key="title-0"
+                                label="recent"
+                                onClick={[Function]}
+                                showToolTip={false}
+                                size="s"
+                                title="recent"
+                                wrapText={false}
+                              >
+                                <li
+                                  className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                >
+                                  <a
+                                    aria-label="recent"
+                                    className="euiListGroupItem__button"
+                                    data-test-subj="collapsibleNavAppLink--recent"
+                                    href="http://localhost/recent"
+                                    onClick={[Function]}
+                                    rel="noreferrer"
+                                    title="recent"
+                                  >
+                                    <span
+                                      className="euiListGroupItem__label"
+                                      title="recent"
+                                    >
+                                      recent
+                                    </span>
+                                  </a>
+                                </li>
+                              </EuiListGroupItem>
+                            </ul>
+                          </EuiListGroup>
+                        </div>
+                      </div>
+                    </div>
+                  </EuiResizeObserver>
+                </div>
+              </div>
+            </EuiAccordion>
+          </EuiCollapsibleNavGroup>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiFlexItem
+            className="eui-yScroll"
+          >
+            <div
+              className="euiFlexItem eui-yScroll"
+            >
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                iconType="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="opensearchDashboards"
+                onToggle={[Function]}
+                title="OpenSearch Dashboards"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            OpenSearch Dashboards
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                  data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                    data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                                  >
+                                    <div
+                                      data-euiicon-type="https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      OpenSearch Dashboards
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, OpenSearch Dashboards"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, OpenSearch Dashboards"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
+                data-test-subj="collapsibleNavGroup-observability"
+                iconType="logoObservability"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="observability"
+                onToggle={[Function]}
+                title="Observability"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="logoObservability"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            Observability
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
+                  data-test-subj="collapsibleNavGroup-observability"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
+                    data-test-subj="collapsibleNavGroup-observability"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="logoObservability"
+                                  >
+                                    <div
+                                      data-euiicon-type="logoObservability"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      Observability
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, Observability"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, Observability"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiShowFor
+                sizes={
+                  Array [
+                    "l",
+                    "xl",
+                  ]
+                }
+              >
+                <EuiCollapsibleNavGroup>
+                  <div
+                    className="euiCollapsibleNavGroup"
+                    id="mockId"
+                  >
+                    <div
+                      className="euiCollapsibleNavGroup__children"
+                    >
+                      <EuiListGroup
+                        flush={true}
+                      >
+                        <ul
+                          className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+                        >
+                          <EuiListGroupItem
+                            aria-label="Dock primary navigation"
+                            buttonRef={
+                              Object {
+                                "current": <button
+                                  aria-label="Dock primary navigation"
+                                  class="euiListGroupItem__button"
+                                  data-test-subj="collapsible-nav-lock"
+                                  type="button"
+                                >
+                                  <div
+                                    class="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                  <span
+                                    class="euiListGroupItem__label"
+                                    title="Dock navigation"
+                                  >
+                                    Dock navigation
+                                  </span>
+                                </button>,
+                              }
+                            }
+                            color="subdued"
+                            data-test-subj="collapsible-nav-lock"
+                            iconType="lockOpen"
+                            label="Dock navigation"
+                            onClick={[Function]}
+                            size="xs"
+                          >
+                            <li
+                              className="euiListGroupItem euiListGroupItem--xSmall euiListGroupItem--subdued euiListGroupItem-isClickable"
+                            >
+                              <button
+                                aria-label="Dock primary navigation"
+                                className="euiListGroupItem__button"
+                                data-test-subj="collapsible-nav-lock"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  className="euiListGroupItem__icon"
+                                  type="lockOpen"
+                                >
+                                  <div
+                                    className="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                </EuiIcon>
+                                <span
+                                  className="euiListGroupItem__label"
+                                  title="Dock navigation"
+                                >
+                                  Dock navigation
                                 </span>
                               </button>
                             </li>

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -5262,6 +5262,18 @@ exports[`Header renders 1`] = `
           "serverBasePath": "/test",
         }
       }
+      branding={
+        Object {
+          "applicationTitle": "OpenSearch Dashboards",
+          "darkMode": false,
+          "logo": Object {
+            "defaultUrl": "/",
+          },
+          "mark": Object {
+            "defaultUrl": "/",
+          },
+        }
+      }
       closeNav={[Function]}
       customNavLink$={
         BehaviorSubject {

--- a/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
@@ -82,6 +82,13 @@ function mockProps() {
     navigateToApp: () => Promise.resolve(),
     navigateToUrl: () => Promise.resolve(),
     customNavLink$: new BehaviorSubject(undefined),
+    branding: {
+      darkMode: false,
+      mark: {
+        defaultUrl: '/defaultModeLogo',
+        darkModeUrl: '/darkModeLogo',
+      },
+    },
   };
 }
 
@@ -205,5 +212,79 @@ describe('CollapsibleNav', () => {
     component.find('[data-test-subj="collapsibleNavGroup-noCategory"] a').simulate('click');
     expect(onClose.callCount).toEqual(3);
     expectNavIsClosed(component);
+  });
+
+  it('renders the nav bar with custom logo in default mode', () => {
+    const navLinks = [
+      mockLink({ category: opensearchDashboards }),
+      mockLink({ category: observability }),
+    ];
+    const recentNavLinks = [mockRecentNavLink({})];
+    const component = mount(
+      <CollapsibleNav
+        {...mockProps()}
+        isNavOpen={true}
+        navLinks$={new BehaviorSubject(navLinks)}
+        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
+      />
+    );
+    // check if nav bar renders default mode custom logo
+    expect(component).toMatchSnapshot();
+
+    // check if nav bar renders the original default mode opensearch mark
+    component.setProps({
+      branding: {
+        darkMode: false,
+        mark: {},
+      },
+    });
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders the nav bar with custom logo in dark mode', () => {
+    const navLinks = [
+      mockLink({ category: opensearchDashboards }),
+      mockLink({ category: observability }),
+    ];
+    const recentNavLinks = [mockRecentNavLink({})];
+    const component = mount(
+      <CollapsibleNav
+        {...mockProps()}
+        isNavOpen={true}
+        navLinks$={new BehaviorSubject(navLinks)}
+        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
+      />
+    );
+    // check if nav bar renders dark mode custom logo
+    component.setProps({
+      branding: {
+        darkMode: true,
+        mark: {
+          defaultUrl: '/defaultModeLogo',
+          darkModeUrl: '/darkModeLogo',
+        },
+      },
+    });
+    expect(component).toMatchSnapshot();
+
+    // check if nav bar renders default mode custom logo
+    component.setProps({
+      branding: {
+        darkMode: true,
+        mark: {
+          defaultUrl: '/defaultModeLogo',
+        },
+      },
+    });
+    expect(component).toMatchSnapshot();
+
+    // check if nav bar renders the original dark mode opensearch mark
+    component.setProps({
+      branding: {
+        darkMode: false,
+        mark: {},
+      },
+    });
+    expect(component).toMatchSnapshot();
   });
 });

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -317,9 +317,7 @@ export function CollapsibleNav({
         {orderedCategories.map((categoryName) => {
           const category = categoryDictionary[categoryName]!;
           const opensearchLinkLogo =
-            category.label === 'OpenSearch Dashboards'
-              ? customSideMenuLogo()
-              : category.euiIconType;
+            category.id === 'opensearchDashboards' ? customSideMenuLogo() : category.euiIconType;
 
           return (
             <EuiCollapsibleNavGroup

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -216,6 +216,7 @@ export function Header({
             }
           }}
           customNavLink$={observables.customNavLink$}
+          branding={branding}
         />
       </header>
     </>

--- a/src/plugins/home/public/application/components/__snapshots__/home.test.js.snap
+++ b/src/plugins/home/public/application/components/__snapshots__/home.test.js.snap
@@ -8,6 +8,7 @@ exports[`home change home route should render a link to change the default route
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -58,6 +59,7 @@ exports[`home directories should not render directory entry when showOnHomePage 
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -108,6 +110,7 @@ exports[`home directories should render ADMIN directory entry in "Manage your da
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -170,6 +173,7 @@ exports[`home directories should render DATA directory entry in "Ingest your dat
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -232,6 +236,7 @@ exports[`home directories should render solutions in the "solution section" 1`] 
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={4}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -335,6 +340,7 @@ exports[`home header render 1`] = `
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -385,6 +391,7 @@ exports[`home header should show "Dev tools" link if console is available 1`] = 
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -447,6 +454,7 @@ exports[`home header should show "Manage" link if stack management is available 
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -497,6 +505,7 @@ exports[`home isNewOpenSearchDashboardsInstance should safely handle execeptions
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -547,6 +556,7 @@ exports[`home isNewOpenSearchDashboardsInstance should set isNewOpenSearchDashbo
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -597,6 +607,7 @@ exports[`home isNewOpenSearchDashboardsInstance should set isNewOpenSearchDashbo
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -647,6 +658,7 @@ exports[`home should render home component 1`] = `
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -697,6 +709,7 @@ exports[`home welcome should show the normal home page if loading fails 1`] = `
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -747,6 +760,7 @@ exports[`home welcome should show the normal home page if welcome screen is disa
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -805,6 +819,7 @@ exports[`home welcome stores skip welcome setting if skipped 1`] = `
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}

--- a/src/plugins/home/public/application/components/home.js
+++ b/src/plugins/home/public/application/components/home.js
@@ -155,6 +155,7 @@ export class Home extends Component {
           showDevToolsLink
           showManagementLink
           title={<FormattedMessage id="home.header.title" defaultMessage="Home" />}
+          branding={getServices().injectedMetadata.getBranding()}
         />
 
         <div className="homContent">

--- a/src/plugins/opensearch_dashboards_overview/public/application.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/application.tsx
@@ -53,6 +53,7 @@ export const renderApp = (
     .filter(({ id }) => id !== 'opensearchDashboards')
     .filter(({ id }) => navLinks.find(({ category, hidden }) => !hidden && category?.id === id));
   const features = home.featureCatalogue.get();
+  const branding = core.injectedMetadata.getBranding();
 
   ReactDOM.render(
     <I18nProvider>
@@ -65,6 +66,7 @@ export const renderApp = (
           newsfeed$={newsfeed$}
           solutions={solutions}
           features={features}
+          branding={branding}
         />
       </OpenSearchDashboardsContextProvider>
     </I18nProvider>,

--- a/src/plugins/opensearch_dashboards_overview/public/components/app.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/app.tsx
@@ -39,6 +39,7 @@ import { NavigationPublicPluginStart } from 'src/plugins/navigation/public';
 import { FetchResult } from 'src/plugins/newsfeed/public';
 import { FeatureCatalogueEntry, FeatureCatalogueSolution } from 'src/plugins/home/public';
 import { Overview } from './overview';
+import { OverviewPluginBranding } from '../plugin';
 
 interface OpenSearchDashboardsOverviewAppDeps {
   basename: string;
@@ -48,6 +49,7 @@ interface OpenSearchDashboardsOverviewAppDeps {
   newsfeed$?: Observable<FetchResult | null | void>;
   solutions: FeatureCatalogueSolution[];
   features: FeatureCatalogueEntry[];
+  branding: OverviewPluginBranding;
 }
 
 export const OpenSearchDashboardsOverviewApp = ({
@@ -55,6 +57,7 @@ export const OpenSearchDashboardsOverviewApp = ({
   newsfeed$,
   solutions,
   features,
+  branding,
 }: OpenSearchDashboardsOverviewAppDeps) => {
   const [newsFetchResult, setNewsFetchResult] = useState<FetchResult | null | void>(null);
 
@@ -73,7 +76,12 @@ export const OpenSearchDashboardsOverviewApp = ({
       <I18nProvider>
         <Switch>
           <Route exact path="/">
-            <Overview newsFetchResult={newsFetchResult} solutions={solutions} features={features} />
+            <Overview
+              newsFetchResult={newsFetchResult}
+              solutions={solutions}
+              features={features}
+              branding={branding}
+            />
           </Route>
         </Switch>
       </I18nProvider>

--- a/src/plugins/opensearch_dashboards_overview/public/components/overview/__snapshots__/overview.test.tsx.snap
+++ b/src/plugins/opensearch_dashboards_overview/public/components/overview/__snapshots__/overview.test.tsx.snap
@@ -70,6 +70,15 @@ exports[`Overview render 1`] = `
         ],
       }
     }
+    branding={
+      Object {
+        "darkMode": false,
+        "mark": Object {
+          "darkModeUrl": "/darkModeUrl",
+          "defaultUrl": "/defaultModeUrl",
+        },
+      }
+    }
     hideToolbar={false}
     iconType="inputOutput"
     title={
@@ -490,6 +499,15 @@ exports[`Overview without features 1`] = `
         ],
       }
     }
+    branding={
+      Object {
+        "darkMode": false,
+        "mark": Object {
+          "darkModeUrl": "/darkModeUrl",
+          "defaultUrl": "/defaultModeUrl",
+        },
+      }
+    }
     hideToolbar={false}
     iconType="inputOutput"
     title={
@@ -908,6 +926,15 @@ exports[`Overview without solutions 1`] = `
             "value": "/plugins/opensearchDashboardsOverview/assets/solutions_solution_4_light_2x.png",
           },
         ],
+      }
+    }
+    branding={
+      Object {
+        "darkMode": false,
+        "mark": Object {
+          "darkModeUrl": "/darkModeUrl",
+          "defaultUrl": "/defaultModeUrl",
+        },
       }
     }
     hideToolbar={false}

--- a/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.test.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.test.tsx
@@ -167,6 +167,14 @@ const mockFeatures = [
   },
 ];
 
+const mockBranding = {
+  darkMode: false,
+  mark: {
+    defaultUrl: '/defaultModeUrl',
+    darkModeUrl: '/darkModeUrl',
+  },
+};
+
 describe('Overview', () => {
   test('render', () => {
     const component = shallowWithIntl(
@@ -174,19 +182,30 @@ describe('Overview', () => {
         newsFetchResult={mockNewsFetchResult}
         solutions={mockSolutions}
         features={mockFeatures}
+        branding={mockBranding}
       />
     );
     expect(component).toMatchSnapshot();
   });
   test('without solutions', () => {
     const component = shallowWithIntl(
-      <Overview newsFetchResult={mockNewsFetchResult} solutions={[]} features={mockFeatures} />
+      <Overview
+        newsFetchResult={mockNewsFetchResult}
+        solutions={[]}
+        features={mockFeatures}
+        branding={mockBranding}
+      />
     );
     expect(component).toMatchSnapshot();
   });
   test('without features', () => {
     const component = shallowWithIntl(
-      <Overview newsFetchResult={mockNewsFetchResult} solutions={mockSolutions} features={[]} />
+      <Overview
+        newsFetchResult={mockNewsFetchResult}
+        solutions={mockSolutions}
+        features={[]}
+        branding={mockBranding}
+      />
     );
     expect(component).toMatchSnapshot();
   });

--- a/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.tsx
@@ -62,17 +62,18 @@ import { AddData } from '../add_data';
 import { GettingStarted } from '../getting_started';
 import { ManageData } from '../manage_data';
 import { NewsFeed } from '../news_feed';
+import { OverviewPluginBranding } from '../../plugin';
 
 const sortByOrder = (featureA: FeatureCatalogueEntry, featureB: FeatureCatalogueEntry) =>
   (featureA.order || Infinity) - (featureB.order || Infinity);
-
 interface Props {
   newsFetchResult: FetchResult | null | void;
   solutions: FeatureCatalogueSolution[];
   features: FeatureCatalogueEntry[];
+  branding: OverviewPluginBranding;
 }
 
-export const Overview: FC<Props> = ({ newsFetchResult, solutions, features }) => {
+export const Overview: FC<Props> = ({ newsFetchResult, solutions, features, branding }) => {
   const [isNewOpenSearchDashboardsInstance, setNewOpenSearchDashboardsInstance] = useState(false);
   const {
     services: { http, data, uiSettings, application },
@@ -155,6 +156,7 @@ export const Overview: FC<Props> = ({ newsFetchResult, solutions, features }) =>
             id="opensearchDashboardsOverview.header.title"
           />
         }
+        branding={branding}
       />
 
       <div className="osdOverviewContent">

--- a/src/plugins/opensearch_dashboards_overview/public/plugin.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/plugin.ts
@@ -41,6 +41,7 @@ import {
   DEFAULT_APP_CATEGORIES,
   AppStatus,
   AppNavLinkStatus,
+  Branding,
 } from '../../../core/public';
 import {
   OpenSearchDashboardsOverviewPluginSetup,
@@ -49,6 +50,9 @@ import {
   AppPluginStartDependencies,
 } from './types';
 import { PLUGIN_ID, PLUGIN_NAME, PLUGIN_PATH, PLUGIN_ICON } from '../common';
+
+/** @public */
+export type OverviewPluginBranding = Branding;
 
 export class OpenSearchDashboardsOverviewPlugin
   implements

--- a/src/plugins/opensearch_dashboards_react/public/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/index.ts
@@ -48,6 +48,10 @@ export { reactToUiComponent, uiToReactComponent } from './adapters';
 export { useUrlTracker } from './use_url_tracker';
 export { toMountPoint, MountPointPortal } from './util';
 export { RedirectAppLinks } from './app_links';
+import { Branding } from 'opensearch-dashboards/public';
+
+/** Custom branding configurations for opensearch dashboards react plugin */
+export type ReactPluginBranding = Branding;
 
 /** dummy plugin, we just want opensearchDashboardsReact to have its own bundle */
 export function plugin() {

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/__snapshots__/overview_page_header.test.tsx.snap
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/__snapshots__/overview_page_header.test.tsx.snap
@@ -1,6 +1,274 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OverviewPageHeader render 1`] = `
+exports[`OverviewPageHeader  in dark mode  render logo as custom dark mode logo 1`] = `
+<header
+  className="osdOverviewPageHeader osdOverviewPageHeader--noOverlap"
+>
+  <div
+    className="osdOverviewPageHeader__inner"
+  >
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <EuiFlexGroup
+          gutterSize="m"
+          responsive={false}
+        >
+          <EuiFlexItem>
+            <EuiTitle
+              size="m"
+            >
+              <h1
+                id="osdOverviewPageHeader__title"
+              >
+                Page Title
+              </h1>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFlexGroup
+          className="osdOverviewPageHeader__actions"
+          responsive={false}
+          wrap={true}
+        >
+          <EuiFlexItem
+            className="osdOverviewPageHeader__actionItem"
+            grow={false}
+          >
+            <mockConstructor
+              application={
+                Object {
+                  "capabilities": Object {
+                    "navLinks": Object {
+                      "dev_tools": true,
+                      "management": true,
+                    },
+                  },
+                }
+              }
+            >
+              <EuiButtonEmpty
+                className="osdOverviewPageHeader__actionButton"
+                flush="both"
+                href="/app/home#/tutorial_directory"
+                iconType="indexOpen"
+              >
+                Add data
+              </EuiButtonEmpty>
+            </mockConstructor>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </div>
+</header>
+`;
+
+exports[`OverviewPageHeader  in dark mode  render logo as custom default mode logo 1`] = `
+<header
+  className="osdOverviewPageHeader osdOverviewPageHeader--noOverlap"
+>
+  <div
+    className="osdOverviewPageHeader__inner"
+  >
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <EuiFlexGroup
+          gutterSize="m"
+          responsive={false}
+        >
+          <EuiFlexItem>
+            <EuiTitle
+              size="m"
+            >
+              <h1
+                id="osdOverviewPageHeader__title"
+              >
+                Page Title
+              </h1>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFlexGroup
+          className="osdOverviewPageHeader__actions"
+          responsive={false}
+          wrap={true}
+        >
+          <EuiFlexItem
+            className="osdOverviewPageHeader__actionItem"
+            grow={false}
+          >
+            <mockConstructor
+              application={
+                Object {
+                  "capabilities": Object {
+                    "navLinks": Object {
+                      "dev_tools": true,
+                      "management": true,
+                    },
+                  },
+                }
+              }
+            >
+              <EuiButtonEmpty
+                className="osdOverviewPageHeader__actionButton"
+                flush="both"
+                href="/app/home#/tutorial_directory"
+                iconType="indexOpen"
+              >
+                Add data
+              </EuiButtonEmpty>
+            </mockConstructor>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </div>
+</header>
+`;
+
+exports[`OverviewPageHeader  in dark mode  render logo as original dark mode opensearch mark 1`] = `
+<header
+  className="osdOverviewPageHeader osdOverviewPageHeader--noOverlap"
+>
+  <div
+    className="osdOverviewPageHeader__inner"
+  >
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <EuiFlexGroup
+          gutterSize="m"
+          responsive={false}
+        >
+          <EuiFlexItem>
+            <EuiTitle
+              size="m"
+            >
+              <h1
+                id="osdOverviewPageHeader__title"
+              >
+                Page Title
+              </h1>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFlexGroup
+          className="osdOverviewPageHeader__actions"
+          responsive={false}
+          wrap={true}
+        >
+          <EuiFlexItem
+            className="osdOverviewPageHeader__actionItem"
+            grow={false}
+          >
+            <mockConstructor
+              application={
+                Object {
+                  "capabilities": Object {
+                    "navLinks": Object {
+                      "dev_tools": true,
+                      "management": true,
+                    },
+                  },
+                }
+              }
+            >
+              <EuiButtonEmpty
+                className="osdOverviewPageHeader__actionButton"
+                flush="both"
+                href="/app/home#/tutorial_directory"
+                iconType="indexOpen"
+              >
+                Add data
+              </EuiButtonEmpty>
+            </mockConstructor>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </div>
+</header>
+`;
+
+exports[`OverviewPageHeader  in default mode  render logo as custom default mode logo 1`] = `
+<header
+  className="osdOverviewPageHeader osdOverviewPageHeader--noOverlap"
+>
+  <div
+    className="osdOverviewPageHeader__inner"
+  >
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <EuiFlexGroup
+          gutterSize="m"
+          responsive={false}
+        >
+          <EuiFlexItem>
+            <EuiTitle
+              size="m"
+            >
+              <h1
+                id="osdOverviewPageHeader__title"
+              >
+                Page Title
+              </h1>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFlexGroup
+          className="osdOverviewPageHeader__actions"
+          responsive={false}
+          wrap={true}
+        >
+          <EuiFlexItem
+            className="osdOverviewPageHeader__actionItem"
+            grow={false}
+          >
+            <mockConstructor
+              application={
+                Object {
+                  "capabilities": Object {
+                    "navLinks": Object {
+                      "dev_tools": true,
+                      "management": true,
+                    },
+                  },
+                }
+              }
+            >
+              <EuiButtonEmpty
+                className="osdOverviewPageHeader__actionButton"
+                flush="both"
+                href="/app/home#/tutorial_directory"
+                iconType="indexOpen"
+              >
+                Add data
+              </EuiButtonEmpty>
+            </mockConstructor>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </div>
+</header>
+`;
+
+exports[`OverviewPageHeader  in default mode  render logo as original default mode opensearch mark 1`] = `
 <header
   className="osdOverviewPageHeader osdOverviewPageHeader--noOverlap"
 >

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.test.tsx
@@ -52,11 +52,76 @@ afterAll(() => jest.clearAllMocks());
 const mockTitle = 'Page Title';
 const addBasePathMock = jest.fn((path: string) => (path ? path : 'path'));
 
-describe('OverviewPageHeader', () => {
-  test('render', () => {
-    const component = shallowWithIntl(
-      <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} />
-    );
-    expect(component).toMatchSnapshot();
+describe('OverviewPageHeader ', () => {
+  describe('in default mode ', () => {
+    test('render logo as custom default mode logo', () => {
+      const branding = {
+        darkMode: false,
+        mark: {
+          defaultUrl: '/defaultModeLogo',
+          darkModeUrl: '/darkModeLogo',
+        },
+      };
+
+      const component = shallowWithIntl(
+        <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} branding={branding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('render logo as original default mode opensearch mark', () => {
+      const branding = {
+        darkMode: false,
+        mark: {},
+      };
+
+      const component = shallowWithIntl(
+        <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} branding={branding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('in dark mode ', () => {
+    test('render logo as custom dark mode logo', () => {
+      const branding = {
+        darkMode: false,
+        mark: {
+          defaultUrl: '/defaultModeLogo',
+          darkModeUrl: '/darkModeLogo',
+        },
+      };
+
+      const component = shallowWithIntl(
+        <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} branding={branding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('render logo as custom default mode logo', () => {
+      const branding = {
+        darkMode: false,
+        mark: {
+          defaultUrl: '/defaultModeLogo',
+        },
+      };
+
+      const component = shallowWithIntl(
+        <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} branding={branding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('render logo as original dark mode opensearch mark', () => {
+      const branding = {
+        darkMode: false,
+        mark: {},
+      };
+
+      const component = shallowWithIntl(
+        <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} branding={branding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/test/functional/apps/visualize/_custom_branding.js
+++ b/test/functional/apps/visualize/_custom_branding.js
@@ -37,6 +37,7 @@ export default function ({ getService, getPageObjects }) {
   const globalNav = getService('globalNav');
   const opensearchArchiver = getService('opensearchArchiver');
   const opensearchDashboardsServer = getService('opensearchDashboardsServer');
+  const appsMenu = getService('appsMenu');
   const PageObjects = getPageObjects(['common', 'home', 'header', 'settings']);
   const testSubjects = getService('testSubjects');
 
@@ -146,6 +147,16 @@ export default function ({ getService, getPageObjects }) {
         expect(actualLabel.toUpperCase()).to.equal(applicationTitle.toUpperCase());
       });
 
+      it('with customized logo for opensearch in side menu', async () => {
+        await appsMenu.openCollapsibleNav();
+        await testSubjects.existOrFail('collapsibleNavGroup-opensearchDashboards');
+        const actualLabel = await testSubjects.getAttribute(
+          'collapsibleNavGroup-opensearchDashboards',
+          'data-test-opensearch-logo'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogo.toUpperCase());
+      });
+
       it('with customized logo in header bar in dark mode', async () => {
         await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
         await PageObjects.settings.toggleAdvancedSettingCheckbox('theme:darkMode');
@@ -166,6 +177,16 @@ export default function ({ getService, getPageObjects }) {
         const actualLabel = await testSubjects.getAttribute(
           'dashboardCustomLogo',
           'data-test-image-url'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogoDarkMode.toUpperCase());
+      });
+
+      it('with customized logo for opensearch in side menu in dark mode', async () => {
+        await appsMenu.openCollapsibleNav();
+        await testSubjects.existOrFail('collapsibleNavGroup-opensearchDashboards');
+        const actualLabel = await testSubjects.getAttribute(
+          'collapsibleNavGroup-opensearchDashboards',
+          'data-test-opensearch-logo'
         );
         expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogoDarkMode.toUpperCase());
       });

--- a/test/functional/apps/visualize/_custom_branding.js
+++ b/test/functional/apps/visualize/_custom_branding.js
@@ -41,14 +41,50 @@ export default function ({ getService, getPageObjects }) {
   const PageObjects = getPageObjects(['common', 'home', 'header', 'settings']);
   const testSubjects = getService('testSubjects');
 
+  const expectedFullLogo =
+    'https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg';
+  const expectedFullLogoDarkMode =
+    'https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_darkmode.svg';
+  const expectedMarkLogo =
+    'https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg';
+  const expectedMarkLogoDarkMode =
+    'https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_darkmode.svg';
+  const applicationTitle = 'OpenSearch';
+  const expectedWelcomeMessage = 'Welcome to OpenSearch';
+
   describe('OpenSearch Dashboards branding configuration', function customHomeBranding() {
+    describe('should render overview page', async () => {
+      this.tags('includeFirefox');
+
+      before(async function () {
+        await PageObjects.common.navigateToApp('home');
+        await PageObjects.common.navigateToApp('opensearch_dashboards_overview');
+      });
+
+      it('with customized logo for opensearch overview header in default mode', async () => {
+        await testSubjects.existOrFail('osdOverviewPageHeaderLogo');
+        const actualLabel = await testSubjects.getAttribute(
+          'osdOverviewPageHeaderLogo',
+          'data-test-logo'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogo.toUpperCase());
+      });
+
+      it('with customized logo for opensearch overview header in dark mode', async () => {
+        await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
+        await PageObjects.settings.toggleAdvancedSettingCheckbox('theme:darkMode');
+        await PageObjects.common.navigateToApp('opensearch_dashboards_overview');
+        await testSubjects.existOrFail('osdOverviewPageHeaderLogo');
+        const actualLabel = await testSubjects.getAttribute(
+          'osdOverviewPageHeaderLogo',
+          'data-test-logo'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogoDarkMode.toUpperCase());
+      });
+    });
+
     describe('should render welcome page', async () => {
       this.tags('includeFirefox');
-      const expectedWelcomeLogo =
-        'https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg';
-      const expectedWelcomeLogoDarkmode =
-        'https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_darkmode.svg';
-      const expectedWelcomeMessage = 'Welcome to OpenSearch';
 
       //unloading any pre-existing settings so the welcome page will appear
       before(async function () {
@@ -76,7 +112,7 @@ export default function ({ getService, getPageObjects }) {
           'welcomeCustomLogo',
           'data-test-image-url'
         );
-        expect(actualLabel.toUpperCase()).to.equal(expectedWelcomeLogo.toUpperCase());
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogo.toUpperCase());
       });
 
       it('with customized title', async () => {
@@ -97,28 +133,25 @@ export default function ({ getService, getPageObjects }) {
           'welcomeCustomLogo',
           'data-test-image-url'
         );
-        expect(actualLabel.toUpperCase()).to.equal(expectedWelcomeLogoDarkmode.toUpperCase());
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogoDarkMode.toUpperCase());
       });
     });
 
     describe('should render home page', async () => {
       this.tags('includeFirefox');
-      const expectedHeaderLogo =
-        'https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg';
-      const expectedHeaderLogoDarkMode =
-        'https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_darkmode.svg';
-      const expectedMarkLogo =
-        'https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg';
-      const expectedMarkLogoDarkMode =
-        'https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_darkmode.svg';
-      const applicationTitle = 'OpenSearch';
 
       before(async function () {
         await PageObjects.common.navigateToApp('home');
       });
 
+      after(async function () {
+        await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
+        await PageObjects.settings.clearAdvancedSettings('theme:darkMode');
+        await PageObjects.common.navigateToApp('home');
+      });
+
       it('with customized logo in header bar', async () => {
-        await globalNav.logoExistsOrFail(expectedHeaderLogo);
+        await globalNav.logoExistsOrFail(expectedFullLogo);
       });
 
       it('with customized logo that can take back to home page', async () => {
@@ -161,7 +194,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
         await PageObjects.settings.toggleAdvancedSettingCheckbox('theme:darkMode');
         await PageObjects.common.navigateToApp('home');
-        await globalNav.logoExistsOrFail(expectedHeaderLogoDarkMode);
+        await globalNav.logoExistsOrFail(expectedFullLogoDarkMode);
       });
 
       it('with customized logo that can take back to home page in dark mode', async () => {


### PR DESCRIPTION
### Description
1. Side Menu Logo

Make side menu opensearch dashboard logo to be configurable. Use config mark.defaultUrl in default mode
and mark.darkModeUrl in dark mode. 
Also replace the original door logo with default opensearch mark in default mode and dark mode opensearch mark
in dark mode. 

<img width="314" alt="Screen Shot 2021-09-26 at 9 07 13 PM" src="https://user-images.githubusercontent.com/43937633/134844050-2d6fed49-1a34-449a-af0d-2f8d791678e1.png">

 
<img width="314" alt="Screen Shot 2021-09-26 at 9 07 28 PM" src="https://user-images.githubusercontent.com/43937633/134844039-0c6dd563-128c-49d5-b460-258fcec829f2.png">

2. Overview Header Logo

Make overview page header logo to be configurable. Use config mark.defaultUrl in default mode
and mark.darkModeUrl in dark mode. 
Also replace the original door logo with default opensearch mark in default mode and dark mode opensearch mark
in dark mode. 

<img width="1131" alt="Screen Shot 2021-09-26 at 10 06 25 PM" src="https://user-images.githubusercontent.com/43937633/134969281-c5ac6eb5-bdb4-4eaf-8226-cc19ac6aa4c7.png">

<img width="1131" alt="Screen Shot 2021-09-26 at 10 06 47 PM" src="https://user-images.githubusercontent.com/43937633/134969293-b5e9db45-c9cf-43be-9c91-c2bd695e64c7.png">

### Details
In default mode, a valid mark.defaultUrl is required for custom side menu logo/custom overview header logo; otherwise, default opensearch mark will be rendered;

In dark mode, a valid mark.darkModeUrl is required for custom side menu logo/custom overview header logo; otherwise, mark.defaultUrl will be rendered; if both invalid, default opensearch dark mode mark will be rendered.

Must provide a valid defaultUrl before providing darkModeUrl.
 
Signed-off-by: Abby Hu <abigailhu2000@gmail.com>

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 