### PR TITLE
Add ARM build for re2

### DIFF
--- a/src/dev/build/tasks/patch_native_modules_task.ts
+++ b/src/dev/build/tasks/patch_native_modules_task.ts
@@ -54,15 +54,19 @@ const packages: Package[] = [
     destinationPath: 'node_modules/re2/build/Release/re2.node',
     extractMethod: 'gunzip',
     archives: {
-      darwin: {
+      'darwin-x64': {
         url: 'https://github.com/uhop/node-re2/releases/download/1.15.4/darwin-x64-64.gz',
         sha256: '595c6653d796493ddb288fc0732a0d1df8560099796f55a1dd242357d96bb8d6',
       },
-      linux: {
+      'linux-x64': {
         url: 'https://github.com/uhop/node-re2/releases/download/1.15.4/linux-x64-64.gz',
         sha256: 'e743587bc96314edf10c3e659c03168bc374a5cd9a6623ee99d989251e331f28',
       },
-      win32: {
+      'linux-arm64': {
+        url: 'https://d1v1sj258etie.cloudfront.net/node-re2/1.15.4/linux-arm64-64.gz',
+        sha256: '19fa97f39d4965276382429bcd932dd696915f711663e7cef9b0a304b3e8e6f7',
+      },
+      'win32-x64': {
         url: 'https://github.com/uhop/node-re2/releases/download/1.15.4/win32-x64-64.gz',
         sha256: 'b33de62cda24fb02dc80a19fb79977d686468ac746e97cd211059d2d4c75d529',
       },
@@ -92,7 +96,7 @@ async function patchModule(
       `Can't patch ${pkg.name}'s native module, we were expecting version ${pkg.version} and found ${installedVersion}`
     );
   }
-  const platformName = platform.getName();
+  const platformName = platform.getNodeArch();
   const archive = pkg.archives[platformName];
   const archiveName = path.basename(archive.url);
   const downloadPath = config.resolveFromRepo(DOWNLOAD_DIRECTORY, pkg.name, archiveName);


### PR DESCRIPTION
### Description
In Timeline, we use node-re2 for the regular expressions specified by
the end users. Currently, re2 doesn't have an ARM build and returns an
error. To solve this issue, we create an linux-arm64-64.gz and store it.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/660

### Test Result 
1) Tested and verified in graviton2 instance with OS 1.1 and OSD 1.1.

Before the change:
<img width="785" alt="Screen Shot 2021-10-24 at 2 32 27 PM" src="https://user-images.githubusercontent.com/79961084/138613794-50b4dda2-6ade-44a3-ae5c-cb1afdfc0271.png">

After the change:
<img width="1579" alt="Screen Shot 2021-10-24 at 2 19 35 PM" src="https://user-images.githubusercontent.com/79961084/138613798-708cae1b-69f3-4a1e-8831-e3d36a9456ee.png">

2) Tested the build `yarn build --skip-os-packages` and below is the relevant console logs which show that all the platforms can fetch correct platform build for node-re2.

```
platform: Platform { name: 'linux', architecture: 'x64', buildName: 'linux-x64' }
platformName: linux-x64
pkg.archives: { 'darwin-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/darwin-x64-64.gz',
     sha256:
      '595c6653d796493ddb288fc0732a0d1df8560099796f55a1dd242357d96bb8d6' },
  'linux-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/linux-x64-64.gz',
     sha256:
      'e743587bc96314edf10c3e659c03168bc374a5cd9a6623ee99d989251e331f28' },
  'linux-arm64':
   { url:
      'https://d1v1sj258etie.cloudfront.net/node-re2/1.15.4/linux-arm64-64.gz',
     sha256:
      '19fa97f39d4965276382429bcd932dd696915f711663e7cef9b0a304b3e8e6f7' },
  'win32-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/win32-x64-64.gz',
     sha256:
      'b33de62cda24fb02dc80a19fb79977d686468ac746e97cd211059d2d4c75d529' } }
archive: { url:
   'https://github.com/uhop/node-re2/releases/download/1.15.4/linux-x64-64.gz',
  sha256:
   'e743587bc96314edf10c3e659c03168bc374a5cd9a6623ee99d989251e331f28' }
archiveName: linux-x64-64.gz
   │ debg Patching re2 binaries from https://github.com/uhop/node-re2/releases/download/1.15.4/linux-x64-64.gz to /home/anan/work/OpenSearch-Dashboards/build/opensearch-dashboards-1.1.0-SNAPSHOT-linux-x64/node_modules/re2/build/Release/re2.node
   │ debg Deleting patterns: [ '/home/anan/work/OpenSearch-Dashboards/build/opensearch-dashboards-1.1.0-SNAPSHOT-linux-x64/node_modules/re2/build/Release/re2.node' ]
platform: Platform {
  name: 'linux',
  architecture: 'arm64',
  buildName: 'linux-arm64' }
platformName: linux-arm64
pkg.archives: { 'darwin-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/darwin-x64-64.gz',
     sha256:
      '595c6653d796493ddb288fc0732a0d1df8560099796f55a1dd242357d96bb8d6' },
  'linux-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/linux-x64-64.gz',
     sha256:
      'e743587bc96314edf10c3e659c03168bc374a5cd9a6623ee99d989251e331f28' },
  'linux-arm64':
   { url:
      'https://d1v1sj258etie.cloudfront.net/node-re2/1.15.4/linux-arm64-64.gz',
     sha256:
      '19fa97f39d4965276382429bcd932dd696915f711663e7cef9b0a304b3e8e6f7' },
  'win32-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/win32-x64-64.gz',
     sha256:
      'b33de62cda24fb02dc80a19fb79977d686468ac746e97cd211059d2d4c75d529' } }
archive: { url:
   'https://d1v1sj258etie.cloudfront.net/node-re2/1.15.4/linux-arm64-64.gz',
  sha256:
   '19fa97f39d4965276382429bcd932dd696915f711663e7cef9b0a304b3e8e6f7' }
archiveName: linux-arm64-64.gz
   │ debg Patching re2 binaries from https://d1v1sj258etie.cloudfront.net/node-re2/1.15.4/linux-arm64-64.gz to /home/anan/work/OpenSearch-Dashboards/build/opensearch-dashboards-1.1.0-SNAPSHOT-linux-arm64/node_modules/re2/build/Release/re2.node
   │ debg Deleting patterns: [ '/home/anan/work/OpenSearch-Dashboards/build/opensearch-dashboards-1.1.0-SNAPSHOT-linux-arm64/node_modules/re2/build/Release/re2.node' ]
platform: Platform { name: 'darwin', architecture: 'x64', buildName: 'darwin-x64' }
platformName: darwin-x64
pkg.archives: { 'darwin-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/darwin-x64-64.gz',
     sha256:
      '595c6653d796493ddb288fc0732a0d1df8560099796f55a1dd242357d96bb8d6' },
  'linux-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/linux-x64-64.gz',
     sha256:
      'e743587bc96314edf10c3e659c03168bc374a5cd9a6623ee99d989251e331f28' },
  'linux-arm64':
   { url:
      'https://d1v1sj258etie.cloudfront.net/node-re2/1.15.4/linux-arm64-64.gz',
     sha256:
      '19fa97f39d4965276382429bcd932dd696915f711663e7cef9b0a304b3e8e6f7' },
  'win32-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/win32-x64-64.gz',
     sha256:
      'b33de62cda24fb02dc80a19fb79977d686468ac746e97cd211059d2d4c75d529' } }
archive: { url:
   'https://github.com/uhop/node-re2/releases/download/1.15.4/darwin-x64-64.gz',
  sha256:
   '595c6653d796493ddb288fc0732a0d1df8560099796f55a1dd242357d96bb8d6' }
archiveName: darwin-x64-64.gz
   │ debg Patching re2 binaries from https://github.com/uhop/node-re2/releases/download/1.15.4/darwin-x64-64.gz to /home/anan/work/OpenSearch-Dashboards/build/opensearch-dashboards-1.1.0-SNAPSHOT-darwin-x64/node_modules/re2/build/Release/re2.node
   │ debg Deleting patterns: [ '/home/anan/work/OpenSearch-Dashboards/build/opensearch-dashboards-1.1.0-SNAPSHOT-darwin-x64/node_modules/re2/build/Release/re2.node' ]
platform: Platform { name: 'win32', architecture: 'x64', buildName: 'windows-x64' }
platformName: win32-x64
pkg.archives: { 'darwin-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/darwin-x64-64.gz',
     sha256:
      '595c6653d796493ddb288fc0732a0d1df8560099796f55a1dd242357d96bb8d6' },
  'linux-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/linux-x64-64.gz',
     sha256:
      'e743587bc96314edf10c3e659c03168bc374a5cd9a6623ee99d989251e331f28' },
  'linux-arm64':
   { url:
      'https://d1v1sj258etie.cloudfront.net/node-re2/1.15.4/linux-arm64-64.gz',
     sha256:
      '19fa97f39d4965276382429bcd932dd696915f711663e7cef9b0a304b3e8e6f7' },
  'win32-x64':
   { url:
      'https://github.com/uhop/node-re2/releases/download/1.15.4/win32-x64-64.gz',
     sha256:
      'b33de62cda24fb02dc80a19fb79977d686468ac746e97cd211059d2d4c75d529' } }
archive: { url:
   'https://github.com/uhop/node-re2/releases/download/1.15.4/win32-x64-64.gz',
  sha256:
   'b33de62cda24fb02dc80a19fb79977d686468ac746e97cd211059d2d4c75d529' }
archiveName: win32-x64-64.gz
   │ debg Patching re2 binaries from https://github.com/uhop/node-re2/releases/download/1.15.4/win32-x64-64.gz to /home/anan/work/OpenSearch-Dashboards/build/opensearch-dashboards-1.1.0-SNAPSHOT-windows-x64/node_modules/re2/build/Release/re2.node
```
Also verify the following build:
```
yarn build-platform --linux
yarn build-platform --linux-arm
yarn build-platform --darwin
```

Signed-off-by: Anan Zhuang <ananzh@amazon.com>


 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 