### PR TITLE
[Backwards Compatibility][OSD] check advanced_settings, default page, loaded sample date, timeline and filter&query

### DIFF
--- a/cypress/integration/osd/check_advanced_settings.js
+++ b/cypress/integration/osd/check_advanced_settings.js
@@ -1,32 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
 
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
-/*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/* es-lint-disable for missing definitions */
 /* eslint-disable */
 import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
   

--- a/cypress/integration/osd/check_default_page.js
+++ b/cypress/integration/osd/check_default_page.js
@@ -1,32 +1,8 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
 
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
-/*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/* es-lint-disable for missing definitions */
 /* eslint-disable */
 import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
   
@@ -37,8 +13,7 @@ describe('verify default landing page work for bwc', () => {
     miscUtils.visitPage('');
   });
   
-  it('the overview page is set as the default landing pag', () => {
+  it('the overview page is set as the default landing page', () => {
     cy.url().should('include', '/app/opensearch_dashboards_overview#/');
-    cy.contains('Display a different page on log in');
   });
 });

--- a/cypress/integration/osd/check_filter_and_query.js
+++ b/cypress/integration/osd/check_filter_and_query.js
@@ -1,50 +1,23 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
  */
 
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
-/*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/* es-lint-disable for missing definitions */
 /* eslint-disable */
-import {
-  MiscUtils,
-  CommonUI
-} from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
-
-const commonUI = new CommonUI(cy);
+import { MiscUtils, CommonUI } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+  
 const miscUtils = new MiscUtils(cy);
