### PR TITLE
feat(router-proxy): added support for proxy endpoint

### DIFF
--- a/src/core/server/http/http_server.ts
+++ b/src/core/server/http/http_server.ts
@@ -247,6 +247,10 @@ export class HttpServer {
           },
         });
       }
+
+      for (const proxy of router.getProxies()) {
+        this.server.route(proxy);
+      }
     }
 
     await this.server.start();

--- a/src/core/server/http/router/router.mock.ts
+++ b/src/core/server/http/router/router.mock.ts
@@ -44,6 +44,8 @@ function create({ routerPath = '' }: { routerPath?: string } = {}): RouterMock {
     patch: jest.fn(),
     getRoutes: jest.fn(),
     handleLegacyErrors: jest.fn().mockImplementation((handler) => handler),
+    proxy: jest.fn(),
+    getProxies: jest.fn(),
   };
 }
 


### PR DESCRIPTION
### Description
Implements proxy method in the Router interface that uses the proxy option of hapi.js server. Allow clients to redirect app requests to a custom backend server.
 
### Issues Resolved
1. #854 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 