### PR TITLE
[1.x] Custom Branding (#826)

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -148,3 +148,16 @@
 #  'ff00::/8',
 # ]
 #vis_type_timeline.graphiteBlockedIPs: []
+
+# opensearchDashboards.branding:
+  # logo:
+    # defaultUrl: ""
+    # darkModeUrl: ""
+  # mark:
+    # defaultUrl: ""
+    # darkModeUrl: ""
+  # loadingLogo: 
+    # defaultUrl: ""
+    # darkModeUrl: ""
+  # faviconUrl: ""
+  # applicationTitle: ""

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -51,6 +51,7 @@ import { ChromeNavLinks, NavLinksService, ChromeNavLink } from './nav_links';
 import { ChromeRecentlyAccessed, RecentlyAccessedService } from './recently_accessed';
 import { Header } from './ui';
 import { ChromeHelpExtensionMenuLink } from './ui/header/header_help_menu';
+import { Branding } from '../';
 export { ChromeNavControls, ChromeRecentlyAccessed, ChromeDocTitle };
 
 const IS_LOCKED_KEY = 'core.chrome.isLocked';
@@ -70,6 +71,9 @@ export interface ChromeBrand {
 
 /** @public */
 export type ChromeBreadcrumb = EuiBreadcrumb;
+
+/** @public */
+export type ChromeBranding = Branding;
 
 /** @public */
 export interface ChromeHelpExtension {
@@ -253,6 +257,7 @@ export class ChromeService {
           navControlsRight$={navControls.getRight$()}
           onIsLockedUpdate={setIsNavDrawerLocked}
           isLocked$={getIsNavDrawerLocked$}
+          branding={injectedMetadata.getBranding()}
         />
       ),
 

--- a/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
@@ -60,6 +60,15 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
       "serverBasePath": "/test",
     }
   }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
+    }
+  }
   closeNav={[Function]}
   customNavLink$={
     BehaviorSubject {
@@ -853,8 +862,9 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
               className="euiFlexItem eui-yScroll"
             >
               <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="/defaultModeLogo"
                 data-test-subj="collapsibleNavGroup-opensearchDashboards"
-                iconType="inputOutput"
+                iconType="/defaultModeLogo"
                 initialIsOpen={true}
                 isCollapsible={true}
                 key="opensearchDashboards"
@@ -875,7 +885,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                       >
                         <EuiIcon
                           size="l"
-                          type="inputOutput"
+                          type="/defaultModeLogo"
                         />
                       </EuiFlexItem>
                       <EuiFlexItem>
@@ -893,6 +903,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexGroup>
                   }
                   className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="/defaultModeLogo"
                   data-test-subj="collapsibleNavGroup-opensearchDashboards"
                   id="mockId"
                   initialIsOpen={true}
@@ -903,6 +914,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 >
                   <div
                     className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="/defaultModeLogo"
                     data-test-subj="collapsibleNavGroup-opensearchDashboards"
                     onToggle={[Function]}
                   >
@@ -951,10 +963,10 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                                 >
                                   <EuiIcon
                                     size="l"
-                                    type="inputOutput"
+                                    type="/defaultModeLogo"
                                   >
                                     <div
-                                      data-euiicon-type="inputOutput"
+                                      data-euiicon-type="/defaultModeLogo"
                                       size="l"
                                     />
                                   </EuiIcon>
@@ -1143,6 +1155,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 </EuiAccordion>
               </EuiCollapsibleNavGroup>
               <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
                 data-test-subj="collapsibleNavGroup-observability"
                 iconType="logoObservability"
                 initialIsOpen={true}
@@ -1183,6 +1196,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexGroup>
                   }
                   className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
                   data-test-subj="collapsibleNavGroup-observability"
                   id="mockId"
                   initialIsOpen={true}
@@ -1193,6 +1207,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 >
                   <div
                     className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
                     data-test-subj="collapsibleNavGroup-observability"
                     onToggle={[Function]}
                   >
@@ -1394,6 +1409,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 </EuiAccordion>
               </EuiCollapsibleNavGroup>
               <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoSecurity"
                 data-test-subj="collapsibleNavGroup-securitySolution"
                 iconType="logoSecurity"
                 initialIsOpen={true}
@@ -1434,6 +1450,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexGroup>
                   }
                   className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoSecurity"
                   data-test-subj="collapsibleNavGroup-securitySolution"
                   id="mockId"
                   initialIsOpen={true}
@@ -1444,6 +1461,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 >
                   <div
                     className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoSecurity"
                     data-test-subj="collapsibleNavGroup-securitySolution"
                     onToggle={[Function]}
                   >
@@ -1606,6 +1624,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 </EuiAccordion>
               </EuiCollapsibleNavGroup>
               <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="managementApp"
                 data-test-subj="collapsibleNavGroup-management"
                 iconType="managementApp"
                 initialIsOpen={true}
@@ -1646,6 +1665,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexGroup>
                   }
                   className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="managementApp"
                   data-test-subj="collapsibleNavGroup-management"
                   id="mockId"
                   initialIsOpen={true}
@@ -1656,6 +1676,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 >
                   <div
                     className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="managementApp"
                     data-test-subj="collapsibleNavGroup-management"
                     onToggle={[Function]}
                   >
@@ -2083,6 +2104,15 @@ exports[`CollapsibleNav renders the default nav 1`] = `
       "serverBasePath": "/test",
     }
   }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
+    }
+  }
   closeNav={[Function]}
   customNavLink$={
     BehaviorSubject {
@@ -2316,6 +2346,15 @@ exports[`CollapsibleNav renders the default nav 2`] = `
       "prepend": [Function],
       "remove": [Function],
       "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
     }
   }
   closeNav={[Function]}
@@ -2552,6 +2591,15 @@ exports[`CollapsibleNav renders the default nav 3`] = `
       "prepend": [Function],
       "remove": [Function],
       "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
     }
   }
   closeNav={[Function]}
@@ -3099,6 +3147,6009 @@ exports[`CollapsibleNav renders the default nav 3`] = `
                                   title="Undock navigation"
                                 >
                                   Undock navigation
