### PR TITLE
1.x Update the dashboard maps end point (#893)

### DIFF
--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -202,14 +202,12 @@ export default () =>
           .default([]),
       }).default(),
       manifestServiceUrl: Joi.string().default('').allow(''),
-      opensearchManifestServiceUrl: Joi.string().default(
-        'https://maps.search-services.aws.a2z.com/v4/ap-southeast-1/manifest'
-      ),
-      emsFileApiUrl: Joi.string().default('https://vectors.maps.search-services.aws.a2z.com'),
-      emsTileApiUrl: Joi.string().default('https://tiles.maps.search-services.aws.a2z.com'),
-      emsLandingPageUrl: Joi.string().default('https://maps.search-services.aws.a2z.com/v4'),
+      opensearchManifestServiceUrl: Joi.string().default('https://maps.opensearch.org/manifest'),
+      emsFileApiUrl: Joi.string().default('https://vectors.maps.opensearch.org'),
+      emsTileApiUrl: Joi.string().default('https://tiles.maps.opensearch.org'),
+      emsLandingPageUrl: Joi.string().default('https://maps.opensearch.org'),
       emsFontLibraryUrl: Joi.string().default(
-        'https://tiles.maps.search-services.aws.a2z.com/fonts/{fontstack}/{range}.pbf'
+        'https://tiles.maps.opensearch.org/fonts/{fontstack}/{range}.pbf'
       ),
       emsTileLayerId: Joi.object({
         bright: Joi.string().default('road_map'),

--- a/src/plugins/maps_legacy/config.ts
+++ b/src/plugins/maps_legacy/config.ts
@@ -41,15 +41,15 @@ export const configSchema = schema.object({
   regionmap: regionmapSchema,
   manifestServiceUrl: schema.string({ defaultValue: '' }),
   opensearchManifestServiceUrl: schema.string({
-    defaultValue: 'https://maps.search-services.aws.a2z.com/v4/us-east-1/manifest',
+    defaultValue: 'https://maps.opensearch.org/manifest',
   }),
   emsFileApiUrl: schema.string({
-    defaultValue: 'https://vectors.maps.search-services.aws.a2z.com',
+    defaultValue: 'https://vectors.maps.opensearch.org',
   }),
-  emsTileApiUrl: schema.string({ defaultValue: 'https://tiles.maps.search-services.aws.a2z.com' }),
-  emsLandingPageUrl: schema.string({ defaultValue: 'https://maps.search-services.aws.a2z.com/v4' }),
+  emsTileApiUrl: schema.string({ defaultValue: 'https://tiles.maps.opensearch.org' }),
+  emsLandingPageUrl: schema.string({ defaultValue: 'https://maps.opensearch.org' }),
   emsFontLibraryUrl: schema.string({
-    defaultValue: 'https://tiles.maps.search-services.aws.a2z.com/fonts/{fontstack}/{range}.pbf',
+    defaultValue: 'https://tiles.maps.opensearch.org/fonts/{fontstack}/{range}.pbf',
   }),
   emsTileLayerId: schema.object({
     bright: schema.string({ defaultValue: 'road_map' }),


### PR DESCRIPTION
Currently the maps end point can't be accessed from India and China, we are going to update maps end point to the new one "maps.opensearch.org" for OpenSearch community users, which will solve the pain for opensource users from some region can't access to the existing one.

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/777

Signed-off-by: Junqiu Lei <junqiu@amazon.com>

 