### PR TITLE
Add bwc cypress test for osd without bundles

### DIFF
--- a/cypress/integration/osd/check_advanced_settings.js
+++ b/cypress/integration/osd/check_advanced_settings.js
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/* es-lint-disable for missing definitions */
+/* eslint-disable */
+import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+  
+const miscUtils = new MiscUtils(cy);
+  
+describe('verify the advanced settings are saved', () => {
+  beforeEach(() => {
+    miscUtils.visitPage('app/management/opensearch-dashboards/settings');
+  });
+  
+  it('the dark mode is on', () => {
+    cy.get('[data-test-subj="advancedSetting-editField-theme:darkMode"]')
+      .invoke('attr', 'aria-checked')
+      .should('eq', 'true');
+  });
+  
+  it('the Timeline default columns field is set to 4', () => {
+    cy.get('[data-test-subj="advancedSetting-editField-timeline:default_columns"]').should(
+      'have.value',
+      4
+    );
+  });
+  
+  it('the Timeline Maximum buckets field is set to 4', () => {
+    cy.get('[data-test-subj="advancedSetting-editField-timeline:max_buckets"]').should(
+      'have.value',
+      4
+    );
+  });
+});

--- a/cypress/integration/osd/check_default_page.js
+++ b/cypress/integration/osd/check_default_page.js
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/* es-lint-disable for missing definitions */
+/* eslint-disable */
+import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+  
+const miscUtils = new MiscUtils(cy);
+  
+describe('verify default landing page work for bwc', () => {
+  beforeEach(() => {
+    miscUtils.visitPage('');
+  });
+  
+  it('the overview page is set as the default landing pag', () => {
+    cy.url().should('include', '/app/opensearch_dashboards_overview#/');
+    cy.contains('Display a different page on log in');
+  });
+});

--- a/cypress/integration/osd/check_filter_and_query.js
+++ b/cypress/integration/osd/check_filter_and_query.js
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/* es-lint-disable for missing definitions */
+/* eslint-disable */
+import {
+  MiscUtils,
+  CommonUI
+} from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+
+const commonUI = new CommonUI(cy);
+const miscUtils = new MiscUtils(cy);
+
+describe('verify dashboards filter and query work properly for bwc', () => {
+  beforeEach(() => {
+    miscUtils.visitPage('app/dashboards#');
+  });
+
+  afterEach(() => {
+    cy.clearCookies();
+  });
+
+  describe('osx filter and query should work in [Logs] Web Traffic dashboards', () => {
+    beforeEach(() => {
+      cy.get('[data-test-subj="dashboardListingTitleLink-[Logs]-Web-Traffic"]').click();
+      cy.get('[data-test-subj="breadcrumb last"]')
+        .invoke('attr', 'title')
+        .should('eq', '[Logs] Web Traffic');
+    });
+
+    it('osx filter and query should exist and be named correctly', () => {
+      cy.get('[data-test-subj="saved-query-management-popover-button"]').click();
+      cy.get('[data-test-subj="saved-query-management-popover"]')
+        .find('[class="osdSavedQueryListItem__labelText"]')
+        .should('have.text', 'test-query')
+        .click();
+      cy.get('[data-test-subj="queryInput"]').should('have.text', 'resp=200');
+      cy.get(
+        '[data-test-subj="filter filter-enabled filter-key-machine.os filter-value-osx filter-unpinned "]'
+      )
+        .should('have.text', 'osx filter')
+        .click();
+      cy.get('[data-test-subj="editFilter"]').click();
+      cy.get('[data-test-subj="filterFieldSuggestionList"]')
+        .find('[data-test-subj="comboBoxInput"]')
+        .should('have.text', 'machine.os');
+      cy.get('[data-test-subj="filterOperatorList"]')
+        .find('[data-test-subj="comboBoxInput"]')
+        .should('have.text', 'is');
+      cy.get('[data-test-subj="filterParams"]').find('input').should('have.value', 'osx');
+    });
+
+    it('osx filter and query should function correctly', () => {
+      commonUI.setDateRange('Oct 10, 2021 @ 00:00:00.000', 'Oct 4, 2021 @ 00:00:00.000');
+      cy.get('[data-test-subj="saved-query-management-popover-button"]').click();
+      cy.get('[data-test-subj="saved-query-management-popover"]')
+        .find('[class="osdSavedQueryListItem__labelText"]')
+        .should('have.text', 'test-query')
+        .click();
+      cy.get('[data-test-subj="dashboardPanel"]').each((item) => {
+        const vsLoader = item.get('[data-test-subj="visualizationLoader"]');
+        //[Logs] unique visitors should be 211
+        if (
+          vsLoader &&
+          vsLoader
+            .get('[data-test-subj="visualizationLoader"]')
+            .find('[class="chart-title"]')
+            .should('have.text', 'Unique Visitors')
+        ) {
+          vsLoader.should('have.class', 'chart-label').should('have.text', '211');
+        }
+        //[Logs] vistor chart should show osx 100%
+        if (
+          vsLoader &&
+          vsLoader.get('[data-test-subj="visualizationLoader"]').invoke('css', 'data-title') ===
+            '[Logs] Visitors by OS'
+        ) {
+          vsLoader.should('have.class', 'label').should('have.text', 'osx (100%)');
+        }
+        //[Logs] Response chart should show 200 label
+        if (
+          vsLoader &&
+          vsLoader.get('[data-test-subj="visualizationLoader"]').invoke('css', 'data-title') ===
+            '[Logs] Response Codes Over Time + Annotations'
+        ) {
+          vsLoader
+            .should('have.class', 'echLegendItem__label echLegendItem__label--clickable')
+            .should('have.text', '200');
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
We need bwc tests on vanilla osd for release to verify
there is no issues from the dashboards. This PR modifies
the previous bwc tests on bundled osd by removing the
login page. Currently all the tests are exactly the same
for two versions but they might be different in the future.
There is no requirement that we need to test the same thing
for osd with and without bundles.

### Partically Resolved:
https://github.com/opensearch-project/opensearch-build/issues/705

Signed-off-by: Anan Zhuang <ananzh@amazon.com>


 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 