### PR TITLE
[1.2] Fix Node selection when using built in node (#912)

### DIFF
--- a/src/dev/build/tasks/bin/scripts/opensearch-dashboards
+++ b/src/dev/build/tasks/bin/scripts/opensearch-dashboards
@@ -17,7 +17,7 @@ DIR="$(dirname "${SCRIPT}")/.."
 CONFIG_DIR=${OSD_PATH_CONF:-"$DIR/config"}
 
 if [ -x "${DIR}/node/bin/node" ]; then
-  NODE="/usr/local/bin/node"
+  NODE="${DIR}/node/bin/node"
 else
   NODE="$(which node)"
 fi


### PR DESCRIPTION
### Description
Fixed node selection to use the node executable instead of the user local node.

Signed-off-by: Sven R <admin@hackacad.net>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/908