### PR TITLE
[1.x][Purify] remove references to non-existent versions

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -14,8 +14,6 @@
 
 # Specifies whether OpenSearch Dashboards should rewrite requests that are prefixed with
 # `server.basePath` or require that they are rewritten by your reverse proxy.
-# This setting was effectively always `false` before OpenSearch Dashboards 6.3 and will
-# default to `true` starting in OpenSearch Dashboards 7.0.
 #server.rewriteBasePath: false
 
 # The maximum payload size in bytes for incoming server requests.

--- a/src/core/server/config/deprecation/core_deprecations.test.ts
+++ b/src/core/server/config/deprecation/core_deprecations.test.ts
@@ -100,7 +100,7 @@ describe('core deprecations', () => {
       });
       expect(messages).toMatchInlineSnapshot(`
         Array [
-          "It is not recommended to disable xsrf protections for API endpoints via [server.xsrf.whitelist]. It will be removed in 8.0 release. Instead, supply the \\"osd-xsrf\\" header.",
+          "It is not recommended to disable xsrf protections for API endpoints via [server.xsrf.whitelist]. Instead, supply the \\"osd-xsrf\\" header.",
         ]
       `);
     });
@@ -115,7 +115,7 @@ describe('core deprecations', () => {
       });
       expect(messages).toMatchInlineSnapshot(`
         Array [
-          "You should set server.basePath along with server.rewriteBasePath. Starting in 7.0, OpenSearch Dashboards will expect that all requests start with server.basePath rather than expecting you to rewrite the requests in your reverse proxy. Set server.rewriteBasePath to false to preserve the current behavior and silence this warning.",
+          "You should set server.basePath along with server.rewriteBasePath. OpenSearch Dashboards will expect that all requests start with server.basePath rather than expecting you to rewrite the requests in your reverse proxy. Set server.rewriteBasePath to false to preserve the current behavior and silence this warning.",
         ]
       `);
     });

--- a/src/core/server/config/deprecation/core_deprecations.ts
+++ b/src/core/server/config/deprecation/core_deprecations.ts
@@ -55,7 +55,7 @@ const xsrfDeprecation: ConfigDeprecation = (settings, fromPath, log) => {
   if ((settings.server?.xsrf?.whitelist ?? []).length > 0) {
     log(
       'It is not recommended to disable xsrf protections for API endpoints via [server.xsrf.whitelist]. ' +
-        'It will be removed in 8.0 release. Instead, supply the "osd-xsrf" header.'
+        'Instead, supply the "osd-xsrf" header.'
     );
   }
   return settings;
@@ -64,7 +64,7 @@ const xsrfDeprecation: ConfigDeprecation = (settings, fromPath, log) => {
 const rewriteBasePathDeprecation: ConfigDeprecation = (settings, fromPath, log) => {
   if (has(settings, 'server.basePath') && !has(settings, 'server.rewriteBasePath')) {
     log(
-      'You should set server.basePath along with server.rewriteBasePath. Starting in 7.0, OpenSearch Dashboards ' +
+      'You should set server.basePath along with server.rewriteBasePath. OpenSearch Dashboards ' +
         'will expect that all requests start with server.basePath rather than expecting you to rewrite ' +
         'the requests in your reverse proxy. Set server.rewriteBasePath to false to preserve the ' +
         'current behavior and silence this warning.'
@@ -118,7 +118,7 @@ const mapManifestServiceUrlDeprecation: ConfigDeprecation = (settings, fromPath,
   if (has(settings, 'map.manifestServiceUrl')) {
     log(
       'You should no longer use the map.manifestServiceUrl setting in opensearch_dashboards.yml to configure the location ' +
-        'of the Elastic Maps Service settings. These settings have moved to the "map.emsTileApiUrl" and ' +
+        'of the Maps Service settings. These settings have moved to the "map.emsTileApiUrl" and ' +
         '"map.emsFileApiUrl" settings instead. These settings are for development use only and should not be ' +
         'modified for use in production environments.'
     );


### PR DESCRIPTION
### Description
Remove references to versions of OpenSearch Dashboards that do
not yet exist but carried over from the legacy application.

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/859

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>