### PR TITLE
Add versioned doc support

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -23,7 +23,7 @@ If you would like to install and run this project, please see the [Downloads Pag
 #### Prerequisites
 
 You need to have an OpenSearch server up and running to be able to run OpenSearch
-Dashboards. The easiest way to do it is [using Docker](https://opensearch.org/docs/opensearch/install/docker).
+Dashboards. The easiest way to do it is [using Docker](https://opensearch.org/docs/latest/opensearch/install/docker).
 
 We recommend using [Node Version Manager](https://github.com/nvm-sh/nvm) to install
 the node version we need.

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -239,7 +239,7 @@ export class ChromeService {
           basePath={http.basePath}
           breadcrumbs$={breadcrumbs$.pipe(takeUntil(this.stop$))}
           customNavLink$={customNavLink$.pipe(takeUntil(this.stop$))}
-          opensearchDashboardsDocLink={docLinks.links.opensearchDashboards}
+          opensearchDashboardsDocLink={docLinks.links.opensearchDashboards.introduction}
           forceAppSwitcherNavigation$={navLinks.getForceAppSwitcherNavigation$()}
           helpExtension$={helpExtension$.pipe(takeUntil(this.stop$))}
           helpSupportUrl$={helpSupportUrl$.pipe(takeUntil(this.stop$))}

--- a/src/core/public/doc_links/doc_links_service.test.ts
+++ b/src/core/public/doc_links/doc_links_service.test.ts
@@ -40,6 +40,30 @@ describe('DocLinksService#start()', () => {
     const service = new DocLinksService();
     const api = service.start({ injectedMetadata });
     expect(api.DOC_LINK_VERSION).toEqual('test-branch');
-    expect(api.links.opensearchDashboards).toEqual('https://opensearch.org/docs/dashboards/');
+    expect(api.links.opensearchDashboards.introduction).toEqual(
+      'https://www.opensearch.org/docs/test-branch/dashboards/index/'
+    );
+  });
+
+  it('templates the doc links with the main branch from injectedMetadata', () => {
+    const injectedMetadata = injectedMetadataServiceMock.createStartContract();
+    injectedMetadata.getOpenSearchDashboardsBranch.mockReturnValue('main');
+    const service = new DocLinksService();
+    const api = service.start({ injectedMetadata });
+    expect(api.DOC_LINK_VERSION).toEqual('latest');
+    expect(api.links.opensearchDashboards.introduction).toEqual(
+      'https://www.opensearch.org/docs/latest/dashboards/index/'
+    );
+  });
+
+  it('templates the doc links with the release branch from injectedMetadata', () => {
+    const injectedMetadata = injectedMetadataServiceMock.createStartContract();
+    injectedMetadata.getOpenSearchDashboardsBranch.mockReturnValue('1.1');
+    const service = new DocLinksService();
+    const api = service.start({ injectedMetadata });
+    expect(api.DOC_LINK_VERSION).toEqual('1.1');
+    expect(api.links.opensearchDashboards.introduction).toEqual(
+      'https://www.opensearch.org/docs/1.1/dashboards/index/'
+    );
   });
 });

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -41,118 +41,377 @@ interface StartDeps {
 export class DocLinksService {
   public setup() {}
   public start({ injectedMetadata }: StartDeps): DocLinksStart {
-    const DOC_LINK_VERSION = injectedMetadata.getOpenSearchDashboardsBranch();
+    const DOC_LINK_VERSION =
+      injectedMetadata.getOpenSearchDashboardsBranch() === 'main'
+        ? 'latest'
+        : injectedMetadata.getOpenSearchDashboardsBranch();
     const OPENSEARCH_WEBSITE_URL = 'https://www.opensearch.org/';
-    const OPENSEARCH_DOCS = `https://opensearch.org/docs/opensearch/`;
-    const OPENSEARCH_DASHBOARDS_DOCS = `https://opensearch.org/docs/dashboards/`;
+    const OPENSEARCH_WEBSITE_DOCS = `${OPENSEARCH_WEBSITE_URL}docs/${DOC_LINK_VERSION}`;
+    const OPENSEARCH_VERSIONED_DOCS = `${OPENSEARCH_WEBSITE_DOCS}/opensearch/`;
+    const OPENSEARCH_DASHBOARDS_VERSIONED_DOCS = `${OPENSEARCH_WEBSITE_DOCS}/dashboards/`;
 
     return deepFreeze({
       DOC_LINK_VERSION,
       OPENSEARCH_WEBSITE_URL,
       links: {
-        dashboard: {
-          drilldowns: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/drilldowns.html`,
-          drilldownsTriggerPicker: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/drilldowns.html#url-drilldowns`,
-          urlDrilldownTemplateSyntax: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/url_templating-language.html`,
-          urlDrilldownVariables: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/url_templating-language.html#url-template-variables`,
+        opensearch: {
+          // https://opensearch.org/docs/latest/opensearch/index/
+          introduction: `${OPENSEARCH_VERSIONED_DOCS}index/`,
+          installation: {
+            // https://opensearch.org/docs/latest/opensearch/install/index/
+            base: `${OPENSEARCH_VERSIONED_DOCS}install/index/`,
+            // https://opensearch.org/docs/latest/opensearch/install/compatibility/
+            compatibility: `${OPENSEARCH_VERSIONED_DOCS}install/compatibility/`,
+            // https://opensearch.org/docs/latest/opensearch/install/docker/
+            docker: `${OPENSEARCH_VERSIONED_DOCS}install/docker`,
+            // https://opensearch.org/docs/latest/opensearch/install/docker-security/
+            dockerSecurity: `${OPENSEARCH_VERSIONED_DOCS}install/docker-security`,
+            // https://opensearch.org/docs/latest/opensearch/install/helm/
+            helm: `${OPENSEARCH_VERSIONED_DOCS}install/helm/`,
+            // https://opensearch.org/docs/latest/opensearch/install/tar/
+            tar: `${OPENSEARCH_VERSIONED_DOCS}install/tar/`,
+            // https://opensearch.org/docs/latest/opensearch/install/ansible/
+            ansible: `${OPENSEARCH_VERSIONED_DOCS}install/ansible/`,
+            // https://opensearch.org/docs/latest/opensearch/install/important-settings/
+            settings: `${OPENSEARCH_VERSIONED_DOCS}install/important-settings/`,
+            // https://opensearch.org/docs/latest/opensearch/install/plugins/
+            plugins: `${OPENSEARCH_VERSIONED_DOCS}install/plugins/`,
+          },
+          // https://opensearch.org/docs/latest/opensearch/configuration/
+          configuration: `${OPENSEARCH_VERSIONED_DOCS}configuration/`,
+          cluster: {
+            // https://opensearch.org/docs/latest/opensearch/cluster/
+            base: `${OPENSEARCH_VERSIONED_DOCS}cluster/`,
+            // https://opensearch.org/docs/latest/opensearch/cluster/#step-1-name-a-cluster
+            naming: `${OPENSEARCH_VERSIONED_DOCS}cluster/#step-1-name-a-cluster`,
+            // https://opensearch.org/docs/latest/opensearch/cluster/#step-2-set-node-attributes-for-each-node-in-a-cluster
+            set_attribute: `${OPENSEARCH_VERSIONED_DOCS}cluster/#step-2-set-node-attributes-for-each-node-in-a-cluster`,
+            // https://opensearch.org/docs/latest/opensearch/cluster/#step-3-bind-a-cluster-to-specific-ip-addresses
+            build_cluster: `${OPENSEARCH_VERSIONED_DOCS}cluster/#step-3-bind-a-cluster-to-specific-ip-addresses`,
+            // https://opensearch.org/docs/latest/opensearch/cluster/#step-4-configure-discovery-hosts-for-a-cluster
+            config_host: `${OPENSEARCH_VERSIONED_DOCS}cluster/cluster/#step-4-configure-discovery-hosts-for-a-cluster`,
+            // https://opensearch.org/docs/latest/opensearch/cluster/#step-5-start-the-cluster
+            start: `${OPENSEARCH_VERSIONED_DOCS}cluster/#step-5-start-the-cluster`,
+            // https://opensearch.org/docs/latest/opensearch/cluster/#advanced-step-6-configure-shard-allocation-awareness-or-forced-awareness
+            config_shard: `${OPENSEARCH_VERSIONED_DOCS}cluster/#advanced-step-6-configure-shard-allocation-awareness-or-forced-awareness`,
+            // https://opensearch.org/docs/latest/opensearch/cluster/#advanced-step-7-set-up-a-hot-warm-architecture
+            setup_hot_arch: `${OPENSEARCH_VERSIONED_DOCS}cluster/#advanced-step-7-set-up-a-hot-warm-architecture`,
+          },
+          indexData: {
+            // https://opensearch.org/docs/latest/opensearch/index-data/
+            base: `${OPENSEARCH_VERSIONED_DOCS}index-data/`,
+            // https://opensearch.org/docs/latest/opensearch/index-data/#naming-restrictions-for-indices
+            naming: `${OPENSEARCH_VERSIONED_DOCS}index-data/#naming-restrictions-for-indices`,
+            // https://opensearch.org/docs/latest/opensearch/index-data/#read-data
+            read_data: `${OPENSEARCH_VERSIONED_DOCS}index-data/#read-data`,
+            // https://opensearch.org/docs/latest/opensearch/index-data/#update-data
+            update_data: `${OPENSEARCH_VERSIONED_DOCS}index-data/#update-data`,
+            // https://opensearch.org/docs/latest/opensearch/index-data/#delete-data
+            delete_data: `${OPENSEARCH_VERSIONED_DOCS}index-data/#delete-data`,
+          },
+          indexAlias: {
+            // https://opensearch.org/docs/latest/opensearch/index-alias/
+            base: `${OPENSEARCH_VERSIONED_DOCS}index-alias/`,
+            // https://opensearch.org/docs/latest/opensearch/index-alias/#create-aliases
+            create_alias: `${OPENSEARCH_VERSIONED_DOCS}index-alias/#create-aliases`,
+            // https://opensearch.org/docs/latest/opensearch/index-alias/#add-or-remove-indices
+            add_remove_index: `${OPENSEARCH_VERSIONED_DOCS}index-alias/#add-or-remove-indices`,
+            // https://opensearch.org/docs/latest/opensearch/index-alias/#manage-aliases
+            manage_alias: `${OPENSEARCH_VERSIONED_DOCS}index-alias/#manage-aliases`,
+            // https://opensearch.org/docs/latest/opensearch/index-alias/#create-filtered-aliases
+            filtered_alias: `${OPENSEARCH_VERSIONED_DOCS}index-alias/#create-filtered-aliases`,
+            // https://opensearch.org/docs/latest/opensearch/index-alias/#index-alias-options
+            alias_option: `${OPENSEARCH_VERSIONED_DOCS}index-alias/#index-alias-options`,
+          },
+          // https://opensearch.org/docs/latest/opensearch/data-streams/
+          dataStreams: `${OPENSEARCH_VERSIONED_DOCS}data-streams/`,
+          // https://opensearch.org/docs/latest/opensearch/aggregations/
+          aggregations: {
+            // https://opensearch.org/docs/latest/opensearch/aggregations/
+            base: `${OPENSEARCH_VERSIONED_DOCS}aggregations/`,
+            metric: {
+              // https://opensearch.org/docs/latest/opensearch/metric-agg/
+              base: `${OPENSEARCH_VERSIONED_DOCS}metric-agg/`,
+              // https://opensearch.org/docs/latest/opensearch/metric-agg/#types-of-metric-aggregations
+              types: `${OPENSEARCH_VERSIONED_DOCS}metric-agg/#types-of-metric-aggregations`,
+              // https://opensearch.org/docs/latest/opensearch/metric-agg/#sum-min-max-avg
+              sum: `${OPENSEARCH_VERSIONED_DOCS}metric-agg/#sum-min-max-avg`,
+              // https://opensearch.org/docs/latest/opensearch/metric-agg/#cardinality
+              cardinality: `${OPENSEARCH_VERSIONED_DOCS}metric-agg/#cardinality`,
+              // https://opensearch.org/docs/latest/opensearch/metric-agg/#value_count
+              value_count: `${OPENSEARCH_VERSIONED_DOCS}metric-agg/#value_count`,
+              // https://opensearch.org/docs/latest/opensearch/metric-agg/#stats-extended_stats-matrix_stats
+              stats: `${OPENSEARCH_VERSIONED_DOCS}metric-agg/#stats-extended_stats-matrix_stats`,
+              // https://opensearch.org/docs/latest/opensearch/metric-agg/#percentile-percentile_ranks
+              percentile: `${OPENSEARCH_VERSIONED_DOCS}metric-agg/#percentile-percentile_ranks`,
+              // https://opensearch.org/docs/latest/opensearch/metric-agg/#geo_bound
+              geo_bound: `${OPENSEARCH_VERSIONED_DOCS}metric-agg/#geo_bound`,
+              // https://opensearch.org/docs/latest/opensearch/metric-agg/#top_hits
+              top_hits: `${OPENSEARCH_VERSIONED_DOCS}metric-agg/#top_hits`,
+              // https://opensearch.org/docs/latest/opensearch/metric-agg/#scripted_metric
+              scripted_metric: `${OPENSEARCH_VERSIONED_DOCS}metric-agg/#scripted_metric`,
+            },
+            bucket: {
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/
+              base: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/`,
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/#terms
+              terms: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/#terms`,
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/#sampler-diversified_sampler
+              smapler: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/#sampler-diversified_sampler`,
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/#significant_terms-significant_text
+              significant_terms: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/#significant_terms-significant_text`,
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/#missing
+              missing: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/#missing`,
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/#histogram-date_histogram
+              histogram: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/#histogram-date_histogram`,
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/#range-date_range-ip_range
+              range: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/#range-date_range-ip_range`,
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/#filter-filters
+              filter: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/#filter-filters`,
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/#global
+              global: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/#global`,
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/#geo_distance-geohash_grid
+              geo: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/#geo_distance-geohash_grid`,
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/#adjacency_matrix
+              adjacency_matrix: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/#adjacency_matrix`,
+              // https://opensearch.org/docs/latest/opensearch/bucket-agg/#nested-reverse_nested
+              nested: `${OPENSEARCH_VERSIONED_DOCS}bucket-agg/#nested-reverse_nested`,
+            },
+            pipeline: {
+              // https://opensearch.org/docs/latest/opensearch/pipeline-agg/
+              base: `${OPENSEARCH_VERSIONED_DOCS}pipeline-agg/`,
+              // https://opensearch.org/docs/latest/opensearch/pipeline-agg/#pipeline-aggregation-syntax
+              syntax: `${OPENSEARCH_VERSIONED_DOCS}pipeline-agg/#pipeline-aggregation-syntax`,
+              // https://opensearch.org/docs/latest/opensearch/pipeline-agg/#types-of-pipeline-aggregations
+              types: `${OPENSEARCH_VERSIONED_DOCS}pipeline-agg/#types-of-pipeline-aggregations`,
+              // https://opensearch.org/docs/latest/opensearch/pipeline-agg/#avg_bucket-sum_bucket-min_bucket-max_bucket
+              avg_bucket: `${OPENSEARCH_VERSIONED_DOCS}pipeline-agg/#avg_bucket-sum_bucket-min_bucket-max_bucket`,
+              // https://opensearch.org/docs/latest/opensearch/pipeline-agg/#stats_bucket-extended_stats_bucket
+              stats_bucket: `${OPENSEARCH_VERSIONED_DOCS}pipeline-agg/#stats_bucket-extended_stats_bucket`,
+              // https://opensearch.org/docs/latest/opensearch/pipeline-agg/#bucket_script-bucket_selector
+              bucket_script: `${OPENSEARCH_VERSIONED_DOCS}pipeline-agg/#bucket_script-bucket_selector`,
+              // https://opensearch.org/docs/latest/opensearch/pipeline-agg/#bucket_sort
+              bucket_sort: `${OPENSEARCH_VERSIONED_DOCS}pipeline-agg/#bucket_sort`,
+              // https://opensearch.org/docs/latest/opensearch/pipeline-agg/#cumulative_sum
+              cumulative_sum: `${OPENSEARCH_VERSIONED_DOCS}pipeline-agg/#cumulative_sum`,
+              // https://opensearch.org/docs/latest/opensearch/pipeline-agg/#derivative
+              derivative: `${OPENSEARCH_VERSIONED_DOCS}pipeline-agg/#derivative`,
+              // https://opensearch.org/docs/latest/opensearch/pipeline-agg/#moving_avg
+              moving_avg: `${OPENSEARCH_VERSIONED_DOCS}pipeline-agg/#moving_avg`,
+              // https://opensearch.org/docs/latest/opensearch/pipeline-agg/#serial_diff
+              serial_diff: `${OPENSEARCH_VERSIONED_DOCS}pipeline-agg/#serial_diff`,
+            },
+          },
+          indexTemplates: {
+            // https://opensearch.org/docs/latest/opensearch/index-templates/
+            base: `${OPENSEARCH_VERSIONED_DOCS}index-templates`,
+            // https://opensearch.org/docs/latest/opensearch/index-templates/#composable-index-templates
+            composable: `${OPENSEARCH_VERSIONED_DOCS}index-templates/#composable-index-templates`,
+            // https://opensearch.org/docs/latest/opensearch/index-templates/#index-template-options
+            options: `${OPENSEARCH_VERSIONED_DOCS}index-templates/#index-template-options`,
+          },
+          reindexData: {
+            // https://opensearch.org/docs/latest/opensearch/reindex-data/
+            base: `${OPENSEARCH_VERSIONED_DOCS}reindex-data/`,
+            // https://opensearch.org/docs/latest/opensearch/reindex-data/#reindex-all-documents
+            all: `${OPENSEARCH_VERSIONED_DOCS}reindex-data/#reindex-all-documents`,
+            // https://opensearch.org/docs/latest/opensearch/reindex-data/#reindex-from-a-remote-cluster
+            remote: `${OPENSEARCH_VERSIONED_DOCS}reindex-data/#reindex-from-a-remote-cluster`,
+            // https://opensearch.org/docs/latest/opensearch/reindex-data/#reindex-a-subset-of-documents
+            subset: `${OPENSEARCH_VERSIONED_DOCS}reindex-data/#reindex-a-subset-of-documents`,
+            // https://opensearch.org/docs/latest/opensearch/reindex-data/#combine-one-or-more-indices
+            combine: `${OPENSEARCH_VERSIONED_DOCS}reindex-data/#combine-one-or-more-indices`,
+            // https://opensearch.org/docs/latest/opensearch/reindex-data/#reindex-only-unique-documents
+            unique: `${OPENSEARCH_VERSIONED_DOCS}reindex-data/#reindex-only-unique-documents`,
+            // https://opensearch.org/docs/latest/opensearch/reindex-data/#transform-documents-during-reindexing
+            transform: `${OPENSEARCH_VERSIONED_DOCS}reindex-data/#transform-documents-during-reindexing`,
+            // https://opensearch.org/docs/latest/opensearch/reindex-data/#update-documents-in-the-current-index
+            update: `${OPENSEARCH_VERSIONED_DOCS}reindex-data/#update-documents-in-the-current-index`,
+            // https://opensearch.org/docs/latest/opensearch/reindex-data/#source-index-options
+            source: `${OPENSEARCH_VERSIONED_DOCS}reindex-data/#source-index-options`,
+            // https://opensearch.org/docs/latest/opensearch/reindex-data/#destination-index-options
+            destination: `${OPENSEARCH_VERSIONED_DOCS}reindex-data/#destination-index-options`,
+          },
+          queryDSL: {
+            // https://opensearch.org/docs/latest/opensearch/query-dsl/index/
+            base: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/index/`,
+            term: {
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/term/
+              base: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/term/`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/term/#terms
+              terms: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/term/#terms`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/term/#ids
+              ids: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/term/#ids`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/term/#range
+              range: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/term/#range`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/term/#prefix
+              prefix: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/term/#prefix`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/term/#exists
+              exists: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/term/#exists`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/term/#wildcards
+              wildcards: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/term/#wildcards`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/term/#regex
+              regex: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/term/#regex`,
+            },
+            fullText: {
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/
+              base: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/full-text/`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#match
+              match: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/full-text/#match`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#multi-match
+              multi_match: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/full-text/#multi-match`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#match-phrase
+              match_phrase: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/full-text/#match-phrase`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#common-terms
+              common_terms: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/full-text/#common-terms`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#query-string
+              query_string: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/full-text/#query-string`,
+              // https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#options
+              options: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/full-text/#options`,
+            },
+            // https://opensearch.org/docs/latest/opensearch/query-dsl/bool/
+            boolQuery: `${OPENSEARCH_VERSIONED_DOCS}query-dsl/bool/`,
+          },
+          searchTemplate: {
+            // https://opensearch.org/docs/latest/opensearch/search-template/
+            base: `${OPENSEARCH_VERSIONED_DOCS}search-template`,
+            // https://opensearch.org/docs/latest/opensearch/search-template/#create-search-templates
+            create: `${OPENSEARCH_VERSIONED_DOCS}search-template/#create-search-templates`,
+            // https://opensearch.org/docs/latest/opensearch/search-template/#save-and-execute-search-templates
+            execute: `${OPENSEARCH_VERSIONED_DOCS}search-template/#save-and-execute-search-templates`,
+            // https://opensearch.org/docs/latest/opensearch/search-template/#advanced-parameter-conversion-with-search-templates
+            advanced_operation: `${OPENSEARCH_VERSIONED_DOCS}search-template/#advanced-parameter-conversion-with-search-templates`,
+            // https://opensearch.org/docs/latest/opensearch/search-template/#multiple-search-templates
+            multiple_search: `${OPENSEARCH_VERSIONED_DOCS}search-template/#multiple-search-templates`,
+            // https://opensearch.org/docs/latest/opensearch/search-template/#manage-search-templates
+            manage: `${OPENSEARCH_VERSIONED_DOCS}search-template/#manage-search-templates`,
+          },
+          searchExperience: {
+            // https://opensearch.org/docs/latest/opensearch/ux/
+            base: `${OPENSEARCH_VERSIONED_DOCS}ux`,
+            // https://opensearch.org/docs/latest/opensearch/ux/#autocomplete-queries
+            autocomplete: `${OPENSEARCH_VERSIONED_DOCS}ux/#autocomplete-queries`,
+            // https://opensearch.org/docs/latest/opensearch/ux/#paginate-results
+            paginate: `${OPENSEARCH_VERSIONED_DOCS}ux/#paginate-results`,
+            // https://opensearch.org/docs/latest/opensearch/ux/#scroll-search
+            scroll: `${OPENSEARCH_VERSIONED_DOCS}ux/#scroll-search`,
+            // https://opensearch.org/docs/latest/opensearch/ux/#sort-results
+            sort: `${OPENSEARCH_VERSIONED_DOCS}ux/#sort-results`,
+            // https://opensearch.org/docs/latest/opensearch/ux/#highlight-query-matches
+            highlight_match: `${OPENSEARCH_VERSIONED_DOCS}ux/#highlight-query-matches`,
+          },
+          logs: {
+            // https://opensearch.org/docs/latest/opensearch/logs/
+            base: `${OPENSEARCH_VERSIONED_DOCS}logs`,
+            // https://opensearch.org/docs/latest/opensearch/logs/#application-logs
+            application_log: `${OPENSEARCH_VERSIONED_DOCS}logs/#application-logs`,
+            // https://opensearch.org/docs/latest/opensearch/logs/#slow-logs
+            slow_log: `${OPENSEARCH_VERSIONED_DOCS}logs/#slow-logs`,
+            // https://opensearch.org/docs/latest/opensearch/logs/#deprecation-logs
+            deprecation_log: `${OPENSEARCH_VERSIONED_DOCS}logs/#deprecation-logs`,
+          },
+          snapshotRestore: {
+            // https://opensearch.org/docs/latest/opensearch/snapshot-restore/
+            base: `${OPENSEARCH_VERSIONED_DOCS}snapshot-restore`,
+            // https://opensearch.org/docs/latest/opensearch/snapshot-restore/#register-repository
+            register: `${OPENSEARCH_VERSIONED_DOCS}snapshot-restore/#register-repository`,
+            // https://opensearch.org/docs/latest/opensearch/snapshot-restore/#take-snapshots
+            take_snapshot: `${OPENSEARCH_VERSIONED_DOCS}snapshot-restore/#take-snapshots`,
+            // https://opensearch.org/docs/latest/opensearch/snapshot-restore/#restore-snapshots
+            restore_snapshot: `${OPENSEARCH_VERSIONED_DOCS}snapshot-restore/#restore-snapshots`,
+            // https://opensearch.org/docs/latest/opensearch/snapshot-restore/#security-plugin-considerations
+            security_plugin: `${OPENSEARCH_VERSIONED_DOCS}snapshot-restore/#security-plugin-considerations`,
+          },
+          // https://opensearch.org/docs/latest/opensearch/units/
+          supportedUnits: `${OPENSEARCH_VERSIONED_DOCS}units`,
+          // https://opensearch.org/docs/latest/opensearch/common-parameters/
+          commonParameters: `${OPENSEARCH_VERSIONED_DOCS}common-parameters`,
+          // https://opensearch.org/docs/latest/opensearch/popular-api/
+          popularAPI: `${OPENSEARCH_VERSIONED_DOCS}popular-api`,
+          // https://opensearch.org/docs/latest/opensearch/rest-api/index/
+          restAPI: `${OPENSEARCH_VERSIONED_DOCS}rest-api/index/`,
         },
-        filebeat: {
-          base: `${OPENSEARCH_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}`,
-          installation: `${OPENSEARCH_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/filebeat-installation-configuration.html`,
-          configuration: `${OPENSEARCH_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/configuring-howto-filebeat.html`,
-          elasticsearchOutput: `${OPENSEARCH_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/elasticsearch-output.html`,
-          startup: `${OPENSEARCH_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/filebeat-starting.html`,
-          exportedFields: `${OPENSEARCH_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/exported-fields.html`,
+        opensearchDashboards: {
+          // https://opensearch.org/docs/latest/dashboards/index/
+          introduction: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}index/`,
+          installation: {
+            // https://opensearch.org/docs/latest/dashboards/install/index/
+            base: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}install/index/`,
+            // https://opensearch.org/docs/latest/dashboards/install/docker/
+            docker: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}install/docker/`,
+            // https://opensearch.org/docs/latest/dashboards/install/tar/
+            tar: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}install/tar/`,
+            // https://opensearch.org/docs/latest/dashboards/install/helm/
+            helm: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}install/helm/`,
+            // https://opensearch.org/docs/latest/dashboards/install/tls/
+            tls: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}install/tls/`,
+            // https://opensearch.org/docs/latest/dashboards/install/plugins/
+            plugins: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}install/plugins/`,
+          },
+          // https://opensearch.org/docs/latest/dashboards/maptiles/
+          mapTiles: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}maptiles`,
+          // https://opensearch.org/docs/latest/dashboards/gantt/
+          ganttCharts: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}gantt`,
+          // https://opensearch.org/docs/latest/dashboards/reporting/
+          reporting: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}reporting`,
+          notebooks: {
+            // https://opensearch.org/docs/latest/dashboards/notebooks/
+            base: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}notebooks`,
+            // https://opensearch.org/docs/latest/dashboards/notebooks/#get-started-with-notebooks
+            notebook_tutorial: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}notebooks/#get-started-with-notebooks`,
+            // https://opensearch.org/docs/latest/dashboards/notebooks/#paragraph-actions
+            paragraph_tutorial: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}notebooks/#paragraph-actions`,
+            // https://opensearch.org/docs/latest/dashboards/notebooks/#sample-notebooks
+            sample_notebook: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}notebooks/#sample-notebooks`,
+            // https://opensearch.org/docs/latest/dashboards/notebooks/#create-a-report
+            create_report: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}notebooks/#create-a-report`,
+          },
+          dql: {
+            // https://opensearch.org/docs/latest/dashboards/dql/
+            base: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}dql`,
+            // https://opensearch.org/docs/latest/dashboards/dql/#terms-query
+            terms_query: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}dql/#terms-query`,
+            // https://opensearch.org/docs/latest/dashboards/dql/#boolean-query
+            boolean_query: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}dql/#boolean-query`,
+            // https://opensearch.org/docs/latest/dashboards/dql/#date-and-range-queries
+            date_query: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}dql/#date-and-range-queries`,
+            // https://opensearch.org/docs/latest/dashboards/dql/#nested-field-query
+            nested_query: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}dql/#nested-field-query`,
+          },
         },
