### PR TITLE
[1.x] Fix yarn build docs and update test

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -66,7 +66,7 @@ access it.
 
 ### Building the artifacts
 
-To build the archives for each platform,  run the following:
+To build the artifacts for all supported platforms,  run the following:
 
 ```
 yarn build --skip-os-packages

--- a/src/dev/build/args.test.ts
+++ b/src/dev/build/args.test.ts
@@ -67,8 +67,34 @@ it('build dist for current platform, without packages, by default', () => {
   `);
 });
 
-it('build dist for linux x64 platform, without packages, if --linux-x64 is passed', () => {
-  expect(readCliArgs(['node', 'scripts/build-platform'])).toMatchInlineSnapshot(`
+it('build dist for linux x64 platform, without packages, if --linux is passed', () => {
+  expect(readCliArgs(['node', 'scripts/build-platform', '--linux'])).toMatchInlineSnapshot(`
+    Object {
+      "buildOptions": Object {
+        "createArchives": true,
+        "createDebPackage": false,
+        "createDockerPackage": false,
+        "createDockerUbiPackage": false,
+        "createRpmPackage": false,
+        "downloadFreshNode": true,
+        "isRelease": false,
+        "targetAllPlatforms": false,
+        "targetPlatforms": Object {
+          "darwin": false,
+          "linux": true,
+          "linuxArm": false,
+        },
+        "versionQualifier": "",
+      },
+      "log": <ToolingLog>,
+      "showHelp": false,
+      "unknownFlags": Array [],
+    }
+  `);
+});
+
+it('build dist for linux arm64 platform, without packages, if --linux-arm is passed', () => {
+  expect(readCliArgs(['node', 'scripts/build-platform', '--linux-arm'])).toMatchInlineSnapshot(`
     Object {
       "buildOptions": Object {
         "createArchives": true,
@@ -82,7 +108,7 @@ it('build dist for linux x64 platform, without packages, if --linux-x64 is passe
         "targetPlatforms": Object {
           "darwin": false,
           "linux": false,
-          "linuxArm": false,
+          "linuxArm": true,
         },
         "versionQualifier": "",
       },
@@ -93,8 +119,8 @@ it('build dist for linux x64 platform, without packages, if --linux-x64 is passe
   `);
 });
 
-it('build dist for linux x64 platform, without packages, if --linux-arm64 is passed', () => {
-  expect(readCliArgs(['node', 'scripts/build-platform'])).toMatchInlineSnapshot(`
+it('build dist for darwin x64 platform, without packages, if --darwin is passed', () => {
+  expect(readCliArgs(['node', 'scripts/build-platform', '--darwin'])).toMatchInlineSnapshot(`
     Object {
       "buildOptions": Object {
         "createArchives": true,
@@ -106,33 +132,7 @@ it('build dist for linux x64 platform, without packages, if --linux-arm64 is pas
         "isRelease": false,
         "targetAllPlatforms": false,
         "targetPlatforms": Object {
-          "darwin": false,
-          "linux": false,
-          "linuxArm": false,
-        },
-        "versionQualifier": "",
-      },
-      "log": <ToolingLog>,
-      "showHelp": false,
-      "unknownFlags": Array [],
-    }
-  `);
-});
-
-it('build dist for linux x64 platform, without packages, if --darwin-x64 is passed', () => {
-  expect(readCliArgs(['node', 'scripts/build-platform'])).toMatchInlineSnapshot(`
-    Object {
-      "buildOptions": Object {
-        "createArchives": true,
-        "createDebPackage": false,
-        "createDockerPackage": false,
-        "createDockerUbiPackage": false,
-        "createRpmPackage": false,
-        "downloadFreshNode": true,
-        "isRelease": false,
-        "targetAllPlatforms": false,
-        "targetPlatforms": Object {
-          "darwin": false,
+          "darwin": true,
           "linux": false,
           "linuxArm": false,
         },

--- a/src/dev/build/cli.ts
+++ b/src/dev/build/cli.ts
@@ -55,9 +55,9 @@ if (showHelp) {
         --skip-archives         {dim Don't produce tar/zip archives}
         --skip-os-packages      {dim Don't produce rpm/deb/docker packages}
         --all-platforms         {dim Produce archives for all platforms, not just this one}
-        --linux-x64             {dim Produce archives for only linux x64 platform}
-        --linux-arm64           {dim Produce archives for only linux arm64 platform}
-        --darwin-x64            {dim Produce archives for only darwin x64 platform}
+        --linux                 {dim Produce archives for only linux x64 platform}
+        --linux-arm             {dim Produce archives for only linux arm64 platform}
+        --darwin                {dim Produce archives for only darwin x64 platform}
         --rpm                   {dim Only build the rpm package}
         --deb                   {dim Only build the deb package}
         --docker                {dim Only build the docker image}


### PR DESCRIPTION
yarn build flags in /src/dev/build/cli.ts are not updated to match
the renamed flags in de-couple PR (#795). This PR fixes the issue
and update the tests. Also modify words in DEVELOPER_GUIDE.md.

PR resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/836

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/840

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 