### PR TITLE
[1.x][Bug] Restore timeline legacy functions and filters

### DIFF
--- a/src/plugins/vis_type_timeline/server/series_functions/opensearch/index.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/opensearch/index.js
@@ -92,6 +92,14 @@ export default new Datasource('es', {
       }),
     },
     {
+      name: 'kibana',
+      types: ['boolean', 'null'],
+      help: i18n.translate('timeline.help.functions.opensearch.args.opensearchDashboardsHelpText', {
+        defaultMessage:
+          'Respect filters on OpenSearch Dashboards dashboards. Only has an effect when using on OpenSearch Dashboards dashboards',
+      }),
+    },
+    {
       name: 'opensearchDashboards',
       types: ['boolean', 'null'],
       help: i18n.translate('timeline.help.functions.opensearch.args.opensearchDashboardsHelpText', {
@@ -110,7 +118,7 @@ export default new Datasource('es', {
   help: i18n.translate('timeline.help.functions.opensearchHelpText', {
     defaultMessage: 'Pull data from an opensearch instance',
   }),
-  aliases: ['es'],
+  aliases: ['elasticsearch', 'opensearch'],
   fn: async function opensearchFn(args, tlConfig) {
     const config = _.defaults(_.clone(args.byName), {
       q: '*',
@@ -118,6 +126,7 @@ export default new Datasource('es', {
       index: tlConfig.settings['timeline:es.default_index'],
       timefield: tlConfig.settings['timeline:es.timefield'],
       interval: tlConfig.time.interval,
+      kibana: true,
       opensearchDashboards: true,
       fit: 'nearest',
     });

--- a/src/plugins/vis_type_timeline/server/series_functions/opensearch/lib/build_request.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/opensearch/lib/build_request.js
@@ -50,9 +50,9 @@ export default function buildRequest(config, tlConfig, scriptedFields, timeout) 
   };
   bool.must.push(timeFilter);
 
-  // Use the opensearchDashboards filter bar filters
-  if (config.opensearchDashboards) {
-    bool.filter = _.get(tlConfig, 'request.body.extended.opensearch.filter');
+  // Use the opensearchDashboards and kibana filter bar filters
+  if (config.opensearchDashboards && config.kibana) {
+    bool.filter = _.get(tlConfig, 'request.body.extended.es.filter');
   }
 
   const aggs = {

--- a/src/plugins/vis_type_timeline/server/series_functions/opensearch/opensearch.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/opensearch/opensearch.test.js
@@ -264,7 +264,7 @@ describe('opensearch', () => {
           request: {
             body: {
               extended: {
-                opensearch: {
+                es: {
                   filter: {
                     bool: {
                       must: [{ query: { query_string: { query: 'foo' } } }],
@@ -281,8 +281,9 @@ describe('opensearch', () => {
         });
       });
 
-      it('adds the contents of body.extended.opensearch.filter to a filter clause of the bool', () => {
+      it('adds the contents of body.extended.es.filter to a filter clause of the bool', () => {
         config.opensearchDashboards = true;
+        config.kibana = true;
         const request = fn(config, tlConfig, emptyScriptedFields);
         const filter = request.params.body.query.bool.filter.bool;
         expect(filter.must.length).to.eql(1);
@@ -291,6 +292,21 @@ describe('opensearch', () => {
 
       it('does not include filters if config.opensearchDashboards = false', () => {
         config.opensearchDashboards = false;
+        config.kibana = true;
+        const request = fn(config, tlConfig, emptyScriptedFields);
+        expect(request.params.body.query.bool.filter).to.eql(undefined);
+      });
+
+      it('does not include filters if config.kibana = false', () => {
+        config.opensearchDashboards = true;
+        config.kibana = false;
+        const request = fn(config, tlConfig, emptyScriptedFields);
+        expect(request.params.body.query.bool.filter).to.eql(undefined);
+      });
+
+      it('does not include filters if config.opensearchDashboards = false and config.kibana = false', () => {
+        config.opensearchDashboards = false;
+        config.kibana = false;
         const request = fn(config, tlConfig, emptyScriptedFields);
         expect(request.params.body.query.bool.filter).to.eql(undefined);
       });

--- a/test/functional/apps/timeline/_expression_typeahead.js
+++ b/test/functional/apps/timeline/_expression_typeahead.js
@@ -52,7 +52,7 @@ export default function ({ getPageObjects }) {
       await PageObjects.timeline.setExpression('.es');
       await PageObjects.timeline.clickSuggestion();
       const suggestions = await PageObjects.timeline.getSuggestionItemsText();
-      expect(suggestions.length).to.eql(9);
+      expect(suggestions.length).to.eql(10);
       expect(suggestions[0].includes('fit=')).to.eql(true);
     });
 


### PR DESCRIPTION
### Description
While renaming we changed values from legacy naming schema to
OpenSearch Dashboards naming schema. However, after realizing
we impacted backwards compatibility, we restored some of the
"under the hood" components backed to legacy application to
allow for seemless migration.

However, upon attempting to restore Timeline to work with saved
objects we neglected to restore the Timeline functions.

Previously users could set kibana=false to ignore filters on
the dashboards being applied to their Timeline visualizations.
Now, if users tried to set it then it would fail because it
didn't know what that function was.

This commit fixes this issue by keeping the update since we
do not want to impact people who have now updated their functions
and re-added the legacy functions.

In this commit, I also restore the aliases for "elasticsearch" and
now included "opensearch" for Timeline queries.

Finally, the key was incorrect for actually accessing the filter
so it never applied the filters in the default state.

Issue resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/820

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/825

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>