-        auditbeat: {
-          base: `${OPENSEARCH_WEBSITE_URL}guide/en/beats/auditbeat/${DOC_LINK_VERSION}`,
-        },
-        metricbeat: {
-          base: `${OPENSEARCH_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}`,
-        },
-        heartbeat: {
-          base: `${OPENSEARCH_WEBSITE_URL}guide/en/beats/heartbeat/${DOC_LINK_VERSION}`,
-        },
-        logstash: {
-          base: `${OPENSEARCH_WEBSITE_URL}guide/en/logstash/${DOC_LINK_VERSION}`,
-        },
-        functionbeat: {
-          base: `${OPENSEARCH_WEBSITE_URL}guide/en/beats/functionbeat/${DOC_LINK_VERSION}`,
-        },
-        winlogbeat: {
-          base: `${OPENSEARCH_WEBSITE_URL}guide/en/beats/winlogbeat/${DOC_LINK_VERSION}`,
-        },
-        aggs: {
-          date_histogram: `${OPENSEARCH_DOCS}bucket-agg/#histogram-date_histogram`,
-          date_range: `${OPENSEARCH_DOCS}bucket-agg/#range-date_range-ip_range`,
-          filter: `${OPENSEARCH_DOCS}bucket-agg/#filter-filters`,
-          filters: `${OPENSEARCH_DOCS}bucket-agg/#filter-filters`,
-          geohash_grid: `${OPENSEARCH_DOCS}bucket-agg/#geo_distance-geohash_grid`,
-          histogram: `${OPENSEARCH_DOCS}bucket-agg/#histogram-date_histogram`,
-          ip_range: `${OPENSEARCH_DOCS}bucket-agg/#range-date_range-ip_range`,
-          range: `${OPENSEARCH_DOCS}bucket-agg/#range-date_range-ip_range`,
-          significant_terms: `${OPENSEARCH_DOCS}bucket-agg/#significant_terms-significant_text`,
-          terms: `${OPENSEARCH_DOCS}bucket-agg/#terms`,
-          avg: `${OPENSEARCH_DOCS}metric-agg/#sum-min-max-avg`,
-          avg_bucket: `${OPENSEARCH_DOCS}pipeline-agg/#avg_bucket-sum_bucket-min_bucket-max_bucket`,
-          max_bucket: `${OPENSEARCH_DOCS}pipeline-agg/#avg_bucket-sum_bucket-min_bucket-max_bucket`,
-          min_bucket: `${OPENSEARCH_DOCS}pipeline-agg/#avg_bucket-sum_bucket-min_bucket-max_bucket`,
-          sum_bucket: `${OPENSEARCH_DOCS}pipeline-agg/#avg_bucket-sum_bucket-min_bucket-max_bucket`,
-          cardinality: `${OPENSEARCH_DOCS}metric-agg/#cardinality`,
-          count: `${OPENSEARCH_DOCS}metric-agg/#value_count`,
-          cumulative_sum: `${OPENSEARCH_DOCS}pipeline-agg/#cumulative_sum`,
-          derivative: `${OPENSEARCH_DOCS}pipeline-agg/#derivative`,
-          geo_bounds: `${OPENSEARCH_DOCS}metric-agg/#geo_bound`,
-          geo_centroid: `${OPENSEARCH_DOCS}metric-agg/#geo_bound`,
-          max: `${OPENSEARCH_DOCS}metric-agg/#sum-min-max-avg`,
-          median: `${OPENSEARCH_DOCS}metric-agg/#sum-min-max-avg`,
-          min: `${OPENSEARCH_DOCS}metric-agg/#sum-min-max-avg`,
-          moving_avg: `${OPENSEARCH_DOCS}pipeline-agg/#moving_avg`,
-          percentile_ranks: `${OPENSEARCH_DOCS}metric-agg/#percentile-percentile_ranks`,
-          serial_diff: `${OPENSEARCH_DOCS}pipeline-agg/#serial_diff`,
-          std_dev: `${OPENSEARCH_DOCS}metric-agg/#stats-extended_stats-matrix_stats`,
-          sum: `${OPENSEARCH_DOCS}metric-agg/#sum-min-max-avg`,
-          top_hits: `${OPENSEARCH_DOCS}metric-agg/#top_hits`,
-        },
-        scriptedFields: {
-          scriptFields: `${OPENSEARCH_DOCS}search-request-script-fields.html`,
-          scriptAggs: `${OPENSEARCH_DOCS}metric-agg/#scripted_metric`,
-          painless: `${OPENSEARCH_DOCS}modules-scripting-painless.html`,
-          painlessApi: `${OPENSEARCH_WEBSITE_URL}guide/en/elasticsearch/painless/${DOC_LINK_VERSION}/painless-api-reference.html`,
-          painlessSyntax: `${OPENSEARCH_DOCS}modules-scripting-painless-syntax.html`,
-          luceneExpressions: `${OPENSEARCH_DOCS}modules-scripting-expression.html`,
-        },
-        indexPatterns: {
-          loadingData: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/tutorial-load-dataset.html`,
-          // TODO: [RENAMEME] Need prod urls.
-          // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-          introduction: `${OPENSEARCH_DASHBOARDS_DOCS}`,
-        },
-        // TODO: [RENAMEME] Need prod urls.
-        // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-        addData: `${OPENSEARCH_DASHBOARDS_DOCS}`,
-        opensearchDashboards: `${OPENSEARCH_DASHBOARDS_DOCS}`,
-        siem: {
-          guide: `${OPENSEARCH_WEBSITE_URL}guide/en/security/${DOC_LINK_VERSION}/index.html`,
-          gettingStarted: `${OPENSEARCH_WEBSITE_URL}guide/en/security/${DOC_LINK_VERSION}/index.html`,
-        },
-        query: {
-          eql: `${OPENSEARCH_DOCS}eql.html`,
-          luceneQuerySyntax: `${OPENSEARCH_DOCS}query-dsl-query-string-query.html#query-string-syntax`,
-          queryDsl: `${OPENSEARCH_DOCS}query-dsl`,
-          kueryQuerySyntax: `${OPENSEARCH_DOCS}query-dsl`,
-        },
-        date: {
-          dateMath: `${OPENSEARCH_DOCS}common-options.html#date-math`,
-        },
-        management: {
-          opensearchDashboardsGeneralSettings: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/advanced-options.html#opensearch-general-settings`,
-          opensearchDashboardsSearchSettings: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/advanced-options.html#opensearch-search-settings`,
-          dashboardSettings: `${OPENSEARCH_WEBSITE_URL}guide/en/opensearch/${DOC_LINK_VERSION}/advanced-options.html#opensearch-dashboard-settings`,
-        },
-        visualize: {
-          guide: `${OPENSEARCH_DASHBOARDS_DOCS}`,
-          timelineDeprecation: `${OPENSEARCH_DASHBOARDS_DOCS}`,
+        noDocumentation: {
+          auditbeat: `${OPENSEARCH_WEBSITE_DOCS}`,
+          filebeat: `${OPENSEARCH_WEBSITE_DOCS}`,
+          metricbeat: `${OPENSEARCH_WEBSITE_DOCS}`,
+          heartbeat: `${OPENSEARCH_WEBSITE_DOCS}`,
+          logstash: `${OPENSEARCH_WEBSITE_DOCS}`,
+          functionbeat: `${OPENSEARCH_WEBSITE_DOCS}`,
+          winlogbeat: `${OPENSEARCH_WEBSITE_DOCS}`,
+          siem: `${OPENSEARCH_WEBSITE_DOCS}`,
+          indexPatterns: {
+            loadingData: `${OPENSEARCH_WEBSITE_DOCS}`,
+            introduction: `${OPENSEARCH_WEBSITE_DOCS}`,
+          },
+          management: {
+            opensearchDashboardsGeneralSettings: `${OPENSEARCH_WEBSITE_DOCS}`,
+            opensearchDashboardsSearchSettings: `${OPENSEARCH_WEBSITE_DOCS}`,
+            dashboardSettings: `${OPENSEARCH_WEBSITE_DOCS}`,
+          },
+          scriptedFields: {
+            scriptFields: `${OPENSEARCH_WEBSITE_DOCS}`,
+            scriptAggs: `${OPENSEARCH_WEBSITE_DOCS}`,
+            painless: `${OPENSEARCH_WEBSITE_DOCS}`,
+            painlessApi: `${OPENSEARCH_WEBSITE_DOCS}`,
+            painlessSyntax: `${OPENSEARCH_WEBSITE_DOCS}`,
+            luceneExpressions: `${OPENSEARCH_WEBSITE_DOCS}`,
+          },
+          visualize: {
+            guide: `${OPENSEARCH_WEBSITE_DOCS}`,
+            timelineDeprecation: `${OPENSEARCH_WEBSITE_DOCS}`,
+          },
+          addData: `${OPENSEARCH_WEBSITE_DOCS}`,
+          vega: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}`,
+          dateMath: `${OPENSEARCH_WEBSITE_DOCS}`,
         },
       },
     });
@@ -164,98 +423,216 @@ export interface DocLinksStart {
   readonly DOC_LINK_VERSION: string;
   readonly OPENSEARCH_WEBSITE_URL: string;
   readonly links: {
-    readonly dashboard: {
-      readonly drilldowns: string;
-      readonly drilldownsTriggerPicker: string;
-      readonly urlDrilldownTemplateSyntax: string;
-      readonly urlDrilldownVariables: string;
-    };
-    readonly filebeat: {
-      readonly base: string;
-      readonly installation: string;
-      readonly configuration: string;
-      readonly elasticsearchOutput: string;
-      readonly startup: string;
-      readonly exportedFields: string;
-    };
-    readonly auditbeat: {
-      readonly base: string;
-    };
-    readonly metricbeat: {
-      readonly base: string;
-    };
-    readonly heartbeat: {
-      readonly base: string;
-    };
-    readonly logstash: {
-      readonly base: string;
-    };
-    readonly functionbeat: {
-      readonly base: string;
-    };
-    readonly winlogbeat: {
-      readonly base: string;
-    };
-    readonly aggs: {
-      readonly date_histogram: string;
-      readonly date_range: string;
-      readonly filter: string;
-      readonly filters: string;
-      readonly geohash_grid: string;
-      readonly histogram: string;
-      readonly ip_range: string;
-      readonly range: string;
-      readonly significant_terms: string;
-      readonly terms: string;
-      readonly avg: string;
-      readonly avg_bucket: string;
-      readonly max_bucket: string;
-      readonly min_bucket: string;
-      readonly sum_bucket: string;
-      readonly cardinality: string;
-      readonly count: string;
-      readonly cumulative_sum: string;
-      readonly derivative: string;
-      readonly geo_bounds: string;
-      readonly geo_centroid: string;
-      readonly max: string;
-      readonly median: string;
-      readonly min: string;
-      readonly moving_avg: string;
-      readonly percentile_ranks: string;
-      readonly serial_diff: string;
-      readonly std_dev: string;
-      readonly sum: string;
-      readonly top_hits: string;
-    };
-    readonly scriptedFields: {
-      readonly scriptFields: string;
-      readonly scriptAggs: string;
-      readonly painless: string;
-      readonly painlessApi: string;
-      readonly painlessSyntax: string;
-      readonly luceneExpressions: string;
-    };
-    readonly indexPatterns: {
-      readonly loadingData: string;
+    readonly opensearch: {
       readonly introduction: string;
+      readonly installation: {
+        readonly base: string;
+        readonly compatibility: string;
+        readonly docker: string;
+        readonly dockerSecurity: string;
+        readonly helm: string;
+        readonly tar: string;
+        readonly ansible: string;
+        readonly settings: string;
+        readonly plugins: string;
+      };
+      readonly configuration: string;
+      readonly cluster: {
+        readonly base: string;
+        readonly naming: string;
+        readonly set_attribute: string;
+        readonly build_cluster: string;
+        readonly config_host: string;
+        readonly start: string;
+        readonly config_shard: string;
+        readonly setup_hot_arch: string;
+      };
+      readonly indexData: {
+        readonly base: string;
+        readonly naming: string;
+        readonly read_data: string;
+        readonly update_data: string;
+        readonly delete_data: string;
+      };
+      readonly indexAlias: {
+        readonly base: string;
+        readonly create_alias: string;
+        readonly add_remove_index: string;
+        readonly manage_alias: string;
+        readonly filtered_alias: string;
+        readonly alias_option: string;
+      };
+      readonly dataStreams: string;
+      readonly aggregations: {
+        readonly base: string;
+        readonly metric: {
+          readonly base: string;
+          readonly types: string;
+          readonly sum: string;
+          readonly cardinality: string;
+          readonly value_count: string;
+          readonly stats: string;
+          readonly percentile: string;
+          readonly geo_bound: string;
+          readonly top_hits: string;
+          readonly scripted_metric: string;
+        };
+        readonly bucket: {
+          readonly base: string;
+          readonly terms: string;
+          readonly smapler: string;
+          readonly significant_terms: string;
+          readonly missing: string;
+          readonly histogram: string;
+          readonly range: string;
+          readonly filter: string;
+          readonly global: string;
+          readonly geo: string;
+          readonly adjacency_matrix: string;
+          readonly nested: string;
+        };
+        readonly pipeline: {
+          readonly base: string;
+          readonly syntax: string;
+          readonly types: string;
+          readonly avg_bucket: string;
+          readonly stats_bucket: string;
+          readonly bucket_script: string;
+          readonly bucket_sort: string;
+          readonly cumulative_sum: string;
+          readonly derivative: string;
+          readonly moving_avg: string;
+          readonly serial_diff: string;
+        };
+      };
+      readonly indexTemplates: {
+        readonly base: string;
+        readonly composable: string;
+        readonly options: string;
+      };
+      readonly reindexData: {
+        readonly base: string;
+        readonly all: string;
+        readonly remote: string;
+        readonly subset: string;
+        readonly combine: string;
+        readonly unique: string;
+        readonly transform: string;
+        readonly update: string;
+        readonly source: string;
+        readonly destination: string;
+      };
+      readonly queryDSL: {
+        readonly base: string;
+        readonly term: {
+          readonly base: string;
+          readonly terms: string;
+          readonly ids: string;
+          readonly range: string;
+          readonly prefix: string;
+          readonly exists: string;
+          readonly wildcards: string;
+          readonly regex: string;
+        };
+        readonly fullText: {
+          readonly base: string;
+          readonly match: string;
+          readonly multi_match: string;
+          readonly match_phrase: string;
+          readonly common_terms: string;
+          readonly query_string: string;
+          readonly options: string;
+        };
+        readonly boolQuery: string;
+      };
+      readonly searchTemplate: {
+        readonly base: string;
+        readonly create: string;
+        readonly execute: string;
+        readonly advanced_operation: string;
+        readonly multiple_search: string;
+        readonly manage: string;
+      };
+      readonly searchExperience: {
+        readonly base: string;
+        readonly autocomplete: string;
+        readonly paginate: string;
+        readonly scroll: string;
+        readonly sort: string;
+        readonly highlight_match: string;
+      };
+      readonly logs: {
+        readonly base: string;
+        readonly application_log: string;
+        readonly slow_log: string;
+        readonly deprecation_log: string;
+      };
+      readonly snapshotRestore: {
+        readonly base: string;
+        readonly register: string;
+        readonly take_snapshot: string;
+        readonly restore_snapshot: string;
+        readonly security_plugin: string;
+      };
+      readonly supportedUnits: string;
+      readonly commonParameters: string;
+      readonly popularAPI: string;
+      readonly restAPI: string;
     };
-    readonly addData: string;
-    readonly opensearchDashboards: string;
-    readonly siem: {
-      readonly guide: string;
-      readonly gettingStarted: string;
+    readonly opensearchDashboards: {
+      readonly introduction: string;
+      readonly installation: {
+        readonly base: string;
+        readonly docker: string;
+        readonly tar: string;
+        readonly helm: string;
+        readonly tls: string;
+        readonly plugins: string;
+      };
+      readonly mapTiles: string;
+      readonly ganttCharts: string;
+      readonly reporting: string;
+      readonly notebooks: {
+        readonly base: string;
+        readonly notebook_tutorial: string;
+        readonly paragraph_tutorial: string;
+        readonly sample_notebook: string;
+        readonly create_report: string;
+      };
+      readonly dql: {
+        readonly base: string;
+        readonly terms_query: string;
+        readonly boolean_query: string;
+        readonly date_query: string;
+        readonly nested_query: string;
+      };
     };
-    readonly query: {
-      readonly eql: string;
-      readonly luceneQuerySyntax: string;
-      readonly queryDsl: string;
-      readonly kueryQuerySyntax: string;
-    };
-    readonly date: {
+    readonly noDocumentation: {
+      readonly auditbeat: string;
+      readonly filebeat: string;
+      readonly metricbeat: string;
+      readonly heartbeat: string;
+      readonly logstash: string;
+      readonly functionbeat: string;
+      readonly winlogbeat: string;
+      readonly siem: string;
+      readonly indexPatterns: {
+        readonly loadingData: string;
+        readonly introduction: string;
+      };
+      readonly scriptedFields: {
+        readonly scriptFields: string;
+        readonly scriptAggs: string;
+        readonly painless: string;
+        readonly painlessApi: string;
+        readonly painlessSyntax: string;
+        readonly luceneExpressions: string;
+      };
+      readonly management: Record<string, string>;
+      readonly visualize: Record<string, string>;
+      readonly addData: string;
+      readonly vega: string;
       readonly dateMath: string;
     };
-    readonly management: Record<string, string>;
-    readonly visualize: Record<string, string>;
   };
 }

--- a/src/core/public/public.api.md
+++ b/src/core/public/public.api.md
@@ -452,104 +452,221 @@ export const DEFAULT_APP_CATEGORIES: Record<string, AppCategory>;
 export interface DocLinksStart {
     // (undocumented)
     readonly DOC_LINK_VERSION: string;
+    readonly OPENSEARCH_WEBSITE_URL: string;
     // (undocumented)
     readonly links: {
-        readonly dashboard: {
-            readonly drilldowns: string;
-            readonly drilldownsTriggerPicker: string;
-            readonly urlDrilldownTemplateSyntax: string;
-            readonly urlDrilldownVariables: string;
-        };
-        readonly filebeat: {
-            readonly base: string;
-            readonly installation: string;
-            readonly configuration: string;
-            readonly elasticsearchOutput: string;
-            readonly startup: string;
-            readonly exportedFields: string;
-        };
-        readonly auditbeat: {
-            readonly base: string;
-        };
-        readonly metricbeat: {
-            readonly base: string;
-        };
-        readonly heartbeat: {
-            readonly base: string;
-        };
-        readonly logstash: {
-            readonly base: string;
-        };
-        readonly functionbeat: {
-            readonly base: string;
-        };
-        readonly winlogbeat: {
-            readonly base: string;
-        };
-        readonly aggs: {
-            readonly date_histogram: string;
-            readonly date_range: string;
-            readonly filter: string;
-            readonly filters: string;
-            readonly geohash_grid: string;
-            readonly histogram: string;
-            readonly ip_range: string;
-            readonly range: string;
-            readonly significant_terms: string;
-            readonly terms: string;
-            readonly avg: string;
-            readonly avg_bucket: string;
-            readonly max_bucket: string;
-            readonly min_bucket: string;
-            readonly sum_bucket: string;
-            readonly cardinality: string;
-            readonly count: string;
-            readonly cumulative_sum: string;
-            readonly derivative: string;
-            readonly geo_bounds: string;
-            readonly geo_centroid: string;
-            readonly max: string;
-            readonly median: string;
-            readonly min: string;
-            readonly moving_avg: string;
-            readonly percentile_ranks: string;
-            readonly serial_diff: string;
-            readonly std_dev: string;
-            readonly sum: string;
-            readonly top_hits: string;
-        };
-        readonly scriptedFields: {
-            readonly scriptFields: string;
-            readonly scriptAggs: string;
-            readonly painless: string;
-            readonly painlessApi: string;
-            readonly painlessSyntax: string;
-            readonly luceneExpressions: string;
-        };
-        readonly indexPatterns: {
-            readonly loadingData: string;
+        readonly opensearch: {
             readonly introduction: string;
+            readonly installation: {
+                readonly base: string;
+                readonly compatibility: string;
+                readonly docker: string;
+                readonly dockerSecurity: string;
+                readonly helm: string;
+                readonly tar: string;
+                readonly ansible: string;
+                readonly settings: string;
+                readonly plugins: string;
+            };
+            readonly configuration: string;
+            readonly cluster: {
+                readonly base: string;
+                readonly naming: string;
+                readonly set_attribute: string;
+                readonly build_cluster: string;
+                readonly config_host: string;
+                readonly start: string;
+                readonly config_shard: string;
+                readonly setup_hot_arch: string;
+            };
+            readonly indexData: {
+                readonly base: string;
+                readonly naming: string;
+                readonly read_data: string;
+                readonly update_data: string;
+                readonly delete_data: string;
+            };
+            readonly indexAlias: {
+                readonly base: string;
+                readonly create_alias: string;
+                readonly add_remove_index: string;
+                readonly manage_alias: string;
+                readonly filtered_alias: string;
+                readonly alias_option: string;
+            };
+            readonly dataStreams: string;
+            readonly aggregations: {
+                readonly base: string;
+                readonly metric: {
+                readonly base: string;
+                readonly types: string;
+                readonly sum: string;
+                readonly cardinality: string;
+                readonly value_count: string;
+                readonly stats: string;
+                readonly percentile: string;
+                readonly geo_bound: string;
+                readonly top_hits: string;
+                readonly scripted_metric: string;
+                };
+                readonly bucket: {
+                readonly base: string;
+                readonly terms: string;
+                readonly smapler: string;
+                readonly significant_terms: string;
+                readonly missing: string;
+                readonly histogram: string;
+                readonly range: string;
+                readonly filter: string;
+                readonly global: string;
+                readonly geo: string;
+                readonly adjacency_matrix: string;
+                readonly nested: string;
+                };
+                readonly pipeline: {
+                readonly base: string;
+                readonly syntax: string;
+                readonly types: string;
+                readonly avg_bucket: string;
+                readonly stats_bucket: string;
+                readonly bucket_script: string;
+                readonly bucket_sort: string;
+                readonly cumulative_sum: string;
+                readonly derivative: string;
+                readonly moving_avg: string;
+                readonly serial_diff: string;
+                };
+            };
+            readonly indexTemplates: {
+                readonly base: string;
+                readonly composable: string;
+                readonly options: string;
+            };
+            readonly reindexData: {
+                readonly base: string;
+                readonly all: string;
+                readonly remote: string;
+                readonly subset: string;
+                readonly combine: string;
+                readonly unique: string;
+                readonly transform: string;
+                readonly update: string;
+                readonly source: string;
+                readonly destination: string;
+            };
+            readonly queryDSL: {
+                readonly base: string;
+                readonly term: {
+                readonly base: string;
+                readonly terms: string;
+                readonly ids: string;
+                readonly range: string;
+                readonly prefix: string;
+                readonly exists: string;
+                readonly wildcards: string;
+                readonly regex: string;
+                };
+                readonly fullText: {
+                readonly base: string;
+                readonly match: string;
+                readonly multi_match: string;
+                readonly match_phrase: string;
+                readonly common_terms: string;
+                readonly query_string: string;
+                readonly options: string;
+                };
+                readonly boolQuery: string;
+            };
+            readonly searchTemplate: {
+                readonly base: string;
+                readonly create: string;
+                readonly execute: string;
+                readonly advanced_operation: string;
+                readonly multiple_search: string;
+                readonly manage: string;
+            };
+            readonly searchExperience: {
+                readonly base: string;
+                readonly autocomplete: string;
+                readonly paginate: string;
+                readonly scroll: string;
+                readonly sort: string;
+                readonly highlight_match: string;
+            };
+            readonly logs: {
+                readonly base: string;
+                readonly application_log: string;
+                readonly slow_log: string;
+                readonly deprecation_log: string;
+            };
+            readonly snapshotRestore: {
+                readonly base: string;
+                readonly register: string;
+                readonly take_snapshot: string;
+                readonly restore_snapshot: string;
+                readonly security_plugin: string;
+            };
+            readonly supportedUnits: string;
+            readonly commonParameters: string;
+            readonly popularAPI: string;
+            readonly restAPI: string;
         };
-        readonly addData: string;
-        readonly opensearchDashboards: string;
-        readonly siem: {
-            readonly guide: string;
-            readonly gettingStarted: string;
+        readonly opensearchDashboards: {
+            readonly introduction: string;
+            readonly installation: {
+                readonly base: string;
+                readonly docker: string;
+                readonly tar: string;
+                readonly helm: string;
+                readonly tls: string;
+                readonly plugins: string;
+            };
+            readonly mapTiles: string;
+            readonly ganttCharts: string;
+            readonly reporting: string;
+            readonly notebooks: {
+                readonly base: string;
+                readonly notebook_tutorial: string;
+                readonly paragraph_tutorial: string;
+                readonly sample_notebook: string;
+                readonly create_report: string;
+            };
+            readonly dql: {
+                readonly base: string;
+                readonly terms_query: string;
+                readonly boolean_query: string;
+                readonly date_query: string;
+                readonly nested_query: string;
+            };
         };
-        readonly query: {
-            readonly eql: string;
-            readonly luceneQuerySyntax: string;
-            readonly queryDsl: string;
-            readonly kueryQuerySyntax: string;
-        };
-        readonly date: {
+        readonly noDocumentation: {
+            readonly auditbeat: string;
+            readonly filebeat: string;
+            readonly metricbeat: string;
+            readonly heartbeat: string;
+            readonly logstash: string;
+            readonly functionbeat: string;
+            readonly winlogbeat: string;
+            readonly siem: string;
+            readonly indexPatterns: {
+                readonly loadingData: string;
+                readonly introduction: string;
+            };
+            readonly scriptedFields: {
+                readonly scriptFields: string;
+                readonly scriptAggs: string;
+                readonly painless: string;
+                readonly painlessApi: string;
+                readonly painlessSyntax: string;
+                readonly luceneExpressions: string;
+            };
+            readonly management: Record<string, string>;
+            readonly visualize: Record<string, string>;
+            readonly addData: string;
+            readonly vega: string;
             readonly dateMath: string;
         };
-        readonly management: Record<string, string>;
-        readonly visualize: Record<string, string>;
     };
-    // (undocumented)
-    readonly OPENSEARCH_WEBSITE_URL: string;
 }
 
 export { EnvironmentMode }

--- a/src/core/server/ui_settings/settings/date_formats.ts
+++ b/src/core/server/ui_settings/settings/date_formats.ts
@@ -168,9 +168,7 @@ export const getDateFormatSettings = (): Record<string, UiSettingsParams> => {
         defaultMessage: 'Used for the {dateNanosLink} datatype of OpenSearch',
         values: {
           dateNanosLink:
-            // TODO: [RENAMEME] Need prod urls.
-            // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-            '<a href="https://opensearch.org/docs/opensearch/units" target="_blank" rel="noopener noreferrer">' +
+            '<a href="https://opensearch.org/docs/latest/opensearch/units/" target="_blank" rel="noopener noreferrer">' +
             i18n.translate('core.ui_settings.params.dateNanosLinkTitle', {
               defaultMessage: 'date_nanos',
             }) +

--- a/src/plugins/advanced_settings/public/management_app/components/field/field.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/field/field.tsx
@@ -528,7 +528,10 @@ export class Field extends PureComponent<FieldProps> {
             <EuiBadge
               color="warning"
               onClick={() => {
-                window.open(links.management[setting.deprecation!.docLinksKey], '_blank');
+                window.open(
+                  links.noDocumentation.management[setting.deprecation!.docLinksKey],
+                  '_blank'
+                );
               }}
               onClickAriaLabel={i18n.translate('advancedSettings.field.deprecationClickAreaLabel', {
                 defaultMessage: 'Click to view deprecation documentation for {settingName}.',

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/msearch.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/msearch.json
@@ -23,6 +23,6 @@
       "{indices}/_msearch",
       "{indices}/{type}/_msearch"
     ],
-    "documentation": "https://opensearch.org/docs/opensearch/query-dsl/full-text/#multi-match"
+    "documentation": "https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#multi-match"
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/msearch_template.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/msearch_template.json
@@ -21,6 +21,6 @@
       "{indices}/_msearch/template",
       "{indices}/{type}/_msearch/template"
     ],
-    "documentation": "https://opensearch.org/docs/opensearch/query-dsl/full-text/#multi-match"
+    "documentation": "https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#multi-match"
   }
 }

--- a/src/plugins/dashboard/public/application/help_menu/help_menu_util.ts
+++ b/src/plugins/dashboard/public/application/help_menu/help_menu_util.ts
@@ -44,9 +44,7 @@ export function addHelpMenuToAppChrome(
     links: [
       {
         linkType: 'documentation',
-        // TODO: [RENAMEME] Need prod urls.
-        // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-        href: `${docLinks.links.opensearchDashboards}`,
+        href: `${docLinks.links.opensearchDashboards.introduction}`,
       },
     ],
   });

--- a/src/plugins/data/common/opensearch_query/kuery/node_types/wildcard.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/node_types/wildcard.ts
@@ -41,7 +41,7 @@ function escapeRegExp(str: string) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
 
-// See https://www.opensearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
+// See https://opensearch.org/docs/latest/opensearch/query-dsl/term/#regex
 function escapeQueryString(str: string) {
   return str.replace(/[+-=&|><!(){}[\]^"~*?:\\/]/g, '\\$&'); // $& means the whole matched string
 }

--- a/src/plugins/data/public/ui/query_string_input/language_switcher.tsx
+++ b/src/plugins/data/public/ui/query_string_input/language_switcher.tsx
@@ -53,8 +53,8 @@ interface Props {
 }
 
 export function QueryLanguageSwitcher(props: Props) {
-  const opensearchDashboards = useOpenSearchDashboards();
-  const kueryQuerySyntaxDocs = opensearchDashboards.services.docLinks!.links.query.kueryQuerySyntax;
+  const osdDQLDocs = useOpenSearchDashboards().services.docLinks?.links.opensearchDashboards.dql
+    .base;
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const luceneLabel = (
     <FormattedMessage id="data.query.queryBar.luceneLanguageName" defaultMessage="Lucene" />
@@ -108,7 +108,7 @@ export function QueryLanguageSwitcher(props: Props) {
               OpenSearch Dashboards uses Lucene."
               values={{
                 docsLink: (
-                  <EuiLink href={kueryQuerySyntaxDocs} target="_blank">
+                  <EuiLink href={osdDQLDocs} target="_blank">
                     {dqlFullName}
                   </EuiLink>
                 ),

--- a/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
@@ -96,7 +96,7 @@ export default function QueryBarTopRow(props: QueryBarTopRowProps) {
   const opensearchDashboards = useOpenSearchDashboards<IDataPluginServices>();
   const { uiSettings, notifications, storage, appName, docLinks } = opensearchDashboards.services;
 
-  const kueryQuerySyntaxLink: string = docLinks!.links.query.kueryQuerySyntax;
+  const osdDQLDocs: string = docLinks!.links.opensearchDashboards.dql.base;
 
   const queryLanguage = props.query && props.query.language;
   const persistedLog: PersistedLog | undefined = React.useMemo(
@@ -344,7 +344,7 @@ export default function QueryBarTopRow(props: QueryBarTopRowProps) {
                have opensearchDashboards Query Language (DQL) selected. Please review the DQL docs {link}."
                 values={{
                   link: (
-                    <EuiLink href={kueryQuerySyntaxLink} target="_blank">
+                    <EuiLink href={osdDQLDocs} target="_blank">
                       <FormattedMessage
                         id="data.query.queryBar.syntaxOptionsDescription.docsLinkText"
                         defaultMessage="here"

--- a/src/plugins/data/public/ui/query_string_input/query_string_input.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_string_input.tsx
@@ -409,7 +409,7 @@ export default class QueryStringInputUI extends Component<Props, State> {
                   Learn more in our {link}."
                   values={{
                     link: (
-                      <EuiLink href={docLinks.links.query.kueryQuerySyntax} target="_blank">
+                      <EuiLink href={docLinks.links.opensearchDashboards.dql.base} target="_blank">
                         <FormattedMessage
                           id="data.query.queryBar.DQLNestedQuerySyntaxInfoDocLinkText"
                           defaultMessage="docs"

--- a/src/plugins/data/server/autocomplete/value_suggestions_route.ts
+++ b/src/plugins/data/server/autocomplete/value_suggestions_route.ts
@@ -105,7 +105,7 @@ async function getBody(
 ) {
   const isFieldObject = (f: any): f is IFieldType => Boolean(f && f.name);
 
-  // https://www.opensearch.org/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html#_standard_operators
+  // See https://opensearch.org/docs/latest/opensearch/query-dsl/term/#regex
   const getEscapedQuery = (q: string = '') =>
     q.replace(/[.?+*|{}[\]()"\\#@&<>~]/g, (match) => `\\${match}`);
 

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -106,9 +106,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'data.advancedSettings.query.queryStringOptionsText',
         values: {
           optionsLink:
-            // TODO: [RENAMEME] Need prod urls.
-            // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-            '<a href="https://opensearch.org/docs/opensearch/query-dsl/index" target="_blank" rel="noopener">' +
+            '<a href="https://opensearch.org/docs/latest/opensearch/query-dsl/index/" target="_blank" rel="noopener">' +
             i18n.translate('data.advancedSettings.query.queryStringOptions.optionsLinkText', {
               defaultMessage: 'Options',
             }) +
@@ -167,7 +165,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'data.advancedSettings.sortOptionsText',
         values: {
           optionsLink:
-            '<a href="https://opensearch.org/docs/opensearch/ux/#sort-results" target="_blank" rel="noopener">' +
+            '<a href="https://opensearch.org/docs/latest/opensearch/ux/#sort-results" target="_blank" rel="noopener">' +
             i18n.translate('data.advancedSettings.sortOptions.optionsLinkText', {
               defaultMessage: 'Options',
             }) +
@@ -249,7 +247,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           setRequestReferenceSetting: `<strong>${UI_SETTINGS.COURIER_SET_REQUEST_PREFERENCE}</strong>`,
           customSettingValue: '"custom"',
           requestPreferenceLink:
-            '<a href="https://opensearch.org/docs/opensearch/popular-api" target="_blank" rel="noopener">' +
+            '<a href="https://opensearch.org/docs/latest/opensearch/popular-api" target="_blank" rel="noopener">' +
             i18n.translate(
               'data.advancedSettings.courier.customRequestPreference.requestPreferenceLinkText',
               {
@@ -273,7 +271,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'Controls the {maxRequestsLink} setting used for _msearch requests sent by OpenSearch Dashboards. ' +
           'Set to 0 to disable this config and use the OpenSearch default.',
         values: {
-          maxRequestsLink: `<a href="https://opensearch.org/docs/opensearch/query-dsl/full-text/#multi-match"
+          maxRequestsLink: `<a href="https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#multi-match"
             target="_blank" rel="noopener" >max_concurrent_shard_requests</a>`,
         },
       }),