+                                </span>
+                              </button>
+                            </li>
+                          </EuiListGroupItem>
+                        </ul>
+                      </EuiListGroup>
+                    </div>
+                  </div>
+                </EuiCollapsibleNavGroup>
+              </EuiShowFor>
+            </div>
+          </EuiFlexItem>
+          <EuiScreenReaderOnly
+            showOnFocus={true}
+          >
+            <EuiButtonEmpty
+              className="euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+              iconType="cross"
+              onClick={[Function]}
+              size="xs"
+              textProps={
+                Object {
+                  "className": "euiCollapsibleNav__closeButtonText",
+                }
+              }
+            >
+              <button
+                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <EuiButtonContent
+                  className="euiButtonEmpty__content"
+                  iconSide="left"
+                  iconType="cross"
+                  textProps={
+                    Object {
+                      "className": "euiButtonEmpty__text euiCollapsibleNav__closeButtonText",
+                    }
+                  }
+                >
+                  <span
+                    className="euiButtonContent euiButtonEmpty__content"
+                  >
+                    <EuiIcon
+                      className="euiButtonContent__icon"
+                      size="m"
+                      type="cross"
+                    >
+                      <div
+                        className="euiButtonContent__icon"
+                        data-euiicon-type="cross"
+                        size="m"
+                      />
+                    </EuiIcon>
+                    <span
+                      className="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+                    >
+                      <EuiI18n
+                        default="close"
+                        token="euiCollapsibleNav.closeButtonLabel"
+                      >
+                        close
+                      </EuiI18n>
+                    </span>
+                  </span>
+                </EuiButtonContent>
+              </button>
+            </EuiButtonEmpty>
+          </EuiScreenReaderOnly>
+        </nav>
+      </div>
+    </EuiFocusTrap>
+  </EuiCollapsibleNav>
+</CollapsibleNav>
+`;
+
+exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 1`] = `
+<CollapsibleNav
+  appId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "test",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  basePath={
+    BasePath {
+      "basePath": "/test",
+      "get": [Function],
+      "prepend": [Function],
+      "remove": [Function],
+      "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": true,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
+    }
+  }
+  closeNav={[Function]}
+  customNavLink$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  homeHref="/"
+  id="collapsibe-nav"
+  isLocked={false}
+  isNavOpen={true}
+  navLinks$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "inputOutput",
+            "id": "opensearchDashboards",
+            "label": "OpenSearch Dashboards",
+            "order": 1000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "logoObservability",
+            "id": "observability",
+            "label": "Observability",
+            "order": 3000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navigateToApp={[Function]}
+  navigateToUrl={[Function]}
+  onIsLockedUpdate={[Function]}
+  recentlyAccessed$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "id": "recent",
+          "label": "recent",
+          "link": "recent",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  storage={
+    StubBrowserStorage {
+      "keys": Array [],
+      "size": 0,
+      "sizeLimit": 5000000,
+      "values": Array [],
+    }
+  }
+>
+  <EuiCollapsibleNav
+    aria-label="Primary"
+    data-test-subj="collapsibleNav"
+    id="collapsibe-nav"
+    isDocked={false}
+    isOpen={true}
+    onClose={[Function]}
+  >
+    <EuiWindowEvent
+      event="keydown"
+      handler={[Function]}
+    />
+    <EuiOverlayMask
+      headerZindexLocation="below"
+      onClick={[Function]}
+    >
+      <Portal
+        containerInfo={
+          <div
+            class="euiOverlayMask euiOverlayMask--belowHeader"
+          />
+        }
+      />
+    </EuiOverlayMask>
+    <EuiFocusTrap
+      clickOutsideDisables={true}
+      disabled={false}
+    >
+      <div
+        data-eui="EuiFocusTrap"
+      >
+        <nav
+          aria-label="Primary"
+          className="euiCollapsibleNav"
+          data-test-subj="collapsibleNav"
+          id="collapsibe-nav"
+        >
+          <EuiFlexItem
+            grow={false}
+            style={
+              Object {
+                "flexShrink": 0,
+              }
+            }
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+              style={
+                Object {
+                  "flexShrink": 0,
+                }
+              }
+            >
+              <EuiCollapsibleNavGroup
+                background="light"
+                className="eui-yScroll"
+                style={
+                  Object {
+                    "maxHeight": "40vh",
+                  }
+                }
+              >
+                <div
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light eui-yScroll"
+                  id="mockId"
+                  style={
+                    Object {
+                      "maxHeight": "40vh",
+                    }
+                  }
+                >
+                  <div
+                    className="euiCollapsibleNavGroup__children"
+                  >
+                    <EuiListGroup
+                      aria-label="Pinned links"
+                      color="text"
+                      gutterSize="none"
+                      listItems={
+                        Array [
+                          Object {
+                            "href": "/",
+                            "iconType": "home",
+                            "label": "Home",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      maxWidth="none"
+                      size="s"
+                    >
+                      <ul
+                        aria-label="Pinned links"
+                        className="euiListGroup"
+                        style={
+                          Object {
+                            "maxWidth": "none",
+                          }
+                        }
+                      >
+                        <EuiListGroupItem
+                          color="text"
+                          href="/"
+                          iconType="home"
+                          key="title-0"
+                          label="Home"
+                          onClick={[Function]}
+                          showToolTip={false}
+                          size="s"
+                          wrapText={false}
+                        >
+                          <li
+                            className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          >
+                            <a
+                              className="euiListGroupItem__button"
+                              href="/"
+                              onClick={[Function]}
+                              rel="noreferrer"
+                            >
+                              <EuiIcon
+                                className="euiListGroupItem__icon"
+                                type="home"
+                              >
+                                <div
+                                  className="euiListGroupItem__icon"
+                                  data-euiicon-type="home"
+                                />
+                              </EuiIcon>
+                              <span
+                                className="euiListGroupItem__label"
+                                title="Home"
+                              >
+                                Home
+                              </span>
+                            </a>
+                          </li>
+                        </EuiListGroupItem>
+                      </ul>
+                    </EuiListGroup>
+                  </div>
+                </div>
+              </EuiCollapsibleNavGroup>
+            </div>
+          </EuiFlexItem>
+          <EuiCollapsibleNavGroup
+            background="light"
+            data-test-subj="collapsibleNavGroup-recentlyViewed"
+            initialIsOpen={true}
+            isCollapsible={true}
+            key="recentlyViewed"
+            onToggle={[Function]}
+            title="Recently viewed"
+          >
+            <EuiAccordion
+              arrowDisplay="right"
+              buttonClassName="euiCollapsibleNavGroup__heading"
+              buttonContent={
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="m"
+                  responsive={false}
+                >
+                  <EuiFlexItem>
+                    <EuiTitle
+                      size="xxs"
+                    >
+                      <h3
+                        className="euiCollapsibleNavGroup__title"
+                        id="mockId__title"
+                      >
+                        Recently viewed
+                      </h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
+              className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+              data-test-subj="collapsibleNavGroup-recentlyViewed"
+              id="mockId"
+              initialIsOpen={true}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                data-test-subj="collapsibleNavGroup-recentlyViewed"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="mockId"
+                    aria-expanded={true}
+                    className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                    id="mockId"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon euiAccordion__icon-isOpen"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <div
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          data-euiicon-type="arrowRight"
+                          size="m"
+                        />
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="m"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiTitle
+                                size="xxs"
+                              >
+                                <h3
+                                  className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                  id="mockId__title"
+                                >
+                                  Recently viewed
+                                </h3>
+                              </EuiTitle>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  className="euiAccordion__childWrapper"
+                  id="mockId"
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <div
+                          className="euiCollapsibleNavGroup__children"
+                        >
+                          <EuiListGroup
+                            aria-label="Recently viewed links"
+                            className="osdCollapsibleNav__recentsListGroup"
+                            color="subdued"
+                            gutterSize="none"
+                            listItems={
+                              Array [
+                                Object {
+                                  "aria-label": "recent",
+                                  "data-test-subj": "collapsibleNavAppLink--recent",
+                                  "href": "http://localhost/recent",
+                                  "label": "recent",
+                                  "onClick": [Function],
+                                  "title": "recent",
+                                },
+                              ]
+                            }
+                            maxWidth="none"
+                            size="s"
+                          >
+                            <ul
+                              aria-label="Recently viewed links"
+                              className="euiListGroup osdCollapsibleNav__recentsListGroup"
+                              style={
+                                Object {
+                                  "maxWidth": "none",
+                                }
+                              }
+                            >
+                              <EuiListGroupItem
+                                aria-label="recent"
+                                color="subdued"
+                                data-test-subj="collapsibleNavAppLink--recent"
+                                href="http://localhost/recent"
+                                key="title-0"
+                                label="recent"
+                                onClick={[Function]}
+                                showToolTip={false}
+                                size="s"
+                                title="recent"
+                                wrapText={false}
+                              >
+                                <li
+                                  className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                >
+                                  <a
+                                    aria-label="recent"
+                                    className="euiListGroupItem__button"
+                                    data-test-subj="collapsibleNavAppLink--recent"
+                                    href="http://localhost/recent"
+                                    onClick={[Function]}
+                                    rel="noreferrer"
+                                    title="recent"
+                                  >
+                                    <span
+                                      className="euiListGroupItem__label"
+                                      title="recent"
+                                    >
+                                      recent
+                                    </span>
+                                  </a>
+                                </li>
+                              </EuiListGroupItem>
+                            </ul>
+                          </EuiListGroup>
+                        </div>
+                      </div>
+                    </div>
+                  </EuiResizeObserver>
+                </div>
+              </div>
+            </EuiAccordion>
+          </EuiCollapsibleNavGroup>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiFlexItem
+            className="eui-yScroll"
+          >
+            <div
+              className="euiFlexItem eui-yScroll"
+            >
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="/darkModeLogo"
+                data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                iconType="/darkModeLogo"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="opensearchDashboards"
+                onToggle={[Function]}
+                title="OpenSearch Dashboards"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="/darkModeLogo"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            OpenSearch Dashboards
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="/darkModeLogo"
+                  data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="/darkModeLogo"
+                    data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="/darkModeLogo"
+                                  >
+                                    <div
+                                      data-euiicon-type="/darkModeLogo"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      OpenSearch Dashboards
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, OpenSearch Dashboards"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, OpenSearch Dashboards"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
+                data-test-subj="collapsibleNavGroup-observability"
+                iconType="logoObservability"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="observability"
+                onToggle={[Function]}
+                title="Observability"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="logoObservability"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            Observability
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
+                  data-test-subj="collapsibleNavGroup-observability"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
+                    data-test-subj="collapsibleNavGroup-observability"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="logoObservability"
+                                  >
+                                    <div
+                                      data-euiicon-type="logoObservability"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      Observability
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, Observability"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, Observability"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiShowFor
+                sizes={
+                  Array [
+                    "l",
+                    "xl",
+                  ]
+                }
+              >
+                <EuiCollapsibleNavGroup>
+                  <div
+                    className="euiCollapsibleNavGroup"
+                    id="mockId"
+                  >
+                    <div
+                      className="euiCollapsibleNavGroup__children"
+                    >
+                      <EuiListGroup
+                        flush={true}
+                      >
+                        <ul
+                          className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+                        >
+                          <EuiListGroupItem
+                            aria-label="Dock primary navigation"
+                            buttonRef={
+                              Object {
+                                "current": <button
+                                  aria-label="Dock primary navigation"
+                                  class="euiListGroupItem__button"
+                                  data-test-subj="collapsible-nav-lock"
+                                  type="button"
+                                >
+                                  <div
+                                    class="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                  <span
+                                    class="euiListGroupItem__label"
+                                    title="Dock navigation"
+                                  >
+                                    Dock navigation
+                                  </span>
+                                </button>,
+                              }
+                            }
+                            color="subdued"
+                            data-test-subj="collapsible-nav-lock"
+                            iconType="lockOpen"
+                            label="Dock navigation"
+                            onClick={[Function]}
+                            size="xs"
+                          >
+                            <li
+                              className="euiListGroupItem euiListGroupItem--xSmall euiListGroupItem--subdued euiListGroupItem-isClickable"
+                            >
+                              <button
+                                aria-label="Dock primary navigation"
+                                className="euiListGroupItem__button"
+                                data-test-subj="collapsible-nav-lock"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  className="euiListGroupItem__icon"
+                                  type="lockOpen"
+                                >
+                                  <div
+                                    className="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                </EuiIcon>
+                                <span
+                                  className="euiListGroupItem__label"
+                                  title="Dock navigation"
+                                >
+                                  Dock navigation
+                                </span>
+                              </button>
+                            </li>
+                          </EuiListGroupItem>
+                        </ul>
+                      </EuiListGroup>
+                    </div>
+                  </div>
+                </EuiCollapsibleNavGroup>
+              </EuiShowFor>
+            </div>
+          </EuiFlexItem>
+          <EuiScreenReaderOnly
+            showOnFocus={true}
+          >
+            <EuiButtonEmpty
+              className="euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+              iconType="cross"
+              onClick={[Function]}
+              size="xs"
+              textProps={
+                Object {
+                  "className": "euiCollapsibleNav__closeButtonText",
+                }
+              }
+            >
+              <button
+                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <EuiButtonContent
+                  className="euiButtonEmpty__content"
+                  iconSide="left"
+                  iconType="cross"
+                  textProps={
+                    Object {
+                      "className": "euiButtonEmpty__text euiCollapsibleNav__closeButtonText",
+                    }
+                  }
+                >
+                  <span
+                    className="euiButtonContent euiButtonEmpty__content"
+                  >
+                    <EuiIcon
+                      className="euiButtonContent__icon"
+                      size="m"
+                      type="cross"
+                    >
+                      <div
+                        className="euiButtonContent__icon"
+                        data-euiicon-type="cross"
+                        size="m"
+                      />
+                    </EuiIcon>
+                    <span
+                      className="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+                    >
+                      <EuiI18n
+                        default="close"
+                        token="euiCollapsibleNav.closeButtonLabel"
+                      >
+                        close
+                      </EuiI18n>
+                    </span>
+                  </span>
+                </EuiButtonContent>
+              </button>
+            </EuiButtonEmpty>
+          </EuiScreenReaderOnly>
+        </nav>
+      </div>
+    </EuiFocusTrap>
+  </EuiCollapsibleNav>
+</CollapsibleNav>
+`;
+
+exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 2`] = `
+<CollapsibleNav
+  appId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "test",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  basePath={
+    BasePath {
+      "basePath": "/test",
+      "get": [Function],
+      "prepend": [Function],
+      "remove": [Function],
+      "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": true,
+      "mark": Object {
+        "defaultUrl": "/defaultModeLogo",
+      },
+    }
+  }
+  closeNav={[Function]}
+  customNavLink$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  homeHref="/"
+  id="collapsibe-nav"
+  isLocked={false}
+  isNavOpen={true}
+  navLinks$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "inputOutput",
+            "id": "opensearchDashboards",
+            "label": "OpenSearch Dashboards",
+            "order": 1000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "logoObservability",
+            "id": "observability",
+            "label": "Observability",
+            "order": 3000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navigateToApp={[Function]}
+  navigateToUrl={[Function]}
+  onIsLockedUpdate={[Function]}
+  recentlyAccessed$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "id": "recent",
+          "label": "recent",
+          "link": "recent",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  storage={
+    StubBrowserStorage {
+      "keys": Array [],
+      "size": 0,
+      "sizeLimit": 5000000,
+      "values": Array [],
+    }
+  }
+>
+  <EuiCollapsibleNav
+    aria-label="Primary"
+    data-test-subj="collapsibleNav"
+    id="collapsibe-nav"
+    isDocked={false}
+    isOpen={true}
+    onClose={[Function]}
+  >
+    <EuiWindowEvent
+      event="keydown"
+      handler={[Function]}
+    />
+    <EuiOverlayMask
+      headerZindexLocation="below"
+      onClick={[Function]}
+    >
+      <Portal
+        containerInfo={
+          <div
+            class="euiOverlayMask euiOverlayMask--belowHeader"
+          />
+        }
+      />
+    </EuiOverlayMask>
+    <EuiFocusTrap
+      clickOutsideDisables={true}
+      disabled={false}
+    >
+      <div
+        data-eui="EuiFocusTrap"
+      >
+        <nav
+          aria-label="Primary"
+          className="euiCollapsibleNav"
+          data-test-subj="collapsibleNav"
+          id="collapsibe-nav"
+        >
+          <EuiFlexItem
+            grow={false}
+            style={
+              Object {
+                "flexShrink": 0,
+              }
+            }
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+              style={
+                Object {
+                  "flexShrink": 0,
+                }
+              }
+            >
+              <EuiCollapsibleNavGroup
+                background="light"
+                className="eui-yScroll"
+                style={
+                  Object {
+                    "maxHeight": "40vh",
+                  }
+                }
+              >
+                <div
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light eui-yScroll"
+                  id="mockId"
+                  style={
+                    Object {
+                      "maxHeight": "40vh",
+                    }
+                  }
+                >
+                  <div
+                    className="euiCollapsibleNavGroup__children"
+                  >
+                    <EuiListGroup
+                      aria-label="Pinned links"
+                      color="text"
+                      gutterSize="none"
+                      listItems={
+                        Array [
+                          Object {
+                            "href": "/",
+                            "iconType": "home",
+                            "label": "Home",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      maxWidth="none"
+                      size="s"
+                    >
+                      <ul
+                        aria-label="Pinned links"
+                        className="euiListGroup"
+                        style={
+                          Object {
+                            "maxWidth": "none",
+                          }
+                        }
+                      >
+                        <EuiListGroupItem
+                          color="text"
+                          href="/"
+                          iconType="home"
+                          key="title-0"
+                          label="Home"
+                          onClick={[Function]}
+                          showToolTip={false}
+                          size="s"
+                          wrapText={false}
+                        >
+                          <li
+                            className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          >
+                            <a
+                              className="euiListGroupItem__button"
+                              href="/"
+                              onClick={[Function]}
+                              rel="noreferrer"
+                            >
+                              <EuiIcon
+                                className="euiListGroupItem__icon"
+                                type="home"
+                              >
+                                <div
+                                  className="euiListGroupItem__icon"
+                                  data-euiicon-type="home"
+                                />
+                              </EuiIcon>
+                              <span
+                                className="euiListGroupItem__label"
+                                title="Home"
+                              >
+                                Home
+                              </span>
+                            </a>
+                          </li>
+                        </EuiListGroupItem>
+                      </ul>
+                    </EuiListGroup>
+                  </div>
+                </div>
+              </EuiCollapsibleNavGroup>
+            </div>
+          </EuiFlexItem>
+          <EuiCollapsibleNavGroup
+            background="light"
+            data-test-subj="collapsibleNavGroup-recentlyViewed"
+            initialIsOpen={true}
+            isCollapsible={true}
+            key="recentlyViewed"
+            onToggle={[Function]}
+            title="Recently viewed"
+          >
+            <EuiAccordion
+              arrowDisplay="right"
+              buttonClassName="euiCollapsibleNavGroup__heading"
+              buttonContent={
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="m"
+                  responsive={false}
+                >
+                  <EuiFlexItem>
+                    <EuiTitle
+                      size="xxs"
+                    >
+                      <h3
+                        className="euiCollapsibleNavGroup__title"
+                        id="mockId__title"
+                      >
+                        Recently viewed
+                      </h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
+              className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+              data-test-subj="collapsibleNavGroup-recentlyViewed"
+              id="mockId"
+              initialIsOpen={true}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                data-test-subj="collapsibleNavGroup-recentlyViewed"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="mockId"
+                    aria-expanded={true}
+                    className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                    id="mockId"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon euiAccordion__icon-isOpen"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <div
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          data-euiicon-type="arrowRight"
+                          size="m"
+                        />
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="m"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiTitle
+                                size="xxs"
+                              >
+                                <h3
+                                  className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                  id="mockId__title"
+                                >
+                                  Recently viewed
+                                </h3>
+                              </EuiTitle>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  className="euiAccordion__childWrapper"
+                  id="mockId"
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <div
+                          className="euiCollapsibleNavGroup__children"
+                        >
+                          <EuiListGroup
+                            aria-label="Recently viewed links"
+                            className="osdCollapsibleNav__recentsListGroup"
+                            color="subdued"
+                            gutterSize="none"
+                            listItems={
+                              Array [
+                                Object {
+                                  "aria-label": "recent",
+                                  "data-test-subj": "collapsibleNavAppLink--recent",
+                                  "href": "http://localhost/recent",
+                                  "label": "recent",
+                                  "onClick": [Function],
+                                  "title": "recent",
+                                },
+                              ]
+                            }
+                            maxWidth="none"
+                            size="s"
+                          >
+                            <ul
+                              aria-label="Recently viewed links"
+                              className="euiListGroup osdCollapsibleNav__recentsListGroup"
+                              style={
+                                Object {
+                                  "maxWidth": "none",
+                                }
+                              }
+                            >
+                              <EuiListGroupItem
+                                aria-label="recent"
+                                color="subdued"
+                                data-test-subj="collapsibleNavAppLink--recent"
+                                href="http://localhost/recent"
+                                key="title-0"
+                                label="recent"
+                                onClick={[Function]}
+                                showToolTip={false}
+                                size="s"
+                                title="recent"
+                                wrapText={false}
+                              >
+                                <li
+                                  className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                >
+                                  <a
+                                    aria-label="recent"
+                                    className="euiListGroupItem__button"
+                                    data-test-subj="collapsibleNavAppLink--recent"
+                                    href="http://localhost/recent"
+                                    onClick={[Function]}
+                                    rel="noreferrer"
+                                    title="recent"
+                                  >
+                                    <span
+                                      className="euiListGroupItem__label"
+                                      title="recent"
+                                    >
+                                      recent
+                                    </span>
+                                  </a>
+                                </li>
+                              </EuiListGroupItem>
+                            </ul>
+                          </EuiListGroup>
+                        </div>
+                      </div>
+                    </div>
+                  </EuiResizeObserver>
+                </div>
+              </div>
+            </EuiAccordion>
+          </EuiCollapsibleNavGroup>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiFlexItem
+            className="eui-yScroll"
+          >
+            <div
+              className="euiFlexItem eui-yScroll"
+            >
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="/defaultModeLogo"
+                data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                iconType="/defaultModeLogo"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="opensearchDashboards"
+                onToggle={[Function]}
+                title="OpenSearch Dashboards"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="/defaultModeLogo"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            OpenSearch Dashboards
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="/defaultModeLogo"
+                  data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="/defaultModeLogo"
+                    data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="/defaultModeLogo"
+                                  >
+                                    <div
+                                      data-euiicon-type="/defaultModeLogo"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      OpenSearch Dashboards
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, OpenSearch Dashboards"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, OpenSearch Dashboards"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
+                data-test-subj="collapsibleNavGroup-observability"
+                iconType="logoObservability"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="observability"
+                onToggle={[Function]}
+                title="Observability"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="logoObservability"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            Observability
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
+                  data-test-subj="collapsibleNavGroup-observability"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
+                    data-test-subj="collapsibleNavGroup-observability"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="logoObservability"
+                                  >
+                                    <div
+                                      data-euiicon-type="logoObservability"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      Observability
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, Observability"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, Observability"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiShowFor
+                sizes={
+                  Array [
+                    "l",
+                    "xl",
+                  ]
+                }
+              >
+                <EuiCollapsibleNavGroup>
+                  <div
+                    className="euiCollapsibleNavGroup"
+                    id="mockId"
+                  >
+                    <div
+                      className="euiCollapsibleNavGroup__children"
+                    >
+                      <EuiListGroup
+                        flush={true}
+                      >
+                        <ul
+                          className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+                        >
+                          <EuiListGroupItem
+                            aria-label="Dock primary navigation"
+                            buttonRef={
+                              Object {
+                                "current": <button
+                                  aria-label="Dock primary navigation"
+                                  class="euiListGroupItem__button"
+                                  data-test-subj="collapsible-nav-lock"
+                                  type="button"
+                                >
+                                  <div
+                                    class="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                  <span
+                                    class="euiListGroupItem__label"
+                                    title="Dock navigation"
+                                  >
+                                    Dock navigation
+                                  </span>
+                                </button>,
+                              }
+                            }
+                            color="subdued"
+                            data-test-subj="collapsible-nav-lock"
+                            iconType="lockOpen"
+                            label="Dock navigation"
+                            onClick={[Function]}
+                            size="xs"
+                          >
+                            <li
+                              className="euiListGroupItem euiListGroupItem--xSmall euiListGroupItem--subdued euiListGroupItem-isClickable"
+                            >
+                              <button
+                                aria-label="Dock primary navigation"
+                                className="euiListGroupItem__button"
+                                data-test-subj="collapsible-nav-lock"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  className="euiListGroupItem__icon"
+                                  type="lockOpen"
+                                >
+                                  <div
+                                    className="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                </EuiIcon>
+                                <span
+                                  className="euiListGroupItem__label"
+                                  title="Dock navigation"
+                                >
+                                  Dock navigation
+                                </span>
+                              </button>
+                            </li>
+                          </EuiListGroupItem>
+                        </ul>
+                      </EuiListGroup>
+                    </div>
+                  </div>
+                </EuiCollapsibleNavGroup>
+              </EuiShowFor>
+            </div>
+          </EuiFlexItem>
+          <EuiScreenReaderOnly
+            showOnFocus={true}
+          >
+            <EuiButtonEmpty
+              className="euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+              iconType="cross"
+              onClick={[Function]}
+              size="xs"
+              textProps={
+                Object {
+                  "className": "euiCollapsibleNav__closeButtonText",
+                }
+              }
+            >
+              <button
+                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <EuiButtonContent
+                  className="euiButtonEmpty__content"
+                  iconSide="left"
+                  iconType="cross"
+                  textProps={
+                    Object {
+                      "className": "euiButtonEmpty__text euiCollapsibleNav__closeButtonText",
+                    }
+                  }
+                >
+                  <span
+                    className="euiButtonContent euiButtonEmpty__content"
+                  >
+                    <EuiIcon
+                      className="euiButtonContent__icon"
+                      size="m"
+                      type="cross"
+                    >
+                      <div
+                        className="euiButtonContent__icon"
+                        data-euiicon-type="cross"
+                        size="m"
+                      />
+                    </EuiIcon>
+                    <span
+                      className="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+                    >
+                      <EuiI18n
+                        default="close"
+                        token="euiCollapsibleNav.closeButtonLabel"
+                      >
+                        close
+                      </EuiI18n>
+                    </span>
+                  </span>
+                </EuiButtonContent>
+              </button>
+            </EuiButtonEmpty>
+          </EuiScreenReaderOnly>
+        </nav>
+      </div>
+    </EuiFocusTrap>
+  </EuiCollapsibleNav>
+</CollapsibleNav>
+`;
+
+exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 3`] = `
+<CollapsibleNav
+  appId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "test",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  basePath={
+    BasePath {
+      "basePath": "/test",
+      "get": [Function],
+      "prepend": [Function],
+      "remove": [Function],
+      "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {},
+    }
+  }
+  closeNav={[Function]}
+  customNavLink$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  homeHref="/"
+  id="collapsibe-nav"
+  isLocked={false}
+  isNavOpen={true}
+  navLinks$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "inputOutput",
+            "id": "opensearchDashboards",
+            "label": "OpenSearch Dashboards",
+            "order": 1000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "logoObservability",
+            "id": "observability",
+            "label": "Observability",
+            "order": 3000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navigateToApp={[Function]}
+  navigateToUrl={[Function]}
+  onIsLockedUpdate={[Function]}
+  recentlyAccessed$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "id": "recent",
+          "label": "recent",
+          "link": "recent",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  storage={
+    StubBrowserStorage {
+      "keys": Array [],
+      "size": 0,
+      "sizeLimit": 5000000,
+      "values": Array [],
+    }
+  }
+>
+  <EuiCollapsibleNav
+    aria-label="Primary"
+    data-test-subj="collapsibleNav"
+    id="collapsibe-nav"
+    isDocked={false}
+    isOpen={true}
+    onClose={[Function]}
+  >
+    <EuiWindowEvent
+      event="keydown"
+      handler={[Function]}
+    />
+    <EuiOverlayMask
+      headerZindexLocation="below"
+      onClick={[Function]}
+    >
+      <Portal
+        containerInfo={
+          <div
+            class="euiOverlayMask euiOverlayMask--belowHeader"
+          />
+        }
+      />
+    </EuiOverlayMask>
+    <EuiFocusTrap
+      clickOutsideDisables={true}
+      disabled={false}
+    >
+      <div
+        data-eui="EuiFocusTrap"
+      >
+        <nav
+          aria-label="Primary"
+          className="euiCollapsibleNav"
+          data-test-subj="collapsibleNav"
+          id="collapsibe-nav"
+        >
+          <EuiFlexItem
+            grow={false}
+            style={
+              Object {
+                "flexShrink": 0,
+              }
+            }
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+              style={
+                Object {
+                  "flexShrink": 0,
+                }
+              }
+            >
+              <EuiCollapsibleNavGroup
+                background="light"
+                className="eui-yScroll"
+                style={
+                  Object {
+                    "maxHeight": "40vh",
+                  }
+                }
+              >
+                <div
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light eui-yScroll"
+                  id="mockId"
+                  style={
+                    Object {
+                      "maxHeight": "40vh",
+                    }
+                  }
+                >
+                  <div
+                    className="euiCollapsibleNavGroup__children"
+                  >
+                    <EuiListGroup
+                      aria-label="Pinned links"
+                      color="text"
+                      gutterSize="none"
+                      listItems={
+                        Array [
+                          Object {
+                            "href": "/",
+                            "iconType": "home",
+                            "label": "Home",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      maxWidth="none"
+                      size="s"
+                    >
+                      <ul
+                        aria-label="Pinned links"
+                        className="euiListGroup"
+                        style={
+                          Object {
+                            "maxWidth": "none",
+                          }
+                        }
+                      >
+                        <EuiListGroupItem
+                          color="text"
+                          href="/"
+                          iconType="home"
+                          key="title-0"
+                          label="Home"
+                          onClick={[Function]}
+                          showToolTip={false}
+                          size="s"
+                          wrapText={false}
+                        >
+                          <li
+                            className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          >
+                            <a
+                              className="euiListGroupItem__button"
+                              href="/"
+                              onClick={[Function]}
+                              rel="noreferrer"
+                            >
+                              <EuiIcon
+                                className="euiListGroupItem__icon"
+                                type="home"
+                              >
+                                <div
+                                  className="euiListGroupItem__icon"
+                                  data-euiicon-type="home"
+                                />
+                              </EuiIcon>
+                              <span
+                                className="euiListGroupItem__label"
+                                title="Home"
+                              >
+                                Home
+                              </span>
+                            </a>
+                          </li>
+                        </EuiListGroupItem>
+                      </ul>
+                    </EuiListGroup>
+                  </div>
+                </div>
+              </EuiCollapsibleNavGroup>
+            </div>
+          </EuiFlexItem>
+          <EuiCollapsibleNavGroup
+            background="light"
+            data-test-subj="collapsibleNavGroup-recentlyViewed"
+            initialIsOpen={true}
+            isCollapsible={true}
+            key="recentlyViewed"
+            onToggle={[Function]}
+            title="Recently viewed"
+          >
+            <EuiAccordion
+              arrowDisplay="right"
+              buttonClassName="euiCollapsibleNavGroup__heading"
+              buttonContent={
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="m"
+                  responsive={false}
+                >
+                  <EuiFlexItem>
+                    <EuiTitle
+                      size="xxs"
+                    >
+                      <h3
+                        className="euiCollapsibleNavGroup__title"
+                        id="mockId__title"
+                      >
+                        Recently viewed
+                      </h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
+              className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+              data-test-subj="collapsibleNavGroup-recentlyViewed"
+              id="mockId"
+              initialIsOpen={true}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                data-test-subj="collapsibleNavGroup-recentlyViewed"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="mockId"
+                    aria-expanded={true}
+                    className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                    id="mockId"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon euiAccordion__icon-isOpen"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <div
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          data-euiicon-type="arrowRight"
+                          size="m"
+                        />
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="m"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiTitle
+                                size="xxs"
+                              >
+                                <h3
+                                  className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                  id="mockId__title"
+                                >
+                                  Recently viewed
+                                </h3>
+                              </EuiTitle>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  className="euiAccordion__childWrapper"
+                  id="mockId"
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <div
+                          className="euiCollapsibleNavGroup__children"
+                        >
+                          <EuiListGroup
+                            aria-label="Recently viewed links"
+                            className="osdCollapsibleNav__recentsListGroup"
+                            color="subdued"
+                            gutterSize="none"
+                            listItems={
+                              Array [
+                                Object {
+                                  "aria-label": "recent",
+                                  "data-test-subj": "collapsibleNavAppLink--recent",
+                                  "href": "http://localhost/recent",
+                                  "label": "recent",
+                                  "onClick": [Function],
+                                  "title": "recent",
+                                },
+                              ]
+                            }
+                            maxWidth="none"
+                            size="s"
+                          >
+                            <ul
+                              aria-label="Recently viewed links"
+                              className="euiListGroup osdCollapsibleNav__recentsListGroup"
+                              style={
+                                Object {
+                                  "maxWidth": "none",
+                                }
+                              }
+                            >
+                              <EuiListGroupItem
+                                aria-label="recent"
+                                color="subdued"
+                                data-test-subj="collapsibleNavAppLink--recent"
+                                href="http://localhost/recent"
+                                key="title-0"
+                                label="recent"
+                                onClick={[Function]}
+                                showToolTip={false}
+                                size="s"
+                                title="recent"
+                                wrapText={false}
+                              >
+                                <li
+                                  className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                >
+                                  <a
+                                    aria-label="recent"
+                                    className="euiListGroupItem__button"
+                                    data-test-subj="collapsibleNavAppLink--recent"
+                                    href="http://localhost/recent"
+                                    onClick={[Function]}
+                                    rel="noreferrer"
+                                    title="recent"
+                                  >
+                                    <span
+                                      className="euiListGroupItem__label"
+                                      title="recent"
+                                    >
+                                      recent
+                                    </span>
+                                  </a>
+                                </li>
+                              </EuiListGroupItem>
+                            </ul>
+                          </EuiListGroup>
+                        </div>
+                      </div>
+                    </div>
+                  </EuiResizeObserver>
+                </div>
+              </div>
+            </EuiAccordion>
+          </EuiCollapsibleNavGroup>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiFlexItem
+            className="eui-yScroll"
+          >
+            <div
+              className="euiFlexItem eui-yScroll"
+            >
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
+                data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                iconType="undefined/opensearch_mark_default_mode.svg"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="opensearchDashboards"
+                onToggle={[Function]}
+                title="OpenSearch Dashboards"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="undefined/opensearch_mark_default_mode.svg"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            OpenSearch Dashboards
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
+                  data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
+                    data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="undefined/opensearch_mark_default_mode.svg"
+                                  >
+                                    <div
+                                      data-euiicon-type="undefined/opensearch_mark_default_mode.svg"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      OpenSearch Dashboards
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, OpenSearch Dashboards"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, OpenSearch Dashboards"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
+                data-test-subj="collapsibleNavGroup-observability"
+                iconType="logoObservability"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="observability"
+                onToggle={[Function]}
+                title="Observability"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="logoObservability"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            Observability
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
+                  data-test-subj="collapsibleNavGroup-observability"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
+                    data-test-subj="collapsibleNavGroup-observability"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="logoObservability"
+                                  >
+                                    <div
+                                      data-euiicon-type="logoObservability"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      Observability
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, Observability"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, Observability"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiShowFor
+                sizes={
+                  Array [
+                    "l",
+                    "xl",
+                  ]
+                }
+              >
+                <EuiCollapsibleNavGroup>
+                  <div
+                    className="euiCollapsibleNavGroup"
+                    id="mockId"
+                  >
+                    <div
+                      className="euiCollapsibleNavGroup__children"
+                    >
+                      <EuiListGroup
+                        flush={true}
+                      >
+                        <ul
+                          className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+                        >
+                          <EuiListGroupItem
+                            aria-label="Dock primary navigation"
+                            buttonRef={
+                              Object {
+                                "current": <button
+                                  aria-label="Dock primary navigation"
+                                  class="euiListGroupItem__button"
+                                  data-test-subj="collapsible-nav-lock"
+                                  type="button"
+                                >
+                                  <div
+                                    class="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                  <span
+                                    class="euiListGroupItem__label"
+                                    title="Dock navigation"
+                                  >
+                                    Dock navigation
+                                  </span>
+                                </button>,
+                              }
+                            }
+                            color="subdued"
+                            data-test-subj="collapsible-nav-lock"
+                            iconType="lockOpen"
+                            label="Dock navigation"
+                            onClick={[Function]}
+                            size="xs"
+                          >
+                            <li
+                              className="euiListGroupItem euiListGroupItem--xSmall euiListGroupItem--subdued euiListGroupItem-isClickable"
+                            >
+                              <button
+                                aria-label="Dock primary navigation"
+                                className="euiListGroupItem__button"
+                                data-test-subj="collapsible-nav-lock"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  className="euiListGroupItem__icon"
+                                  type="lockOpen"
+                                >
+                                  <div
+                                    className="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                </EuiIcon>
+                                <span
+                                  className="euiListGroupItem__label"
+                                  title="Dock navigation"
+                                >
+                                  Dock navigation
+                                </span>
+                              </button>
+                            </li>
+                          </EuiListGroupItem>
+                        </ul>
+                      </EuiListGroup>
+                    </div>
+                  </div>
+                </EuiCollapsibleNavGroup>
+              </EuiShowFor>
+            </div>
+          </EuiFlexItem>
+          <EuiScreenReaderOnly
+            showOnFocus={true}
+          >
+            <EuiButtonEmpty
+              className="euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+              iconType="cross"
+              onClick={[Function]}
+              size="xs"
+              textProps={
+                Object {
+                  "className": "euiCollapsibleNav__closeButtonText",
+                }
+              }
+            >
+              <button
+                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <EuiButtonContent
+                  className="euiButtonEmpty__content"
+                  iconSide="left"
+                  iconType="cross"
+                  textProps={
+                    Object {
+                      "className": "euiButtonEmpty__text euiCollapsibleNav__closeButtonText",
+                    }
+                  }
+                >
+                  <span
+                    className="euiButtonContent euiButtonEmpty__content"
+                  >
+                    <EuiIcon
+                      className="euiButtonContent__icon"
+                      size="m"
+                      type="cross"
+                    >
+                      <div
+                        className="euiButtonContent__icon"
+                        data-euiicon-type="cross"
+                        size="m"
+                      />
+                    </EuiIcon>
+                    <span
+                      className="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+                    >
+                      <EuiI18n
+                        default="close"
+                        token="euiCollapsibleNav.closeButtonLabel"
+                      >
+                        close
+                      </EuiI18n>
+                    </span>
+                  </span>
+                </EuiButtonContent>
+              </button>
+            </EuiButtonEmpty>
+          </EuiScreenReaderOnly>
+        </nav>
+      </div>
+    </EuiFocusTrap>
+  </EuiCollapsibleNav>
+</CollapsibleNav>
+`;
+
+exports[`CollapsibleNav renders the nav bar with custom logo in default mode 1`] = `
+<CollapsibleNav
+  appId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "test",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  basePath={
+    BasePath {
+      "basePath": "/test",
+      "get": [Function],
+      "prepend": [Function],
+      "remove": [Function],
+      "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {
+        "darkModeUrl": "/darkModeLogo",
+        "defaultUrl": "/defaultModeLogo",
+      },
+    }
+  }
+  closeNav={[Function]}
+  customNavLink$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  homeHref="/"
+  id="collapsibe-nav"
+  isLocked={false}
+  isNavOpen={true}
+  navLinks$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "inputOutput",
+            "id": "opensearchDashboards",
+            "label": "OpenSearch Dashboards",
+            "order": 1000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "logoObservability",
+            "id": "observability",
+            "label": "Observability",
+            "order": 3000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navigateToApp={[Function]}
+  navigateToUrl={[Function]}
+  onIsLockedUpdate={[Function]}
+  recentlyAccessed$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "id": "recent",
+          "label": "recent",
+          "link": "recent",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  storage={
+    StubBrowserStorage {
+      "keys": Array [],
+      "size": 0,
+      "sizeLimit": 5000000,
+      "values": Array [],
+    }
+  }
+>
+  <EuiCollapsibleNav
+    aria-label="Primary"
+    data-test-subj="collapsibleNav"
+    id="collapsibe-nav"
+    isDocked={false}
+    isOpen={true}
+    onClose={[Function]}
+  >
+    <EuiWindowEvent
+      event="keydown"
+      handler={[Function]}
+    />
+    <EuiOverlayMask
+      headerZindexLocation="below"
+      onClick={[Function]}
+    >
+      <Portal
+        containerInfo={
+          <div
+            class="euiOverlayMask euiOverlayMask--belowHeader"
+          />
+        }
+      />
+    </EuiOverlayMask>
+    <EuiFocusTrap
+      clickOutsideDisables={true}
+      disabled={false}
+    >
+      <div
+        data-eui="EuiFocusTrap"
+      >
+        <nav
+          aria-label="Primary"
+          className="euiCollapsibleNav"
+          data-test-subj="collapsibleNav"
+          id="collapsibe-nav"
+        >
+          <EuiFlexItem
+            grow={false}
+            style={
+              Object {
+                "flexShrink": 0,
+              }
+            }
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+              style={
+                Object {
+                  "flexShrink": 0,
+                }
+              }
+            >
+              <EuiCollapsibleNavGroup
+                background="light"
+                className="eui-yScroll"
+                style={
+                  Object {
+                    "maxHeight": "40vh",
+                  }
+                }
+              >
+                <div
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light eui-yScroll"
+                  id="mockId"
+                  style={
+                    Object {
+                      "maxHeight": "40vh",
+                    }
+                  }
+                >
+                  <div
+                    className="euiCollapsibleNavGroup__children"
+                  >
+                    <EuiListGroup
+                      aria-label="Pinned links"
+                      color="text"
+                      gutterSize="none"
+                      listItems={
+                        Array [
+                          Object {
+                            "href": "/",
+                            "iconType": "home",
+                            "label": "Home",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      maxWidth="none"
+                      size="s"
+                    >
+                      <ul
+                        aria-label="Pinned links"
+                        className="euiListGroup"
+                        style={
+                          Object {
+                            "maxWidth": "none",
+                          }
+                        }
+                      >
+                        <EuiListGroupItem
+                          color="text"
+                          href="/"
+                          iconType="home"
+                          key="title-0"
+                          label="Home"
+                          onClick={[Function]}
+                          showToolTip={false}
+                          size="s"
+                          wrapText={false}
+                        >
+                          <li
+                            className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          >
+                            <a
+                              className="euiListGroupItem__button"
+                              href="/"
+                              onClick={[Function]}
+                              rel="noreferrer"
+                            >
+                              <EuiIcon
+                                className="euiListGroupItem__icon"
+                                type="home"
+                              >
+                                <div
+                                  className="euiListGroupItem__icon"
+                                  data-euiicon-type="home"
+                                />
+                              </EuiIcon>
+                              <span
+                                className="euiListGroupItem__label"
+                                title="Home"
+                              >
+                                Home
+                              </span>
+                            </a>
+                          </li>
+                        </EuiListGroupItem>
+                      </ul>
+                    </EuiListGroup>
+                  </div>
+                </div>
+              </EuiCollapsibleNavGroup>
+            </div>
+          </EuiFlexItem>
+          <EuiCollapsibleNavGroup
+            background="light"
+            data-test-subj="collapsibleNavGroup-recentlyViewed"
+            initialIsOpen={true}
+            isCollapsible={true}
+            key="recentlyViewed"
+            onToggle={[Function]}
+            title="Recently viewed"
+          >
+            <EuiAccordion
+              arrowDisplay="right"
+              buttonClassName="euiCollapsibleNavGroup__heading"
+              buttonContent={
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="m"
+                  responsive={false}
+                >
+                  <EuiFlexItem>
+                    <EuiTitle
+                      size="xxs"
+                    >
+                      <h3
+                        className="euiCollapsibleNavGroup__title"
+                        id="mockId__title"
+                      >
+                        Recently viewed
+                      </h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
+              className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+              data-test-subj="collapsibleNavGroup-recentlyViewed"
+              id="mockId"
+              initialIsOpen={true}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                data-test-subj="collapsibleNavGroup-recentlyViewed"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="mockId"
+                    aria-expanded={true}
+                    className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                    id="mockId"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon euiAccordion__icon-isOpen"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <div
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          data-euiicon-type="arrowRight"
+                          size="m"
+                        />
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="m"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiTitle
+                                size="xxs"
+                              >
+                                <h3
+                                  className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                  id="mockId__title"
+                                >
+                                  Recently viewed
+                                </h3>
+                              </EuiTitle>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  className="euiAccordion__childWrapper"
+                  id="mockId"
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <div
+                          className="euiCollapsibleNavGroup__children"
+                        >
+                          <EuiListGroup
+                            aria-label="Recently viewed links"
+                            className="osdCollapsibleNav__recentsListGroup"
+                            color="subdued"
+                            gutterSize="none"
+                            listItems={
+                              Array [
+                                Object {
+                                  "aria-label": "recent",
+                                  "data-test-subj": "collapsibleNavAppLink--recent",
+                                  "href": "http://localhost/recent",
+                                  "label": "recent",
+                                  "onClick": [Function],
+                                  "title": "recent",
+                                },
+                              ]
+                            }
+                            maxWidth="none"
+                            size="s"
+                          >
+                            <ul
+                              aria-label="Recently viewed links"
+                              className="euiListGroup osdCollapsibleNav__recentsListGroup"
+                              style={
+                                Object {
+                                  "maxWidth": "none",
+                                }
+                              }
+                            >
+                              <EuiListGroupItem
+                                aria-label="recent"
+                                color="subdued"
+                                data-test-subj="collapsibleNavAppLink--recent"
+                                href="http://localhost/recent"
+                                key="title-0"
+                                label="recent"
+                                onClick={[Function]}
+                                showToolTip={false}
+                                size="s"
+                                title="recent"
+                                wrapText={false}
+                              >
+                                <li
+                                  className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                >
+                                  <a
+                                    aria-label="recent"
+                                    className="euiListGroupItem__button"
+                                    data-test-subj="collapsibleNavAppLink--recent"
+                                    href="http://localhost/recent"
+                                    onClick={[Function]}
+                                    rel="noreferrer"
+                                    title="recent"
+                                  >
+                                    <span
+                                      className="euiListGroupItem__label"
+                                      title="recent"
+                                    >
+                                      recent
+                                    </span>
+                                  </a>
+                                </li>
+                              </EuiListGroupItem>
+                            </ul>
+                          </EuiListGroup>
+                        </div>
+                      </div>
+                    </div>
+                  </EuiResizeObserver>
+                </div>
+              </div>
+            </EuiAccordion>
+          </EuiCollapsibleNavGroup>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiFlexItem
+            className="eui-yScroll"
+          >
+            <div
+              className="euiFlexItem eui-yScroll"
+            >
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="/defaultModeLogo"
+                data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                iconType="/defaultModeLogo"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="opensearchDashboards"
+                onToggle={[Function]}
+                title="OpenSearch Dashboards"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="/defaultModeLogo"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            OpenSearch Dashboards
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="/defaultModeLogo"
+                  data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="/defaultModeLogo"
+                    data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="/defaultModeLogo"
+                                  >
+                                    <div
+                                      data-euiicon-type="/defaultModeLogo"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      OpenSearch Dashboards
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, OpenSearch Dashboards"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, OpenSearch Dashboards"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
+                data-test-subj="collapsibleNavGroup-observability"
+                iconType="logoObservability"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="observability"
+                onToggle={[Function]}
+                title="Observability"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="logoObservability"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            Observability
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
+                  data-test-subj="collapsibleNavGroup-observability"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
+                    data-test-subj="collapsibleNavGroup-observability"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="logoObservability"
+                                  >
+                                    <div
+                                      data-euiicon-type="logoObservability"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      Observability
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, Observability"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, Observability"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiShowFor
+                sizes={
+                  Array [
+                    "l",
+                    "xl",
+                  ]
+                }
+              >
+                <EuiCollapsibleNavGroup>
+                  <div
+                    className="euiCollapsibleNavGroup"
+                    id="mockId"
+                  >
+                    <div
+                      className="euiCollapsibleNavGroup__children"
+                    >
+                      <EuiListGroup
+                        flush={true}
+                      >
+                        <ul
+                          className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+                        >
+                          <EuiListGroupItem
+                            aria-label="Dock primary navigation"
+                            buttonRef={
+                              Object {
+                                "current": <button
+                                  aria-label="Dock primary navigation"
+                                  class="euiListGroupItem__button"
+                                  data-test-subj="collapsible-nav-lock"
+                                  type="button"
+                                >
+                                  <div
+                                    class="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                  <span
+                                    class="euiListGroupItem__label"
+                                    title="Dock navigation"
+                                  >
+                                    Dock navigation
+                                  </span>
+                                </button>,
+                              }
+                            }
+                            color="subdued"
+                            data-test-subj="collapsible-nav-lock"
+                            iconType="lockOpen"
+                            label="Dock navigation"
+                            onClick={[Function]}
+                            size="xs"
+                          >
+                            <li
+                              className="euiListGroupItem euiListGroupItem--xSmall euiListGroupItem--subdued euiListGroupItem-isClickable"
+                            >
+                              <button
+                                aria-label="Dock primary navigation"
+                                className="euiListGroupItem__button"
+                                data-test-subj="collapsible-nav-lock"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  className="euiListGroupItem__icon"
+                                  type="lockOpen"
+                                >
+                                  <div
+                                    className="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                </EuiIcon>
+                                <span
+                                  className="euiListGroupItem__label"
+                                  title="Dock navigation"
+                                >
+                                  Dock navigation
+                                </span>
+                              </button>
+                            </li>
+                          </EuiListGroupItem>
+                        </ul>
+                      </EuiListGroup>
+                    </div>
+                  </div>
+                </EuiCollapsibleNavGroup>
+              </EuiShowFor>
+            </div>
+          </EuiFlexItem>
+          <EuiScreenReaderOnly
+            showOnFocus={true}
+          >
+            <EuiButtonEmpty
+              className="euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+              iconType="cross"
+              onClick={[Function]}
+              size="xs"
+              textProps={
+                Object {
+                  "className": "euiCollapsibleNav__closeButtonText",
+                }
+              }
+            >
+              <button
+                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <EuiButtonContent
+                  className="euiButtonEmpty__content"
+                  iconSide="left"
+                  iconType="cross"
+                  textProps={
+                    Object {
+                      "className": "euiButtonEmpty__text euiCollapsibleNav__closeButtonText",
+                    }
+                  }
+                >
+                  <span
+                    className="euiButtonContent euiButtonEmpty__content"
+                  >
+                    <EuiIcon
+                      className="euiButtonContent__icon"
+                      size="m"
+                      type="cross"
+                    >
+                      <div
+                        className="euiButtonContent__icon"
+                        data-euiicon-type="cross"
+                        size="m"
+                      />
+                    </EuiIcon>
+                    <span
+                      className="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+                    >
+                      <EuiI18n
+                        default="close"
+                        token="euiCollapsibleNav.closeButtonLabel"
+                      >
+                        close
+                      </EuiI18n>
+                    </span>
+                  </span>
+                </EuiButtonContent>
+              </button>
+            </EuiButtonEmpty>
+          </EuiScreenReaderOnly>
+        </nav>
+      </div>
+    </EuiFocusTrap>
+  </EuiCollapsibleNav>
+</CollapsibleNav>
+`;
+
+exports[`CollapsibleNav renders the nav bar with custom logo in default mode 2`] = `
+<CollapsibleNav
+  appId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "test",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  basePath={
+    BasePath {
+      "basePath": "/test",
+      "get": [Function],
+      "prepend": [Function],
+      "remove": [Function],
+      "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "darkMode": false,
+      "mark": Object {},
+    }
+  }
+  closeNav={[Function]}
+  customNavLink$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  homeHref="/"
+  id="collapsibe-nav"
+  isLocked={false}
+  isNavOpen={true}
+  navLinks$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "inputOutput",
+            "id": "opensearchDashboards",
+            "label": "OpenSearch Dashboards",
+            "order": 1000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+        Object {
+          "baseUrl": "/",
+          "category": Object {
+            "euiIconType": "logoObservability",
+            "id": "observability",
+            "label": "Observability",
+            "order": 3000,
+          },
+          "data-test-subj": "discover",
+          "href": "discover",
+          "id": "discover",
+          "isActive": true,
+          "title": "discover",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navigateToApp={[Function]}
+  navigateToUrl={[Function]}
+  onIsLockedUpdate={[Function]}
+  recentlyAccessed$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [
+        Object {
+          "id": "recent",
+          "label": "recent",
+          "link": "recent",
+        },
+      ],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  storage={
+    StubBrowserStorage {
+      "keys": Array [],
+      "size": 0,
+      "sizeLimit": 5000000,
+      "values": Array [],
+    }
+  }
+>
+  <EuiCollapsibleNav
+    aria-label="Primary"
+    data-test-subj="collapsibleNav"
+    id="collapsibe-nav"
+    isDocked={false}
+    isOpen={true}
+    onClose={[Function]}
+  >
+    <EuiWindowEvent
+      event="keydown"
+      handler={[Function]}
+    />
+    <EuiOverlayMask
+      headerZindexLocation="below"
+      onClick={[Function]}
+    >
+      <Portal
+        containerInfo={
+          <div
+            class="euiOverlayMask euiOverlayMask--belowHeader"
+          />
+        }
+      />
+    </EuiOverlayMask>
+    <EuiFocusTrap
+      clickOutsideDisables={true}
+      disabled={false}
+    >
+      <div
+        data-eui="EuiFocusTrap"
+      >
+        <nav
+          aria-label="Primary"
+          className="euiCollapsibleNav"
+          data-test-subj="collapsibleNav"
+          id="collapsibe-nav"
+        >
+          <EuiFlexItem
+            grow={false}
+            style={
+              Object {
+                "flexShrink": 0,
+              }
+            }
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+              style={
+                Object {
+                  "flexShrink": 0,
+                }
+              }
+            >
+              <EuiCollapsibleNavGroup
+                background="light"
+                className="eui-yScroll"
+                style={
+                  Object {
+                    "maxHeight": "40vh",
+                  }
+                }
+              >
+                <div
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light eui-yScroll"
+                  id="mockId"
+                  style={
+                    Object {
+                      "maxHeight": "40vh",
+                    }
+                  }
+                >
+                  <div
+                    className="euiCollapsibleNavGroup__children"
+                  >
+                    <EuiListGroup
+                      aria-label="Pinned links"
+                      color="text"
+                      gutterSize="none"
+                      listItems={
+                        Array [
+                          Object {
+                            "href": "/",
+                            "iconType": "home",
+                            "label": "Home",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      maxWidth="none"
+                      size="s"
+                    >
+                      <ul
+                        aria-label="Pinned links"
+                        className="euiListGroup"
+                        style={
+                          Object {
+                            "maxWidth": "none",
+                          }
+                        }
+                      >
+                        <EuiListGroupItem
+                          color="text"
+                          href="/"
+                          iconType="home"
+                          key="title-0"
+                          label="Home"
+                          onClick={[Function]}
+                          showToolTip={false}
+                          size="s"
+                          wrapText={false}
+                        >
+                          <li
+                            className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          >
+                            <a
+                              className="euiListGroupItem__button"
+                              href="/"
+                              onClick={[Function]}
+                              rel="noreferrer"
+                            >
+                              <EuiIcon
+                                className="euiListGroupItem__icon"
+                                type="home"
+                              >
+                                <div
+                                  className="euiListGroupItem__icon"
+                                  data-euiicon-type="home"
+                                />
+                              </EuiIcon>
+                              <span
+                                className="euiListGroupItem__label"
+                                title="Home"
+                              >
+                                Home
+                              </span>
+                            </a>
+                          </li>
+                        </EuiListGroupItem>
+                      </ul>
+                    </EuiListGroup>
+                  </div>
+                </div>
+              </EuiCollapsibleNavGroup>
+            </div>
+          </EuiFlexItem>
+          <EuiCollapsibleNavGroup
+            background="light"
+            data-test-subj="collapsibleNavGroup-recentlyViewed"
+            initialIsOpen={true}
+            isCollapsible={true}
+            key="recentlyViewed"
+            onToggle={[Function]}
+            title="Recently viewed"
+          >
+            <EuiAccordion
+              arrowDisplay="right"
+              buttonClassName="euiCollapsibleNavGroup__heading"
+              buttonContent={
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="m"
+                  responsive={false}
+                >
+                  <EuiFlexItem>
+                    <EuiTitle
+                      size="xxs"
+                    >
+                      <h3
+                        className="euiCollapsibleNavGroup__title"
+                        id="mockId__title"
+                      >
+                        Recently viewed
+                      </h3>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
+              className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+              data-test-subj="collapsibleNavGroup-recentlyViewed"
+              id="mockId"
+              initialIsOpen={true}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                data-test-subj="collapsibleNavGroup-recentlyViewed"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="mockId"
+                    aria-expanded={true}
+                    className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                    id="mockId"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon euiAccordion__icon-isOpen"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <div
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          data-euiicon-type="arrowRight"
+                          size="m"
+                        />
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="m"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiTitle
+                                size="xxs"
+                              >
+                                <h3
+                                  className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                  id="mockId__title"
+                                >
+                                  Recently viewed
+                                </h3>
+                              </EuiTitle>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  className="euiAccordion__childWrapper"
+                  id="mockId"
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <div
+                          className="euiCollapsibleNavGroup__children"
+                        >
+                          <EuiListGroup
+                            aria-label="Recently viewed links"
+                            className="osdCollapsibleNav__recentsListGroup"
+                            color="subdued"
+                            gutterSize="none"
+                            listItems={
+                              Array [
+                                Object {
+                                  "aria-label": "recent",
+                                  "data-test-subj": "collapsibleNavAppLink--recent",
+                                  "href": "http://localhost/recent",
+                                  "label": "recent",
+                                  "onClick": [Function],
+                                  "title": "recent",
+                                },
+                              ]
+                            }
+                            maxWidth="none"
+                            size="s"
+                          >
+                            <ul
+                              aria-label="Recently viewed links"
+                              className="euiListGroup osdCollapsibleNav__recentsListGroup"
+                              style={
+                                Object {
+                                  "maxWidth": "none",
+                                }
+                              }
+                            >
+                              <EuiListGroupItem
+                                aria-label="recent"
+                                color="subdued"
+                                data-test-subj="collapsibleNavAppLink--recent"
+                                href="http://localhost/recent"
+                                key="title-0"
+                                label="recent"
+                                onClick={[Function]}
+                                showToolTip={false}
+                                size="s"
+                                title="recent"
+                                wrapText={false}
+                              >
+                                <li
+                                  className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                >
+                                  <a
+                                    aria-label="recent"
+                                    className="euiListGroupItem__button"
+                                    data-test-subj="collapsibleNavAppLink--recent"
+                                    href="http://localhost/recent"
+                                    onClick={[Function]}
+                                    rel="noreferrer"
+                                    title="recent"
+                                  >
+                                    <span
+                                      className="euiListGroupItem__label"
+                                      title="recent"
+                                    >
+                                      recent
+                                    </span>
+                                  </a>
+                                </li>
+                              </EuiListGroupItem>
+                            </ul>
+                          </EuiListGroup>
+                        </div>
+                      </div>
+                    </div>
+                  </EuiResizeObserver>
+                </div>
+              </div>
+            </EuiAccordion>
+          </EuiCollapsibleNavGroup>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiFlexItem
+            className="eui-yScroll"
+          >
+            <div
+              className="euiFlexItem eui-yScroll"
+            >
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
+                data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                iconType="undefined/opensearch_mark_default_mode.svg"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="opensearchDashboards"
+                onToggle={[Function]}
+                title="OpenSearch Dashboards"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="undefined/opensearch_mark_default_mode.svg"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            OpenSearch Dashboards
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
+                  data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
+                    data-test-subj="collapsibleNavGroup-opensearchDashboards"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="undefined/opensearch_mark_default_mode.svg"
+                                  >
+                                    <div
+                                      data-euiicon-type="undefined/opensearch_mark_default_mode.svg"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      OpenSearch Dashboards
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, OpenSearch Dashboards"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, OpenSearch Dashboards"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                data-test-opensearch-logo="logoObservability"
+                data-test-subj="collapsibleNavGroup-observability"
+                iconType="logoObservability"
+                initialIsOpen={true}
+                isCollapsible={true}
+                key="observability"
+                onToggle={[Function]}
+                title="Observability"
+              >
+                <EuiAccordion
+                  arrowDisplay="right"
+                  buttonClassName="euiCollapsibleNavGroup__heading"
+                  buttonContent={
+                    <EuiFlexGroup
+                      alignItems="center"
+                      gutterSize="m"
+                      responsive={false}
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <EuiIcon
+                          size="l"
+                          type="logoObservability"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiTitle
+                          size="xxs"
+                        >
+                          <h3
+                            className="euiCollapsibleNavGroup__title"
+                            id="mockId__title"
+                          >
+                            Observability
+                          </h3>
+                        </EuiTitle>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  data-test-opensearch-logo="logoObservability"
+                  data-test-subj="collapsibleNavGroup-observability"
+                  id="mockId"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                    data-test-opensearch-logo="logoObservability"
+                    data-test-subj="collapsibleNavGroup-observability"
+                    onToggle={[Function]}
+                  >
+                    <div
+                      className="euiAccordion__triggerWrapper"
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                        id="mockId"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="euiAccordion__iconWrapper"
+                        >
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
+                          >
+                            <div
+                              className="euiAccordion__icon euiAccordion__icon-isOpen"
+                              data-euiicon-type="arrowRight"
+                              size="m"
+                            />
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="m"
+                            responsive={false}
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiIcon
+                                    size="l"
+                                    type="logoObservability"
+                                  >
+                                    <div
+                                      data-euiicon-type="logoObservability"
+                                      size="l"
+                                    />
+                                  </EuiIcon>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiTitle
+                                    size="xxs"
+                                  >
+                                    <h3
+                                      className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                      id="mockId__title"
+                                    >
+                                      Observability
+                                    </h3>
+                                  </EuiTitle>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      className="euiAccordion__childWrapper"
+                      id="mockId"
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
+                          <div
+                            className=""
+                          >
+                            <div
+                              className="euiCollapsibleNavGroup__children"
+                            >
+                              <EuiListGroup
+                                aria-label="Primary navigation links, Observability"
+                                color="subdued"
+                                gutterSize="none"
+                                listItems={
+                                  Array [
+                                    Object {
+                                      "data-test-subj": "collapsibleNavAppLink",
+                                      "href": "discover",
+                                      "isActive": false,
+                                      "isDisabled": undefined,
+                                      "label": "discover",
+                                      "onClick": [Function],
+                                    },
+                                  ]
+                                }
+                                maxWidth="none"
+                                size="s"
+                              >
+                                <ul
+                                  aria-label="Primary navigation links, Observability"
+                                  className="euiListGroup"
+                                  style={
+                                    Object {
+                                      "maxWidth": "none",
+                                    }
+                                  }
+                                >
+                                  <EuiListGroupItem
+                                    color="subdued"
+                                    data-test-subj="collapsibleNavAppLink"
+                                    href="discover"
+                                    isActive={false}
+                                    key="title-0"
+                                    label="discover"
+                                    onClick={[Function]}
+                                    showToolTip={false}
+                                    size="s"
+                                    wrapText={false}
+                                  >
+                                    <li
+                                      className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
+                                    >
+                                      <a
+                                        className="euiListGroupItem__button"
+                                        data-test-subj="collapsibleNavAppLink"
+                                        href="discover"
+                                        onClick={[Function]}
+                                        rel="noreferrer"
+                                      >
+                                        <span
+                                          className="euiListGroupItem__label"
+                                          title="discover"
+                                        >
+                                          discover
+                                        </span>
+                                      </a>
+                                    </li>
+                                  </EuiListGroupItem>
+                                </ul>
+                              </EuiListGroup>
+                            </div>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </EuiCollapsibleNavGroup>
+              <EuiShowFor
+                sizes={
+                  Array [
+                    "l",
+                    "xl",
+                  ]
+                }
+              >
+                <EuiCollapsibleNavGroup>
+                  <div
+                    className="euiCollapsibleNavGroup"
+                    id="mockId"
+                  >
+                    <div
+                      className="euiCollapsibleNavGroup__children"
+                    >
+                      <EuiListGroup
+                        flush={true}
+                      >
+                        <ul
+                          className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+                        >
+                          <EuiListGroupItem
+                            aria-label="Dock primary navigation"
+                            buttonRef={
+                              Object {
+                                "current": <button
+                                  aria-label="Dock primary navigation"
+                                  class="euiListGroupItem__button"
+                                  data-test-subj="collapsible-nav-lock"
+                                  type="button"
+                                >
+                                  <div
+                                    class="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                  <span
+                                    class="euiListGroupItem__label"
+                                    title="Dock navigation"
+                                  >
+                                    Dock navigation
+                                  </span>
+                                </button>,
+                              }
+                            }
+                            color="subdued"
+                            data-test-subj="collapsible-nav-lock"
+                            iconType="lockOpen"
+                            label="Dock navigation"
+                            onClick={[Function]}
+                            size="xs"
+                          >
+                            <li
+                              className="euiListGroupItem euiListGroupItem--xSmall euiListGroupItem--subdued euiListGroupItem-isClickable"
+                            >
+                              <button
+                                aria-label="Dock primary navigation"
+                                className="euiListGroupItem__button"
+                                data-test-subj="collapsible-nav-lock"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  className="euiListGroupItem__icon"
+                                  type="lockOpen"
+                                >
+                                  <div
+                                    className="euiListGroupItem__icon"
+                                    data-euiicon-type="lockOpen"
+                                  />
+                                </EuiIcon>
+                                <span
+                                  className="euiListGroupItem__label"
+                                  title="Dock navigation"
+                                >
+                                  Dock navigation
                                 </span>
                               </button>
                             </li>

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -247,6 +247,18 @@ exports[`Header renders 1`] = `
       "serverBasePath": "/test",
     }
   }
+  branding={
+    Object {
+      "applicationTitle": "OpenSearch Dashboards",
+      "darkMode": false,
+      "logo": Object {
+        "defaultUrl": "/",
+      },
+      "mark": Object {
+        "defaultUrl": "/",
+      },
+    }
+  }
   breadcrumbs$={
     BehaviorSubject {
       "_isScalar": false,
@@ -1665,6 +1677,18 @@ exports[`Header renders 1`] = `
               "borders": "none",
               "items": Array [
                 <HeaderLogo
+                  branding={
+                    Object {
+                      "applicationTitle": "OpenSearch Dashboards",
+                      "darkMode": false,
+                      "logo": Object {
+                        "defaultUrl": "/",
+                      },
+                      "mark": Object {
+                        "defaultUrl": "/",
+                      },
+                    }
+                  }
                   forceNavigation$={
                     BehaviorSubject {
                       "_isScalar": false,
@@ -2771,6 +2795,18 @@ exports[`Header renders 1`] = `
                   className="euiHeaderSectionItem"
                 >
                   <HeaderLogo
+                    branding={
+                      Object {
+                        "applicationTitle": "OpenSearch Dashboards",
+                        "darkMode": false,
+                        "logo": Object {
+                          "defaultUrl": "/",
+                        },
+                        "mark": Object {
+                          "defaultUrl": "/",
+                        },
+                      }
+                    }
                     forceNavigation$={
                       BehaviorSubject {
                         "_isScalar": false,
@@ -2916,36 +2952,41 @@ exports[`Header renders 1`] = `
                     }
                     navigateToApp={[MockFunction]}
                   >
-                    <EuiHeaderLogo
+                    <a
                       aria-label="Go to home page"
+                      className="logoContainer"
                       data-test-subj="logo"
                       href="/"
-                      iconType={[Function]}
                       onClick={[Function]}
                     >
-                      <a
-                        aria-label="Go to home page"
-                        className="euiHeaderLogo"
-                        data-test-subj="logo"
-                        href="/"
-                        onClick={[Function]}
-                        rel="noreferrer"
+                      <CustomLogo
+                        applicationTitle="OpenSearch Dashboards"
+                        darkMode={false}
+                        logo={
+                          Object {
+                            "defaultUrl": "/",
+                          }
+                        }
+                        mark={
+                          Object {
+                            "defaultUrl": "/",
+                          }
+                        }
                       >
-                        <EuiIcon
-                          aria-label="Elastic"
-                          className="euiHeaderLogo__icon"
-                          size="l"
-                          type={[Function]}
+                        <div
+                          className="logoContainer"
                         >
-                          <div
-                            aria-label="Elastic"
-                            className="euiHeaderLogo__icon"
-                            data-euiicon-type="OpenSearchDashboardsLogoDarkMode"
-                            size="l"
+                          <img
+                            alt="OpenSearch Dashboards logo"
+                            className="logoImage"
+                            data-test-image-url="/"
+                            data-test-subj="customLogo"
+                            loading="lazy"
+                            src="/"
                           />
-                        </EuiIcon>
-                      </a>
-                    </EuiHeaderLogo>
+                        </div>
+                      </CustomLogo>
+                    </a>
                   </HeaderLogo>
                 </div>
               </EuiHeaderSectionItem>
@@ -5219,6 +5260,18 @@ exports[`Header renders 1`] = `
           "prepend": [Function],
           "remove": [Function],
           "serverBasePath": "/test",
+        }
+      }
+      branding={
+        Object {
+          "applicationTitle": "OpenSearch Dashboards",
+          "darkMode": false,
+          "logo": Object {
+            "defaultUrl": "/",
+          },
+          "mark": Object {
+            "defaultUrl": "/",
+          },
         }
       }
       closeNav={[Function]}

--- a/src/core/public/chrome/ui/header/branding/__snapshots__/opensearch_dashboards_custom_logo.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/branding/__snapshots__/opensearch_dashboards_custom_logo.test.tsx.snap
@@ -1,0 +1,1013 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Header logo  in dark mode  rendered using logo dark mode URL 1`] = `
+<CustomLogo
+  applicationTitle="custom title"
+  darkMode={true}
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+  logo={
+    Object {
+      "darkModeUrl": "/darkModeLogo",
+      "defaultUrl": "/defaultModeLogo",
+    }
+  }
+  mark={
+    Object {
+      "darkModeUrl": "/darkModeMark",
+      "defaultUrl": "/defaultModeMark",
+    }
+  }
+>
+  <div
+    className="logoContainer"
+  >
+    <img
+      alt="custom title logo"
+      className="logoImage"
+      data-test-image-url="/darkModeLogo"
+      data-test-subj="customLogo"
+      loading="lazy"
+      src="/darkModeLogo"
+    />
+  </div>
+</CustomLogo>
+`;
+
+exports[`Header logo  in dark mode  rendered using logo default mode URL 1`] = `
+<CustomLogo
+  applicationTitle="custom title"
+  darkMode={true}
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+  logo={
+    Object {
+      "defaultUrl": "/defaultModeLogo",
+    }
+  }
+  mark={
+    Object {
+      "darkModeUrl": "/darkModeMark",
+      "defaultUrl": "/defaultModeMark",
+    }
+  }
+>
+  <div
+    className="logoContainer"
+  >
+    <img
+      alt="custom title logo"
+      className="logoImage"
+      data-test-image-url="/defaultModeLogo"
+      data-test-subj="customLogo"
+      loading="lazy"
+      src="/defaultModeLogo"
+    />
+  </div>
+</CustomLogo>
+`;
+
+exports[`Header logo  in dark mode  rendered using mark dark mode URL 1`] = `
+<CustomLogo
+  applicationTitle="custom title"
+  darkMode={true}
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+  logo={Object {}}
+  mark={
+    Object {
+      "darkModeUrl": "/darkModeMark",
+      "defaultUrl": "/defaultModeMark",
+    }
+  }
+>
+  <div
+    className="logoContainer"
+  >
+    <img
+      alt="custom title logo"
+      className="logoImage"
+      data-test-image-url="/darkModeMark"
+      data-test-subj="customLogo"
+      loading="lazy"
+      src="/darkModeMark"
+    />
+  </div>
+</CustomLogo>
+`;
+
+exports[`Header logo  in dark mode  rendered using mark default mode URL 1`] = `
+<CustomLogo
+  applicationTitle="custom title"
+  darkMode={true}
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+  logo={Object {}}
+  mark={
+    Object {
+      "defaultUrl": "/defaultModeMark",
+    }
+  }
+>
+  <div
+    className="logoContainer"
+  >
+    <img
+      alt="custom title logo"
+      className="logoImage"
+      data-test-image-url="/defaultModeMark"
+      data-test-subj="customLogo"
+      loading="lazy"
+      src="/defaultModeMark"
+    />
+  </div>
+</CustomLogo>
+`;
+
+exports[`Header logo  in dark mode  rendered using original opensearch logo 1`] = `
+<CustomLogo
+  applicationTitle="custom title"
+  darkMode={true}
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+  logo={Object {}}
+  mark={Object {}}
+>
+  <img
+    alt="custom title logo"
+    src="undefined/opensearch_logo.svg"
+  />
+</CustomLogo>
+`;
+
+exports[`Header logo  in default mode  rendered using logo default mode URL 1`] = `
+<CustomLogo
+  applicationTitle="custom title"
+  darkMode={false}
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+  logo={
+    Object {
+      "defaultUrl": "/defaultModeLogo",
+    }
+  }
+  mark={Object {}}
+>
+  <div
+    className="logoContainer"
+  >
+    <img
+      alt="custom title logo"
+      className="logoImage"
+      data-test-image-url="/defaultModeLogo"
+      data-test-subj="customLogo"
+      loading="lazy"
+      src="/defaultModeLogo"
+    />
+  </div>
+</CustomLogo>
+`;
+
+exports[`Header logo  in default mode  rendered using mark default mode URL 1`] = `
+<CustomLogo
+  applicationTitle="custom title"
+  darkMode={false}
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+  logo={Object {}}
+  mark={
+    Object {
+      "defaultUrl": "/defaultModeMark",
+    }
+  }
+>
+  <div
+    className="logoContainer"
+  >
+    <img
+      alt="custom title logo"
+      className="logoImage"
+      data-test-image-url="/defaultModeMark"
+      data-test-subj="customLogo"
+      loading="lazy"
+      src="/defaultModeMark"
+    />
+  </div>
+</CustomLogo>
+`;
+
+exports[`Header logo  in default mode  rendered using the original opensearch logo 1`] = `
+<CustomLogo
+  applicationTitle="custom title"
+  darkMode={false}
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+  logo={Object {}}
+  mark={Object {}}
+>
+  <img
+    alt="custom title logo"
+    src="undefined/opensearch_logo.svg"
+  />
+</CustomLogo>
+`;

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.test.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import React from 'react';
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
+import { CustomLogo } from './opensearch_dashboards_custom_logo';
+
+describe('Header logo ', () => {
+  describe('in default mode ', () => {
+    it('rendered using logo default mode URL', () => {
+      const branding = {
+        darkMode: false,
+        logo: { defaultUrl: '/defaultModeLogo' },
+        mark: {},
+        applicationTitle: 'custom title',
+      };
+      const component = mountWithIntl(<CustomLogo {...branding} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using mark default mode URL', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: { defaultUrl: '/defaultModeMark' },
+        applicationTitle: 'custom title',
+      };
+      const component = mountWithIntl(<CustomLogo {...branding} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using the original opensearch logo', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: {},
+        applicationTitle: 'custom title',
+      };
+      const component = mountWithIntl(<CustomLogo {...branding} />);
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('in dark mode ', () => {
+    it('rendered using logo dark mode URL', () => {
+      const branding = {
+        darkMode: true,
+        logo: { defaultUrl: '/defaultModeLogo', darkModeUrl: '/darkModeLogo' },
+        mark: { defaultUrl: '/defaultModeMark', darkModeUrl: '/darkModeMark' },
+        applicationTitle: 'custom title',
+      };
+      const component = mountWithIntl(<CustomLogo {...branding} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using logo default mode URL', () => {
+      const branding = {
+        darkMode: true,
+        logo: { defaultUrl: '/defaultModeLogo' },
+        mark: { defaultUrl: '/defaultModeMark', darkModeUrl: '/darkModeMark' },
+        applicationTitle: 'custom title',
+      };
+      const component = mountWithIntl(<CustomLogo {...branding} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using mark dark mode URL', () => {
+      const branding = {
+        darkMode: true,
+        logo: {},
+        mark: { defaultUrl: '/defaultModeMark', darkModeUrl: '/darkModeMark' },
+        applicationTitle: 'custom title',
+      };
+      const component = mountWithIntl(<CustomLogo {...branding} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using mark default mode URL', () => {
+      const branding = {
+        darkMode: true,
+        logo: {},
+        mark: { defaultUrl: '/defaultModeMark' },
+        applicationTitle: 'custom title',
+      };
+      const component = mountWithIntl(<CustomLogo {...branding} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using original opensearch logo', () => {
+      const branding = {
+        darkMode: true,
+        logo: {},
+        mark: {},
+        applicationTitle: 'custom title',
+      };
+      const component = mountWithIntl(<CustomLogo {...branding} />);
+      expect(component).toMatchSnapshot();
+    });
+  });
+});

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.tsx
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from 'react';
+import '../header_logo.scss';
+import { ChromeBranding } from '../../../chrome_service';
+
+/**
+ * Use branding configurations to render the header logo on the nav bar.
+ *
+ * @param {ChromeBranding} - branding object consist of logo, mark and title
+ * @returns Custom branding logo component which is going to be rendered on the main page header bar.
+ *          If logo default is valid, the full logo by logo default config will be rendered;
+ *          if not, the logo icon by mark default config will be rendered; if both are not found,
+ *          the default OpenSearch Dashboards logo will be rendered.
+ */
+export const CustomLogo = ({ ...branding }: ChromeBranding) => {
+  const darkMode = branding.darkMode;
+  const assetFolderUrl = branding.assetFolderUrl;
+  const logoDefault = branding.logo?.defaultUrl;
+  const logoDarkMode = branding.logo?.darkModeUrl;
+  const markDefault = branding.mark?.defaultUrl;
+  const markDarkMode = branding.mark?.darkModeUrl;
+  const applicationTitle = branding.applicationTitle;
+
+  /**
+   * Use branding configurations to check which URL to use for rendering
+   * header logo in nav bar in default mode
+   *
+   * @returns a valid custom URL or undefined if no valid URL is provided
+   */
+  const customHeaderLogoDefaultMode = () => {
+    return logoDefault ?? markDefault ?? undefined;
+  };
+
+  /**
+   * Use branding configurations to check which URL to use for rendering
+   * header logo in nav bar in dark mode
+   *
+   * @returns a valid custom URL or undefined if no valid URL is provided
+   */
+  const customHeaderLogoDarkMode = () => {
+    return logoDarkMode ?? logoDefault ?? markDarkMode ?? markDefault ?? undefined;
+  };
+
+  /**
+   * Render custom header logo for both default mode and dark mode
+   *
+   * @returns a valid custom header logo URL, or undefined
+   */
+  const customHeaderLogo = () => {
+    return darkMode ? customHeaderLogoDarkMode() : customHeaderLogoDefaultMode();
+  };
+
+  return customHeaderLogo() ? (
+    <div className="logoContainer">
+      <img
+        data-test-subj="customLogo"
+        data-test-image-url={customHeaderLogo()}
+        src={customHeaderLogo()}
+        alt={applicationTitle + ' logo'}
+        loading="lazy"
+        className="logoImage"
+      />
+    </div>
+  ) : (
+    <img src={`${assetFolderUrl}/opensearch_logo.svg`} alt={applicationTitle + ' logo'} />
+  );
+};

--- a/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
@@ -82,6 +82,13 @@ function mockProps() {
     navigateToApp: () => Promise.resolve(),
     navigateToUrl: () => Promise.resolve(),
     customNavLink$: new BehaviorSubject(undefined),
+    branding: {
+      darkMode: false,
+      mark: {
+        defaultUrl: '/defaultModeLogo',
+        darkModeUrl: '/darkModeLogo',
+      },
+    },
   };
 }
 
@@ -205,5 +212,79 @@ describe('CollapsibleNav', () => {
     component.find('[data-test-subj="collapsibleNavGroup-noCategory"] a').simulate('click');
     expect(onClose.callCount).toEqual(3);
     expectNavIsClosed(component);
+  });
+
+  it('renders the nav bar with custom logo in default mode', () => {
+    const navLinks = [
+      mockLink({ category: opensearchDashboards }),
+      mockLink({ category: observability }),
+    ];
+    const recentNavLinks = [mockRecentNavLink({})];
+    const component = mount(
+      <CollapsibleNav
+        {...mockProps()}
+        isNavOpen={true}
+        navLinks$={new BehaviorSubject(navLinks)}
+        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
+      />
+    );
+    // check if nav bar renders default mode custom logo
+    expect(component).toMatchSnapshot();
+
+    // check if nav bar renders the original default mode opensearch mark
+    component.setProps({
+      branding: {
+        darkMode: false,
+        mark: {},
+      },
+    });
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders the nav bar with custom logo in dark mode', () => {
+    const navLinks = [
+      mockLink({ category: opensearchDashboards }),
+      mockLink({ category: observability }),
+    ];
+    const recentNavLinks = [mockRecentNavLink({})];
+    const component = mount(
+      <CollapsibleNav
+        {...mockProps()}
+        isNavOpen={true}
+        navLinks$={new BehaviorSubject(navLinks)}
+        recentlyAccessed$={new BehaviorSubject(recentNavLinks)}
+      />
+    );
+    // check if nav bar renders dark mode custom logo
+    component.setProps({
+      branding: {
+        darkMode: true,
+        mark: {
+          defaultUrl: '/defaultModeLogo',
+          darkModeUrl: '/darkModeLogo',
+        },
+      },
+    });
+    expect(component).toMatchSnapshot();
+
+    // check if nav bar renders default mode custom logo
+    component.setProps({
+      branding: {
+        darkMode: true,
+        mark: {
+          defaultUrl: '/defaultModeLogo',
+        },
+      },
+    });
+    expect(component).toMatchSnapshot();
+
+    // check if nav bar renders the original dark mode opensearch mark
+    component.setProps({
+      branding: {
+        darkMode: false,
+        mark: {},
+      },
+    });
+    expect(component).toMatchSnapshot();
   });
 });

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -52,6 +52,7 @@ import { InternalApplicationStart } from '../../../application/types';
 import { HttpStart } from '../../../http';
 import { OnIsLockedUpdate } from './';
 import { createEuiListItem, createRecentNavLink, isModifiedOrPrevented } from './nav_link';
+import { ChromeBranding } from '../../chrome_service';
 
 function getAllCategories(allCategorizedLinks: Record<string, ChromeNavLink[]>) {
   const allCategories = {} as Record<string, AppCategory | undefined>;
@@ -102,6 +103,7 @@ interface Props {
   navigateToApp: InternalApplicationStart['navigateToApp'];
   navigateToUrl: InternalApplicationStart['navigateToUrl'];
   customNavLink$: Rx.Observable<ChromeNavLink | undefined>;
+  branding: ChromeBranding;
 }
 
 export function CollapsibleNav({
@@ -115,6 +117,7 @@ export function CollapsibleNav({
   closeNav,
   navigateToApp,
   navigateToUrl,
+  branding,
   ...observables
 }: Props) {
   const navLinks = useObservable(observables.navLinks$, []).filter((link) => !link.hidden);
@@ -135,6 +138,42 @@ export function CollapsibleNav({
       onClick: closeNav,
       ...(needsIcon && { basePath }),
     });
+  };
+
+  const DEFAULT_OPENSEARCH_MARK = `${branding.assetFolderUrl}/opensearch_mark_default_mode.svg`;
+  const DARKMODE_OPENSEARCH_MARK = `${branding.assetFolderUrl}/opensearch_mark_dark_mode.svg`;
+
+  const darkMode = branding.darkMode;
+  const markDefault = branding.mark?.defaultUrl;
+  const markDarkMode = branding.mark?.darkModeUrl;
+
+  /**
+   * Use branding configurations to check which URL to use for rendering
+   * side menu opensearch logo in default mode
+   *
+   * @returns a valid custom URL or original default mode opensearch mark if no valid URL is provided
+   */
+  const customSideMenuLogoDefaultMode = () => {
+    return markDefault ?? DEFAULT_OPENSEARCH_MARK;
+  };
+
+  /**
+   * Use branding configurations to check which URL to use for rendering
+   * side menu opensearch logo in dark mode
+   *
+   * @returns a valid custom URL or original dark mode opensearch mark if no valid URL is provided
+   */
+  const customSideMenuLogoDarkMode = () => {
+    return markDarkMode ?? markDefault ?? DARKMODE_OPENSEARCH_MARK;
+  };
+
+  /**
+   * Render custom side menu logo for both default mode and dark mode
+   *
+   * @returns a valid logo URL
+   */
+  const customSideMenuLogo = () => {
+    return darkMode ? customSideMenuLogoDarkMode() : customSideMenuLogoDefaultMode();
   };
 
   return (
@@ -273,16 +312,19 @@ export function CollapsibleNav({
         {/* OpenSearchDashboards, Observability, Security, and Management sections */}
         {orderedCategories.map((categoryName) => {
           const category = categoryDictionary[categoryName]!;
+          const opensearchLinkLogo =
+            category.id === 'opensearchDashboards' ? customSideMenuLogo() : category.euiIconType;
 
           return (
             <EuiCollapsibleNavGroup
               key={category.id}
-              iconType={category.euiIconType}
+              iconType={opensearchLinkLogo}
               title={category.label}
               isCollapsible={true}
               initialIsOpen={getIsCategoryOpen(category.id, storage)}
               onToggle={(isCategoryOpen) => setIsCategoryOpen(category.id, isCategoryOpen, storage)}
               data-test-subj={`collapsibleNavGroup-${category.id}`}
+              data-test-opensearch-logo={opensearchLinkLogo}
             >
               <EuiListGroup
                 aria-label={i18n.translate('core.ui.primaryNavSection.screenReaderLabel', {

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -69,6 +69,12 @@ function mockProps() {
     isLocked$: new BehaviorSubject(false),
     loadingCount$: new BehaviorSubject(0),
     onIsLockedUpdate: () => {},
+    branding: {
+      darkMode: false,
+      logo: { defaultUrl: '/' },
+      mark: { defaultUrl: '/' },
+      applicationTitle: 'OpenSearch Dashboards',
+    },
   };
 }
 

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -55,7 +55,7 @@ import {
 } from '../..';
 import { InternalApplicationStart } from '../../../application/types';
 import { HttpStart } from '../../../http';
-import { ChromeHelpExtension } from '../../chrome_service';
+import { ChromeHelpExtension, ChromeBranding } from '../../chrome_service';
 import { OnIsLockedUpdate } from './';
 import { CollapsibleNav } from './collapsible_nav';
 import { HeaderBadge } from './header_badge';
@@ -87,6 +87,7 @@ export interface HeaderProps {
   isLocked$: Observable<boolean>;
   loadingCount$: ReturnType<HttpStart['getLoadingCount$']>;
   onIsLockedUpdate: OnIsLockedUpdate;
+  branding: ChromeBranding;
 }
 
 export function Header({
@@ -96,6 +97,7 @@ export function Header({
   basePath,
   onIsLockedUpdate,
   homeHref,
+  branding,
   ...observables
 }: HeaderProps) {
   const isVisible = useObservable(observables.isVisible$, false);
@@ -125,6 +127,7 @@ export function Header({
                     forceNavigation$={observables.forceAppSwitcherNavigation$}
                     navLinks$={observables.navLinks$}
                     navigateToApp={application.navigateToApp}
+                    branding={branding}
                   />,
                   <LoadingIndicator loadingCount$={observables.loadingCount$} />,
                 ],
@@ -213,6 +216,7 @@ export function Header({
             }
           }}
           customNavLink$={observables.customNavLink$}
+          branding={branding}
         />
       </header>
     </>

--- a/src/core/public/chrome/ui/header/header_logo.scss
+++ b/src/core/public/chrome/ui/header/header_logo.scss
@@ -1,0 +1,9 @@
+.logoContainer {
+    height: 30px;
+    padding: 3px 3px 3px 10px;
+}
+
+.logoImage {
+    height: 100%;
+    max-width: 100%;
+}

--- a/src/core/public/chrome/ui/header/header_logo.tsx
+++ b/src/core/public/chrome/ui/header/header_logo.tsx
@@ -30,14 +30,15 @@
  * GitHub history for details.
  */
 
-import { EuiHeaderLogo } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import React from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { Observable } from 'rxjs';
 import Url from 'url';
 import { ChromeNavLink } from '../..';
-import { OpenSearchDashboardsLogoDarkMode } from './branding/opensearch_dashboards_logo_darkmode';
+import { CustomLogo } from './branding/opensearch_dashboards_custom_logo';
+import { ChromeBranding } from '../../chrome_service';
+import './header_logo.scss';
 
 function findClosestAnchor(element: HTMLElement): HTMLAnchorElement | void {
   let current = element;
@@ -104,21 +105,24 @@ interface Props {
   navLinks$: Observable<ChromeNavLink[]>;
   forceNavigation$: Observable<boolean>;
   navigateToApp: (appId: string) => void;
+  branding: ChromeBranding;
 }
 
-export function HeaderLogo({ href, navigateToApp, ...observables }: Props) {
+export function HeaderLogo({ href, navigateToApp, branding, ...observables }: Props) {
   const forceNavigation = useObservable(observables.forceNavigation$, false);
   const navLinks = useObservable(observables.navLinks$, []);
 
   return (
-    <EuiHeaderLogo
+    <a
       data-test-subj="logo"
-      iconType={OpenSearchDashboardsLogoDarkMode}
       onClick={(e) => onClick(e, forceNavigation, navLinks, navigateToApp)}
       href={href}
       aria-label={i18n.translate('core.ui.chrome.headerGlobalNav.goHomePageIconAriaLabel', {
         defaultMessage: 'Go to home page',
       })}
-    />
+      className="logoContainer"
+    >
+      <CustomLogo {...branding} />
+    </a>
   );
 }

--- a/src/core/public/core_system.ts
+++ b/src/core/public/core_system.ts
@@ -239,7 +239,7 @@ export class CoreSystem {
         docLinks,
         http,
         i18n,
-        injectedMetadata: pick(injectedMetadata, ['getInjectedVar']),
+        injectedMetadata: pick(injectedMetadata, ['getInjectedVar', 'getBranding']),
         notifications,
         overlays,
         savedObjects,

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -89,6 +89,7 @@ import {
   HandlerContextType,
   HandlerParameters,
 } from './context';
+import { Branding } from '../types';
 
 export { PackageInfo, EnvironmentMode } from '../server/types';
 /** @interal */
@@ -236,6 +237,7 @@ export interface CoreSetup<TPluginsStart extends object = object, TStart = unkno
    * */
   injectedMetadata: {
     getInjectedVar: (name: string, defaultValue?: any) => unknown;
+    getBranding: () => Branding;
   };
   /** {@link StartServicesAccessor} */
   getStartServices: StartServicesAccessor<TPluginsStart, TStart>;
@@ -291,6 +293,7 @@ export interface CoreStart {
    * */
   injectedMetadata: {
     getInjectedVar: (name: string, defaultValue?: any) => unknown;
+    getBranding: () => Branding;
   };
 }
 
@@ -337,6 +340,7 @@ export {
   IUiSettingsClient,
   UiSettingsState,
   NavType,
+  Branding,
 };
 
 export { __osdBootstrap__ } from './osd_bootstrap';

--- a/src/core/public/injected_metadata/injected_metadata_service.mock.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.mock.ts
@@ -45,6 +45,7 @@ const createSetupContractMock = () => {
     getInjectedVar: jest.fn(),
     getInjectedVars: jest.fn(),
     getOpenSearchDashboardsBuildNumber: jest.fn(),
+    getBranding: jest.fn(),
   };
   setupContract.getCspConfig.mockReturnValue({ warnLegacyBrowsers: true });
   setupContract.getOpenSearchDashboardsVersion.mockReturnValue('opensearchDashboardsVersion');

--- a/src/core/public/injected_metadata/injected_metadata_service.test.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.test.ts
@@ -229,3 +229,16 @@ describe('setup.getInjectedVars()', () => {
     );
   });
 });
+
+describe('setup.getBranding()', () => {
+  it('returns injectedMetadata.branding', () => {
+    const injectedMetadata = new InjectedMetadataService({
+      injectedMetadata: {
+        branding: { fullLogoUrl: '/', logoUrl: '/', title: 'title' },
+      },
+    } as any);
+
+    const branding = injectedMetadata.setup().getBranding();
+    expect(branding).toEqual({ fullLogoUrl: '/', logoUrl: '/', title: 'title' });
+  });
+});

--- a/src/core/public/injected_metadata/injected_metadata_service.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.ts
@@ -39,7 +39,7 @@ import {
   UiSettingsParams,
   UserProvidedValues,
 } from '../../server/types';
-import { AppCategory } from '../';
+import { AppCategory, Branding } from '../';
 
 export interface InjectedPluginMetadata {
   id: PluginName;
@@ -76,6 +76,7 @@ export interface InjectedMetadataParams {
         user?: Record<string, UserProvidedValues>;
       };
     };
+    branding: Branding;
   };
 }
 
@@ -143,6 +144,10 @@ export class InjectedMetadataService {
       getOpenSearchDashboardsBranch: () => {
         return this.state.branch;
       },
+
+      getBranding: () => {
+        return this.state.branding;
+      },
     };
   }
 }
@@ -176,6 +181,7 @@ export interface InjectedMetadataSetup {
   getInjectedVars: () => {
     [key: string]: unknown;
   };
+  getBranding: () => Branding;
 }
 
 /** @internal */

--- a/src/core/public/mocks.ts
+++ b/src/core/public/mocks.ts
@@ -103,6 +103,7 @@ function createCoreStartMock({ basePath = '' } = {}) {
     savedObjects: savedObjectsServiceMock.createStartContract(),
     injectedMetadata: {
       getInjectedVar: injectedMetadataServiceMock.createStartContract().getInjectedVar,
+      getBranding: injectedMetadataServiceMock.createStartContract().getBranding,
     },
     fatalErrors: fatalErrorsServiceMock.createStartContract(),
   };

--- a/src/core/public/plugins/plugin_context.ts
+++ b/src/core/public/plugins/plugin_context.ts
@@ -120,6 +120,7 @@ export function createPluginSetupContext<
     uiSettings: deps.uiSettings,
     injectedMetadata: {
       getInjectedVar: deps.injectedMetadata.getInjectedVar,
+      getBranding: deps.injectedMetadata.getBranding,
     },
     getStartServices: () => plugin.startDependencies,
   };
@@ -166,6 +167,7 @@ export function createPluginStartContext<
     savedObjects: deps.savedObjects,
     injectedMetadata: {
       getInjectedVar: deps.injectedMetadata.getInjectedVar,
+      getBranding: deps.injectedMetadata.getBranding,
     },
     fatalErrors: deps.fatalErrors,
   };

--- a/src/core/public/plugins/plugins_service.test.ts
+++ b/src/core/public/plugins/plugins_service.test.ts
@@ -113,7 +113,7 @@ describe('PluginsService', () => {
       ...mockSetupDeps,
       application: expect.any(Object),
       getStartServices: expect.any(Function),
-      injectedMetadata: pick(mockSetupDeps.injectedMetadata, 'getInjectedVar'),
+      injectedMetadata: pick(mockSetupDeps.injectedMetadata, 'getInjectedVar', 'getBranding'),
     };
     mockStartDeps = {
       application: applicationServiceMock.createInternalStartContract(),
@@ -132,7 +132,7 @@ describe('PluginsService', () => {
       ...mockStartDeps,
       application: expect.any(Object),
       chrome: omit(mockStartDeps.chrome, 'getComponent'),
-      injectedMetadata: pick(mockStartDeps.injectedMetadata, 'getInjectedVar'),
+      injectedMetadata: pick(mockStartDeps.injectedMetadata, 'getInjectedVar', 'getBranding'),
     };
 
     // Reset these for each test.

--- a/src/core/server/core_app/assets/default_branding/opensearch_logo.svg
+++ b/src/core/server/core_app/assets/default_branding/opensearch_logo.svg
@@ -1,39 +1,33 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
+<!--
+ SPDX-License-Identifier: Apache-2.0
+ This conversation was marked as resolved by abbyhu2000
+ 
+ The OpenSearch Contributors require contributions made to
+ this file be licensed under the Apache-2.0 license or a
+ compatible open source license.
+ 
+ Licensed to Elasticsearch B.V. under one or more contributor
+ license agreements. See the NOTICE file distributed with
+ this work for additional information regarding copyright
+ ownership. Elasticsearch B.V. licenses this file to you under
+ the Apache License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+    http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ 
+ Modifications Copyright OpenSearch Contributors. See
+ GitHub history for details.
+ -->
 
-/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-import React from 'react';
-
-export function OpenSearchDashboardsLogoDarkMode() {
-  return (
-    <svg height="28" viewBox="0 0 148 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg height="28" viewBox="0 0 148 16" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M13.7235 5.87915C13.4537 5.87915 13.2349 6.0979 13.2349 6.36775C13.2349 10.3884 9.97556 13.6478 5.9549 13.6478C5.68506 13.6478 5.46631 13.8665 5.46631 14.1364C5.46631 14.4062 5.68506 14.625 5.9549 14.625C10.5153 14.625 14.2121 10.9281 14.2121 6.36775C14.2121 6.0979 13.9934 5.87915 13.7235 5.87915Z"
         fill="#00A3E0"
@@ -99,5 +93,3 @@ export function OpenSearchDashboardsLogoDarkMode() {
         fill="#D9E1E2"
       />
     </svg>
-  );
-}

--- a/src/core/server/core_app/assets/default_branding/opensearch_mark_dark_mode.svg
+++ b/src/core/server/core_app/assets/default_branding/opensearch_mark_dark_mode.svg
@@ -1,0 +1,34 @@
+<!--
+ SPDX-License-Identifier: Apache-2.0
+ This conversation was marked as resolved by abbyhu2000
+ 
+ The OpenSearch Contributors require contributions made to
+ this file be licensed under the Apache-2.0 license or a
+ compatible open source license.
+ 
+ Licensed to Elasticsearch B.V. under one or more contributor
+ license agreements. See the NOTICE file distributed with
+ this work for additional information regarding copyright
+ ownership. Elasticsearch B.V. licenses this file to you under
+ the Apache License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+    http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ 
+ Modifications Copyright OpenSearch Contributors. See
+ GitHub history for details.
+ -->
+ 
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+<path d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3814 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z" fill="#00A3E0"/>
+<path d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.0631 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z" fill="#B9D9EB"/>
+<path d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93695 27.2283C5.78747 24.1704 2.95092 20.6257 3.91861 14Z" fill="#00A3E0"/>
+</svg>

--- a/src/core/server/core_app/assets/default_branding/opensearch_mark_default_mode.svg
+++ b/src/core/server/core_app/assets/default_branding/opensearch_mark_default_mode.svg
@@ -1,0 +1,34 @@
+<!--
+ SPDX-License-Identifier: Apache-2.0
+ This conversation was marked as resolved by abbyhu2000
+ 
+ The OpenSearch Contributors require contributions made to
+ this file be licensed under the Apache-2.0 license or a
+ compatible open source license.
+ 
+ Licensed to Elasticsearch B.V. under one or more contributor
+ license agreements. See the NOTICE file distributed with
+ this work for additional information regarding copyright
+ ownership. Elasticsearch B.V. licenses this file to you under
+ the Apache License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+    http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ 
+ Modifications Copyright OpenSearch Contributors. See
+ GitHub history for details.
+ -->
+ 
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+<path d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z" fill="#005EB8"/>
+<path d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z" fill="#003B5C"/>
+<path d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z" fill="#005EB8"/>
+</svg>

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -52,6 +52,38 @@ export const config = {
     index: schema.string({ defaultValue: '.kibana' }),
     autocompleteTerminateAfter: schema.duration({ defaultValue: 100000 }),
     autocompleteTimeout: schema.duration({ defaultValue: 1000 }),
+    branding: schema.object({
+      logo: schema.object({
+        defaultUrl: schema.string({
+          defaultValue: '/',
+        }),
+        darkModeUrl: schema.string({
+          defaultValue: '/',
+        }),
+      }),
+      mark: schema.object({
+        defaultUrl: schema.string({
+          defaultValue: '/',
+        }),
+        darkModeUrl: schema.string({
+          defaultValue: '/',
+        }),
+      }),
+      loadingLogo: schema.object({
+        defaultUrl: schema.string({
+          defaultValue: '/',
+        }),
+        darkModeUrl: schema.string({
+          defaultValue: '/',
+        }),
+      }),
+      faviconUrl: schema.string({
+        defaultValue: '/',
+      }),
+      applicationTitle: schema.string({
+        defaultValue: '',
+      }),
+    }),
   }),
   deprecations,
 };

--- a/src/core/server/rendering/__mocks__/rendering_service.ts
+++ b/src/core/server/rendering/__mocks__/rendering_service.ts
@@ -41,9 +41,13 @@ export const setupMock: jest.Mocked<InternalRenderingServiceSetup> = {
 };
 export const mockSetup = jest.fn().mockResolvedValue(setupMock);
 export const mockStop = jest.fn();
+export const mockIsUrlValid = jest.fn();
+export const mockIsTitleValid = jest.fn();
 export const mockRenderingService: jest.Mocked<IRenderingService> = {
   setup: mockSetup,
   stop: mockStop,
+  isUrlValid: mockIsUrlValid,
+  isTitleValid: mockIsTitleValid,
 };
 export const RenderingService = jest.fn<IRenderingService, [typeof mockRenderingServiceParams]>(
   () => mockRenderingService

--- a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
@@ -5,6 +5,14 @@ Object {
   "anonymousStatusPage": false,
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
+  "branding": Object {
+    "applicationTitle": "OpenSearch Dashboards",
+    "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
+    "darkMode": false,
+    "loadingLogo": Object {},
+    "logo": Object {},
+    "mark": Object {},
+  },
   "buildNumber": Any<Number>,
   "csp": Object {
     "warnLegacyBrowsers": true,
@@ -48,6 +56,14 @@ Object {
   "anonymousStatusPage": false,
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
+  "branding": Object {
+    "applicationTitle": "OpenSearch Dashboards",
+    "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
+    "darkMode": false,
+    "loadingLogo": Object {},
+    "logo": Object {},
+    "mark": Object {},
+  },
   "buildNumber": Any<Number>,
   "csp": Object {
     "warnLegacyBrowsers": true,
@@ -91,6 +107,14 @@ Object {
   "anonymousStatusPage": false,
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
+  "branding": Object {
+    "applicationTitle": "OpenSearch Dashboards",
+    "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
+    "darkMode": true,
+    "loadingLogo": Object {},
+    "logo": Object {},
+    "mark": Object {},
+  },
   "buildNumber": Any<Number>,
   "csp": Object {
     "warnLegacyBrowsers": true,
@@ -138,6 +162,14 @@ Object {
   "anonymousStatusPage": false,
   "basePath": "",
   "branch": Any<String>,
+  "branding": Object {
+    "applicationTitle": "OpenSearch Dashboards",
+    "assetFolderUrl": "/ui/default_branding",
+    "darkMode": false,
+    "loadingLogo": Object {},
+    "logo": Object {},
+    "mark": Object {},
+  },
   "buildNumber": Any<Number>,
   "csp": Object {
     "warnLegacyBrowsers": true,
@@ -181,6 +213,14 @@ Object {
   "anonymousStatusPage": false,
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
+  "branding": Object {
+    "applicationTitle": "OpenSearch Dashboards",
+    "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
+    "darkMode": false,
+    "loadingLogo": Object {},
+    "logo": Object {},
+    "mark": Object {},
+  },
   "buildNumber": Any<Number>,
   "csp": Object {
     "warnLegacyBrowsers": true,

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -32,6 +32,7 @@
 
 import { i18n } from '@osd/i18n';
 
+import { Branding } from 'src/core/types';
 import { EnvironmentMode, PackageInfo } from '../config';
 import { ICspConfig } from '../csp';
 import { InternalHttpServiceSetup, OpenSearchDashboardsRequest, LegacyRequest } from '../http';
@@ -74,6 +75,7 @@ export interface RenderingMetadata {
         user: Record<string, UserProvidedValues<any>>;
       };
     };
+    branding: Branding;
   };
 }
 
@@ -116,4 +118,37 @@ export interface InternalRenderingServiceSetup {
     uiSettings: IUiSettingsClient,
     options?: IRenderOptions
   ): Promise<string>;
+}
+
+/**
+ * For each branding config:
+ * check if user provides a valid URL.
+ * Assign True -- if user provides a valid URL
+ * Assign False -- if user provides an invalid URL or user does not provide any URL
+ */
+export interface BrandingValidation {
+  isLogoDefaultValid: boolean;
+  isLogoDarkmodeValid: boolean;
+  isMarkDefaultValid: boolean;
+  isMarkDarkmodeValid: boolean;
+  isLoadingLogoDefaultValid: boolean;
+  isLoadingLogoDarkmodeValid: boolean;
+  isFaviconValid: boolean;
+  isTitleValid: boolean;
+}
+
+/**
+ * For each branding config:
+ * if user provides a valid URL, the URL will be assigned;
+ * otherwise, undefined will be assigned.
+ */
+export interface BrandingAssignment {
+  logoDefault?: string;
+  logoDarkmode?: string;
+  markDefault?: string;
+  markDarkmode?: string;
+  loadingLogoDefault?: string;
+  loadingLogoDarkmode?: string;
+  favicon?: string;
+  applicationTitle?: string;
 }

--- a/src/core/server/rendering/views/__snapshots__/template.test.tsx.snap
+++ b/src/core/server/rendering/views/__snapshots__/template.test.tsx.snap
@@ -1,0 +1,1480 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Loading page  logo in dark mode  rendered using loading logo dark mode URL 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title />,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\",\\"darkModeUrl\\":\\"/darkModeMark\\"},\\"loadingLogo\\":{\\"defaultUrl\\":\\"/defaultModeLoadingLogo\\",\\"darkModeUrl\\":\\"/darkModeLoadingLogo\\"},\\"title\\":\\"custom title\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <div
+        class="loadingLogoContainer"
+      >
+        <img
+          alt="undefined logo"
+          class="loadingLogo"
+          src="/darkModeLoadingLogo"
+        />
+      </div>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Loading page  logo in dark mode  rendered using loading logo default mode URL 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title />,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\",\\"darkModeUrl\\":\\"/darkModeMark\\"},\\"loadingLogo\\":{\\"defaultUrl\\":\\"/defaultModeLoadingLogo\\"},\\"title\\":\\"custom title\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <div
+        class="loadingLogoContainer"
+      >
+        <img
+          alt="undefined logo"
+          class="loadingLogo"
+          src="/defaultModeLoadingLogo"
+        />
+      </div>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Loading page  logo in dark mode  rendered using mark dark mode URL with loading bar 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title />,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\",\\"darkModeUrl\\":\\"/darkModeMark\\"},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <div
+        class="loadingLogoContainer"
+      >
+        <img
+          alt="undefined logo"
+          class="loadingLogo"
+          src="/darkModeMark"
+        />
+      </div>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+      <div
+        class="osdProgress"
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Loading page  logo in dark mode  rendered using mark default mode URL with loading bar 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title />,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\"},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <div
+        class="loadingLogoContainer"
+      >
+        <img
+          alt="undefined logo"
+          class="loadingLogo"
+          src="/defaultModeMark"
+        />
+      </div>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+      <div
+        class="osdProgress"
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Loading page  logo in dark mode  renders using original opensearch loading spinner 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title />,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 90 90"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M75.7374 37.5C74.4878 37.5 73.4748 38.513 73.4748 39.7626C73.4748 58.3813 58.3813 73.4748 39.7626 73.4748C38.513 73.4748 37.5 74.4878 37.5 75.7374C37.5 76.987 38.513 78 39.7626 78C60.8805 78 78 60.8805 78 39.7626C78 38.513 76.987 37.5 75.7374 37.5Z"
+            fill="#005EB8"
+          />
+          <animateTransform
+            attributeName="transform"
+            dur="1.5s"
+            from="0 40 40"
+            keyTimes="0; .3; .7; 1"
+            repeatCount="indefinite"
+            to="359.9 40 40"
+            type="rotate"
+            values="0 40 40; 15 40 40; 340 40 40; 359.9 40 40"
+          />
+        </g>
+        <path
+          d="M62.0814 52C64.2572 48.4505 66.3615 43.7178 65.9475 37.0921C65.0899 23.3673 52.6589 12.9554 40.9206 14.0837C36.3253 14.5255 31.6068 18.2712 32.026 24.9805C32.2082 27.8961 33.6352 29.6169 35.9544 30.9399C38.1618 32.1992 40.9978 32.9969 44.2128 33.9011C48.0962 34.9934 52.6009 36.2203 56.0631 38.7717C60.2125 41.8296 63.0491 45.3743 62.0814 52Z"
+          fill="#003B5C"
+        />
+        <path
+          d="M17.9186 28C15.7428 31.5495 13.6385 36.2822 14.0525 42.9079C14.9101 56.6327 27.3411 67.0446 39.0794 65.9163C43.6747 65.4745 48.3932 61.7288 47.974 55.0195C47.7918 52.1039 46.3647 50.3831 44.0456 49.0601C41.8382 47.8008 39.0022 47.0031 35.7872 46.0989C31.9038 45.0066 27.3991 43.7797 23.9369 41.2283C19.7875 38.1704 16.9509 34.6257 17.9186 28Z"
+          fill="#005EB8"
+        />
+      </svg>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Loading page  logo in default mode  rendered using loading logo default mode URL 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title>
+    custom title
+  </title>,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\"},\\"loadingLogo\\":{\\"defaultUrl\\":\\"defaultModeLoadingLogo/\\"},\\"applicationTitle\\":\\"custom title\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <div
+        class="loadingLogoContainer"
+      >
+        <img
+          alt="custom title logo"
+          class="loadingLogo"
+          src="defaultModeLoadingLogo/"
+        />
+      </div>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Loading page  logo in default mode  rendered using mark default mode URL with horizontal loading bar 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title>
+    custom title
+  </title>,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{\\"defaultUrl\\":\\"/defaultModeMark\\"},\\"loadingLogo\\":{},\\"applicationTitle\\":\\"custom title\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <div
+        class="loadingLogoContainer"
+      >
+        <img
+          alt="custom title logo"
+          class="loadingLogo"
+          src="/defaultModeMark"
+        />
+      </div>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+      <div
+        class="osdProgress"
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Loading page  logo in default mode  rendered using the original OpenSearch loading logo spinner 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title>
+    custom title
+  </title>,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"applicationTitle\\":\\"custom title\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 90 90"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M75.7374 37.5C74.4878 37.5 73.4748 38.513 73.4748 39.7626C73.4748 58.3813 58.3813 73.4748 39.7626 73.4748C38.513 73.4748 37.5 74.4878 37.5 75.7374C37.5 76.987 38.513 78 39.7626 78C60.8805 78 78 60.8805 78 39.7626C78 38.513 76.987 37.5 75.7374 37.5Z"
+            fill="#005EB8"
+          />
+          <animateTransform
+            attributeName="transform"
+            dur="1.5s"
+            from="0 40 40"
+            keyTimes="0; .3; .7; 1"
+            repeatCount="indefinite"
+            to="359.9 40 40"
+            type="rotate"
+            values="0 40 40; 15 40 40; 340 40 40; 359.9 40 40"
+          />
+        </g>
+        <path
+          d="M62.0814 52C64.2572 48.4505 66.3615 43.7178 65.9475 37.0921C65.0899 23.3673 52.6589 12.9554 40.9206 14.0837C36.3253 14.5255 31.6068 18.2712 32.026 24.9805C32.2082 27.8961 33.6352 29.6169 35.9544 30.9399C38.1618 32.1992 40.9978 32.9969 44.2128 33.9011C48.0962 34.9934 52.6009 36.2203 56.0631 38.7717C60.2125 41.8296 63.0491 45.3743 62.0814 52Z"
+          fill="#003B5C"
+        />
+        <path
+          d="M17.9186 28C15.7428 31.5495 13.6385 36.2822 14.0525 42.9079C14.9101 56.6327 27.3411 67.0446 39.0794 65.9163C43.6747 65.4745 48.3932 61.7288 47.974 55.0195C47.7918 52.1039 46.3647 50.3831 44.0456 49.0601C41.8382 47.8008 39.0022 47.0031 35.7872 46.0989C31.9038 45.0066 27.3991 43.7797 23.9369 41.2283C19.7875 38.1704 16.9509 34.6257 17.9186 28Z"
+          fill="#005EB8"
+        />
+      </svg>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Loading page  render favicon  using a valid URL 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title />,
+  null,
+  <link
+    href="/customFavicon"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="/customFavicon"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="/customFavicon"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href=""
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="/customFavicon"
+    rel="mask-icon"
+  />,
+  <link
+    href="/customFavicon"
+    rel="shortcut icon"
+  />,
+  <meta
+    content=""
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"faviconUrl\\":\\"/customFavicon\\",\\"title\\":\\"custom title\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 90 90"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M75.7374 37.5C74.4878 37.5 73.4748 38.513 73.4748 39.7626C73.4748 58.3813 58.3813 73.4748 39.7626 73.4748C38.513 73.4748 37.5 74.4878 37.5 75.7374C37.5 76.987 38.513 78 39.7626 78C60.8805 78 78 60.8805 78 39.7626C78 38.513 76.987 37.5 75.7374 37.5Z"
+            fill="#005EB8"
+          />
+          <animateTransform
+            attributeName="transform"
+            dur="1.5s"
+            from="0 40 40"
+            keyTimes="0; .3; .7; 1"
+            repeatCount="indefinite"
+            to="359.9 40 40"
+            type="rotate"
+            values="0 40 40; 15 40 40; 340 40 40; 359.9 40 40"
+          />
+        </g>
+        <path
+          d="M62.0814 52C64.2572 48.4505 66.3615 43.7178 65.9475 37.0921C65.0899 23.3673 52.6589 12.9554 40.9206 14.0837C36.3253 14.5255 31.6068 18.2712 32.026 24.9805C32.2082 27.8961 33.6352 29.6169 35.9544 30.9399C38.1618 32.1992 40.9978 32.9969 44.2128 33.9011C48.0962 34.9934 52.6009 36.2203 56.0631 38.7717C60.2125 41.8296 63.0491 45.3743 62.0814 52Z"
+          fill="#003B5C"
+        />
+        <path
+          d="M17.9186 28C15.7428 31.5495 13.6385 36.2822 14.0525 42.9079C14.9101 56.6327 27.3411 67.0446 39.0794 65.9163C43.6747 65.4745 48.3932 61.7288 47.974 55.0195C47.7918 52.1039 46.3647 50.3831 44.0456 49.0601C41.8382 47.8008 39.0022 47.0031 35.7872 46.0989C31.9038 45.0066 27.3991 43.7797 23.9369 41.2283C19.7875 38.1704 16.9509 34.6257 17.9186 28Z"
+          fill="#005EB8"
+        />
+      </svg>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;
+
+exports[`Loading page  render favicon  using an invalid URL 1`] = `
+Array [
+  <meta
+    charset="utf-8"
+  />,
+  <meta
+    content="IE=edge,chrome=1"
+    http-equiv="X-UA-Compatible"
+  />,
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />,
+  <title />,
+  null,
+  <link
+    href="[object Object]/ui/favicons/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />,
+  <link
+    href="[object Object]/ui/favicons/manifest.json"
+    rel="manifest"
+  />,
+  <link
+    color="#e8488b"
+    href="[object Object]/ui/favicons/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />,
+  <link
+    href="[object Object]/ui/favicons/favicon.ico"
+    rel="shortcut icon"
+  />,
+  <meta
+    content="[object Object]/ui/favicons/browserconfig.xml"
+    name="msapplication-config"
+  />,
+  <meta
+    content="#ffffff"
+    name="theme-color"
+  />,
+  null,
+  <meta
+    name="add-styles-here"
+  />,
+  <meta
+    name="add-scripts-here"
+  />,
+  <osd-csp
+    data="{\\"strictCsp\\":true}"
+  />,
+  <osd-injected-metadata
+    data="{\\"version\\":\\"opensearchDashboardsVersion\\",\\"buildNumber\\":1,\\"basePath\\":\\"\\",\\"serverBasePath\\":\\"\\",\\"env\\":{\\"packageInfo\\":{\\"version\\":\\"\\",\\"branch\\":\\"\\",\\"buildNum\\":1,\\"buildSha\\":\\"\\",\\"dist\\":true},\\"mode\\":{\\"name\\":\\"production\\",\\"dev\\":true,\\"prod\\":false}},\\"anonymousStatusPage\\":false,\\"i18n\\":{\\"translationsUrl\\":\\"\\"},\\"csp\\":{\\"warnLegacyBrowsers\\":true},\\"uiPlugins\\":[],\\"legacyMetadata\\":{\\"uiSettings\\":{\\"defaults\\":{\\"legacyInjectedUiSettingDefaults\\":true},\\"user\\":{}}},\\"branding\\":{\\"darkMode\\":false,\\"logo\\":{},\\"mark\\":{},\\"loadingLogo\\":{},\\"title\\":\\"custom title\\"}}"
+  />,
+  <div
+    class="osdWelcomeView"
+    data-test-subj="osdLoadingMessage"
+    id="osd_loading_message"
+    style="display:none"
+  >
+    <div
+      class="osdLoaderWrap"
+      data-test-subj="loadingLogo"
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 90 90"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M75.7374 37.5C74.4878 37.5 73.4748 38.513 73.4748 39.7626C73.4748 58.3813 58.3813 73.4748 39.7626 73.4748C38.513 73.4748 37.5 74.4878 37.5 75.7374C37.5 76.987 38.513 78 39.7626 78C60.8805 78 78 60.8805 78 39.7626C78 38.513 76.987 37.5 75.7374 37.5Z"
+            fill="#005EB8"
+          />
+          <animateTransform
+            attributeName="transform"
+            dur="1.5s"
+            from="0 40 40"
+            keyTimes="0; .3; .7; 1"
+            repeatCount="indefinite"
+            to="359.9 40 40"
+            type="rotate"
+            values="0 40 40; 15 40 40; 340 40 40; 359.9 40 40"
+          />
+        </g>
+        <path
+          d="M62.0814 52C64.2572 48.4505 66.3615 43.7178 65.9475 37.0921C65.0899 23.3673 52.6589 12.9554 40.9206 14.0837C36.3253 14.5255 31.6068 18.2712 32.026 24.9805C32.2082 27.8961 33.6352 29.6169 35.9544 30.9399C38.1618 32.1992 40.9978 32.9969 44.2128 33.9011C48.0962 34.9934 52.6009 36.2203 56.0631 38.7717C60.2125 41.8296 63.0491 45.3743 62.0814 52Z"
+          fill="#003B5C"
+        />
+        <path
+          d="M17.9186 28C15.7428 31.5495 13.6385 36.2822 14.0525 42.9079C14.9101 56.6327 27.3411 67.0446 39.0794 65.9163C43.6747 65.4745 48.3932 61.7288 47.974 55.0195C47.7918 52.1039 46.3647 50.3831 44.0456 49.0601C41.8382 47.8008 39.0022 47.0031 35.7872 46.0989C31.9038 45.0066 27.3991 43.7797 23.9369 41.2283C19.7875 38.1704 16.9509 34.6257 17.9186 28Z"
+          fill="#005EB8"
+        />
+      </svg>
+      <div
+        class="osdWelcomeText"
+        data-error-message=""
+      />
+    </div>
+  </div>,
+  <div
+    class="osdWelcomeView"
+    id="osd_legacy_browser_error"
+    style="display:none"
+  >
+    <svg
+      fill="none"
+      height="64"
+      viewBox="0 0 64 64"
+      width="64"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M61.7374 23.5C60.4878 23.5 59.4748 24.513 59.4748 25.7626C59.4748 44.3813 44.3813 59.4748 25.7626 59.4748C24.513 59.4748 23.5 60.4878 23.5 61.7374C23.5 62.987 24.513 64 25.7626 64C46.8805 64 64 46.8805 64 25.7626C64 24.513 62.987 23.5 61.7374 23.5Z"
+        fill="#005EB8"
+      />
+      <path
+        d="M48.0814 38C50.2572 34.4505 52.3615 29.7178 51.9475 23.0921C51.0899 9.36725 38.6589 -1.04463 26.9206 0.0837327C22.3253 0.525465 17.6068 4.2712 18.026 10.9805C18.2082 13.8961 19.6352 15.6169 21.9544 16.9399C24.1618 18.1992 26.9978 18.9969 30.2128 19.9011C34.0962 20.9934 38.6009 22.2203 42.063 24.7717C46.2125 27.8295 49.0491 31.3743 48.0814 38Z"
+        fill="#003B5C"
+      />
+      <path
+        d="M3.91861 14C1.74276 17.5495 -0.361506 22.2822 0.0524931 28.9079C0.910072 42.6327 13.3411 53.0446 25.0794 51.9163C29.6747 51.4745 34.3932 47.7288 33.974 41.0195C33.7918 38.1039 32.3647 36.3831 30.0456 35.0601C27.8382 33.8008 25.0022 33.0031 21.7872 32.0989C17.9038 31.0066 13.3991 29.7797 9.93694 27.2283C5.78746 24.1704 2.95092 20.6257 3.91861 14Z"
+        fill="#005EB8"
+      />
+    </svg>
+    <h2
+      class="osdWelcomeTitle"
+    />
+    <div
+      class="osdWelcomeText"
+    />
+  </div>,
+  <script>
+    
+            // Since this is an unsafe inline script, this code will not run
+            // in browsers that support content security policy(CSP). This is
+            // intentional as we check for the existence of __osdCspNotEnforced__ in
+            // bootstrap.
+            window.__osdCspNotEnforced__ = true;
+          
+  </script>,
+  <script
+    src="[object Object]/bootstrap.js"
+  />,
+]
+`;

--- a/src/core/server/rendering/views/styles.tsx
+++ b/src/core/server/rendering/views/styles.tsx
@@ -159,6 +159,16 @@ export const Styles: FunctionComponent<Props> = ({ darkMode }) => {
             background-color: ${darkMode ? '#1BA9F5' : '#006DE4'};
           }
 
+          .loadingLogoContainer {
+            height: 60px;
+            padding: 10px 10px 10px 10px;
+          }
+          
+          .loadingLogo {
+            height: 100%;
+            max-width: 100%;
+          }
+
           @keyframes osdProgress {
             0% {
               transform: scaleX(1) translateX(-100%);

--- a/src/core/server/rendering/views/template.test.tsx
+++ b/src/core/server/rendering/views/template.test.tsx
@@ -1,0 +1,222 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from 'react';
+import { injectedMetadataServiceMock } from '../../../public/mocks';
+import { httpServiceMock } from '../../http/http_service.mock';
+import { Template } from './template';
+import { renderWithIntl } from 'test_utils/enzyme_helpers';
+
+const http = httpServiceMock.createStartContract();
+const injectedMetadata = injectedMetadataServiceMock.createSetupContract();
+
+function mockProps() {
+  return {
+    uiPublicUrl: `${http.basePath}/ui`,
+    locale: '',
+    darkMode: true,
+    i18n: () => '',
+    bootstrapScriptUrl: `${http.basePath}/bootstrap.js`,
+    strictCsp: true,
+    injectedMetadata: {
+      version: injectedMetadata.getOpenSearchDashboardsVersion(),
+      buildNumber: 1,
+      branch: injectedMetadata.getBasePath(),
+      basePath: '',
+      serverBasePath: '',
+      env: {
+        packageInfo: {
+          version: '',
+          branch: '',
+          buildNum: 1,
+          buildSha: '',
+          dist: true,
+        },
+        mode: {
+          name: 'production' as 'development' | 'production',
+          dev: true,
+          prod: false,
+        },
+      },
+      anonymousStatusPage: injectedMetadata.getAnonymousStatusPage(),
+      i18n: { translationsUrl: '' },
+      csp: injectedMetadata.getCspConfig(),
+      vars: injectedMetadata.getInjectedVars(),
+      uiPlugins: injectedMetadata.getPlugins(),
+      legacyMetadata: {
+        uiSettings: {
+          defaults: { legacyInjectedUiSettingDefaults: true },
+          user: {},
+        },
+      },
+      branding: injectedMetadata.getBranding(),
+    },
+  };
+}
+
+describe('Loading page ', () => {
+  describe('logo in default mode ', () => {
+    it('rendered using loading logo default mode URL', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: { defaultUrl: '/defaultModeMark' },
+        loadingLogo: { defaultUrl: 'defaultModeLoadingLogo/' },
+        applicationTitle: 'custom title',
+      };
+      injectedMetadata.getBranding.mockReturnValue(branding);
+      const component = renderWithIntl(<Template metadata={mockProps()} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using mark default mode URL with horizontal loading bar', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: { defaultUrl: '/defaultModeMark' },
+        loadingLogo: {},
+        applicationTitle: 'custom title',
+      };
+      injectedMetadata.getBranding.mockReturnValue(branding);
+      const component = renderWithIntl(<Template metadata={mockProps()} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using the original OpenSearch loading logo spinner', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: {},
+        loadingLogo: {},
+        applicationTitle: 'custom title',
+      };
+      injectedMetadata.getBranding.mockReturnValue(branding);
+      const component = renderWithIntl(<Template metadata={mockProps()} />);
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('logo in dark mode ', () => {
+    it('rendered using loading logo dark mode URL', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: { defaultUrl: '/defaultModeMark', darkModeUrl: '/darkModeMark' },
+        loadingLogo: { defaultUrl: '/defaultModeLoadingLogo', darkModeUrl: '/darkModeLoadingLogo' },
+        title: 'custom title',
+      };
+      injectedMetadata.getBranding.mockReturnValue(branding);
+      const component = renderWithIntl(<Template metadata={mockProps()} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using loading logo default mode URL', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: { defaultUrl: '/defaultModeMark', darkModeUrl: '/darkModeMark' },
+        loadingLogo: { defaultUrl: '/defaultModeLoadingLogo' },
+        title: 'custom title',
+      };
+      injectedMetadata.getBranding.mockReturnValue(branding);
+      const component = renderWithIntl(<Template metadata={mockProps()} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using mark dark mode URL with loading bar', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: { defaultUrl: '/defaultModeMark', darkModeUrl: '/darkModeMark' },
+        loadingLogo: {},
+        title: 'custom title',
+      };
+      injectedMetadata.getBranding.mockReturnValue(branding);
+      const component = renderWithIntl(<Template metadata={mockProps()} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using mark default mode URL with loading bar', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: { defaultUrl: '/defaultModeMark' },
+        loadingLogo: {},
+        title: 'custom title',
+      };
+      injectedMetadata.getBranding.mockReturnValue(branding);
+      const component = renderWithIntl(<Template metadata={mockProps()} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('renders using original opensearch loading spinner', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: {},
+        loadingLogo: {},
+        title: 'custom title',
+      };
+      injectedMetadata.getBranding.mockReturnValue(branding);
+      const component = renderWithIntl(<Template metadata={mockProps()} />);
+      expect(component).toMatchSnapshot();
+    });
+  });
+  describe('render favicon ', () => {
+    it('using a valid URL', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: {},
+        loadingLogo: {},
+        faviconUrl: '/customFavicon',
+        title: 'custom title',
+      };
+      injectedMetadata.getBranding.mockReturnValue(branding);
+      const component = renderWithIntl(<Template metadata={mockProps()} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('using an invalid URL', () => {
+      const branding = {
+        darkMode: false,
+        logo: {},
+        mark: {},
+        loadingLogo: {},
+        title: 'custom title',
+      };
+      injectedMetadata.getBranding.mockReturnValue(branding);
+      const component = renderWithIntl(<Template metadata={mockProps()} />);
+      expect(component).toMatchSnapshot();
+    });
+  });
+});

--- a/src/core/server/types.ts
+++ b/src/core/server/types.ts
@@ -36,3 +36,4 @@ export * from './saved_objects/types';
 export * from './ui_settings/types';
 export * from './legacy/types';
 export type { EnvironmentMode, PackageInfo } from '@osd/config';
+export { Branding } from '../../core/types';

--- a/src/core/types/custom_branding.ts
+++ b/src/core/types/custom_branding.ts
@@ -30,37 +30,33 @@
  * GitHub history for details.
  */
 
-import React from 'react';
-import { shallow } from 'enzyme';
-import { SolutionPanel } from './solution_panel';
+/**
+ * A type definition for custom branding configurations from yml file
+ * @public
+ */
 
-const solutionEntry = {
-  id: 'opensearchDashboards',
-  title: 'OpenSearch Dashboards',
-  subtitle: 'Visualize & analyze',
-  description: 'Explore and analyze your data',
-  appDescriptions: ['Analyze data in dashboards'],
-  icon: 'inputOutput',
-  path: 'opensearch_dashboards_landing_page',
-  order: 1,
-};
-
-const addBasePathMock = (path: string) => (path ? path : 'path');
-
-const branding = {
-  darkMode: false,
-  mark: {
-    defaultUrl: '/defaultModeLogo',
-    darkModeUrl: '/darkModeLogo',
-  },
-  applicationTitle: 'custom title',
-};
-
-describe('SolutionPanel', () => {
-  test('renders the solution panel for the given solution', () => {
-    const component = shallow(
-      <SolutionPanel addBasePath={addBasePathMock} solution={solutionEntry} branding={branding} />
-    );
-    expect(component).toMatchSnapshot();
-  });
-});
+export interface Branding {
+  /** Default mode or Dark mode*/
+  darkMode?: boolean;
+  /** Relative path to the asset folder */
+  assetFolderUrl?: string;
+  /** Small logo icon that will be used in most logo occurrences */
+  mark?: {
+    defaultUrl?: string;
+    darkModeUrl?: string;
+  };
+  /** Fuller logo that will be rendered on nav bar header */
+  logo?: {
+    defaultUrl?: string;
+    darkModeUrl?: string;
+  };
+  /** Loading logo that will be rendered on the loading page */
+  loadingLogo?: {
+    defaultUrl?: string;
+    darkModeUrl?: string;
+  };
+  /** Custom favicon that will be rendered on the browser tab */
+  faviconUrl?: string;
+  /** Application title that will replace the default opensearch dashboard string */
+  applicationTitle?: string;
+}

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -40,3 +40,4 @@ export * from './app_category';
 export * from './ui_settings';
 export * from './saved_objects';
 export * from './serializable';
+export * from './custom_branding';

--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -233,6 +233,22 @@ export default () =>
       autocompleteTerminateAfter: Joi.number().integer().min(1).default(100000),
       // TODO Also allow units here like in opensearch config once this is moved to the new platform
       autocompleteTimeout: Joi.number().integer().min(1).default(1000),
+      branding: Joi.object({
+        logo: Joi.object({
+          defaultUrl: Joi.any().default('/'),
+          darkModeUrl: Joi.any().default('/'),
+        }),
+        mark: Joi.object({
+          defaultUrl: Joi.any().default('/'),
+          darkModeUrl: Joi.any().default('/'),
+        }),
+        loadingLogo: Joi.object({
+          defaultUrl: Joi.any().default('/'),
+          darkModeUrl: Joi.any().default('/'),
+        }),
+        faviconUrl: Joi.any().default('/'),
+        applicationTitle: Joi.any().default(''),
+      }),
     }).default(),
 
     savedObjects: HANDLED_IN_NEW_PLATFORM,

--- a/src/plugins/home/public/application/components/__snapshots__/home.test.js.snap
+++ b/src/plugins/home/public/application/components/__snapshots__/home.test.js.snap
@@ -8,6 +8,7 @@ exports[`home change home route should render a link to change the default route
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -58,6 +59,7 @@ exports[`home directories should not render directory entry when showOnHomePage 
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -108,6 +110,7 @@ exports[`home directories should render ADMIN directory entry in "Manage your da
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -170,6 +173,7 @@ exports[`home directories should render DATA directory entry in "Ingest your dat
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -232,6 +236,7 @@ exports[`home directories should render solutions in the "solution section" 1`] 
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={4}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -248,6 +253,7 @@ exports[`home directories should render solutions in the "solution section" 1`] 
   >
     <SolutionsSection
       addBasePath={[Function]}
+      branding={Object {}}
       directories={Array []}
       solutions={
         Array [
@@ -334,6 +340,7 @@ exports[`home header render 1`] = `
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -384,6 +391,7 @@ exports[`home header should show "Dev tools" link if console is available 1`] = 
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -446,6 +454,7 @@ exports[`home header should show "Manage" link if stack management is available 
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -496,6 +505,7 @@ exports[`home isNewOpenSearchDashboardsInstance should safely handle execeptions
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -546,6 +556,7 @@ exports[`home isNewOpenSearchDashboardsInstance should set isNewOpenSearchDashbo
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -596,6 +607,7 @@ exports[`home isNewOpenSearchDashboardsInstance should set isNewOpenSearchDashbo
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -646,6 +658,7 @@ exports[`home should render home component 1`] = `
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -696,6 +709,7 @@ exports[`home welcome should show the normal home page if loading fails 1`] = `
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -746,6 +760,7 @@ exports[`home welcome should show the normal home page if welcome screen is disa
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}
@@ -790,6 +805,7 @@ exports[`home welcome should show the normal home page if welcome screen is disa
 
 exports[`home welcome should show the welcome screen if enabled, and there are no index patterns defined 1`] = `
 <Welcome
+  branding={Object {}}
   onSkip={[Function]}
   urlBasePath="goober"
 />
@@ -803,6 +819,7 @@ exports[`home welcome stores skip welcome setting if skipped 1`] = `
 >
   <mockConstructor
     addBasePath={[Function]}
+    branding={Object {}}
     overlap={0}
     showDevToolsLink={true}
     showManagementLink={true}

--- a/src/plugins/home/public/application/components/__snapshots__/welcome.test.tsx.snap
+++ b/src/plugins/home/public/application/components/__snapshots__/welcome.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render a Welcome screen with no telemetry disclaimer 1`] = `
+exports[`Welcome page  should render a Welcome screen  with no telemetry disclaimer 1`] = `
 <EuiPortal>
   <div
     className="homWelcome"
@@ -14,21 +14,26 @@ exports[`should render a Welcome screen with no telemetry disclaimer 1`] = `
         <EuiSpacer
           size="xl"
         />
-        <span
-          className="homWelcome__logo"
+        <div
+          className="homWelcome__customLogoContainer"
         >
-          <EuiIcon
-            size="original"
-            type="test-file-stub"
+          <img
+            alt="OpenSearch Dashboards logo"
+            className="homWelcome__customLogo"
+            data-test-image-url="/"
+            data-test-subj="welcomeCustomLogo"
+            src="/"
           />
-        </span>
+        </div>
         <EuiTitle
           className="homWelcome__title"
+          data-test-subj="welcomeCustomTitle"
+          data-test-title-message="Welcome to OpenSearch Dashboards"
           size="l"
         >
           <h1>
             <FormattedMessage
-              defaultMessage="Welcome to OpenSearch"
+              defaultMessage="Welcome to OpenSearch Dashboards"
               id="home.welcomeTitle"
               values={Object {}}
             />
@@ -61,7 +66,7 @@ exports[`should render a Welcome screen with no telemetry disclaimer 1`] = `
 </EuiPortal>
 `;
 
-exports[`should render a Welcome screen with the telemetry disclaimer when optIn is false 1`] = `
+exports[`Welcome page  should render a Welcome screen  with the telemetry disclaimer when optIn is false 1`] = `
 <EuiPortal>
   <div
     className="homWelcome"
@@ -75,21 +80,26 @@ exports[`should render a Welcome screen with the telemetry disclaimer when optIn
         <EuiSpacer
           size="xl"
         />
-        <span
-          className="homWelcome__logo"
+        <div
+          className="homWelcome__customLogoContainer"
         >
-          <EuiIcon
-            size="original"
-            type="test-file-stub"
+          <img
+            alt="OpenSearch Dashboards logo"
+            className="homWelcome__customLogo"
+            data-test-image-url="/"
+            data-test-subj="welcomeCustomLogo"
+            src="/"
           />
-        </span>
+        </div>
         <EuiTitle
           className="homWelcome__title"
+          data-test-subj="welcomeCustomTitle"
+          data-test-title-message="Welcome to OpenSearch Dashboards"
           size="l"
         >
           <h1>
             <FormattedMessage
-              defaultMessage="Welcome to OpenSearch"
+              defaultMessage="Welcome to OpenSearch Dashboards"
               id="home.welcomeTitle"
               values={Object {}}
             />
@@ -159,7 +169,7 @@ exports[`should render a Welcome screen with the telemetry disclaimer when optIn
 </EuiPortal>
 `;
 
-exports[`should render a Welcome screen with the telemetry disclaimer when optIn is true 1`] = `
+exports[`Welcome page  should render a Welcome screen  with the telemetry disclaimer when optIn is true 1`] = `
 <EuiPortal>
   <div
     className="homWelcome"
@@ -173,21 +183,26 @@ exports[`should render a Welcome screen with the telemetry disclaimer when optIn
         <EuiSpacer
           size="xl"
         />
-        <span
-          className="homWelcome__logo"
+        <div
+          className="homWelcome__customLogoContainer"
         >
-          <EuiIcon
-            size="original"
-            type="test-file-stub"
+          <img
+            alt="OpenSearch Dashboards logo"
+            className="homWelcome__customLogo"
+            data-test-image-url="/"
+            data-test-subj="welcomeCustomLogo"
+            src="/"
           />
-        </span>
+        </div>
         <EuiTitle
           className="homWelcome__title"
+          data-test-subj="welcomeCustomTitle"
+          data-test-title-message="Welcome to OpenSearch Dashboards"
           size="l"
         >
           <h1>
             <FormattedMessage
-              defaultMessage="Welcome to OpenSearch"
+              defaultMessage="Welcome to OpenSearch Dashboards"
               id="home.welcomeTitle"
               values={Object {}}
             />
@@ -249,6 +264,330 @@ exports[`should render a Welcome screen with the telemetry disclaimer when optIn
           </EuiTextColor>
           <EuiSpacer
             size="xs"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  </div>
+</EuiPortal>
+`;
+
+exports[`Welcome page  should render welcome logo in dark mode  using mark dark mode URL 1`] = `
+<EuiPortal>
+  <div
+    className="homWelcome"
+  >
+    <header
+      className="homWelcome__header"
+    >
+      <div
+        className="homWelcome__content eui-textCenter"
+      >
+        <EuiSpacer
+          size="xl"
+        />
+        <div
+          className="homWelcome__customLogoContainer"
+        >
+          <img
+            alt="undefined logo"
+            className="homWelcome__customLogo"
+            data-test-image-url="/darkModeMark"
+            data-test-subj="welcomeCustomLogo"
+            src="/darkModeMark"
+          />
+        </div>
+        <EuiTitle
+          className="homWelcome__title"
+          data-test-subj="welcomeCustomTitle"
+          data-test-title-message="Welcome to undefined"
+          size="l"
+        >
+          <h1>
+            <FormattedMessage
+              defaultMessage="Welcome to undefined"
+              id="home.welcomeTitle"
+              values={Object {}}
+            />
+          </h1>
+        </EuiTitle>
+        <EuiSpacer
+          size="m"
+        />
+      </div>
+    </header>
+    <div
+      className="homWelcome__content homWelcome-body"
+    >
+      <EuiFlexGroup
+        gutterSize="l"
+      >
+        <EuiFlexItem>
+          <SampleDataCard
+            onConfirm={[Function]}
+            onDecline={[Function]}
+            urlBasePath="/"
+          />
+          <EuiSpacer
+            size="s"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  </div>
+</EuiPortal>
+`;
+
+exports[`Welcome page  should render welcome logo in dark mode  using mark default mode URL 1`] = `
+<EuiPortal>
+  <div
+    className="homWelcome"
+  >
+    <header
+      className="homWelcome__header"
+    >
+      <div
+        className="homWelcome__content eui-textCenter"
+      >
+        <EuiSpacer
+          size="xl"
+        />
+        <div
+          className="homWelcome__customLogoContainer"
+        >
+          <img
+            alt="undefined logo"
+            className="homWelcome__customLogo"
+            data-test-image-url="/defaultModeMark"
+            data-test-subj="welcomeCustomLogo"
+            src="/defaultModeMark"
+          />
+        </div>
+        <EuiTitle
+          className="homWelcome__title"
+          data-test-subj="welcomeCustomTitle"
+          data-test-title-message="Welcome to undefined"
+          size="l"
+        >
+          <h1>
+            <FormattedMessage
+              defaultMessage="Welcome to undefined"
+              id="home.welcomeTitle"
+              values={Object {}}
+            />
+          </h1>
+        </EuiTitle>
+        <EuiSpacer
+          size="m"
+        />
+      </div>
+    </header>
+    <div
+      className="homWelcome__content homWelcome-body"
+    >
+      <EuiFlexGroup
+        gutterSize="l"
+      >
+        <EuiFlexItem>
+          <SampleDataCard
+            onConfirm={[Function]}
+            onDecline={[Function]}
+            urlBasePath="/"
+          />
+          <EuiSpacer
+            size="s"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  </div>
+</EuiPortal>
+`;
+
+exports[`Welcome page  should render welcome logo in dark mode  using the original opensearch logo 1`] = `
+<EuiPortal>
+  <div
+    className="homWelcome"
+  >
+    <header
+      className="homWelcome__header"
+    >
+      <div
+        className="homWelcome__content eui-textCenter"
+      >
+        <EuiSpacer
+          size="xl"
+        />
+        <span
+          className="homWelcome__logo"
+        >
+          <EuiIcon
+            size="original"
+            type="test-file-stub"
+          />
+        </span>
+        <EuiTitle
+          className="homWelcome__title"
+          data-test-subj="welcomeCustomTitle"
+          data-test-title-message="Welcome to undefined"
+          size="l"
+        >
+          <h1>
+            <FormattedMessage
+              defaultMessage="Welcome to undefined"
+              id="home.welcomeTitle"
+              values={Object {}}
+            />
+          </h1>
+        </EuiTitle>
+        <EuiSpacer
+          size="m"
+        />
+      </div>
+    </header>
+    <div
+      className="homWelcome__content homWelcome-body"
+    >
+      <EuiFlexGroup
+        gutterSize="l"
+      >
+        <EuiFlexItem>
+          <SampleDataCard
+            onConfirm={[Function]}
+            onDecline={[Function]}
+            urlBasePath="/"
+          />
+          <EuiSpacer
+            size="s"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  </div>
+</EuiPortal>
+`;
+
+exports[`Welcome page  should render welcome logo in default mode  using mark default mode URL 1`] = `
+<EuiPortal>
+  <div
+    className="homWelcome"
+  >
+    <header
+      className="homWelcome__header"
+    >
+      <div
+        className="homWelcome__content eui-textCenter"
+      >
+        <EuiSpacer
+          size="xl"
+        />
+        <div
+          className="homWelcome__customLogoContainer"
+        >
+          <img
+            alt="custom title logo"
+            className="homWelcome__customLogo"
+            data-test-image-url="/defaultModeMark"
+            data-test-subj="welcomeCustomLogo"
+            src="/defaultModeMark"
+          />
+        </div>
+        <EuiTitle
+          className="homWelcome__title"
+          data-test-subj="welcomeCustomTitle"
+          data-test-title-message="Welcome to custom title"
+          size="l"
+        >
+          <h1>
+            <FormattedMessage
+              defaultMessage="Welcome to custom title"
+              id="home.welcomeTitle"
+              values={Object {}}
+            />
+          </h1>
+        </EuiTitle>
+        <EuiSpacer
+          size="m"
+        />
+      </div>
+    </header>
+    <div
+      className="homWelcome__content homWelcome-body"
+    >
+      <EuiFlexGroup
+        gutterSize="l"
+      >
+        <EuiFlexItem>
+          <SampleDataCard
+            onConfirm={[Function]}
+            onDecline={[Function]}
+            urlBasePath="/"
+          />
+          <EuiSpacer
+            size="s"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  </div>
+</EuiPortal>
+`;
+
+exports[`Welcome page  should render welcome logo in default mode  using the original OpenSearch Dashboards logo 1`] = `
+<EuiPortal>
+  <div
+    className="homWelcome"
+  >
+    <header
+      className="homWelcome__header"
+    >
+      <div
+        className="homWelcome__content eui-textCenter"
+      >
+        <EuiSpacer
+          size="xl"
+        />
+        <span
+          className="homWelcome__logo"
+        >
+          <EuiIcon
+            size="original"
+            type="test-file-stub"
+          />
+        </span>
+        <EuiTitle
+          className="homWelcome__title"
+          data-test-subj="welcomeCustomTitle"
+          data-test-title-message="Welcome to OpenSearch Dashboards"
+          size="l"
+        >
+          <h1>
+            <FormattedMessage
+              defaultMessage="Welcome to OpenSearch Dashboards"
+              id="home.welcomeTitle"
+              values={Object {}}
+            />
+          </h1>
+        </EuiTitle>
+        <EuiSpacer
+          size="m"
+        />
+      </div>
+    </header>
+    <div
+      className="homWelcome__content homWelcome-body"
+    >
+      <EuiFlexGroup
+        gutterSize="l"
+      >
+        <EuiFlexItem>
+          <SampleDataCard
+            onConfirm={[Function]}
+            onDecline={[Function]}
+            urlBasePath="/"
+          />
+          <EuiSpacer
+            size="s"
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/src/plugins/home/public/application/components/_solutions_section.scss
+++ b/src/plugins/home/public/application/components/_solutions_section.scss
@@ -135,3 +135,13 @@
     background-size: $euiSizeL * 2;
   }
 }
+
+.homSolutionPanel__customIconContainer {
+  height: 50px;
+  padding: 5px 5px 5px 5px;
+}
+
+.homSolutionPanel__customIcon {
+  height: 100%;
+  max-width: 100%;
+}

--- a/src/plugins/home/public/application/components/_welcome.scss
+++ b/src/plugins/home/public/application/components/_welcome.scss
@@ -14,6 +14,16 @@
   @include euiBottomShadowMedium;
 }
 
+.homWelcome__customLogoContainer {
+  height: 80px;
+  padding: 10px 10px 10px 10px;
+}
+
+.homWelcome__customLogo {
+  height: 100%;
+  max-width: 100%;
+}
+
 .homWelcome__footerAction {
   margin-right: $euiSizeS;
 }

--- a/src/plugins/home/public/application/components/home.js
+++ b/src/plugins/home/public/application/components/home.js
@@ -155,6 +155,7 @@ export class Home extends Component {
           showDevToolsLink
           showManagementLink
           title={<FormattedMessage id="home.header.title" defaultMessage="Home" />}
+          branding={getServices().injectedMetadata.getBranding()}
         />
 
         <div className="homContent">
@@ -163,6 +164,7 @@ export class Home extends Component {
               addBasePath={addBasePath}
               solutions={solutions}
               directories={directories}
+              branding={getServices().injectedMetadata.getBranding()}
             />
           ) : null}
 
@@ -201,6 +203,7 @@ export class Home extends Component {
         onSkip={this.skipWelcome}
         urlBasePath={this.props.urlBasePath}
         telemetry={this.props.telemetry}
+        branding={getServices().injectedMetadata.getBranding()}
       />
     );
   }
@@ -216,7 +219,6 @@ export class Home extends Component {
         return this.renderWelcome();
       }
     }
-
     return this.renderNormal();
   }
 }

--- a/src/plugins/home/public/application/components/home.test.js
+++ b/src/plugins/home/public/application/components/home.test.js
@@ -45,6 +45,9 @@ jest.mock('../opensearch_dashboards_services', () => ({
     chrome: {
       setBreadcrumbs: () => {},
     },
+    injectedMetadata: {
+      getBranding: () => ({}),
+    },
   }),
 }));
 

--- a/src/plugins/home/public/application/components/solutions_section/__snapshots__/solution_panel.test.tsx.snap
+++ b/src/plugins/home/public/application/components/solutions_section/__snapshots__/solution_panel.test.tsx.snap
@@ -24,6 +24,16 @@ exports[`SolutionPanel renders the solution panel for the given solution 1`] = `
           grow={1}
         >
           <SolutionTitle
+            branding={
+              Object {
+                "applicationTitle": "custom title",
+                "darkMode": false,
+                "mark": Object {
+                  "darkModeUrl": "/darkModeLogo",
+                  "defaultUrl": "/defaultModeLogo",
+                },
+              }
+            }
             iconType="inputOutput"
             subtitle="Visualize & analyze"
             title="OpenSearch Dashboards"

--- a/src/plugins/home/public/application/components/solutions_section/__snapshots__/solution_title.test.tsx.snap
+++ b/src/plugins/home/public/application/components/solutions_section/__snapshots__/solution_title.test.tsx.snap
@@ -1,6 +1,98 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SolutionTitle renders the title section of the solution panel 1`] = `
+exports[`SolutionTitle  in dark mode renders the home dashboard logo using mark dark mode URL 1`] = `
+<EuiFlexGroup
+  alignItems="center"
+  gutterSize="none"
+>
+  <EuiFlexItem
+    className="eui-textCenter"
+  >
+    <div
+      className="homSolutionPanel__customIcon"
+    >
+      <img
+        alt="custom title logo"
+        className="homSolutionPanel__customIconContainer"
+        data-test-image-url="/darkModeUrl"
+        data-test-subj="dashboardCustomLogo"
+        src="/darkModeUrl"
+      />
+    </div>
+    <EuiTitle
+      className="homSolutionPanel__title eui-textInheritColor"
+      data-test-subj="dashboardCustomTitle"
+      data-test-title="custom title"
+      size="s"
+    >
+      <h3>
+        custom title
+      </h3>
+    </EuiTitle>
+    <EuiText
+      size="s"
+    >
+      <p
+        className="homSolutionPanel__subtitle"
+      >
+        Visualize & analyze
+         
+        <EuiIcon
+          type="sortRight"
+        />
+      </p>
+    </EuiText>
+  </EuiFlexItem>
+</EuiFlexGroup>
+`;
+
+exports[`SolutionTitle  in dark mode renders the home dashboard logo using mark default mode URL 1`] = `
+<EuiFlexGroup
+  alignItems="center"
+  gutterSize="none"
+>
+  <EuiFlexItem
+    className="eui-textCenter"
+  >
+    <div
+      className="homSolutionPanel__customIcon"
+    >
+      <img
+        alt="custom title logo"
+        className="homSolutionPanel__customIconContainer"
+        data-test-image-url="/defaultModeUrl"
+        data-test-subj="dashboardCustomLogo"
+        src="/defaultModeUrl"
+      />
+    </div>
+    <EuiTitle
+      className="homSolutionPanel__title eui-textInheritColor"
+      data-test-subj="dashboardCustomTitle"
+      data-test-title="custom title"
+      size="s"
+    >
+      <h3>
+        custom title
+      </h3>
+    </EuiTitle>
+    <EuiText
+      size="s"
+    >
+      <p
+        className="homSolutionPanel__subtitle"
+      >
+        Visualize & analyze
+         
+        <EuiIcon
+          type="sortRight"
+        />
+      </p>
+    </EuiText>
+  </EuiFlexItem>
+</EuiFlexGroup>
+`;
+
+exports[`SolutionTitle  in dark mode renders the home dashboard logo using original in and out door logo 1`] = `
 <EuiFlexGroup
   alignItems="center"
   gutterSize="none"
@@ -11,16 +103,152 @@ exports[`SolutionTitle renders the title section of the solution panel 1`] = `
     <EuiToken
       className="homSolutionPanel__icon"
       fill="light"
-      iconType="inputOutput"
+      iconType="undefined/opensearch_mark_dark_mode.svg"
       shape="circle"
       size="l"
     />
     <EuiTitle
       className="homSolutionPanel__title eui-textInheritColor"
+      data-test-subj="dashboardCustomTitle"
+      data-test-title="custom title"
       size="s"
     >
       <h3>
-        OpenSearch Dashboards
+        custom title
+      </h3>
+    </EuiTitle>
+    <EuiText
+      size="s"
+    >
+      <p
+        className="homSolutionPanel__subtitle"
+      >
+        Visualize & analyze
+         
+        <EuiIcon
+          type="sortRight"
+        />
+      </p>
+    </EuiText>
+  </EuiFlexItem>
+</EuiFlexGroup>
+`;
+
+exports[`SolutionTitle  in default mode renders the home dashboard logo using mark default mode URL 1`] = `
+<EuiFlexGroup
+  alignItems="center"
+  gutterSize="none"
+>
+  <EuiFlexItem
+    className="eui-textCenter"
+  >
+    <div
+      className="homSolutionPanel__customIcon"
+    >
+      <img
+        alt="custom title logo"
+        className="homSolutionPanel__customIconContainer"
+        data-test-image-url="/defaultModeUrl"
+        data-test-subj="dashboardCustomLogo"
+        src="/defaultModeUrl"
+      />
+    </div>
+    <EuiTitle
+      className="homSolutionPanel__title eui-textInheritColor"
+      data-test-subj="dashboardCustomTitle"
+      data-test-title="custom title"
+      size="s"
+    >
+      <h3>
+        custom title
+      </h3>
+    </EuiTitle>
+    <EuiText
+      size="s"
+    >
+      <p
+        className="homSolutionPanel__subtitle"
+      >
+        Visualize & analyze
+         
+        <EuiIcon
+          type="sortRight"
+        />
+      </p>
+    </EuiText>
+  </EuiFlexItem>
+</EuiFlexGroup>
+`;
+
+exports[`SolutionTitle  in default mode renders the home dashboard logo using original in and out door logo 1`] = `
+<EuiFlexGroup
+  alignItems="center"
+  gutterSize="none"
+>
+  <EuiFlexItem
+    className="eui-textCenter"
+  >
+    <EuiToken
+      className="homSolutionPanel__icon"
+      fill="light"
+      iconType="undefined/opensearch_mark_default_mode.svg"
+      shape="circle"
+      size="l"
+    />
+    <EuiTitle
+      className="homSolutionPanel__title eui-textInheritColor"
+      data-test-subj="dashboardCustomTitle"
+      data-test-title="custom title"
+      size="s"
+    >
+      <h3>
+        custom title
+      </h3>
+    </EuiTitle>
+    <EuiText
+      size="s"
+    >
+      <p
+        className="homSolutionPanel__subtitle"
+      >
+        Visualize & analyze
+         
+        <EuiIcon
+          type="sortRight"
+        />
+      </p>
+    </EuiText>
+  </EuiFlexItem>
+</EuiFlexGroup>
+`;
+
+exports[`SolutionTitle  in default mode renders the title section of the solution panel 1`] = `
+<EuiFlexGroup
+  alignItems="center"
+  gutterSize="none"
+>
+  <EuiFlexItem
+    className="eui-textCenter"
+  >
+    <div
+      className="homSolutionPanel__customIcon"
+    >
+      <img
+        alt="custom title logo"
+        className="homSolutionPanel__customIconContainer"
+        data-test-image-url="/defaultModeUrl"
+        data-test-subj="dashboardCustomLogo"
+        src="/defaultModeUrl"
+      />
+    </div>
+    <EuiTitle
+      className="homSolutionPanel__title eui-textInheritColor"
+      data-test-subj="dashboardCustomTitle"
+      data-test-title="custom title"
+      size="s"
+    >
+      <h3>
+        custom title
       </h3>
     </EuiTitle>
     <EuiText

--- a/src/plugins/home/public/application/components/solutions_section/__snapshots__/solutions_section.test.tsx.snap
+++ b/src/plugins/home/public/application/components/solutions_section/__snapshots__/solutions_section.test.tsx.snap
@@ -52,6 +52,16 @@ exports[`SolutionsSection renders a single solution 1`] = `
     >
       <SolutionPanel
         addBasePath={[Function]}
+        branding={
+          Object {
+            "applicationTitle": "custom title",
+            "darkMode": false,
+            "mark": Object {
+              "darkModeUrl": "/darkModeLogo",
+              "defaultUrl": "/defaultModeLogo",
+            },
+          }
+        }
         solution={
           Object {
             "appDescriptions": Array [
@@ -105,6 +115,16 @@ exports[`SolutionsSection renders multiple solutions in a single column when Ope
         >
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "applicationTitle": "custom title",
+                "darkMode": false,
+                "mark": Object {
+                  "darkModeUrl": "/darkModeLogo",
+                  "defaultUrl": "/defaultModeLogo",
+                },
+              }
+            }
             key="solution-2"
             solution={
               Object {
@@ -123,6 +143,16 @@ exports[`SolutionsSection renders multiple solutions in a single column when Ope
           />
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "applicationTitle": "custom title",
+                "darkMode": false,
+                "mark": Object {
+                  "darkModeUrl": "/darkModeLogo",
+                  "defaultUrl": "/defaultModeLogo",
+                },
+              }
+            }
             key="solution-3"
             solution={
               Object {
@@ -141,6 +171,16 @@ exports[`SolutionsSection renders multiple solutions in a single column when Ope
           />
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "applicationTitle": "custom title",
+                "darkMode": false,
+                "mark": Object {
+                  "darkModeUrl": "/darkModeLogo",
+                  "defaultUrl": "/defaultModeLogo",
+                },
+              }
+            }
             key="solution-4"
             solution={
               Object {
@@ -198,6 +238,16 @@ exports[`SolutionsSection renders multiple solutions in two columns with OpenSea
         >
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "applicationTitle": "custom title",
+                "darkMode": false,
+                "mark": Object {
+                  "darkModeUrl": "/darkModeLogo",
+                  "defaultUrl": "/defaultModeLogo",
+                },
+              }
+            }
             key="solution-2"
             solution={
               Object {
@@ -216,6 +266,16 @@ exports[`SolutionsSection renders multiple solutions in two columns with OpenSea
           />
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "applicationTitle": "custom title",
+                "darkMode": false,
+                "mark": Object {
+                  "darkModeUrl": "/darkModeLogo",
+                  "defaultUrl": "/defaultModeLogo",
+                },
+              }
+            }
             key="solution-3"
             solution={
               Object {
@@ -234,6 +294,16 @@ exports[`SolutionsSection renders multiple solutions in two columns with OpenSea
           />
           <SolutionPanel
             addBasePath={[Function]}
+            branding={
+              Object {
+                "applicationTitle": "custom title",
+                "darkMode": false,
+                "mark": Object {
+                  "darkModeUrl": "/darkModeLogo",
+                  "defaultUrl": "/defaultModeLogo",
+                },
+              }
+            }
             key="solution-4"
             solution={
               Object {
@@ -254,6 +324,16 @@ exports[`SolutionsSection renders multiple solutions in two columns with OpenSea
       </EuiFlexItem>
       <SolutionPanel
         addBasePath={[Function]}
+        branding={
+          Object {
+            "applicationTitle": "custom title",
+            "darkMode": false,
+            "mark": Object {
+              "darkModeUrl": "/darkModeLogo",
+              "defaultUrl": "/defaultModeLogo",
+            },
+          }
+        }
         solution={
           Object {
             "appDescriptions": Array [

--- a/src/plugins/home/public/application/components/solutions_section/solution_panel.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_panel.tsx
@@ -35,6 +35,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText } from '@elasti
 import { FeatureCatalogueEntry, FeatureCatalogueSolution } from '../../../';
 import { createAppNavigationHandler } from '../app_navigation_handler';
 import { SolutionTitle } from './solution_title';
+import { HomePluginBranding } from '../../../plugin';
 
 const getDescriptionText = (description: string): JSX.Element => (
   <EuiText size="s" key={`${description}`}>
@@ -64,9 +65,10 @@ interface Props {
   addBasePath: (path: string) => string;
   solution: FeatureCatalogueSolution;
   apps?: FeatureCatalogueEntry[];
+  branding: HomePluginBranding;
 }
 
-export const SolutionPanel: FC<Props> = ({ addBasePath, solution, apps = [] }) => (
+export const SolutionPanel: FC<Props> = ({ addBasePath, solution, apps = [], branding }) => (
   <EuiFlexItem
     key={solution.id}
     data-test-subj={`homSolutionPanel homSolutionPanel_${solution.id}`}
@@ -89,6 +91,7 @@ export const SolutionPanel: FC<Props> = ({ addBasePath, solution, apps = [] }) =
               iconType={solution.icon}
               title={solution.title}
               subtitle={solution.subtitle}
+              branding={branding}
             />
           </EuiFlexItem>
 

--- a/src/plugins/home/public/application/components/solutions_section/solution_title.test.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_title.test.tsx
@@ -44,15 +44,121 @@ const solutionEntry = {
   order: 1,
 };
 
-describe('SolutionTitle', () => {
-  test('renders the title section of the solution panel', () => {
-    const component = shallow(
-      <SolutionTitle
-        title={solutionEntry.title}
-        subtitle={solutionEntry.subtitle}
-        iconType={solutionEntry.icon}
-      />
-    );
-    expect(component).toMatchSnapshot();
+describe('SolutionTitle ', () => {
+  describe('in default mode', () => {
+    test('renders the title section of the solution panel', () => {
+      const branding = {
+        darkMode: false,
+        mark: {
+          defaultUrl: '/defaultModeUrl',
+          darkModeUrl: '/darkModeUrl',
+        },
+        applicationTitle: 'custom title',
+      };
+      const component = shallow(
+        <SolutionTitle
+          title={solutionEntry.title}
+          subtitle={solutionEntry.subtitle}
+          iconType={solutionEntry.icon}
+          branding={branding}
+        />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('renders the home dashboard logo using mark default mode URL', () => {
+      const branding = {
+        darkMode: false,
+        mark: {
+          defaultUrl: '/defaultModeUrl',
+          darkModeUrl: '/darkModeUrl',
+        },
+        applicationTitle: 'custom title',
+      };
+      const component = shallow(
+        <SolutionTitle
+          title={solutionEntry.title}
+          subtitle={solutionEntry.subtitle}
+          iconType={solutionEntry.icon}
+          branding={branding}
+        />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('renders the home dashboard logo using original in and out door logo', () => {
+      const branding = {
+        darkMode: false,
+        mark: {},
+        applicationTitle: 'custom title',
+      };
+      const component = shallow(
+        <SolutionTitle
+          title={solutionEntry.title}
+          subtitle={solutionEntry.subtitle}
+          iconType={solutionEntry.icon}
+          branding={branding}
+        />
+      );
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('in dark mode', () => {
+    test('renders the home dashboard logo using mark dark mode URL', () => {
+      const branding = {
+        darkMode: true,
+        mark: {
+          defaultUrl: '/defaultModeUrl',
+          darkModeUrl: '/darkModeUrl',
+        },
+        applicationTitle: 'custom title',
+      };
+      const component = shallow(
+        <SolutionTitle
+          title={solutionEntry.title}
+          subtitle={solutionEntry.subtitle}
+          iconType={solutionEntry.icon}
+          branding={branding}
+        />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('renders the home dashboard logo using mark default mode URL', () => {
+      const branding = {
+        darkMode: true,
+        mark: {
+          defaultUrl: '/defaultModeUrl',
+        },
+        applicationTitle: 'custom title',
+      };
+      const component = shallow(
+        <SolutionTitle
+          title={solutionEntry.title}
+          subtitle={solutionEntry.subtitle}
+          iconType={solutionEntry.icon}
+          branding={branding}
+        />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('renders the home dashboard logo using original in and out door logo', () => {
+      const branding = {
+        darkMode: true,
+        mark: {},
+        applicationTitle: 'custom title',
+      };
+      const component = shallow(
+        <SolutionTitle
+          title={solutionEntry.title}
+          subtitle={solutionEntry.subtitle}
+          iconType={solutionEntry.icon}
+          branding={branding}
+        />
+      );
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/plugins/home/public/application/components/solutions_section/solution_title.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_title.tsx
@@ -40,26 +40,120 @@ import {
   EuiIcon,
   IconType,
 } from '@elastic/eui';
+import { HomePluginBranding } from '../../../plugin';
 
 interface Props {
+  /**
+   * @deprecated
+   * Title will be deprecated because we will use title config from branding
+   */
   title: string;
   subtitle: string;
+  /**
+   * @deprecated
+   * IconType will be deprecated because we will make rendering custom dashboard logo logic consistent with other logos' logic
+   */
   iconType: IconType;
+  branding: HomePluginBranding;
 }
 
-export const SolutionTitle: FC<Props> = ({ title, subtitle, iconType }) => (
+/**
+ * Use branding configurations to check which URL to use for rendering
+ * home card logo in default mode. In default mode, home card logo will
+ * proritize default mode mark URL. If it is invalid, default opensearch logo
+ * will be rendered.
+ *
+ * @param {HomePluginBranding} - pass in custom branding configurations
+ * @returns a valid custom URL or undefined if no valid URL is provided
+ */
+const customHomeLogoDefaultMode = (branding: HomePluginBranding) => {
+  return branding.mark?.defaultUrl ?? undefined;
+};
+
+/**
+ * Use branding configurations to check which URL to use for rendering
+ * home logo in dark mode. In dark mode, home logo will render
+ * dark mode mark URL if valid. Otherwise, it will render the default
+ * mode mark URL if valid. If both dark mode mark URL and default mode mark
+ * URL are invalid, the default opensearch logo will be rendered.
+ *
+ * @param {HomePluginBranding} - pass in custom branding configurations
+ * @returns {string|undefined} a valid custom URL or undefined if no valid URL is provided
+ */
+const customHomeLogoDarkMode = (branding: HomePluginBranding) => {
+  return branding.mark?.darkModeUrl ?? branding.mark?.defaultUrl ?? undefined;
+};
+
+/**
+ * Render custom home logo for both default mode and dark mode
+ *
+ * @param {HomePluginBranding} - pass in custom branding configurations
+ * @returns {string|undefined} a valid custom loading logo URL, or undefined
+ */
+const customHomeLogo = (branding: HomePluginBranding) => {
+  return branding.darkMode ? customHomeLogoDarkMode(branding) : customHomeLogoDefaultMode(branding);
+};
+
+/**
+ * Check if we render a custom home logo or the default opensearch spinner.
+ * If customWelcomeLogo() returns undefined(no valid custom URL is found), we
+ * render the default opensearch logo
+ *
+ * @param {HomePluginBranding} - pass in custom branding configurations
+ * @returns a image component with custom logo URL, or the default opensearch logo
+ */
+const renderBrandingEnabledOrDisabledLogo = (branding: HomePluginBranding) => {
+  const customLogo = customHomeLogo(branding);
+  if (customLogo) {
+    return (
+      <div className="homSolutionPanel__customIcon">
+        <img
+          className="homSolutionPanel__customIconContainer"
+          data-test-subj="dashboardCustomLogo"
+          data-test-image-url={customLogo}
+          alt={branding.applicationTitle + ' logo'}
+          src={customLogo}
+        />
+      </div>
+    );
+  }
+  const DEFAULT_OPENSEARCH_MARK = `${branding.assetFolderUrl}/opensearch_mark_default_mode.svg`;
+  const DARKMODE_OPENSEARCH_MARK = `${branding.assetFolderUrl}/opensearch_mark_dark_mode.svg`;
+
+  return (
+    <EuiToken
+      iconType={branding.darkMode ? DARKMODE_OPENSEARCH_MARK : DEFAULT_OPENSEARCH_MARK}
+      shape="circle"
+      fill="light"
+      size="l"
+      className="homSolutionPanel__icon"
+    />
+  );
+};
+
+/**
+ *
+ * @param {string} title
+ * @param {string} subtitle
+ * @param {IconType} iconType - will always be inputOutput icon type here
+ * @param {HomePluginBranding} branding - custom branding configurations
+ *
+ * @returns - a EUI component <EuiFlexGroup> that renders the blue dashboard card on home page,
+ * title and iconType are deprecated here because SolutionTitle component will only be rendered once
+ * as the home dashboard card, and we are now in favor of using custom branding configurations.
+ */
+export const SolutionTitle: FC<Props> = ({ title, subtitle, iconType, branding }) => (
   <EuiFlexGroup gutterSize="none" alignItems="center">
     <EuiFlexItem className="eui-textCenter">
-      <EuiToken
-        iconType={iconType}
-        shape="circle"
-        fill="light"
-        size="l"
-        className="homSolutionPanel__icon"
-      />
+      {renderBrandingEnabledOrDisabledLogo(branding)}
 
-      <EuiTitle className="homSolutionPanel__title eui-textInheritColor" size="s">
-        <h3>{title}</h3>
+      <EuiTitle
+        className="homSolutionPanel__title eui-textInheritColor"
+        size="s"
+        data-test-subj="dashboardCustomTitle"
+        data-test-title={branding.applicationTitle}
+      >
+        <h3>{branding.applicationTitle}</h3>
       </EuiTitle>
 
       <EuiText size="s">

--- a/src/plugins/home/public/application/components/solutions_section/solutions_section.test.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solutions_section.test.tsx
@@ -107,6 +107,15 @@ const mockDirectories = [
 
 const addBasePathMock = (path: string) => (path ? path : 'path');
 
+const branding = {
+  darkMode: false,
+  mark: {
+    defaultUrl: '/defaultModeLogo',
+    darkModeUrl: '/darkModeLogo',
+  },
+  applicationTitle: 'custom title',
+};
+
 describe('SolutionsSection', () => {
   test('only renders a spacer if no solutions are available', () => {
     const component = shallow(
@@ -114,6 +123,7 @@ describe('SolutionsSection', () => {
         addBasePath={addBasePathMock}
         solutions={[]}
         directories={mockDirectories}
+        branding={branding}
       />
     );
     expect(component).toMatchSnapshot();
@@ -125,6 +135,7 @@ describe('SolutionsSection', () => {
         addBasePath={addBasePathMock}
         solutions={[solutionEntry1]}
         directories={mockDirectories}
+        branding={branding}
       />
     );
     expect(component).toMatchSnapshot();
@@ -136,6 +147,7 @@ describe('SolutionsSection', () => {
         addBasePath={addBasePathMock}
         solutions={[solutionEntry1, solutionEntry2, solutionEntry3, solutionEntry4]}
         directories={mockDirectories}
+        branding={branding}
       />
     );
     expect(component).toMatchSnapshot();
@@ -146,6 +158,7 @@ describe('SolutionsSection', () => {
         addBasePath={addBasePathMock}
         solutions={[solutionEntry2, solutionEntry3, solutionEntry4]}
         directories={mockDirectories}
+        branding={branding}
       />
     );
     expect(component).toMatchSnapshot();

--- a/src/plugins/home/public/application/components/solutions_section/solutions_section.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solutions_section.tsx
@@ -35,6 +35,7 @@ import PropTypes from 'prop-types';
 import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiScreenReaderOnly } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { SolutionPanel } from './solution_panel';
+import { HomePluginBranding } from '../../../plugin';
 import { FeatureCatalogueEntry, FeatureCatalogueSolution } from '../../../';
 
 const sortByOrder = (
@@ -46,9 +47,10 @@ interface Props {
   addBasePath: (path: string) => string;
   solutions: FeatureCatalogueSolution[];
   directories: FeatureCatalogueEntry[];
+  branding: HomePluginBranding;
 }
 
-export const SolutionsSection: FC<Props> = ({ addBasePath, solutions, directories }) => {
+export const SolutionsSection: FC<Props> = ({ addBasePath, solutions, directories, branding }) => {
   // Separate OpenSearch Dashboards from other solutions
   const opensearchDashboards = solutions.find(({ id }) => id === 'opensearchDashboards');
   const opensearchDashboardsApps = directories
@@ -73,7 +75,12 @@ export const SolutionsSection: FC<Props> = ({ addBasePath, solutions, directorie
             <EuiFlexItem grow={1} className="homSolutions__group homSolutions__group--multiple">
               <EuiFlexGroup direction="column">
                 {solutions.map((solution) => (
-                  <SolutionPanel key={solution.id} solution={solution} addBasePath={addBasePath} />
+                  <SolutionPanel
+                    key={solution.id}
+                    solution={solution}
+                    addBasePath={addBasePath}
+                    branding={branding}
+                  />
                 ))}
               </EuiFlexGroup>
             </EuiFlexItem>
@@ -83,6 +90,7 @@ export const SolutionsSection: FC<Props> = ({ addBasePath, solutions, directorie
               solution={opensearchDashboards}
               addBasePath={addBasePath}
               apps={opensearchDashboardsApps.length ? opensearchDashboardsApps : undefined}
+              branding={branding}
             />
           ) : null}
         </EuiFlexGroup>

--- a/src/plugins/home/public/application/components/welcome.test.tsx
+++ b/src/plugins/home/public/application/components/welcome.test.tsx
@@ -49,33 +49,122 @@ test('should render a Welcome screen with the telemetry disclaimer', () => {
   expect(component).toMatchSnapshot();
 });
 */
-test('should render a Welcome screen with the telemetry disclaimer when optIn is true', () => {
-  const telemetry = telemetryPluginMock.createStartContract();
-  telemetry.telemetryService.getIsOptedIn = jest.fn().mockReturnValue(true);
-  const component = shallow(<Welcome urlBasePath="/" onSkip={() => {}} telemetry={telemetry} />);
 
-  expect(component).toMatchSnapshot();
-});
+const branding = {
+  darkMode: false,
+  mark: {
+    defaultUrl: '/',
+  },
+  applicationTitle: 'OpenSearch Dashboards',
+};
 
-test('should render a Welcome screen with the telemetry disclaimer when optIn is false', () => {
-  const telemetry = telemetryPluginMock.createStartContract();
-  telemetry.telemetryService.getIsOptedIn = jest.fn().mockReturnValue(false);
-  const component = shallow(<Welcome urlBasePath="/" onSkip={() => {}} telemetry={telemetry} />);
+describe('Welcome page ', () => {
+  describe('should render a Welcome screen ', () => {
+    test('with the telemetry disclaimer when optIn is true', () => {
+      const telemetry = telemetryPluginMock.createStartContract();
+      telemetry.telemetryService.getIsOptedIn = jest.fn().mockReturnValue(true);
+      const component = shallow(
+        <Welcome urlBasePath="/" onSkip={() => {}} telemetry={telemetry} branding={branding} />
+      );
 
-  expect(component).toMatchSnapshot();
-});
+      expect(component).toMatchSnapshot();
+    });
 
-test('should render a Welcome screen with no telemetry disclaimer', () => {
-  const component = shallow(<Welcome urlBasePath="/" onSkip={() => {}} />);
+    test('with the telemetry disclaimer when optIn is false', () => {
+      const telemetry = telemetryPluginMock.createStartContract();
+      telemetry.telemetryService.getIsOptedIn = jest.fn().mockReturnValue(false);
+      const component = shallow(
+        <Welcome urlBasePath="/" onSkip={() => {}} telemetry={telemetry} branding={branding} />
+      );
 
-  expect(component).toMatchSnapshot();
-});
+      expect(component).toMatchSnapshot();
+    });
 
-test('fires opt-in seen when mounted', () => {
-  const telemetry = telemetryPluginMock.createStartContract();
-  const mockSetOptedInNoticeSeen = jest.fn();
-  telemetry.telemetryNotifications.setOptedInNoticeSeen = mockSetOptedInNoticeSeen;
-  shallow(<Welcome urlBasePath="/" onSkip={() => {}} telemetry={telemetry} />);
+    test('with no telemetry disclaimer', () => {
+      const component = shallow(<Welcome urlBasePath="/" onSkip={() => {}} branding={branding} />);
 
-  expect(mockSetOptedInNoticeSeen).toHaveBeenCalled();
+      expect(component).toMatchSnapshot();
+    });
+
+    test('fires opt-in seen when mounted', () => {
+      const telemetry = telemetryPluginMock.createStartContract();
+      const mockSetOptedInNoticeSeen = jest.fn();
+      telemetry.telemetryNotifications.setOptedInNoticeSeen = mockSetOptedInNoticeSeen;
+      shallow(
+        <Welcome urlBasePath="/" onSkip={() => {}} telemetry={telemetry} branding={branding} />
+      );
+
+      expect(mockSetOptedInNoticeSeen).toHaveBeenCalled();
+    });
+  });
+
+  describe('should render welcome logo in default mode ', () => {
+    test('using mark default mode URL', () => {
+      const customBranding = {
+        darkMode: false,
+        mark: {
+          defaultUrl: '/defaultModeMark',
+        },
+        applicationTitle: 'custom title',
+      };
+      const component = shallow(
+        <Welcome urlBasePath="/" onSkip={() => {}} branding={customBranding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('using the original OpenSearch Dashboards logo', () => {
+      const defaultBranding = {
+        darkMode: false,
+        mark: {},
+        applicationTitle: 'OpenSearch Dashboards',
+      };
+      const component = shallow(
+        <Welcome urlBasePath="/" onSkip={() => {}} branding={defaultBranding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+  });
+  describe('should render welcome logo in dark mode ', () => {
+    test('using mark dark mode URL', () => {
+      const customBranding = {
+        darkMode: true,
+        mark: {
+          defaultUrl: '/defaultModeMark',
+          darkModeUrl: '/darkModeMark',
+        },
+        title: 'custom title',
+      };
+      const component = shallow(
+        <Welcome urlBasePath="/" onSkip={() => {}} branding={customBranding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('using mark default mode URL', () => {
+      const customBranding = {
+        darkMode: true,
+        mark: {
+          defaultUrl: '/defaultModeMark',
+        },
+        title: 'custom title',
+      };
+      const component = shallow(
+        <Welcome urlBasePath="/" onSkip={() => {}} branding={customBranding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('using the original opensearch logo', () => {
+      const customBranding = {
+        darkMode: true,
+        mark: {},
+        title: 'custom title',
+      };
+      const component = shallow(
+        <Welcome urlBasePath="/" onSkip={() => {}} branding={customBranding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+  });
 });

--- a/src/plugins/home/public/application/opensearch_dashboards_services.ts
+++ b/src/plugins/home/public/application/opensearch_dashboards_services.ts
@@ -47,6 +47,7 @@ import { TutorialService } from '../services/tutorials';
 import { FeatureCatalogueRegistry } from '../services/feature_catalogue';
 import { EnvironmentService } from '../services/environment';
 import { ConfigSchema } from '../../config';
+import { HomePluginBranding } from '..';
 
 export interface HomeOpenSearchDashboardsServices {
   indexPatternService: any;
@@ -68,6 +69,10 @@ export interface HomeOpenSearchDashboardsServices {
   environmentService: EnvironmentService;
   telemetry?: TelemetryPluginStart;
   tutorialService: TutorialService;
+  injectedMetadata: {
+    getInjectedVar: (name: string, defaultValue?: any) => unknown;
+    getBranding: () => HomePluginBranding;
+  };
 }
 
 let services: HomeOpenSearchDashboardsServices | null = null;

--- a/src/plugins/home/public/index.ts
+++ b/src/plugins/home/public/index.ts
@@ -38,6 +38,7 @@ export {
   TutorialSetup,
   HomePublicPluginSetup,
   HomePublicPluginStart,
+  HomePluginBranding,
 } from './plugin';
 export {
   FeatureCatalogueEntry,

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -40,6 +40,7 @@ import {
 import { i18n } from '@osd/i18n';
 import { first } from 'rxjs/operators';
 
+import { Branding } from 'src/core/types';
 import {
   EnvironmentService,
   EnvironmentServiceSetup,
@@ -119,6 +120,7 @@ export class HomePublicPlugin
           homeConfig: this.initializerContext.config.get(),
           tutorialService: this.tutorialService,
           featureCatalogue: this.featuresCatalogueRegistry,
+          injectedMetadata: coreStart.injectedMetadata,
         });
         coreStart.chrome.docTitle.change(
           i18n.translate('home.pageTitle', { defaultMessage: 'Home' })
@@ -186,6 +188,9 @@ export type EnvironmentSetup = EnvironmentServiceSetup;
 
 /** @public */
 export type TutorialSetup = TutorialServiceSetup;
+
+/** @public */
+export type HomePluginBranding = Branding;
 
 /** @public */
 export interface HomePublicPluginSetup {

--- a/src/plugins/opensearch_dashboards_overview/public/application.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/application.tsx
@@ -53,6 +53,7 @@ export const renderApp = (
     .filter(({ id }) => id !== 'opensearchDashboards')
     .filter(({ id }) => navLinks.find(({ category, hidden }) => !hidden && category?.id === id));
   const features = home.featureCatalogue.get();
+  const branding = core.injectedMetadata.getBranding();
 
   ReactDOM.render(
     <I18nProvider>
@@ -65,6 +66,7 @@ export const renderApp = (
           newsfeed$={newsfeed$}
           solutions={solutions}
           features={features}
+          branding={branding}
         />
       </OpenSearchDashboardsContextProvider>
     </I18nProvider>,

--- a/src/plugins/opensearch_dashboards_overview/public/components/app.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/app.tsx
@@ -39,6 +39,7 @@ import { NavigationPublicPluginStart } from 'src/plugins/navigation/public';
 import { FetchResult } from 'src/plugins/newsfeed/public';
 import { FeatureCatalogueEntry, FeatureCatalogueSolution } from 'src/plugins/home/public';
 import { Overview } from './overview';
+import { OverviewPluginBranding } from '../plugin';
 
 interface OpenSearchDashboardsOverviewAppDeps {
   basename: string;
@@ -48,6 +49,7 @@ interface OpenSearchDashboardsOverviewAppDeps {
   newsfeed$?: Observable<FetchResult | null | void>;
   solutions: FeatureCatalogueSolution[];
   features: FeatureCatalogueEntry[];
+  branding: OverviewPluginBranding;
 }
 
 export const OpenSearchDashboardsOverviewApp = ({
@@ -55,6 +57,7 @@ export const OpenSearchDashboardsOverviewApp = ({
   newsfeed$,
   solutions,
   features,
+  branding,
 }: OpenSearchDashboardsOverviewAppDeps) => {
   const [newsFetchResult, setNewsFetchResult] = useState<FetchResult | null | void>(null);
 
@@ -73,7 +76,12 @@ export const OpenSearchDashboardsOverviewApp = ({
       <I18nProvider>
         <Switch>
           <Route exact path="/">
-            <Overview newsFetchResult={newsFetchResult} solutions={solutions} features={features} />
+            <Overview
+              newsFetchResult={newsFetchResult}
+              solutions={solutions}
+              features={features}
+              branding={branding}
+            />
           </Route>
         </Switch>
       </I18nProvider>

--- a/src/plugins/opensearch_dashboards_overview/public/components/overview/__snapshots__/overview.test.tsx.snap
+++ b/src/plugins/opensearch_dashboards_overview/public/components/overview/__snapshots__/overview.test.tsx.snap
@@ -70,6 +70,15 @@ exports[`Overview render 1`] = `
         ],
       }
     }
+    branding={
+      Object {
+        "darkMode": false,
+        "mark": Object {
+          "darkModeUrl": "/darkModeUrl",
+          "defaultUrl": "/defaultModeUrl",
+        },
+      }
+    }
     hideToolbar={false}
     iconType="inputOutput"
     title={
@@ -490,6 +499,15 @@ exports[`Overview without features 1`] = `
         ],
       }
     }
+    branding={
+      Object {
+        "darkMode": false,
+        "mark": Object {
+          "darkModeUrl": "/darkModeUrl",
+          "defaultUrl": "/defaultModeUrl",
+        },
+      }
+    }
     hideToolbar={false}
     iconType="inputOutput"
     title={
@@ -908,6 +926,15 @@ exports[`Overview without solutions 1`] = `
             "value": "/plugins/opensearchDashboardsOverview/assets/solutions_solution_4_light_2x.png",
           },
         ],
+      }
+    }
+    branding={
+      Object {
+        "darkMode": false,
+        "mark": Object {
+          "darkModeUrl": "/darkModeUrl",
+          "defaultUrl": "/defaultModeUrl",
+        },
       }
     }
     hideToolbar={false}

--- a/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.test.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.test.tsx
@@ -167,6 +167,14 @@ const mockFeatures = [
   },
 ];
 
+const mockBranding = {
+  darkMode: false,
+  mark: {
+    defaultUrl: '/defaultModeUrl',
+    darkModeUrl: '/darkModeUrl',
+  },
+};
+
 describe('Overview', () => {
   test('render', () => {
     const component = shallowWithIntl(
@@ -174,19 +182,30 @@ describe('Overview', () => {
         newsFetchResult={mockNewsFetchResult}
         solutions={mockSolutions}
         features={mockFeatures}
+        branding={mockBranding}
       />
     );
     expect(component).toMatchSnapshot();
   });
   test('without solutions', () => {
     const component = shallowWithIntl(
-      <Overview newsFetchResult={mockNewsFetchResult} solutions={[]} features={mockFeatures} />
+      <Overview
+        newsFetchResult={mockNewsFetchResult}
+        solutions={[]}
+        features={mockFeatures}
+        branding={mockBranding}
+      />
     );
     expect(component).toMatchSnapshot();
   });
   test('without features', () => {
     const component = shallowWithIntl(
-      <Overview newsFetchResult={mockNewsFetchResult} solutions={mockSolutions} features={[]} />
+      <Overview
+        newsFetchResult={mockNewsFetchResult}
+        solutions={mockSolutions}
+        features={[]}
+        branding={mockBranding}
+      />
     );
     expect(component).toMatchSnapshot();
   });

--- a/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.tsx
@@ -62,17 +62,18 @@ import { AddData } from '../add_data';
 import { GettingStarted } from '../getting_started';
 import { ManageData } from '../manage_data';
 import { NewsFeed } from '../news_feed';
+import { OverviewPluginBranding } from '../../plugin';
 
 const sortByOrder = (featureA: FeatureCatalogueEntry, featureB: FeatureCatalogueEntry) =>
   (featureA.order || Infinity) - (featureB.order || Infinity);
-
 interface Props {
   newsFetchResult: FetchResult | null | void;
   solutions: FeatureCatalogueSolution[];
   features: FeatureCatalogueEntry[];
+  branding: OverviewPluginBranding;
 }
 
-export const Overview: FC<Props> = ({ newsFetchResult, solutions, features }) => {
+export const Overview: FC<Props> = ({ newsFetchResult, solutions, features, branding }) => {
   const [isNewOpenSearchDashboardsInstance, setNewOpenSearchDashboardsInstance] = useState(false);
   const {
     services: { http, data, uiSettings, application },
@@ -155,6 +156,7 @@ export const Overview: FC<Props> = ({ newsFetchResult, solutions, features }) =>
             id="opensearchDashboardsOverview.header.title"
           />
         }
+        branding={branding}
       />
 
       <div className="osdOverviewContent">

--- a/src/plugins/opensearch_dashboards_overview/public/plugin.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/plugin.ts
@@ -41,6 +41,7 @@ import {
   DEFAULT_APP_CATEGORIES,
   AppStatus,
   AppNavLinkStatus,
+  Branding,
 } from '../../../core/public';
 import {
   OpenSearchDashboardsOverviewPluginSetup,
@@ -49,6 +50,9 @@ import {
   AppPluginStartDependencies,
 } from './types';
 import { PLUGIN_ID, PLUGIN_NAME, PLUGIN_PATH, PLUGIN_ICON } from '../common';
+
+/** @public */
+export type OverviewPluginBranding = Branding;
 
 export class OpenSearchDashboardsOverviewPlugin
   implements

--- a/src/plugins/opensearch_dashboards_react/public/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/index.ts
@@ -48,6 +48,10 @@ export { reactToUiComponent, uiToReactComponent } from './adapters';
 export { useUrlTracker } from './use_url_tracker';
 export { toMountPoint, MountPointPortal } from './util';
 export { RedirectAppLinks } from './app_links';
+import { Branding } from 'opensearch-dashboards/public';
+
+/** Custom branding configurations for opensearch dashboards react plugin */
+export type ReactPluginBranding = Branding;
 
 /** dummy plugin, we just want opensearchDashboardsReact to have its own bundle */
 export function plugin() {

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/__snapshots__/overview_page_header.test.tsx.snap
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/__snapshots__/overview_page_header.test.tsx.snap
@@ -1,6 +1,274 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OverviewPageHeader render 1`] = `
+exports[`OverviewPageHeader  in dark mode  render logo as custom dark mode logo 1`] = `
+<header
+  className="osdOverviewPageHeader osdOverviewPageHeader--noOverlap"
+>
+  <div
+    className="osdOverviewPageHeader__inner"
+  >
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <EuiFlexGroup
+          gutterSize="m"
+          responsive={false}
+        >
+          <EuiFlexItem>
+            <EuiTitle
+              size="m"
+            >
+              <h1
+                id="osdOverviewPageHeader__title"
+              >
+                Page Title
+              </h1>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFlexGroup
+          className="osdOverviewPageHeader__actions"
+          responsive={false}
+          wrap={true}
+        >
+          <EuiFlexItem
+            className="osdOverviewPageHeader__actionItem"
+            grow={false}
+          >
+            <mockConstructor
+              application={
+                Object {
+                  "capabilities": Object {
+                    "navLinks": Object {
+                      "dev_tools": true,
+                      "management": true,
+                    },
+                  },
+                }
+              }
+            >
+              <EuiButtonEmpty
+                className="osdOverviewPageHeader__actionButton"
+                flush="both"
+                href="/app/home#/tutorial_directory"
+                iconType="indexOpen"
+              >
+                Add data
+              </EuiButtonEmpty>
+            </mockConstructor>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </div>
+</header>
+`;
+
+exports[`OverviewPageHeader  in dark mode  render logo as custom default mode logo 1`] = `
+<header
+  className="osdOverviewPageHeader osdOverviewPageHeader--noOverlap"
+>
+  <div
+    className="osdOverviewPageHeader__inner"
+  >
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <EuiFlexGroup
+          gutterSize="m"
+          responsive={false}
+        >
+          <EuiFlexItem>
+            <EuiTitle
+              size="m"
+            >
+              <h1
+                id="osdOverviewPageHeader__title"
+              >
+                Page Title
+              </h1>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFlexGroup
+          className="osdOverviewPageHeader__actions"
+          responsive={false}
+          wrap={true}
+        >
+          <EuiFlexItem
+            className="osdOverviewPageHeader__actionItem"
+            grow={false}
+          >
+            <mockConstructor
+              application={
+                Object {
+                  "capabilities": Object {
+                    "navLinks": Object {
+                      "dev_tools": true,
+                      "management": true,
+                    },
+                  },
+                }
+              }
+            >
+              <EuiButtonEmpty
+                className="osdOverviewPageHeader__actionButton"
+                flush="both"
+                href="/app/home#/tutorial_directory"
+                iconType="indexOpen"
+              >
+                Add data
+              </EuiButtonEmpty>
+            </mockConstructor>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </div>
+</header>
+`;
+
+exports[`OverviewPageHeader  in dark mode  render logo as original dark mode opensearch mark 1`] = `
+<header
+  className="osdOverviewPageHeader osdOverviewPageHeader--noOverlap"
+>
+  <div
+    className="osdOverviewPageHeader__inner"
+  >
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <EuiFlexGroup
+          gutterSize="m"
+          responsive={false}
+        >
+          <EuiFlexItem>
+            <EuiTitle
+              size="m"
+            >
+              <h1
+                id="osdOverviewPageHeader__title"
+              >
+                Page Title
+              </h1>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFlexGroup
+          className="osdOverviewPageHeader__actions"
+          responsive={false}
+          wrap={true}
+        >
+          <EuiFlexItem
+            className="osdOverviewPageHeader__actionItem"
+            grow={false}
+          >
+            <mockConstructor
+              application={
+                Object {
+                  "capabilities": Object {
+                    "navLinks": Object {
+                      "dev_tools": true,
+                      "management": true,
+                    },
+                  },
+                }
+              }
+            >
+              <EuiButtonEmpty
+                className="osdOverviewPageHeader__actionButton"
+                flush="both"
+                href="/app/home#/tutorial_directory"
+                iconType="indexOpen"
+              >
+                Add data
+              </EuiButtonEmpty>
+            </mockConstructor>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </div>
+</header>
+`;
+
+exports[`OverviewPageHeader  in default mode  render logo as custom default mode logo 1`] = `
+<header
+  className="osdOverviewPageHeader osdOverviewPageHeader--noOverlap"
+>
+  <div
+    className="osdOverviewPageHeader__inner"
+  >
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <EuiFlexGroup
+          gutterSize="m"
+          responsive={false}
+        >
+          <EuiFlexItem>
+            <EuiTitle
+              size="m"
+            >
+              <h1
+                id="osdOverviewPageHeader__title"
+              >
+                Page Title
+              </h1>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiFlexGroup
+          className="osdOverviewPageHeader__actions"
+          responsive={false}
+          wrap={true}
+        >
+          <EuiFlexItem
+            className="osdOverviewPageHeader__actionItem"
+            grow={false}
+          >
+            <mockConstructor
+              application={
+                Object {
+                  "capabilities": Object {
+                    "navLinks": Object {
+                      "dev_tools": true,
+                      "management": true,
+                    },
+                  },
+                }
+              }
+            >
+              <EuiButtonEmpty
+                className="osdOverviewPageHeader__actionButton"
+                flush="both"
+                href="/app/home#/tutorial_directory"
+                iconType="indexOpen"
+              >
+                Add data
+              </EuiButtonEmpty>
+            </mockConstructor>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </div>
+</header>
+`;
+
+exports[`OverviewPageHeader  in default mode  render logo as original default mode opensearch mark 1`] = `
 <header
   className="osdOverviewPageHeader osdOverviewPageHeader--noOverlap"
 >

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.test.tsx
@@ -52,11 +52,76 @@ afterAll(() => jest.clearAllMocks());
 const mockTitle = 'Page Title';
 const addBasePathMock = jest.fn((path: string) => (path ? path : 'path'));
 
-describe('OverviewPageHeader', () => {
-  test('render', () => {
-    const component = shallowWithIntl(
-      <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} />
-    );
-    expect(component).toMatchSnapshot();
+describe('OverviewPageHeader ', () => {
+  describe('in default mode ', () => {
+    test('render logo as custom default mode logo', () => {
+      const branding = {
+        darkMode: false,
+        mark: {
+          defaultUrl: '/defaultModeLogo',
+          darkModeUrl: '/darkModeLogo',
+        },
+      };
+
+      const component = shallowWithIntl(
+        <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} branding={branding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('render logo as original default mode opensearch mark', () => {
+      const branding = {
+        darkMode: false,
+        mark: {},
+      };
+
+      const component = shallowWithIntl(
+        <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} branding={branding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('in dark mode ', () => {
+    test('render logo as custom dark mode logo', () => {
+      const branding = {
+        darkMode: false,
+        mark: {
+          defaultUrl: '/defaultModeLogo',
+          darkModeUrl: '/darkModeLogo',
+        },
+      };
+
+      const component = shallowWithIntl(
+        <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} branding={branding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('render logo as custom default mode logo', () => {
+      const branding = {
+        darkMode: false,
+        mark: {
+          defaultUrl: '/defaultModeLogo',
+        },
+      };
+
+      const component = shallowWithIntl(
+        <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} branding={branding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('render logo as original dark mode opensearch mark', () => {
+      const branding = {
+        darkMode: false,
+        mark: {},
+      };
+
+      const component = shallowWithIntl(
+        <OverviewPageHeader addBasePath={addBasePathMock} title={mockTitle} branding={branding} />
+      );
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
@@ -43,6 +43,7 @@ import { i18n } from '@osd/i18n';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { RedirectAppLinks } from '../../app_links';
 import { useOpenSearchDashboards } from '../../context';
+import { ReactPluginBranding } from '../..';
 
 import './index.scss';
 
@@ -54,6 +55,7 @@ interface Props {
   showManagementLink?: boolean;
   title: JSX.Element | string;
   addBasePath: (path: string) => string;
+  branding: ReactPluginBranding;
 }
 
 export const OverviewPageHeader: FC<Props> = ({
@@ -64,6 +66,7 @@ export const OverviewPageHeader: FC<Props> = ({
   showManagementLink,
   title,
   addBasePath,
+  branding,
 }) => {
   const {
     services: { application },
@@ -73,6 +76,58 @@ export const OverviewPageHeader: FC<Props> = ({
     management: isManagementEnabled,
     dev_tools: isDevToolsEnabled,
   } = application.capabilities.navLinks;
+
+  const DEFAULT_OPENSEARCH_MARK = `${branding.assetFolderUrl}/opensearch_mark_default_mode.svg`;
+  const DARKMODE_OPENSEARCH_MARK = `${branding.assetFolderUrl}/opensearch_mark_dark_mode.svg`;
+
+  const darkMode = branding.darkMode;
+  const markDefault = branding.mark?.defaultUrl;
+  const markDarkMode = branding.mark?.darkModeUrl;
+
+  /**
+   * Use branding configurations to check which URL to use for rendering
+   * overview logo in default mode. In default mode, overview logo will
+   * proritize default mode mark URL. If it is invalid, default opensearch logo
+   * will be rendered.
+   *
+   * @returns a valid custom URL or undefined if no valid URL is provided
+   */
+  const customOverviewLogoDefaultMode = () => {
+    return markDefault ?? DEFAULT_OPENSEARCH_MARK;
+  };
+
+  /**
+   * Use branding configurations to check which URL to use for rendering
+   * overview logo in dark mode. In dark mode, overview logo will render
+   * dark mode mark URL if valid. Otherwise, it will render the default
+   * mode mark URL if valid. If both dark mode mark URL and default mode mark
+   * URL are invalid, the default opensearch logo will be rendered.
+   *
+   * @returns a valid custom URL or undefined if no valid URL is provided
+   */
+  const customOverviewLogoDarkMode = () => {
+    return markDarkMode ?? markDefault ?? DARKMODE_OPENSEARCH_MARK;
+  };
+
+  /**
+   * Render custom overview logo for both default mode and dark mode
+   *
+   * @returns a valid custom loading logo URL, or undefined
+   */
+  const customOverviewLogo = () => {
+    return darkMode ? customOverviewLogoDarkMode() : customOverviewLogoDefaultMode();
+  };
+
+  /**
+   * Check if we render a custom overview logo or the default opensearch spinner.
+   * If customOverviewLogo() returns undefined(no valid custom URL is found), we
+   * render the default opensearch logo
+   *
+   * @returns a image component with custom logo URL, or the default opensearch logo
+   */
+  const renderBrandingEnabledOrDisabledLogo = (iconTypeInput?: IconType) => {
+    return customOverviewLogo() ?? iconTypeInput ?? '';
+  };
 
   return (
     <header
@@ -86,7 +141,12 @@ export const OverviewPageHeader: FC<Props> = ({
             <EuiFlexGroup gutterSize="m" responsive={false}>
               {iconType && (
                 <EuiFlexItem grow={false}>
-                  <EuiIcon size="xxl" type={iconType} />
+                  <EuiIcon
+                    size="xxl"
+                    type={renderBrandingEnabledOrDisabledLogo(iconType)}
+                    data-test-subj={`osdOverviewPageHeaderLogo`}
+                    data-test-logo={renderBrandingEnabledOrDisabledLogo(iconType)}
+                  />
                 </EuiFlexItem>
               )}
 

--- a/test/common/config.js
+++ b/test/common/config.js
@@ -60,7 +60,7 @@ export default function () {
         `--opensearch.hosts=${formatUrl(servers.opensearch)}`,
         `--opensearch.username=${opensearchDashboardsServerTestUser.username}`,
         `--opensearch.password=${opensearchDashboardsServerTestUser.password}`,
-        `--home.disableWelcomeScreen=true`,
+        `--home.disableWelcomeScreen=false`,
         // Needed for async search functional tests to introduce a delay
         `--data.search.aggs.shardDelay.enabled=true`,
         //`--security.showInsecureClusterWarning=false`,
@@ -74,6 +74,12 @@ export default function () {
         // `--plugin-path=${path.join(__dirname, 'fixtures', 'plugins', 'newsfeed')}`,
         // `--newsfeed.service.urlRoot=${servers.opensearchDashboards.protocol}://${servers.opensearchDashboards.hostname}:${servers.opensearchDashboards.port}`,
         // `--newsfeed.service.pathTemplate=/api/_newsfeed-FTS-external-service-simulators/opensearch-dashboards/v{VERSION}.json`,
+        // Custom branding config
+        `--opensearchDashboards.branding.logo.defaultUrl=https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg`,
+        `--opensearchDashboards.branding.logo.darkModeUrl=https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_darkmode.svg`,
+        `--opensearchDashboards.branding.mark.defaultUrl=https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg`,
+        `--opensearchDashboards.branding.mark.darkModeUrl=https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_darkmode.svg`,
+        `--opensearchDashboards.branding.applicationTitle=OpenSearch`,
       ],
     },
     services,

--- a/test/functional/apps/visualize/_custom_branding.js
+++ b/test/functional/apps/visualize/_custom_branding.js
@@ -1,0 +1,228 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+import expect from '@osd/expect';
+import { UI_SETTINGS } from '../../../../src/plugins/data/common';
+
+export default function ({ getService, getPageObjects }) {
+  const browser = getService('browser');
+  const globalNav = getService('globalNav');
+  const opensearchArchiver = getService('opensearchArchiver');
+  const opensearchDashboardsServer = getService('opensearchDashboardsServer');
+  const appsMenu = getService('appsMenu');
+  const PageObjects = getPageObjects(['common', 'home', 'header', 'settings']);
+  const testSubjects = getService('testSubjects');
+
+  const expectedFullLogo =
+    'https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg';
+  const expectedFullLogoDarkMode =
+    'https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_darkmode.svg';
+  const expectedMarkLogo =
+    'https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_default.svg';
+  const expectedMarkLogoDarkMode =
+    'https://opensearch.org/assets/brand/SVG/Mark/opensearch_mark_darkmode.svg';
+  const applicationTitle = 'OpenSearch';
+  const expectedWelcomeMessage = 'Welcome to OpenSearch';
+
+  describe('OpenSearch Dashboards branding configuration', function customHomeBranding() {
+    describe('should render overview page', async () => {
+      this.tags('includeFirefox');
+
+      before(async function () {
+        await PageObjects.common.navigateToApp('home');
+        await PageObjects.common.navigateToApp('opensearch_dashboards_overview');
+      });
+
+      it('with customized logo for opensearch overview header in default mode', async () => {
+        await testSubjects.existOrFail('osdOverviewPageHeaderLogo');
+        const actualLabel = await testSubjects.getAttribute(
+          'osdOverviewPageHeaderLogo',
+          'data-test-logo'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogo.toUpperCase());
+      });
+
+      it('with customized logo for opensearch overview header in dark mode', async () => {
+        await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
+        await PageObjects.settings.toggleAdvancedSettingCheckbox('theme:darkMode');
+        await PageObjects.common.navigateToApp('opensearch_dashboards_overview');
+        await testSubjects.existOrFail('osdOverviewPageHeaderLogo');
+        const actualLabel = await testSubjects.getAttribute(
+          'osdOverviewPageHeaderLogo',
+          'data-test-logo'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogoDarkMode.toUpperCase());
+      });
+    });
+
+    describe('should render welcome page', async () => {
+      this.tags('includeFirefox');
+
+      //unloading any pre-existing settings so the welcome page will appear
+      before(async function () {
+        await opensearchArchiver.unload('logstash_functional');
+        await opensearchArchiver.unload('long_window_logstash');
+        await opensearchArchiver.unload('visualize');
+        await PageObjects.common.navigateToApp('home');
+      });
+
+      //loading the settings again for
+      after(async function () {
+        await browser.setWindowSize(1280, 800);
+        await opensearchArchiver.loadIfNeeded('logstash_functional');
+        await opensearchArchiver.loadIfNeeded('long_window_logstash');
+        await opensearchArchiver.load('visualize');
+        await opensearchDashboardsServer.uiSettings.replace({
+          defaultIndex: 'logstash-*',
+          [UI_SETTINGS.FORMAT_BYTES_DEFAULT_PATTERN]: '0,0.[000]b',
+        });
+      });
+
+      it('with customized logo', async () => {
+        await testSubjects.existOrFail('welcomeCustomLogo');
+        const actualLabel = await testSubjects.getAttribute(
+          'welcomeCustomLogo',
+          'data-test-image-url'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogo.toUpperCase());
+      });
+
+      it('with customized title', async () => {
+        await testSubjects.existOrFail('welcomeCustomTitle');
+        const actualLabel = await testSubjects.getAttribute(
+          'welcomeCustomTitle',
+          'data-test-title-message'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedWelcomeMessage.toUpperCase());
+      });
+
+      it('with customized logo in dark mode', async () => {
+        await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
+        await PageObjects.settings.toggleAdvancedSettingCheckbox('theme:darkMode');
+        await PageObjects.common.navigateToApp('home');
+        await testSubjects.existOrFail('welcomeCustomLogo');
+        const actualLabel = await testSubjects.getAttribute(
+          'welcomeCustomLogo',
+          'data-test-image-url'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogoDarkMode.toUpperCase());
+      });
+    });
+
+    describe('should render home page', async () => {
+      this.tags('includeFirefox');
+
+      before(async function () {
+        await PageObjects.common.navigateToApp('home');
+      });
+
+      after(async function () {
+        await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
+        await PageObjects.settings.clearAdvancedSettings('theme:darkMode');
+        await PageObjects.common.navigateToApp('home');
+      });
+
+      it('with customized logo in header bar', async () => {
+        await globalNav.logoExistsOrFail(expectedFullLogo);
+      });
+
+      it('with customized logo that can take back to home page', async () => {
+        await PageObjects.common.navigateToApp('settings');
+        await globalNav.clickLogo();
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        const url = await browser.getCurrentUrl();
+        expect(url.includes('/app/home')).to.be(true);
+      });
+
+      it('with customized logo in home dashboard card', async () => {
+        await testSubjects.existOrFail('dashboardCustomLogo');
+        const actualLabel = await testSubjects.getAttribute(
+          'dashboardCustomLogo',
+          'data-test-image-url'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogo.toUpperCase());
+      });
+
+      it('with customized title in home dashboard card', async () => {
+        await testSubjects.existOrFail('dashboardCustomTitle');
+        const actualLabel = await testSubjects.getAttribute(
+          'dashboardCustomTitle',
+          'data-test-title'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(applicationTitle.toUpperCase());
+      });
+
+      it('with customized logo for opensearch in side menu', async () => {
+        await appsMenu.openCollapsibleNav();
+        await testSubjects.existOrFail('collapsibleNavGroup-opensearchDashboards');
+        const actualLabel = await testSubjects.getAttribute(
+          'collapsibleNavGroup-opensearchDashboards',
+          'data-test-opensearch-logo'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogo.toUpperCase());
+      });
+
+      it('with customized logo in header bar in dark mode', async () => {
+        await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
+        await PageObjects.settings.toggleAdvancedSettingCheckbox('theme:darkMode');
+        await PageObjects.common.navigateToApp('home');
+        await globalNav.logoExistsOrFail(expectedFullLogoDarkMode);
+      });
+
+      it('with customized logo that can take back to home page in dark mode', async () => {
+        await PageObjects.common.navigateToApp('settings');
+        await globalNav.clickLogo();
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        const url = await browser.getCurrentUrl();
+        expect(url.includes('/app/home')).to.be(true);
+      });
+
+      it('with customized logo in home dashboard card in dark mode', async () => {
+        await testSubjects.existOrFail('dashboardCustomLogo');
+        const actualLabel = await testSubjects.getAttribute(
+          'dashboardCustomLogo',
+          'data-test-image-url'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogoDarkMode.toUpperCase());
+      });
+
+      it('with customized logo for opensearch in side menu in dark mode', async () => {
+        await appsMenu.openCollapsibleNav();
+        await testSubjects.existOrFail('collapsibleNavGroup-opensearchDashboards');
+        const actualLabel = await testSubjects.getAttribute(
+          'collapsibleNavGroup-opensearchDashboards',
+          'data-test-opensearch-logo'
+        );
+        expect(actualLabel.toUpperCase()).to.equal(expectedMarkLogoDarkMode.toUpperCase());
+      });
+    });
+  });
+}

--- a/test/functional/apps/visualize/index.ts
+++ b/test/functional/apps/visualize/index.ts
@@ -58,6 +58,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     describe('', function () {
       this.tags('ciGroup9');
 
+      loadTestFile(require.resolve('./_custom_branding'));
       loadTestFile(require.resolve('./_embedding_chart'));
       loadTestFile(require.resolve('./_chart_types'));
       loadTestFile(require.resolve('./_area_chart'));

--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -68,8 +68,9 @@ export function CommonPageProvider({ getService, getPageObjects }: FtrProviderCo
       // Disable the welcome screen. This is relevant for environments
       // which don't allow to use the yml setting, e.g. cloud production.
       // It is done here so it applies to logins but also to a login re-use.
-      await browser.setLocalStorageItem('home:welcome:show', 'false');
 
+      // Update: Enable the welcome screen for functional tests on the welcome screen.
+      await browser.setLocalStorageItem('home:welcome:show', 'true');
       let currentUrl = await browser.getCurrentUrl();
       log.debug(`currentUrl = ${currentUrl}\n    appUrl = ${appUrl}`);
       await testSubjects.find('opensearchDashboardsChrome', 6 * defaultFindTimeout); // 60 sec waiting

--- a/test/functional/services/global_nav.ts
+++ b/test/functional/services/global_nav.ts
@@ -74,6 +74,15 @@ export function GlobalNavProvider({ getService }: FtrProviderContext) {
     public async badgeMissingOrFail(): Promise<void> {
       await testSubjects.missingOrFail('headerBadge');
     }
+
+    public async logoExistsOrFail(expectedUrl: string): Promise<void> {
+      await testSubjects.exists('headerGlobalNav > logo > customLogo');
+      const actualLabel = await testSubjects.getAttribute(
+        'headerGlobalNav > logo > customLogo',
+        'data-test-image-url'
+      );
+      expect(actualLabel.toUpperCase()).to.equal(expectedUrl.toUpperCase());
+    }
   }
 
   return new GlobalNav();


### PR DESCRIPTION
* Make top left logo on the main screen configurable

Add a new config opensearchDashboards.branding.logoUrl in yaml file
for making top left corner logo on the main screen configurable. If
URL is invalid, the default OpenSearch logo will be shown.

Signed-off-by: Abby Hu <abigailhu2000@gmail.com>

* Welcome page title and logo configurable (#738)

Add two new configs branding.smallLogoUrl and branding.title
in the yaml file for making the welcome page logo and title
 configurable. If URL is invalid, the default branding will be shown.

Signed-off-by: Qingyang(Abby) Hu <abigailhu2000@gmail.com>

* Make loading page logo and title configurable (#746)

Add one new config branding.loadingLogoUrl for making loading page logo
configurable. URL can be in svg and gif format. If no loading logo is found,
the static logo with a horizontal bar loading bar will be shown. If logo is also
not found, the default OpenSearch loading logo and spinner will be shown.

Signed-off-by: Qingyang(Abby) Hu <abigailhu2000@gmail.com>

* Branding configs rename and improvement (#771)

Change config smallLogoUrl to logoUrl, config logoUrl to fullLogoUrl to emphasize that thumbnail version
of the logo will be used mostly in the application. Full version of the logo will only be used on the main
page nav bar. If full logo is not provided, thumbnail logo will be used on the nav bar. Some config improvement
includes fixing the validation error when inputting empty string, and add title validation function.

Signed-off-by: Qingyang(Abby) Hu <abigailhu2000@gmail.com>

* Branding config structure change and renaming (#793)

Change the branding related config to a map structure in the yml file.
Also rename the configs according to the official branding guidelines.
The full logo on the main page header will be called logo; the small
logo icon will be called mark.

Signed-off-by: Qingyang(Abby) Hu <abigailhu2000@gmail.com>

* Darkmode configurations for header logo, welcome logo and loading logo (#797)

Add dark mode configs in the yml file that allows user to configure a
dark mode version of the logo. When user toggles dark mode under the
Advanced Setting, the logo will be rendered accordingly.

Signed-off-by: Qingyang(Abby) Hu <abigailhu2000@gmail.com>

* Add favicon configuration (#801)

Added a configuration on favicon inside opensearchDashboards.branding
in the yml file. If user inputs a valid URL, we gurantee basic browser
favicon customization, while remaining places show the default browser/device
favicon icon. If user does not provide a valid URL for favicon, the
opensearch favicon icon will be used.

Signed-off-by: Qingyang(Abby) Hu <abigailhu2000@gmail.com>

* Make home page primary dashboard card logo and title configurable (#809)

Home page dashboard card logo and title can be customized by config
mark.defaultUrl and mark.darkModeUrl. Unit test and functional test
are also written.

Signed-off-by: Qingyang(Abby) Hu <abigailhu2000@gmail.com>

* Side menu logo configuration

Make logo for opensearch dashboard side menu be configurable.
Use config mark.defaultUrl and mark.darkModeUrl.

Signed-off-by: Abby Hu <abigailhu2000@gmail.com>

* Overview Header Logo Configuration

Make logo for opensearch dashboard overview header logo be configurable.
Use config mark.defaultUrl and mark.darkModeUrl.

Signed-off-by: Abby Hu <abigailhu2000@gmail.com>

* Redirect URL not allowed

Add an addtional parameter to the checkUrlValid function
so that max redirect count is 0. We do not allow URLs that
can be redirected because of potential security issues.

Signed-off-by: Abby Hu <abigailhu2000@gmail.com>

* Store default opensearch branding asset folder

Store the original opensearch branding logos in an asset folder,
instead of making API calls.

Signed-off-by: Abby Hu <abigailhu2000@gmail.com>

* [Branding] handle comments from PR

Handling the helper function rename and grammar issues.

To avoid risk, we will not remove the duplicate code for 1.2 and
everything related to those comments (ie function renames).

That will be handled in 1.3. Here is the issue tracking it:

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/895

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

Co-authored-by: Kawika Avilla <kavilla414@gmail.com>

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/897