-
-describe('verify dashboards filter and query work properly for bwc', () => {
+const commonUI = new CommonUI(cy);
+  
+describe('check dashboards filter and query', () => {
   beforeEach(() => {
     miscUtils.visitPage('app/dashboards#');
   });
-
+  
   afterEach(() => {
     cy.clearCookies();
   });
-
+  
   describe('osx filter and query should work in [Logs] Web Traffic dashboards', () => {
     beforeEach(() => {
       cy.get('[data-test-subj="dashboardListingTitleLink-[Logs]-Web-Traffic"]').click();
@@ -52,7 +25,7 @@ describe('verify dashboards filter and query work properly for bwc', () => {
         .invoke('attr', 'title')
         .should('eq', '[Logs] Web Traffic');
     });
-
+  
     it('osx filter and query should exist and be named correctly', () => {
       cy.get('[data-test-subj="saved-query-management-popover-button"]').click();
       cy.get('[data-test-subj="saved-query-management-popover"]')
@@ -74,45 +47,24 @@ describe('verify dashboards filter and query work properly for bwc', () => {
         .should('have.text', 'is');
       cy.get('[data-test-subj="filterParams"]').find('input').should('have.value', 'osx');
     });
-
+  
     it('osx filter and query should function correctly', () => {
-      commonUI.setDateRange('Oct 10, 2021 @ 00:00:00.000', 'Oct 4, 2021 @ 00:00:00.000');
       cy.get('[data-test-subj="saved-query-management-popover-button"]').click();
       cy.get('[data-test-subj="saved-query-management-popover"]')
         .find('[class="osdSavedQueryListItem__labelText"]')
         .should('have.text', 'test-query')
         .click();
-      cy.get('[data-test-subj="dashboardPanel"]').each((item) => {
-        const vsLoader = item.get('[data-test-subj="visualizationLoader"]');
-        //[Logs] unique visitors should be 211
-        if (
-          vsLoader &&
-          vsLoader
-            .get('[data-test-subj="visualizationLoader"]')
-            .find('[class="chart-title"]')
-            .should('have.text', 'Unique Visitors')
-        ) {
-          vsLoader.should('have.class', 'chart-label').should('have.text', '211');
-        }
-        //[Logs] vistor chart should show osx 100%
-        if (
-          vsLoader &&
-          vsLoader.get('[data-test-subj="visualizationLoader"]').invoke('css', 'data-title') ===
-            '[Logs] Visitors by OS'
-        ) {
-          vsLoader.should('have.class', 'label').should('have.text', 'osx (100%)');
-        }
-        //[Logs] Response chart should show 200 label
-        if (
-          vsLoader &&
-          vsLoader.get('[data-test-subj="visualizationLoader"]').invoke('css', 'data-title') ===
-            '[Logs] Response Codes Over Time + Annotations'
-        ) {
-          vsLoader
-            .should('have.class', 'echLegendItem__label echLegendItem__label--clickable')
-            .should('have.text', '200');
-        }
-      });
+      commonUI.setDateRange('Dec 1, 2021 @ 00:00:00.000', 'Jan 1, 2021 @ 00:00:00.000');  
+        
+      //[Logs] vistor chart should show osx 100%
+      cy.get('[data-title="[Logs] Visitors by OS"]')
+        .find('[class="label"]')
+        .should('have.text', 'osx (100%)');
+        
+      //[Logs] Response chart should show 200 label
+      cy.get('[data-title="[Logs] Response Codes Over Time + Annotations"]')
+        .find('[title="200"]')
+        .should('have.text', '200');
     });
   });
 });

--- a/cypress/integration/osd/check_loaded_data.js
+++ b/cypress/integration/osd/check_loaded_data.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable */
+import { MiscUtils, CommonUI } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+
+const miscUtils = new MiscUtils(cy);
+const commonUI = new CommonUI(cy);
+
+describe('check previously loaded data', () => {
+    beforeEach(() => {
+        miscUtils.visitPage('app/dashboards#');
+    });
+
+    it('previous loaded data should exist in dashboards', () => {
+        let items = cy.get('[data-test-subj="itemsInMemTable"]');
+        
+        items.get('[data-test-subj="dashboardListingTitleLink-[Flights]-Global-Flight-Dashboard"]')
+             .should('have.text', '[Flights] Global Flight Dashboard');
+            
+        items.get('[data-test-subj="dashboardListingTitleLink-[Logs]-Web-Traffic"]')
+             .should('have.text', '[Logs] Web Traffic');  
+
+        items.get('[data-test-subj="dashboardListingTitleLink-[eCommerce]-Revenue-Dashboard"]')
+             .should('have.text', '[eCommerce] Revenue Dashboard');
+    });
+
+    describe('Global Flight Dashboard should function properly', () => {
+        beforeEach(() => {
+            cy.get('[data-test-subj="itemsInMemTable"]')
+              .get('[data-test-subj="dashboardListingTitleLink-[Flights]-Global-Flight-Dashboard"]')
+              .click();            
+            commonUI.removeAllFilters();
+            commonUI.setDateRange('Dec 1, 2021 @ 00:00:00.000', 'Nov 1, 2021 @ 00:00:00.000');
+        });
+
+        it('Global Flight Dashboard is loaded when clicked', () => {
+            cy.get('[data-test-subj="breadcrumb last"]').should('have.text', '[Flights] Global Flight Dashboard');
+            cy.get('[data-title="[Flights] Total Flights"]').should('exist');
+            cy.get('[data-title="[Flights] Average Ticket Price"]').should('exist');
+        });
+
+        it('If set filter for carrier, [Flights] Airline Carrier should show correct carrier', () => {
+            commonUI.addFilterRetrySelection('Carrier', 'is', 'Logstash Airways');
+            cy.get('[data-title="[Flights] Airline Carrier"]')
+              .find('[class="label-text"]')
+              .should('have.text', 'Logstash Airways (100%)');
+        });
+
+        it('If set filter for FlightDelayType, [Flights] Delay Type should filter out selected type', () => {
+            commonUI.addFilterRetrySelection('FlightDelayType', 'is not', 'No Delay');
+            let types = cy.get('[data-title="[Flights] Delay Type"]')
+            types.find('[data-label="Weather Delay"]').should('exist');
+            types.find('[data-label="No Delay"]').should('not.exist'); ;
+        });
+    });
+
+    describe('eCommerce Revenue Dashboard should function properly', () => {
+        beforeEach(() => {
+            cy.get('[data-test-subj="itemsInMemTable"]')
+              .get('[data-test-subj="dashboardListingTitleLink-[eCommerce]-Revenue-Dashboard"]')
+              .click();          
+            commonUI.removeAllFilters();
+            commonUI.setDateRange('Nov 1, 2021 @ 00:00:00.000', 'Nov 1, 2016 @ 00:00:00.000');
+        });
+
+        it('eCommerce Revenue Dashboard is loaded when clicked', () => {
+            cy.get('[data-test-subj="breadcrumb last"]').should('have.text', '[eCommerce] Revenue Dashboard');
+            cy.get('[data-title="[eCommerce] Average Sales Price"]').should('exist');
+            cy.get('[data-title="[eCommerce] Average Sold Quantity"]').should('exist');
+        });
+
+        it('If set filter for gender, [eCommerce] Sales by Gender should show one gender', () => {
+            commonUI.addFilterRetrySelection('customer_gender', 'is', 'FEMALE');
+            cy.get('[data-title="[eCommerce] Sales by Gender"]')
+              .find('[class="label-text"]')
+              .should('have.text', 'FEMALE (100%)');
+        })
+
+        it('If filter out Women\'s Clothing, [eCommerce] Sales by Category should not show this category', () => {
+            commonUI.addFilterRetrySelection('category', 'is not', "Women's Clothing");
+            let category = cy.get('[data-title="[eCommerce] Sales by Category"]')
+            category.find('[data-label="Men\'s Clothing"]').should('exist');
+            category.find('[data-label="Women\'s Clothing"]').should('not.exist');        
+        });
+    });
+});

--- a/cypress/integration/osd/check_timeline.js
+++ b/cypress/integration/osd/check_timeline.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable */
+import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+
+const miscUtils = new MiscUtils(cy);
+  
+describe('check timeline visualization', () => {
+    beforeEach(() => {
+        miscUtils.visitPage('app/visualize#');
+    });
+    
+    it('timeline visualizations should be saved and named correctly', () => {
+        cy.get('[data-test-subj="visualizationLandingPage"]')
+          .find('[class="euiFormControlLayout__childrenWrapper"]')
+          .type('timeline');        
+        cy.get('[data-test-subj="visListingTitleLink-test-timeline"]').should('have.text', 'test-timeline').click();
+        cy.get('[class="view-line"]').contains('.es(*)');
+    });
+
+    describe('timeline visualizations should work properly', () => {
+        beforeEach(() => {
+           cy.get('[data-test-subj="visualizationLandingPage"]')
+             .find('[data-test-subj="newItemButton"]')
+             .click();     
+           cy.get('[data-test-subj="visType-timelion"]').click();
+         });
+
+         it('.es(*, kibana1=true) should report search error', () => {
+            cy.get('[class="view-line"]').type('{selectall}{backspace}, kibana1=true)');
+            cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+            cy.get('[data-test-subj="globalToastList"]').find('[data-test-subj="errorToastMessage"]').contains('Timeline request error: undefined Error: Unknown argument to es: kibana1')
+         });
+
+         it('.es(*, kibana=true) should not report search error', () => {
+            cy.get('[class="view-line"]').type('{selectall}{backspace}, kibana=true)');
+            cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+            cy.get('[data-test-subj="globalToastList"]').find('[data-test-subj="errorToastMessage"]').should('not.exist')
+         });
+
+         it('.es(*, opensearchDashboards=true) should not report search error', () => {
+            cy.get('[class="view-line"]').type('{selectall}{backspace}, opensearchDashboards=true)');
+            cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+            cy.get('[data-test-subj="globalToastList"]').find('[data-test-subj="errorToastMessage"]').should('not.exist')
+         });  
+         
+         it('.elasticsearch(*, kibana1=true) should report search error', () => {
+            cy.get('[class="view-line"]').type('{selectall}{backspace}{backspace}{backspace}{backspace}{backspace}elasticsearch(*, kibana1=true)');
+            cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+            cy.get('[data-test-subj="globalToastList"]').find('[data-test-subj="errorToastMessage"]').contains('Timeline request error: undefined Error: Unknown argument to es: kibana1')
+         });
+
+         it('.elasticsearch(*, kibana=true) should not report search error', () => {
+            cy.get('[class="view-line"]').type('{selectall}{backspace}{backspace}{backspace}{backspace}{backspace}elasticsearch(*, kibana=true)');
+            cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+            cy.get('[data-test-subj="globalToastList"]').find('[data-test-subj="errorToastMessage"]').should('not.exist')
+         });
+
+         it('.elasticsearch(*, opensearchDashboards=true) should not report search error', () => {
+            cy.get('[class="view-line"]').type('{selectall}{backspace}{backspace}{backspace}{backspace}{backspace}elasticsearch(*, opensearchDashboards=true)');
+            cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+            cy.get('[data-test-subj="globalToastList"]').find('[data-test-subj="errorToastMessage"]').should('not.exist')
+         });
+
+         it('.opensearch(*, kibana1=true) should report search error', () => {
+            cy.get('[class="view-line"]').type('{selectall}{backspace}{backspace}{backspace}{backspace}{backspace}opensearch(*, kibana1=true)');
+            cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+            cy.get('[data-test-subj="globalToastList"]').find('[data-test-subj="errorToastMessage"]').contains('Timeline request error: undefined Error: Unknown argument to es: kibana1')
+         });
+
+         it('.opensearch(*, kibana=true) should not report search error', () => {
+            cy.get('[class="view-line"]').type('{selectall}{backspace}{backspace}{backspace}{backspace}{backspace}opensearch(*, kibana=true)');
+            cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+            cy.get('[data-test-subj="globalToastList"]').find('[data-test-subj="errorToastMessage"]').should('not.exist')
+         });
+
+         it('.opensearch(*, opensearchDashboards=true) should not report search error', () => {
+            cy.get('[class="view-line"]').type('{selectall}{backspace}{backspace}{backspace}{backspace}{backspace}opensearch(*, opensearchDashboards=true)');
+            cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+            cy.get('[data-test-subj="globalToastList"]').find('[data-test-subj="errorToastMessage"]').should('not.exist')
+         });                 
+    });
+});      


### PR DESCRIPTION
### Description
This PR adds the following bwc tests:
1) verify sample data work properly for bwc
2) verify timeline visualization work properly for bwc
This PR also simplifies check_filter_and_query bwc test.
It first removes Unique Visitors check because even fix
the time interval, the number of unique visitors number
is random. Then it simplifies this bwc test.

### Partially Resolved:
https://github.com/opensearch-project/opensearch-build/issues/705

Signed-off-by: Anan Zhuang <ananzh@amazon.com>
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 