@@ -296,7 +294,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
     },
     [UI_SETTINGS.SEARCH_INCLUDE_FROZEN]: {
       name: 'Search in frozen indices',
-      description: `Will include <a href="https://opensearch.org/docs/opensearch/index-data"
+      description: `Will include <a href="https://opensearch.org/docs/latest/opensearch/index-data"
         target="_blank" rel="noopener">frozen indices</a> in results if enabled. Searching through frozen indices
         might increase the search time.`,
       value: false,
@@ -645,7 +643,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'data.advancedSettings.timepicker.quickRanges.acceptedFormatsLinkText',
         values: {
           acceptedFormatsLink:
-            `<a href="https://opensearch.org/docs/opensearch/units"
+            `<a href="https://opensearch.org/docs/latest/opensearch/units"
             target="_blank" rel="noopener">` +
             i18n.translate('data.advancedSettings.timepicker.quickRanges.acceptedFormatsLinkText', {
               defaultMessage: 'accepted formats',

--- a/src/plugins/discover/public/application/angular/context/api/utils/get_opensearch_query_sort.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/get_opensearch_query_sort.ts
@@ -37,7 +37,7 @@ import {
 
 /**
  * Returns `OpenSearchQuerySort` which is used to sort records in the OpenSearch query
- * https://opensearch.org/docs/opensearch/ux/#sort-results
+ * https://opensearch.org/docs/latest/opensearch/ux/#sort-results
  * @param timeField
  * @param tieBreakerField
  * @param sortDir

--- a/src/plugins/discover/public/application/angular/directives/no_results.js
+++ b/src/plugins/discover/public/application/angular/directives/no_results.js
@@ -176,7 +176,7 @@ export class DiscoverNoResults extends Component {
                   queryStringSyntaxLink: (
                     <EuiLink
                       target="_blank"
-                      href={getServices().docLinks.links.query.luceneQuerySyntax}
+                      href={getServices().docLinks.links.opensearch.queryDSL.base}
                     >
                       <FormattedMessage
                         id="discover.noResults.searchExamples.queryStringSyntaxLinkText"

--- a/src/plugins/discover/public/application/angular/directives/no_results.test.js
+++ b/src/plugins/discover/public/application/angular/directives/no_results.test.js
@@ -40,8 +40,10 @@ jest.mock('../../../opensearch_dashboards_services', () => {
     getServices: () => ({
       docLinks: {
         links: {
-          query: {
-            luceneQuerySyntax: 'documentation-link',
+          opensearch: {
+            queryDSL: {
+              base: 'documentation-link',
+            },
           },
         },
       },

--- a/src/plugins/discover/public/application/components/doc/use_opensearch_doc_search.ts
+++ b/src/plugins/discover/public/application/components/doc/use_opensearch_doc_search.ts
@@ -44,7 +44,7 @@ export enum OpenSearchRequestState {
 
 /**
  * helper function to build a query body for OpenSearch
- * https://www.opensearch.org/guide/en/elasticsearch/reference/current//query-dsl-ids-query.html
+ * https://opensearch.org/docs/latest/opensearch/query-dsl/index/
  */
 export function buildSearchBody(id: string, indexPattern: IndexPattern): Record<string, any> {
   const computedFields = indexPattern.getComputedFields();

--- a/src/plugins/discover/public/application/components/help_menu/help_menu_util.js
+++ b/src/plugins/discover/public/application/components/help_menu/help_menu_util.js
@@ -42,9 +42,7 @@ export function addHelpMenuToAppChrome(chrome) {
     links: [
       {
         linkType: 'documentation',
-        // TODO: [RENAMEME] Need prod urls.
-        // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-        href: `${docLinks.links.opensearchDashboards}`,
+        href: `${docLinks.links.opensearchDashboards.introduction}`,
       },
     ],
   });

--- a/src/plugins/home/public/application/components/tutorial/replace_template_strings.js
+++ b/src/plugins/home/public/application/components/tutorial/replace_template_strings.js
@@ -56,16 +56,16 @@ export function replaceTemplateStrings(text, params = {}) {
     config: {
       ...tutorialService.getVariables(),
       docs: {
-        base_url: docLinks.ELASTIC_WEBSITE_URL,
+        base_url: docLinks.OPENSEARCH_WEBSITE_URL,
         beats: {
-          filebeat: docLinks.links.filebeat.base,
-          metricbeat: docLinks.links.metricbeat.base,
-          heartbeat: docLinks.links.heartbeat.base,
-          functionbeat: docLinks.links.functionbeat.base,
-          winlogbeat: docLinks.links.winlogbeat.base,
-          auditbeat: docLinks.links.auditbeat.base,
+          filebeat: docLinks.links.noDocumentation.filebeat,
+          metricbeat: docLinks.links.noDocumentation.metricbeat,
+          heartbeat: docLinks.links.noDocumentation.heartbeat,
+          functionbeat: docLinks.links.noDocumentation.functionbeat,
+          winlogbeat: docLinks.links.noDocumentation.winlogbeat,
+          auditbeat: docLinks.links.noDocumentation.auditbeat,
         },
-        logstash: docLinks.links.logstash.base,
+        logstash: docLinks.links.noDocumentation.logstash,
         version: docLinks.DOC_LINK_VERSION,
       },
       opensearchDashboards: {

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/__snapshots__/create_index_pattern_wizard.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/__snapshots__/create_index_pattern_wizard.test.tsx.snap
@@ -19,8 +19,10 @@ exports[`CreateIndexPatternWizard renders index pattern step when there are indi
       docLinks={
         Object {
           "links": Object {
-            "indexPatterns": Object {},
-            "scriptedFields": Object {},
+            "noDocumentation": Object {
+              "indexPatterns": Object {},
+              "scriptedFields": Object {},
+            },
           },
         }
       }
@@ -67,8 +69,10 @@ exports[`CreateIndexPatternWizard renders the empty state when there are no indi
       docLinks={
         Object {
           "links": Object {
-            "indexPatterns": Object {},
-            "scriptedFields": Object {},
+            "noDocumentation": Object {
+              "indexPatterns": Object {},
+              "scriptedFields": Object {},
+            },
           },
         }
       }
@@ -109,8 +113,10 @@ exports[`CreateIndexPatternWizard renders time field step when step is set to 2 
       docLinks={
         Object {
           "links": Object {
-            "indexPatterns": Object {},
-            "scriptedFields": Object {},
+            "noDocumentation": Object {
+              "indexPatterns": Object {},
+              "scriptedFields": Object {},
+            },
           },
         }
       }
@@ -151,8 +157,10 @@ exports[`CreateIndexPatternWizard renders when there are no indices but there ar
       docLinks={
         Object {
           "links": Object {
-            "indexPatterns": Object {},
-            "scriptedFields": Object {},
+            "noDocumentation": Object {
+              "indexPatterns": Object {},
+              "scriptedFields": Object {},
+            },
           },
         }
       }
@@ -193,8 +201,10 @@ exports[`CreateIndexPatternWizard shows system indices even if there are no othe
       docLinks={
         Object {
           "links": Object {
-            "indexPatterns": Object {},
-            "scriptedFields": Object {},
+            "noDocumentation": Object {
+              "indexPatterns": Object {},
+              "scriptedFields": Object {},
+            },
           },
         }
       }

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/__snapshots__/header.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/__snapshots__/header.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`Header should render a different name, prompt, and beta tag if provided
     docLinks={
       Object {
         "links": Object {
-          "indexPatterns": Object {},
+          "noDocumentation": Object {
+            "indexPatterns": Object {},
+          },
         },
       }
     }
@@ -147,7 +149,9 @@ exports[`Header should render normally 1`] = `
     docLinks={
       Object {
         "links": Object {
-          "indexPatterns": Object {},
+          "noDocumentation": Object {
+            "indexPatterns": Object {},
+          },
         },
       }
     }
@@ -259,7 +263,9 @@ exports[`Header should render without including system indices 1`] = `
     docLinks={
       Object {
         "links": Object {
-          "indexPatterns": Object {},
+          "noDocumentation": Object {
+            "indexPatterns": Object {},
+          },
         },
       }
     }

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.test.tsx
@@ -43,7 +43,9 @@ describe('Header', () => {
   const mockedContext = mockManagementPlugin.createIndexPatternManagmentContext();
   const mockedDocLinks = {
     links: {
-      indexPatterns: {},
+      noDocumentation: {
+        indexPatterns: {},
+      },
     },
   } as DocLinksStart;
 

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.tsx
@@ -93,7 +93,11 @@ export const Header = ({
             }}
           />
           <br />
-          <EuiLink href={docLinks.links.indexPatterns.introduction} target="_blank" external>
+          <EuiLink
+            href={docLinks.links.noDocumentation.indexPatterns.introduction}
+            target="_blank"
+            external
+          >
             <FormattedMessage
               id="indexPatternManagement.createIndexPattern.documentation"
               defaultMessage="Read documentation"

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -102,6 +102,7 @@ export const EditIndexPattern = withRouter(
       savedObjects,
       chrome,
       data,
+      docLinks,
     } = useOpenSearchDashboards<IndexPatternManagmentContext>().services;
     const [fields, setFields] = useState<IndexPatternField[]>(indexPattern.getNonScriptedFields());
     const [conflictedFields, setConflictedFields] = useState<IndexPatternField[]>(
@@ -231,9 +232,7 @@ export const EditIndexPattern = withRouter(
                 values={{ indexPatternTitle: <strong>{indexPattern.title}</strong> }}
               />{' '}
               <EuiLink
-                // TODO: [RENAMEME] Need prod urls.
-                // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-                href="https://opensearch.org/docs/opensearch/index-templates"
+                href={docLinks.links.opensearch.indexTemplates.base}
                 target="_blank"
                 external
               >

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/tabs/tabs.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/tabs/tabs.tsx
@@ -215,7 +215,7 @@ export function Tabs({ indexPattern, saveIndexPattern, fields, history, location
                   },
                 }}
                 onRemoveField={refreshFilters}
-                painlessDocLink={docLinks.links.scriptedFields.painless}
+                painlessDocLink={docLinks.links.noDocumentation.scriptedFields.painless}
               />
             </Fragment>
           );
@@ -237,7 +237,7 @@ export function Tabs({ indexPattern, saveIndexPattern, fields, history, location
       }
     },
     [
-      docLinks.links.scriptedFields.painless,
+      docLinks.links.noDocumentation.scriptedFields.painless,
       fieldFilter,
       fieldWildcardMatcherDecorated,
       fields,

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.tsx
@@ -45,7 +45,7 @@ export interface ScriptingWarningCallOutProps {
 
 export const ScriptingWarningCallOut = ({ isVisible = false }: ScriptingWarningCallOutProps) => {
   const docLinksScriptedFields = useOpenSearchDashboards<IndexPatternManagmentContext>().services
-    .docLinks?.links.scriptedFields;
+    .docLinks?.links.noDocumentation.scriptedFields;
   return isVisible ? (
     <Fragment>
       <EuiCallOut

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/scripting_syntax.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/scripting_syntax.tsx
@@ -39,7 +39,7 @@ import { IndexPatternManagmentContext } from '../../../../types';
 
 export const ScriptingSyntax = () => {
   const docLinksScriptedFields = useOpenSearchDashboards<IndexPatternManagmentContext>().services
-    .docLinks?.links.scriptedFields;
+    .docLinks?.links.noDocumentation.scriptedFields;
   return (
     <Fragment>
       <EuiSpacer />

--- a/src/plugins/index_pattern_management/public/components/field_editor/field_editor.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/field_editor.tsx
@@ -377,7 +377,9 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
                   painlessLink: (
                     <EuiLink
                       target="_blank"
-                      href={this.context.services.docLinks.links.scriptedFields.painless}
+                      href={
+                        this.context.services.docLinks.links.noDocumentation.scriptedFields.painless
+                      }
                     >
                       <FormattedMessage
                         id="indexPatternManagement.warningLabel.painlessLinkLabel"

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/__snapshots__/empty_state.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/__snapshots__/empty_state.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`EmptyState should render normally 1`] = `
                   Object {
                     "description": <EuiLink
                       external={true}
-                      href="https://opensearch.org/docs/dashboards/"
+                      href="https://www.opensearch.org/docs/mocked-test-branch"
                       target="_blank"
                     >
                       <FormattedMessage

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/empty_state.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/empty_state.tsx
@@ -207,7 +207,11 @@ export const EmptyState = ({
                         />
                       ),
                       description: (
-                        <EuiLink href={docLinks.links.addData} target="_blank" external>
+                        <EuiLink
+                          href={docLinks.links.noDocumentation.addData}
+                          target="_blank"
+                          external
+                        >
                           <FormattedMessage
                             id="indexPatternManagement.createIndexPattern.emptyState.readDocs"
                             defaultMessage="Read documentation"

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -227,7 +227,7 @@ export const IndexPatternTable = ({ canSave, history }: Props) => {
         <EmptyIndexPatternPrompt
           canSave={canSave}
           creationOptions={creationOptions}
-          docLinksIndexPatternIntro={docLinks.links.indexPatterns.introduction}
+          docLinksIndexPatternIntro={docLinks.links.noDocumentation.indexPatterns.introduction}
           setBreadcrumbs={setBreadcrumbs}
         />
       );

--- a/src/plugins/index_pattern_management/public/mocks.ts
+++ b/src/plugins/index_pattern_management/public/mocks.ts
@@ -94,8 +94,10 @@ const createInstance = async () => {
 
 const docLinks = {
   links: {
-    indexPatterns: {},
-    scriptedFields: {},
+    noDocumentation: {
+      indexPatterns: {},
+      scriptedFields: {},
+    },
   },
 };
 

--- a/src/plugins/input_control_vis/public/control/list_control_factory.ts
+++ b/src/plugins/input_control_vis/public/control/list_control_factory.ts
@@ -45,7 +45,7 @@ import { ControlParams } from '../editor_utils';
 import { InputControlSettings, InputControlVisDependencies } from '../plugin';
 
 function getEscapedQuery(query = '') {
-  // https://www.opensearch.org/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html#_standard_operators
+  // https://opensearch.org/docs/latest/opensearch/query-dsl/index/
   return query.replace(/[.?+*|{}[\]()"\\#@&<>~]/g, (match) => `\\${match}`);
 }
 

--- a/src/plugins/maps_legacy/public/map/map_messages.js
+++ b/src/plugins/maps_legacy/public/map/map_messages.js
@@ -112,10 +112,9 @@ export const createZoomWarningMsg = (function () {
               defaultMessage="You've reached the maximum number of zoom
               levels. To zoom all the way in, you can configure your own map server.
               Please go to { wms } for more information."
-              // TODO: [RENAMEME] Need prod urls.
               values={{
                 wms: (
-                  <a target="_blank" href="https://opensearch.org/docs/dashboards/maptiles/">
+                  <a target="_blank" href="https://opensearch.org/docs/latest/dashboards/maptiles/">
                     {`Custom WMS Configuration`}
                   </a>
                 ),

--- a/src/plugins/maps_legacy/server/ui_settings.ts
+++ b/src/plugins/maps_legacy/server/ui_settings.ts
@@ -51,9 +51,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
             'maps_legacy.advancedSettings.visualization.tileMap.maxPrecision.cellDimensionsLinkText',
           values: {
             cellDimensionsLink:
-              // TODO: [RENAMEME] Need prod urls.
-              // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-              `<a href="https://opensearch.org/docs/dashboards/maptiles"
+              `<a href="https://opensearch.org/docs/latest/dashboards/maptiles"
             target="_blank" rel="noopener">` +
               i18n.translate(
                 'maps_legacy.advancedSettings.visualization.tileMap.maxPrecision.cellDimensionsLinkText',

--- a/src/plugins/timeline/public/components/timeline_deprecation.tsx
+++ b/src/plugins/timeline/public/components/timeline_deprecation.tsx
@@ -35,7 +35,7 @@ import React from 'react';
 import { DocLinksStart } from '../../../../core/public';
 
 export const TimelineDeprecation = ({ links }: DocLinksStart) => {
-  const timelineDeprecationLink = links.visualize.timelineDeprecation;
+  const timelineDeprecationLink = links.noDocumentation.visualize.timelineDeprecation;
   return (
     <>
       <EuiCallOut

--- a/src/plugins/vis_default_editor/public/components/agg_select.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_select.tsx
@@ -85,8 +85,7 @@ function DefaultEditorAggSelect({
 
   let aggHelpLink: string | undefined;
   if (has(value, 'name')) {
-    // @ts-expect-error
-    aggHelpLink = services.docLinks.links.aggs[value.name];
+    aggHelpLink = services.docLinks.links.opensearch.aggregations.base;
   }
 
   const helpLink = value && aggHelpLink && (

--- a/src/plugins/vis_default_editor/public/components/controls/date_ranges.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/date_ranges.tsx
@@ -141,7 +141,7 @@ function DateRangesParamEditor({
     <EuiFormRow compressed fullWidth>
       <>
         <EuiText size="xs">
-          <EuiLink href={services.docLinks.links.date.dateMath} target="_blank">
+          <EuiLink href={services.docLinks.links.noDocumentation.dateMath} target="_blank">
             <FormattedMessage
               id="visDefaultEditor.controls.dateRanges.acceptedDateFormatsLinkText"
               defaultMessage="Acceptable date formats"

--- a/src/plugins/vis_type_vega/public/components/vega_help_menu.tsx
+++ b/src/plugins/vis_type_vega/public/components/vega_help_menu.tsx
@@ -34,12 +34,15 @@ import React, { useCallback, useState } from 'react';
 import { EuiButtonIcon, EuiContextMenuPanel, EuiContextMenuItem, EuiPopover } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { i18n } from '@osd/i18n';
+import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
 
 function VegaHelpMenu() {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const onButtonClick = useCallback(() => setIsPopoverOpen(!isPopoverOpen), [isPopoverOpen]);
 
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
+
+  const vegaHelpDoc = useOpenSearchDashboards().services.docLinks?.links.noDocumentation.vega;
 
   const button = (
     <EuiButtonIcon
@@ -52,14 +55,7 @@ function VegaHelpMenu() {
   );
 
   const items = [
-    <EuiContextMenuItem
-      key="vegaHelp"
-      // TODO: [RENAMEME] Need prod urls.
-      // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/335#issuecomment-868294864
-      href="https://opensearch.org/docs/dashboards"
-      target="_blank"
-      onClick={closePopover}
-    >
+    <EuiContextMenuItem key="vegaHelp" href={vegaHelpDoc} target="_blank" onClick={closePopover}>
       <FormattedMessage
         id="visTypeVega.editor.vegaHelpLinkText"
         defaultMessage="OpenSearch Dashboards Vega help"

--- a/src/plugins/visualize/public/application/utils/utils.ts
+++ b/src/plugins/visualize/public/application/utils/utils.ts
@@ -44,7 +44,7 @@ export const addHelpMenuToAppChrome = (chrome: ChromeStart, docLinks: DocLinksSt
     links: [
       {
         linkType: 'documentation',
-        href: `${docLinks.links.visualize.guide}`,
+        href: `${docLinks.links.noDocumentation.visualize.guide}`,
       },
     ],
   });


### PR DESCRIPTION
### Description
This PR is to add versioned doc url support in DocLinksServices.
1.  My proposal is to use `package.json` to control the doc url versioning.  If the `branch` value is `main` then convert it to `latest` as the document version, otherwise use the `branch` value as the document version (e.g. `1.1`, or `1.0`) 
2. Create new doc link mappings based on doc website. Group them into three parts : `opeansearch`,  `opensearchDashboards` and `noDocuments`.  Mapping the structure into: [Group] -> [sub-page]->[sub-subpage] -> [anchor].
3. Fix DQL link related bug
4. Fix unit tests
4. Update URL links to latest version.
 
### Issues Resolved

- Fixed DQL Links Bug https://github.com/opensearch-project/OpenSearch-Dashboards/issues/769
- https://github.com/opensearch-project/OpenSearch-Dashboards/issues/892
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 