### PR TITLE
[1.1][Build] fail silently on register git hook failure

### DIFF
--- a/packages/osd-dev-utils/src/precommit_hook/cli.ts
+++ b/packages/osd-dev-utils/src/precommit_hook/cli.ts
@@ -36,16 +36,26 @@ import { promisify } from 'util';
 import { REPO_ROOT } from '@osd/utils';
 
 import { run } from '../run';
+import { createFailError, isFailError } from '../run';
 import { SCRIPT_SOURCE } from './script_source';
 import { getGitDir } from './get_git_dir';
 
 const chmodAsync = promisify(chmod);
 const writeFileAsync = promisify(writeFile);
 
+function validateGitDir(gitDir: string) {
+  if (gitDir === '--git-common-dir') {
+    throw createFailError(
+      `--git-common-dir not accessible on current git version. Skipping installation of pre-commit git hook.`
+    );
+  }
+}
+
 run(
   async ({ log }) => {
     try {
       const gitDir = await getGitDir();
+      validateGitDir(gitDir);
       const installPath = Path.resolve(REPO_ROOT, gitDir, 'hooks/pre-commit');
 
       log.info(`Registering OpenSearch Dashboards pre-commit git hook...`);
@@ -53,6 +63,9 @@ run(
       await chmodAsync(installPath, 0o755);
       log.success(`OpenSearch Dashboards pre-commit git hook was installed successfully.`);
     } catch (e) {
+      if (isFailError(e)) {
+        return;
+      }
       log.error(`OpenSearch Dashboards pre-commit git hook was not installed as an error occur.`);
       throw e;
     }


### PR DESCRIPTION
Note: This does not have to be released. This is purely for build purposes since we have been building towards 1.1.
---
`node scripts/register_git_hook` fails depending on the installed
git version because it ends up calling `git rev-parse --git-common-dir`.
Depending on the git version, `--git-common-dir` returns the literal
string `--git-common-dir` when it is suppose to return $GIT_COMMON_DIR
if set and $GIT_DIR if the previous is not set. Then it proceeds to try
to install from a path that doesn't exist because it will use
`--git-common-dir` in the path.

The goal for this fix is to bypass hard failures in 1.x since I do
not believe it is appropriate to fail building something due to git.
But I do not want to just remove adding the pre-commit git hook
if people are already used to it being installed while bootstrapping.

Here, I propose the removal of git hooks on bootstrap in a 2+ version
of Dashboards:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/851

Issue resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/850

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/852

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>