### PR TITLE
Redirect URL not allowed

### DIFF
--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -317,7 +317,7 @@ export class RenderingService {
       this.logger.get('branding').info(configName + ' config is not found or invalid.');
       return false;
     }
-    return await Axios.get(url, { adapter: AxiosHttpAdapter })
+    return await Axios.get(url, { adapter: AxiosHttpAdapter, maxRedirects: 0 })
       .then(() => {
         return true;
       })


### PR DESCRIPTION
Add an additional parameter to the checkUrlValid function
so that max redirect count is 0. We do not allow URLs that
can be redirected because of potential security issues.

Signed-off-by: Abby Hu <abigailhu2000@gmail.com>

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 