### PR TITLE
[LIC] Simplified licence header across the project

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
@@ -32,11 +35,8 @@
 
 const NEW_OSS_HEADER = `
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a 
- * compatible open source license.
  */
 `;
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/cypress/integration/osd/check_advanced_settings.js
+++ b/cypress/integration/osd/check_advanced_settings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/cypress/integration/osd/check_default_page.js
+++ b/cypress/integration/osd/check_default_page.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/cypress/integration/osd/check_filter_and_query.js
+++ b/cypress/integration/osd/check_filter_and_query.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/components/count_until/index.tsx
+++ b/examples/bfetch_explorer/public/components/count_until/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/components/double_integers/index.tsx
+++ b/examples/bfetch_explorer/public/components/double_integers/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/components/page/index.tsx
+++ b/examples/bfetch_explorer/public/components/page/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/containers/app/index.tsx
+++ b/examples/bfetch_explorer/public/containers/app/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/containers/app/pages/page_count_until/index.tsx
+++ b/examples/bfetch_explorer/public/containers/app/pages/page_count_until/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/containers/app/pages/page_double_integers/index.tsx
+++ b/examples/bfetch_explorer/public/containers/app/pages/page_double_integers/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/containers/app/sidebar/index.tsx
+++ b/examples/bfetch_explorer/public/containers/app/sidebar/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/hooks/use_deps.ts
+++ b/examples/bfetch_explorer/public/hooks/use_deps.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/index.ts
+++ b/examples/bfetch_explorer/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/mount.tsx
+++ b/examples/bfetch_explorer/public/mount.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/plugin.tsx
+++ b/examples/bfetch_explorer/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/public/routes.tsx
+++ b/examples/bfetch_explorer/public/routes.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/server/index.ts
+++ b/examples/bfetch_explorer/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/bfetch_explorer/server/plugin.ts
+++ b/examples/bfetch_explorer/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/dashboard_embeddable_examples/public/app.tsx
+++ b/examples/dashboard_embeddable_examples/public/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/dashboard_embeddable_examples/public/by_value/embeddable.tsx
+++ b/examples/dashboard_embeddable_examples/public/by_value/embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/dashboard_embeddable_examples/public/by_value/input_editor.tsx
+++ b/examples/dashboard_embeddable_examples/public/by_value/input_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/dashboard_embeddable_examples/public/index.ts
+++ b/examples/dashboard_embeddable_examples/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/dashboard_embeddable_examples/public/plugin.tsx
+++ b/examples/dashboard_embeddable_examples/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/developer_examples/public/app.tsx
+++ b/examples/developer_examples/public/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/developer_examples/public/index.ts
+++ b/examples/developer_examples/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/developer_examples/public/plugin.ts
+++ b/examples/developer_examples/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/developer_examples/public/types.ts
+++ b/examples/developer_examples/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/common/book_saved_object_attributes.ts
+++ b/examples/embeddable_examples/common/book_saved_object_attributes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/common/index.ts
+++ b/examples/embeddable_examples/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/common/todo_saved_object_attributes.ts
+++ b/examples/embeddable_examples/common/todo_saved_object_attributes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/book/add_book_to_library_action.tsx
+++ b/examples/embeddable_examples/public/book/add_book_to_library_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/book/book_component.tsx
+++ b/examples/embeddable_examples/public/book/book_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/book/book_embeddable.tsx
+++ b/examples/embeddable_examples/public/book/book_embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/book/book_embeddable_factory.tsx
+++ b/examples/embeddable_examples/public/book/book_embeddable_factory.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/book/create_edit_book_component.tsx
+++ b/examples/embeddable_examples/public/book/create_edit_book_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/book/edit_book_action.tsx
+++ b/examples/embeddable_examples/public/book/edit_book_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/book/index.ts
+++ b/examples/embeddable_examples/public/book/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/book/unlink_book_from_library_action.tsx
+++ b/examples/embeddable_examples/public/book/unlink_book_from_library_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/create_sample_data.ts
+++ b/examples/embeddable_examples/public/create_sample_data.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/hello_world/hello_world_embeddable.tsx
+++ b/examples/embeddable_examples/public/hello_world/hello_world_embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/hello_world/hello_world_embeddable_factory.ts
+++ b/examples/embeddable_examples/public/hello_world/hello_world_embeddable_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/hello_world/index.ts
+++ b/examples/embeddable_examples/public/hello_world/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/index.ts
+++ b/examples/embeddable_examples/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/list_container/index.ts
+++ b/examples/embeddable_examples/public/list_container/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/list_container/list_container.tsx
+++ b/examples/embeddable_examples/public/list_container/list_container.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/list_container/list_container_component.tsx
+++ b/examples/embeddable_examples/public/list_container/list_container_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/list_container/list_container_factory.ts
+++ b/examples/embeddable_examples/public/list_container/list_container_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/multi_task_todo/index.ts
+++ b/examples/embeddable_examples/public/multi_task_todo/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/multi_task_todo/multi_task_todo_component.tsx
+++ b/examples/embeddable_examples/public/multi_task_todo/multi_task_todo_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/multi_task_todo/multi_task_todo_embeddable.tsx
+++ b/examples/embeddable_examples/public/multi_task_todo/multi_task_todo_embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/multi_task_todo/multi_task_todo_embeddable_factory.ts
+++ b/examples/embeddable_examples/public/multi_task_todo/multi_task_todo_embeddable_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/plugin.ts
+++ b/examples/embeddable_examples/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/searchable_list_container/index.ts
+++ b/examples/embeddable_examples/public/searchable_list_container/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/searchable_list_container/searchable_list_container.tsx
+++ b/examples/embeddable_examples/public/searchable_list_container/searchable_list_container.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/searchable_list_container/searchable_list_container_component.tsx
+++ b/examples/embeddable_examples/public/searchable_list_container/searchable_list_container_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/searchable_list_container/searchable_list_container_factory.ts
+++ b/examples/embeddable_examples/public/searchable_list_container/searchable_list_container_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/todo/index.ts
+++ b/examples/embeddable_examples/public/todo/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/todo/todo_component.tsx
+++ b/examples/embeddable_examples/public/todo/todo_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/todo/todo_embeddable.tsx
+++ b/examples/embeddable_examples/public/todo/todo_embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/todo/todo_embeddable_factory.tsx
+++ b/examples/embeddable_examples/public/todo/todo_embeddable_factory.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/todo/todo_ref_component.tsx
+++ b/examples/embeddable_examples/public/todo/todo_ref_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/todo/todo_ref_embeddable.tsx
+++ b/examples/embeddable_examples/public/todo/todo_ref_embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/public/todo/todo_ref_embeddable_factory.tsx
+++ b/examples/embeddable_examples/public/todo/todo_ref_embeddable_factory.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/server/book_saved_object.ts
+++ b/examples/embeddable_examples/server/book_saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/server/index.ts
+++ b/examples/embeddable_examples/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/server/plugin.ts
+++ b/examples/embeddable_examples/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_examples/server/todo_saved_object.ts
+++ b/examples/embeddable_examples/server/todo_saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_explorer/public/app.tsx
+++ b/examples/embeddable_explorer/public/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_explorer/public/embeddable_panel_example.tsx
+++ b/examples/embeddable_explorer/public/embeddable_panel_example.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_explorer/public/hello_world_embeddable_example.tsx
+++ b/examples/embeddable_explorer/public/hello_world_embeddable_example.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_explorer/public/index.ts
+++ b/examples/embeddable_explorer/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_explorer/public/list_container_example.tsx
+++ b/examples/embeddable_explorer/public/list_container_example.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_explorer/public/plugin.tsx
+++ b/examples/embeddable_explorer/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/embeddable_explorer/public/todo_embeddable_example.tsx
+++ b/examples/embeddable_explorer/public/todo_embeddable_example.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/common/index.ts
+++ b/examples/routing_example/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/public/app.tsx
+++ b/examples/routing_example/public/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/public/get_message_example.tsx
+++ b/examples/routing_example/public/get_message_example.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/public/index.ts
+++ b/examples/routing_example/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/public/is_error.ts
+++ b/examples/routing_example/public/is_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/public/plugin.tsx
+++ b/examples/routing_example/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/public/post_message_example.tsx
+++ b/examples/routing_example/public/post_message_example.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/public/random_number_between_example.tsx
+++ b/examples/routing_example/public/random_number_between_example.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/public/random_number_example.tsx
+++ b/examples/routing_example/public/random_number_example.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/public/services.ts
+++ b/examples/routing_example/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/server/index.ts
+++ b/examples/routing_example/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/server/plugin.ts
+++ b/examples/routing_example/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/server/routes/index.ts
+++ b/examples/routing_example/server/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/server/routes/message_routes.ts
+++ b/examples/routing_example/server/routes/message_routes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/server/routes/random_number_between_generator.ts
+++ b/examples/routing_example/server/routes/random_number_between_generator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/server/routes/random_number_generator.ts
+++ b/examples/routing_example/server/routes/random_number_generator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/routing_example/server/routes/register_routes.ts
+++ b/examples/routing_example/server/routes/register_routes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/common/index.ts
+++ b/examples/search_examples/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/public/application.tsx
+++ b/examples/search_examples/public/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/public/components/app.tsx
+++ b/examples/search_examples/public/components/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/public/index.ts
+++ b/examples/search_examples/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/public/plugin.ts
+++ b/examples/search_examples/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/public/types.ts
+++ b/examples/search_examples/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/server/index.ts
+++ b/examples/search_examples/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/server/my_strategy.ts
+++ b/examples/search_examples/server/my_strategy.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/server/plugin.ts
+++ b/examples/search_examples/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/server/routes/index.ts
+++ b/examples/search_examples/server/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/server/routes/register_routes.ts
+++ b/examples/search_examples/server/routes/register_routes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/server/routes/server_search_route.ts
+++ b/examples/search_examples/server/routes/server_search_route.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/search_examples/server/types.ts
+++ b/examples/search_examples/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/common/index.ts
+++ b/examples/state_containers_examples/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/public/index.ts
+++ b/examples/state_containers_examples/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/public/plugin.ts
+++ b/examples/state_containers_examples/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/public/todo/app.tsx
+++ b/examples/state_containers_examples/public/todo/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/public/todo/todo.tsx
+++ b/examples/state_containers_examples/public/todo/todo.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/public/with_data_services/application.tsx
+++ b/examples/state_containers_examples/public/with_data_services/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/public/with_data_services/components/app.tsx
+++ b/examples/state_containers_examples/public/with_data_services/components/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/public/with_data_services/types.ts
+++ b/examples/state_containers_examples/public/with_data_services/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/server/index.ts
+++ b/examples/state_containers_examples/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/server/plugin.ts
+++ b/examples/state_containers_examples/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/server/routes/index.ts
+++ b/examples/state_containers_examples/server/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/state_containers_examples/server/types.ts
+++ b/examples/state_containers_examples/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_action_examples/public/hello_world_action.tsx
+++ b/examples/ui_action_examples/public/hello_world_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_action_examples/public/hello_world_trigger.ts
+++ b/examples/ui_action_examples/public/hello_world_trigger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_action_examples/public/index.ts
+++ b/examples/ui_action_examples/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_action_examples/public/plugin.ts
+++ b/examples/ui_action_examples/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/actions/actions.tsx
+++ b/examples/ui_actions_explorer/public/actions/actions.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/app.tsx
+++ b/examples/ui_actions_explorer/public/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/context_menu_examples/context_menu_examples.tsx
+++ b/examples/ui_actions_explorer/public/context_menu_examples/context_menu_examples.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/context_menu_examples/index.tsx
+++ b/examples/ui_actions_explorer/public/context_menu_examples/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/context_menu_examples/panel_edit.tsx
+++ b/examples/ui_actions_explorer/public/context_menu_examples/panel_edit.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/context_menu_examples/panel_edit_with_drilldowns.tsx
+++ b/examples/ui_actions_explorer/public/context_menu_examples/panel_edit_with_drilldowns.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/context_menu_examples/panel_edit_with_drilldowns_and_context_actions.tsx
+++ b/examples/ui_actions_explorer/public/context_menu_examples/panel_edit_with_drilldowns_and_context_actions.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/context_menu_examples/panel_view.tsx
+++ b/examples/ui_actions_explorer/public/context_menu_examples/panel_view.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/context_menu_examples/panel_view_with_sharing.tsx
+++ b/examples/ui_actions_explorer/public/context_menu_examples/panel_view_with_sharing.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/context_menu_examples/panel_view_with_sharing_long.tsx
+++ b/examples/ui_actions_explorer/public/context_menu_examples/panel_view_with_sharing_long.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/context_menu_examples/util.ts
+++ b/examples/ui_actions_explorer/public/context_menu_examples/util.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/index.ts
+++ b/examples/ui_actions_explorer/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/page.tsx
+++ b/examples/ui_actions_explorer/public/page.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/plugin.tsx
+++ b/examples/ui_actions_explorer/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/ui_actions_explorer/public/trigger_context_example.tsx
+++ b/examples/ui_actions_explorer/public/trigger_context_example.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/url_generators_examples/public/app.tsx
+++ b/examples/url_generators_examples/public/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/url_generators_examples/public/index.ts
+++ b/examples/url_generators_examples/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/url_generators_examples/public/plugin.tsx
+++ b/examples/url_generators_examples/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/url_generators_examples/public/url_generator.ts
+++ b/examples/url_generators_examples/public/url_generator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/url_generators_explorer/public/app.tsx
+++ b/examples/url_generators_explorer/public/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/url_generators_explorer/public/index.ts
+++ b/examples/url_generators_explorer/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/url_generators_explorer/public/page.tsx
+++ b/examples/url_generators_explorer/public/page.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/examples/url_generators_explorer/public/plugin.tsx
+++ b/examples/url_generators_explorer/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/opensearch_dashboards.d.ts
+++ b/opensearch_dashboards.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/opensearch-datemath/__tests__/index.js
+++ b/packages/opensearch-datemath/__tests__/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/opensearch-datemath/index.d.ts
+++ b/packages/opensearch-datemath/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/opensearch-datemath/index.js
+++ b/packages/opensearch-datemath/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/scripts/build.js
+++ b/packages/osd-ace/scripts/build.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/src/ace/modes/index.ts
+++ b/packages/osd-ace/src/ace/modes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/src/ace/modes/lexer_rules/index.ts
+++ b/packages/osd-ace/src/ace/modes/lexer_rules/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/src/ace/modes/lexer_rules/opensearch_sql_highlight_rules.ts
+++ b/packages/osd-ace/src/ace/modes/lexer_rules/opensearch_sql_highlight_rules.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/src/ace/modes/lexer_rules/script_highlight_rules.ts
+++ b/packages/osd-ace/src/ace/modes/lexer_rules/script_highlight_rules.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/src/ace/modes/lexer_rules/x_json_highlight_rules.ts
+++ b/packages/osd-ace/src/ace/modes/lexer_rules/x_json_highlight_rules.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/src/ace/modes/x_json/index.ts
+++ b/packages/osd-ace/src/ace/modes/x_json/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/src/ace/modes/x_json/worker/index.ts
+++ b/packages/osd-ace/src/ace/modes/x_json/worker/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/src/ace/modes/x_json/worker/worker.d.ts
+++ b/packages/osd-ace/src/ace/modes/x_json/worker/worker.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/src/ace/modes/x_json/worker/x_json.ace.worker.js
+++ b/packages/osd-ace/src/ace/modes/x_json/worker/x_json.ace.worker.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/src/ace/modes/x_json/x_json.ts
+++ b/packages/osd-ace/src/ace/modes/x_json/x_json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ace/src/index.ts
+++ b/packages/osd-ace/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/babel.config.js
+++ b/packages/osd-analytics/babel.config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/scripts/build.js
+++ b/packages/osd-analytics/scripts/build.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/src/index.ts
+++ b/packages/osd-analytics/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/src/metrics/application_usage.ts
+++ b/packages/osd-analytics/src/metrics/application_usage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/src/metrics/index.ts
+++ b/packages/osd-analytics/src/metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/src/metrics/stats.ts
+++ b/packages/osd-analytics/src/metrics/stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/src/metrics/ui_stats.ts
+++ b/packages/osd-analytics/src/metrics/ui_stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/src/metrics/user_agent.ts
+++ b/packages/osd-analytics/src/metrics/user_agent.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/src/report.ts
+++ b/packages/osd-analytics/src/report.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/src/reporter.ts
+++ b/packages/osd-analytics/src/reporter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/src/storage.ts
+++ b/packages/osd-analytics/src/storage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-analytics/src/util.ts
+++ b/packages/osd-analytics/src/util.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/config.test.mocks.ts
+++ b/packages/osd-apm-config-loader/src/config.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/config.test.ts
+++ b/packages/osd-apm-config-loader/src/config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/config.ts
+++ b/packages/osd-apm-config-loader/src/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/config_loader.test.mocks.ts
+++ b/packages/osd-apm-config-loader/src/config_loader.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/config_loader.test.ts
+++ b/packages/osd-apm-config-loader/src/config_loader.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/config_loader.ts
+++ b/packages/osd-apm-config-loader/src/config_loader.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/index.ts
+++ b/packages/osd-apm-config-loader/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/types.ts
+++ b/packages/osd-apm-config-loader/src/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/utils/apply_config_overrides.test.ts
+++ b/packages/osd-apm-config-loader/src/utils/apply_config_overrides.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/utils/apply_config_overrides.ts
+++ b/packages/osd-apm-config-loader/src/utils/apply_config_overrides.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/utils/ensure_deep_object.test.ts
+++ b/packages/osd-apm-config-loader/src/utils/ensure_deep_object.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/utils/ensure_deep_object.ts
+++ b/packages/osd-apm-config-loader/src/utils/ensure_deep_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/utils/get_config_file_paths.test.ts
+++ b/packages/osd-apm-config-loader/src/utils/get_config_file_paths.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/utils/get_config_file_paths.ts
+++ b/packages/osd-apm-config-loader/src/utils/get_config_file_paths.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/utils/index.ts
+++ b/packages/osd-apm-config-loader/src/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/utils/read_argv.test.ts
+++ b/packages/osd-apm-config-loader/src/utils/read_argv.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/utils/read_argv.ts
+++ b/packages/osd-apm-config-loader/src/utils/read_argv.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/utils/read_config.test.ts
+++ b/packages/osd-apm-config-loader/src/utils/read_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-apm-config-loader/src/utils/read_config.ts
+++ b/packages/osd-apm-config-loader/src/utils/read_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-babel-preset/common_babel_parser_options.js
+++ b/packages/osd-babel-preset/common_babel_parser_options.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-babel-preset/common_preset.js
+++ b/packages/osd-babel-preset/common_preset.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-babel-preset/node_preset.js
+++ b/packages/osd-babel-preset/node_preset.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-babel-preset/webpack_preset.js
+++ b/packages/osd-babel-preset/webpack_preset.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/byte_size_value/index.test.ts
+++ b/packages/osd-config-schema/src/byte_size_value/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/byte_size_value/index.ts
+++ b/packages/osd-config-schema/src/byte_size_value/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/duration/index.ts
+++ b/packages/osd-config-schema/src/duration/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/errors/__snapshots__/schema_error.test.ts.snap
+++ b/packages/osd-config-schema/src/errors/__snapshots__/schema_error.test.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`includes stack 1`] = `
 "Error: test
-    at Object.<anonymous>.it (packages/osd-config-schema/src/errors/schema_error.test.ts:57:11)
+    at Object.<anonymous>.it (packages/osd-config-schema/src/errors/schema_error.test.ts:60:11)
     at new Promise (<anonymous>)"
 `;

--- a/packages/osd-config-schema/src/errors/index.ts
+++ b/packages/osd-config-schema/src/errors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/errors/schema_error.test.ts
+++ b/packages/osd-config-schema/src/errors/schema_error.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/errors/schema_error.ts
+++ b/packages/osd-config-schema/src/errors/schema_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/errors/schema_type_error.ts
+++ b/packages/osd-config-schema/src/errors/schema_type_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/errors/schema_types_error.ts
+++ b/packages/osd-config-schema/src/errors/schema_types_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/errors/validation_error.ts
+++ b/packages/osd-config-schema/src/errors/validation_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/index.ts
+++ b/packages/osd-config-schema/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/internals/index.ts
+++ b/packages/osd-config-schema/src/internals/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/references/context_reference.ts
+++ b/packages/osd-config-schema/src/references/context_reference.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/references/index.ts
+++ b/packages/osd-config-schema/src/references/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/references/reference.test.ts
+++ b/packages/osd-config-schema/src/references/reference.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/references/reference.ts
+++ b/packages/osd-config-schema/src/references/reference.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/references/sibling_reference.ts
+++ b/packages/osd-config-schema/src/references/sibling_reference.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/typeguards/index.ts
+++ b/packages/osd-config-schema/src/typeguards/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/typeguards/is_config_schema.test.ts
+++ b/packages/osd-config-schema/src/typeguards/is_config_schema.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/typeguards/is_config_schema.ts
+++ b/packages/osd-config-schema/src/typeguards/is_config_schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/any_type.test.ts
+++ b/packages/osd-config-schema/src/types/any_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/any_type.ts
+++ b/packages/osd-config-schema/src/types/any_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/array_type.test.ts
+++ b/packages/osd-config-schema/src/types/array_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/array_type.ts
+++ b/packages/osd-config-schema/src/types/array_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/boolean_type.test.ts
+++ b/packages/osd-config-schema/src/types/boolean_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/boolean_type.ts
+++ b/packages/osd-config-schema/src/types/boolean_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/buffer_type.test.ts
+++ b/packages/osd-config-schema/src/types/buffer_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/buffer_type.ts
+++ b/packages/osd-config-schema/src/types/buffer_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/byte_size_type.test.ts
+++ b/packages/osd-config-schema/src/types/byte_size_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/byte_size_type.ts
+++ b/packages/osd-config-schema/src/types/byte_size_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/conditional_type.test.ts
+++ b/packages/osd-config-schema/src/types/conditional_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/conditional_type.ts
+++ b/packages/osd-config-schema/src/types/conditional_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/duration_type.test.ts
+++ b/packages/osd-config-schema/src/types/duration_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/duration_type.ts
+++ b/packages/osd-config-schema/src/types/duration_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/index.ts
+++ b/packages/osd-config-schema/src/types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/ip_type.test.ts
+++ b/packages/osd-config-schema/src/types/ip_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/ip_type.ts
+++ b/packages/osd-config-schema/src/types/ip_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/literal_type.test.ts
+++ b/packages/osd-config-schema/src/types/literal_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/literal_type.ts
+++ b/packages/osd-config-schema/src/types/literal_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/map_of_type.test.ts
+++ b/packages/osd-config-schema/src/types/map_of_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/map_type.ts
+++ b/packages/osd-config-schema/src/types/map_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/maybe_type.test.ts
+++ b/packages/osd-config-schema/src/types/maybe_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/maybe_type.ts
+++ b/packages/osd-config-schema/src/types/maybe_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/never_type.test.ts
+++ b/packages/osd-config-schema/src/types/never_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/never_type.ts
+++ b/packages/osd-config-schema/src/types/never_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/nullable_type.test.ts
+++ b/packages/osd-config-schema/src/types/nullable_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/number_type.test.ts
+++ b/packages/osd-config-schema/src/types/number_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/number_type.ts
+++ b/packages/osd-config-schema/src/types/number_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/object_type.test.ts
+++ b/packages/osd-config-schema/src/types/object_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/object_type.ts
+++ b/packages/osd-config-schema/src/types/object_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/one_of_type.test.ts
+++ b/packages/osd-config-schema/src/types/one_of_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/record_of_type.test.ts
+++ b/packages/osd-config-schema/src/types/record_of_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/record_type.ts
+++ b/packages/osd-config-schema/src/types/record_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/stream_type.test.ts
+++ b/packages/osd-config-schema/src/types/stream_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/stream_type.ts
+++ b/packages/osd-config-schema/src/types/stream_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/string_type.test.ts
+++ b/packages/osd-config-schema/src/types/string_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/string_type.ts
+++ b/packages/osd-config-schema/src/types/string_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/type.ts
+++ b/packages/osd-config-schema/src/types/type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/union_type.ts
+++ b/packages/osd-config-schema/src/types/union_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/uri_type.test.ts
+++ b/packages/osd-config-schema/src/types/uri_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/src/types/uri_type.ts
+++ b/packages/osd-config-schema/src/types/uri_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config-schema/types/joi.d.ts
+++ b/packages/osd-config-schema/types/joi.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/__mocks__/env.ts
+++ b/packages/osd-config/src/__mocks__/env.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/apply_argv.test.ts
+++ b/packages/osd-config/src/apply_argv.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/config.mock.ts
+++ b/packages/osd-config/src/config.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/config.test.ts
+++ b/packages/osd-config/src/config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/config.ts
+++ b/packages/osd-config/src/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/config_service.mock.ts
+++ b/packages/osd-config/src/config_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/config_service.test.mocks.ts
+++ b/packages/osd-config/src/config_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/config_service.test.ts
+++ b/packages/osd-config/src/config_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/config_service.ts
+++ b/packages/osd-config/src/config_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/deprecation/apply_deprecations.test.ts
+++ b/packages/osd-config/src/deprecation/apply_deprecations.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/deprecation/apply_deprecations.ts
+++ b/packages/osd-config/src/deprecation/apply_deprecations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/deprecation/deprecation_factory.test.ts
+++ b/packages/osd-config/src/deprecation/deprecation_factory.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/deprecation/deprecation_factory.ts
+++ b/packages/osd-config/src/deprecation/deprecation_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/deprecation/index.ts
+++ b/packages/osd-config/src/deprecation/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/deprecation/types.ts
+++ b/packages/osd-config/src/deprecation/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/env.test.mocks.ts
+++ b/packages/osd-config/src/env.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/env.test.ts
+++ b/packages/osd-config/src/env.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/env.ts
+++ b/packages/osd-config/src/env.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/index.ts
+++ b/packages/osd-config/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/legacy/index.ts
+++ b/packages/osd-config/src/legacy/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/legacy/legacy_object_to_config_adapter.test.ts
+++ b/packages/osd-config/src/legacy/legacy_object_to_config_adapter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/legacy/legacy_object_to_config_adapter.ts
+++ b/packages/osd-config/src/legacy/legacy_object_to_config_adapter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/mocks.ts
+++ b/packages/osd-config/src/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/object_to_config_adapter.test.ts
+++ b/packages/osd-config/src/object_to_config_adapter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/object_to_config_adapter.ts
+++ b/packages/osd-config/src/object_to_config_adapter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/raw/ensure_deep_object.test.ts
+++ b/packages/osd-config/src/raw/ensure_deep_object.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/raw/ensure_deep_object.ts
+++ b/packages/osd-config/src/raw/ensure_deep_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/raw/index.ts
+++ b/packages/osd-config/src/raw/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/raw/raw_config_service.mock.ts
+++ b/packages/osd-config/src/raw/raw_config_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/raw/raw_config_service.test.mocks.ts
+++ b/packages/osd-config/src/raw/raw_config_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/raw/raw_config_service.test.ts
+++ b/packages/osd-config/src/raw/raw_config_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/raw/raw_config_service.ts
+++ b/packages/osd-config/src/raw/raw_config_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/raw/read_config.test.ts
+++ b/packages/osd-config/src/raw/read_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/raw/read_config.ts
+++ b/packages/osd-config/src/raw/read_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-config/src/types.ts
+++ b/packages/osd-config/src/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/axios/errors.ts
+++ b/packages/osd-dev-utils/src/axios/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/axios/index.ts
+++ b/packages/osd-dev-utils/src/axios/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/babel.ts
+++ b/packages/osd-dev-utils/src/babel.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/certs.ts
+++ b/packages/osd-dev-utils/src/certs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
+++ b/packages/osd-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/ci_stats_reporter/index.ts
+++ b/packages/osd-dev-utils/src/ci_stats_reporter/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/index.ts
+++ b/packages/osd-dev-utils/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/osd_client/index.ts
+++ b/packages/osd-dev-utils/src/osd_client/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/osd_client/osd_client.ts
+++ b/packages/osd-dev-utils/src/osd_client/osd_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/osd_client/osd_client_plugins.ts
+++ b/packages/osd-dev-utils/src/osd_client/osd_client_plugins.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/osd_client/osd_client_requester.ts
+++ b/packages/osd-dev-utils/src/osd_client/osd_client_requester.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/osd_client/osd_client_saved_objects.ts
+++ b/packages/osd-dev-utils/src/osd_client/osd_client_saved_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/osd_client/osd_client_status.ts
+++ b/packages/osd-dev-utils/src/osd_client/osd_client_status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/osd_client/osd_client_ui_settings.ts
+++ b/packages/osd-dev-utils/src/osd_client/osd_client_ui_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/osd_client/osd_client_version.ts
+++ b/packages/osd-dev-utils/src/osd_client/osd_client_version.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/parse_opensearch_dashboards_platform_plugin.ts
+++ b/packages/osd-dev-utils/src/parse_opensearch_dashboards_platform_plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/plugin_list/discover_plugins.ts
+++ b/packages/osd-dev-utils/src/plugin_list/discover_plugins.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/plugin_list/extract_asciidoc_info.test.ts
+++ b/packages/osd-dev-utils/src/plugin_list/extract_asciidoc_info.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/plugin_list/extract_asciidoc_info.ts
+++ b/packages/osd-dev-utils/src/plugin_list/extract_asciidoc_info.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/plugin_list/generate_plugin_list.ts
+++ b/packages/osd-dev-utils/src/plugin_list/generate_plugin_list.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/plugin_list/index.ts
+++ b/packages/osd-dev-utils/src/plugin_list/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/plugin_list/run_plugin_list_cli.ts
+++ b/packages/osd-dev-utils/src/plugin_list/run_plugin_list_cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/precommit_hook/cli.ts
+++ b/packages/osd-dev-utils/src/precommit_hook/cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/precommit_hook/get_git_dir.ts
+++ b/packages/osd-dev-utils/src/precommit_hook/get_git_dir.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/precommit_hook/script_source.ts
+++ b/packages/osd-dev-utils/src/precommit_hook/script_source.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/proc_runner/errors.ts
+++ b/packages/osd-dev-utils/src/proc_runner/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/proc_runner/index.ts
+++ b/packages/osd-dev-utils/src/proc_runner/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/proc_runner/proc.ts
+++ b/packages/osd-dev-utils/src/proc_runner/proc.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/proc_runner/proc_runner.ts
+++ b/packages/osd-dev-utils/src/proc_runner/proc_runner.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/proc_runner/with_proc_runner.test.ts
+++ b/packages/osd-dev-utils/src/proc_runner/with_proc_runner.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/proc_runner/with_proc_runner.ts
+++ b/packages/osd-dev-utils/src/proc_runner/with_proc_runner.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/run/cleanup.ts
+++ b/packages/osd-dev-utils/src/run/cleanup.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/run/fail.ts
+++ b/packages/osd-dev-utils/src/run/fail.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/run/flags.test.ts
+++ b/packages/osd-dev-utils/src/run/flags.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/run/flags.ts
+++ b/packages/osd-dev-utils/src/run/flags.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/run/help.test.ts
+++ b/packages/osd-dev-utils/src/run/help.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/run/help.ts
+++ b/packages/osd-dev-utils/src/run/help.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/run/index.ts
+++ b/packages/osd-dev-utils/src/run/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/run/run.ts
+++ b/packages/osd-dev-utils/src/run/run.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/run/run_with_commands.test.ts
+++ b/packages/osd-dev-utils/src/run/run_with_commands.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/run/run_with_commands.ts
+++ b/packages/osd-dev-utils/src/run/run_with_commands.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/serializers/absolute_path_serializer.ts
+++ b/packages/osd-dev-utils/src/serializers/absolute_path_serializer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/serializers/any_instance_serizlizer.ts
+++ b/packages/osd-dev-utils/src/serializers/any_instance_serizlizer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/serializers/index.ts
+++ b/packages/osd-dev-utils/src/serializers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/serializers/recursive_serializer.ts
+++ b/packages/osd-dev-utils/src/serializers/recursive_serializer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/serializers/replace_serializer.ts
+++ b/packages/osd-dev-utils/src/serializers/replace_serializer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/serializers/strip_ansi_serializer.ts
+++ b/packages/osd-dev-utils/src/serializers/strip_ansi_serializer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/simple_opensearch_dashboards_platform_plugin_discovery.ts
+++ b/packages/osd-dev-utils/src/simple_opensearch_dashboards_platform_plugin_discovery.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/stdio/index.ts
+++ b/packages/osd-dev-utils/src/stdio/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/stdio/observe_lines.ts
+++ b/packages/osd-dev-utils/src/stdio/observe_lines.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/stdio/observe_readable.ts
+++ b/packages/osd-dev-utils/src/stdio/observe_readable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/streams.ts
+++ b/packages/osd-dev-utils/src/streams.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/tooling_log/index.ts
+++ b/packages/osd-dev-utils/src/tooling_log/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/tooling_log/log_levels.test.ts
+++ b/packages/osd-dev-utils/src/tooling_log/log_levels.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/tooling_log/log_levels.ts
+++ b/packages/osd-dev-utils/src/tooling_log/log_levels.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/tooling_log/message.ts
+++ b/packages/osd-dev-utils/src/tooling_log/message.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/tooling_log/tooling_log.test.ts
+++ b/packages/osd-dev-utils/src/tooling_log/tooling_log.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/tooling_log/tooling_log.ts
+++ b/packages/osd-dev-utils/src/tooling_log/tooling_log.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/tooling_log/tooling_log_collecting_writer.ts
+++ b/packages/osd-dev-utils/src/tooling_log/tooling_log_collecting_writer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/tooling_log/tooling_log_text_writer.test.ts
+++ b/packages/osd-dev-utils/src/tooling_log/tooling_log_text_writer.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/tooling_log/tooling_log_text_writer.ts
+++ b/packages/osd-dev-utils/src/tooling_log/tooling_log_text_writer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-dev-utils/src/tooling_log/writer.ts
+++ b/packages/osd-dev-utils/src/tooling_log/writer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-import-resolver-opensearch-dashboards/import_resolver_opensearch_dashboards.js
+++ b/packages/osd-eslint-import-resolver-opensearch-dashboards/import_resolver_opensearch_dashboards.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/debug.js
+++ b/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/debug.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/get_is_path_request.js
+++ b/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/get_is_path_request.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/get_opensearch_dashboards_path.js
+++ b/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/get_opensearch_dashboards_path.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/get_path_type.js
+++ b/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/get_path_type.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/get_project_root.js
+++ b/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/get_project_root.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/get_webpack_config.js
+++ b/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/get_webpack_config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/index.js
+++ b/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/resolve_webpack_alias.js
+++ b/packages/osd-eslint-import-resolver-opensearch-dashboards/lib/resolve_webpack_alias.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-plugin-eslint/index.js
+++ b/packages/osd-eslint-plugin-eslint/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-plugin-eslint/lib.js
+++ b/packages/osd-eslint-plugin-eslint/lib.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-plugin-eslint/rules/__tests__/disallow_license_headers.js
+++ b/packages/osd-eslint-plugin-eslint/rules/__tests__/disallow_license_headers.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-plugin-eslint/rules/__tests__/require_license_header.js
+++ b/packages/osd-eslint-plugin-eslint/rules/__tests__/require_license_header.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-plugin-eslint/rules/disallow_license_headers.js
+++ b/packages/osd-eslint-plugin-eslint/rules/disallow_license_headers.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-plugin-eslint/rules/module_migration.js
+++ b/packages/osd-eslint-plugin-eslint/rules/module_migration.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-eslint-plugin-eslint/rules/require_license_header.js
+++ b/packages/osd-eslint-plugin-eslint/rules/require_license_header.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/babel.config.js
+++ b/packages/osd-i18n/babel.config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/scripts/build.js
+++ b/packages/osd-i18n/scripts/build.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/angular/directive.test.ts
+++ b/packages/osd-i18n/src/angular/directive.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/angular/directive.ts
+++ b/packages/osd-i18n/src/angular/directive.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/angular/filter.test.ts
+++ b/packages/osd-i18n/src/angular/filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/angular/filter.ts
+++ b/packages/osd-i18n/src/angular/filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/angular/index.ts
+++ b/packages/osd-i18n/src/angular/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/angular/provider.test.ts
+++ b/packages/osd-i18n/src/angular/provider.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/angular/provider.ts
+++ b/packages/osd-i18n/src/angular/provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/browser.ts
+++ b/packages/osd-i18n/src/browser.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/core/formats.ts
+++ b/packages/osd-i18n/src/core/formats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/core/helper.test.ts
+++ b/packages/osd-i18n/src/core/helper.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/core/helper.ts
+++ b/packages/osd-i18n/src/core/helper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/core/i18n.test.ts
+++ b/packages/osd-i18n/src/core/i18n.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/core/i18n.ts
+++ b/packages/osd-i18n/src/core/i18n.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/core/index.ts
+++ b/packages/osd-i18n/src/core/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/core/pseudo_locale.test.ts
+++ b/packages/osd-i18n/src/core/pseudo_locale.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/core/pseudo_locale.ts
+++ b/packages/osd-i18n/src/core/pseudo_locale.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/index.ts
+++ b/packages/osd-i18n/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/loader.test.ts
+++ b/packages/osd-i18n/src/loader.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/loader.ts
+++ b/packages/osd-i18n/src/loader.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/react/index.tsx
+++ b/packages/osd-i18n/src/react/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/react/inject.tsx
+++ b/packages/osd-i18n/src/react/inject.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/react/provider.test.tsx
+++ b/packages/osd-i18n/src/react/provider.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/react/provider.tsx
+++ b/packages/osd-i18n/src/react/provider.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/react/pseudo_locale_wrapper.tsx
+++ b/packages/osd-i18n/src/react/pseudo_locale_wrapper.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/src/translation.ts
+++ b/packages/osd-i18n/src/translation.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/types/intl_format_cache.d.ts
+++ b/packages/osd-i18n/types/intl_format_cache.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-i18n/types/intl_relativeformat.d.ts
+++ b/packages/osd-i18n/types/intl_relativeformat.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/scripts/build.js
+++ b/packages/osd-interpreter/scripts/build.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/index.d.ts
+++ b/packages/osd-interpreter/src/common/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/index.js
+++ b/packages/osd-interpreter/src/common/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/arg.js
+++ b/packages/osd-interpreter/src/common/lib/arg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/arg.test.js
+++ b/packages/osd-interpreter/src/common/lib/arg.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/ast.d.ts
+++ b/packages/osd-interpreter/src/common/lib/ast.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/ast.from_expression.test.js
+++ b/packages/osd-interpreter/src/common/lib/ast.from_expression.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/ast.js
+++ b/packages/osd-interpreter/src/common/lib/ast.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/ast.to_expression.test.js
+++ b/packages/osd-interpreter/src/common/lib/ast.to_expression.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/cast.js
+++ b/packages/osd-interpreter/src/common/lib/cast.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/fn.js
+++ b/packages/osd-interpreter/src/common/lib/fn.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/get_by_alias.js
+++ b/packages/osd-interpreter/src/common/lib/get_by_alias.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/get_by_alias.test.js
+++ b/packages/osd-interpreter/src/common/lib/get_by_alias.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/get_type.d.ts
+++ b/packages/osd-interpreter/src/common/lib/get_type.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/get_type.js
+++ b/packages/osd-interpreter/src/common/lib/get_type.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/registry.d.ts
+++ b/packages/osd-interpreter/src/common/lib/registry.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/registry.js
+++ b/packages/osd-interpreter/src/common/lib/registry.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/lib/registry.test.js
+++ b/packages/osd-interpreter/src/common/lib/registry.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/src/common/registries.js
+++ b/packages/osd-interpreter/src/common/registries.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/tasks/build/cli.js
+++ b/packages/osd-interpreter/tasks/build/cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-interpreter/tasks/build/paths.js
+++ b/packages/osd-interpreter/tasks/build/paths.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-logging/src/appenders.ts
+++ b/packages/osd-logging/src/appenders.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-logging/src/index.ts
+++ b/packages/osd-logging/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-logging/src/layout.ts
+++ b/packages/osd-logging/src/layout.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-logging/src/log_level.test.ts
+++ b/packages/osd-logging/src/log_level.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-logging/src/log_level.ts
+++ b/packages/osd-logging/src/log_level.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-logging/src/log_record.ts
+++ b/packages/osd-logging/src/log_record.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-logging/src/logger.ts
+++ b/packages/osd-logging/src/logger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-logging/src/logger_factory.ts
+++ b/packages/osd-logging/src/logger_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-logging/src/mocks/index.ts
+++ b/packages/osd-logging/src/mocks/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-logging/src/mocks/logger.mock.ts
+++ b/packages/osd-logging/src/mocks/logger.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/scripts/build.js
+++ b/packages/osd-monaco/scripts/build.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/index.ts
+++ b/packages/osd-monaco/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/monaco.ts
+++ b/packages/osd-monaco/src/monaco.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/constants.ts
+++ b/packages/osd-monaco/src/xjson/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/grammar.ts
+++ b/packages/osd-monaco/src/xjson/grammar.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/index.ts
+++ b/packages/osd-monaco/src/xjson/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/language.ts
+++ b/packages/osd-monaco/src/xjson/language.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/lexer_rules/index.ts
+++ b/packages/osd-monaco/src/xjson/lexer_rules/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/lexer_rules/opensearchql.ts
+++ b/packages/osd-monaco/src/xjson/lexer_rules/opensearchql.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/lexer_rules/painless.ts
+++ b/packages/osd-monaco/src/xjson/lexer_rules/painless.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/lexer_rules/shared.ts
+++ b/packages/osd-monaco/src/xjson/lexer_rules/shared.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/lexer_rules/xjson.ts
+++ b/packages/osd-monaco/src/xjson/lexer_rules/xjson.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/worker/index.ts
+++ b/packages/osd-monaco/src/xjson/worker/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/worker/xjson.worker.ts
+++ b/packages/osd-monaco/src/xjson/worker/xjson.worker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/worker/xjson_worker.ts
+++ b/packages/osd-monaco/src/xjson/worker/xjson_worker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/src/xjson/worker_proxy_service.ts
+++ b/packages/osd-monaco/src/xjson/worker_proxy_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-monaco/webpack.config.js
+++ b/packages/osd-monaco/webpack.config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/actions/edit.ts
+++ b/packages/osd-opensearch-archiver/src/actions/edit.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/actions/empty_opensearch_dashboards_index.ts
+++ b/packages/osd-opensearch-archiver/src/actions/empty_opensearch_dashboards_index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/actions/index.ts
+++ b/packages/osd-opensearch-archiver/src/actions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/actions/load.ts
+++ b/packages/osd-opensearch-archiver/src/actions/load.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/actions/rebuild_all.ts
+++ b/packages/osd-opensearch-archiver/src/actions/rebuild_all.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/actions/save.ts
+++ b/packages/osd-opensearch-archiver/src/actions/save.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/actions/unload.ts
+++ b/packages/osd-opensearch-archiver/src/actions/unload.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/cli.ts
+++ b/packages/osd-opensearch-archiver/src/cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/index.ts
+++ b/packages/osd-opensearch-archiver/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/__tests__/stats.ts
+++ b/packages/osd-opensearch-archiver/src/lib/__tests__/stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/archives/__tests__/format.ts
+++ b/packages/osd-opensearch-archiver/src/lib/archives/__tests__/format.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/archives/__tests__/parse.ts
+++ b/packages/osd-opensearch-archiver/src/lib/archives/__tests__/parse.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/archives/constants.ts
+++ b/packages/osd-opensearch-archiver/src/lib/archives/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/archives/filenames.ts
+++ b/packages/osd-opensearch-archiver/src/lib/archives/filenames.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/archives/format.ts
+++ b/packages/osd-opensearch-archiver/src/lib/archives/format.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/archives/index.ts
+++ b/packages/osd-opensearch-archiver/src/lib/archives/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/archives/parse.ts
+++ b/packages/osd-opensearch-archiver/src/lib/archives/parse.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/directory.ts
+++ b/packages/osd-opensearch-archiver/src/lib/directory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/docs/__tests__/generate_doc_records_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/docs/__tests__/generate_doc_records_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/docs/__tests__/index_doc_records_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/docs/__tests__/index_doc_records_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/docs/__tests__/stubs.ts
+++ b/packages/osd-opensearch-archiver/src/lib/docs/__tests__/stubs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/docs/generate_doc_records_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/docs/generate_doc_records_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/docs/index.ts
+++ b/packages/osd-opensearch-archiver/src/lib/docs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/docs/index_doc_records_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/docs/index_doc_records_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/index.ts
+++ b/packages/osd-opensearch-archiver/src/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/indices/__tests__/create_index_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/__tests__/create_index_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/indices/__tests__/delete_index_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/__tests__/delete_index_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/indices/__tests__/generate_index_records_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/__tests__/generate_index_records_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/indices/__tests__/stubs.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/__tests__/stubs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/indices/create_index_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/create_index_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/indices/delete_index.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/delete_index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/indices/delete_index_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/delete_index_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/indices/generate_index_records_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/generate_index_records_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/indices/index.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/indices/opensearch_dashboards_index.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/opensearch_dashboards_index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/progress.ts
+++ b/packages/osd-opensearch-archiver/src/lib/progress.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/records/__tests__/filter_records_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/records/__tests__/filter_records_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/records/filter_records_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/records/filter_records_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/records/index.ts
+++ b/packages/osd-opensearch-archiver/src/lib/records/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/stats.ts
+++ b/packages/osd-opensearch-archiver/src/lib/stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/concat_stream.test.js
+++ b/packages/osd-opensearch-archiver/src/lib/streams/concat_stream.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/concat_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/concat_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/concat_stream_providers.test.js
+++ b/packages/osd-opensearch-archiver/src/lib/streams/concat_stream_providers.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/concat_stream_providers.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/concat_stream_providers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/filter_stream.test.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/filter_stream.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/filter_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/filter_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/index.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/intersperse_stream.test.js
+++ b/packages/osd-opensearch-archiver/src/lib/streams/intersperse_stream.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/intersperse_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/intersperse_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/list_stream.test.js
+++ b/packages/osd-opensearch-archiver/src/lib/streams/list_stream.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/list_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/list_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/map_stream.test.js
+++ b/packages/osd-opensearch-archiver/src/lib/streams/map_stream.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/map_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/map_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/promise_from_streams.test.js
+++ b/packages/osd-opensearch-archiver/src/lib/streams/promise_from_streams.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/promise_from_streams.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/promise_from_streams.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/reduce_stream.test.js
+++ b/packages/osd-opensearch-archiver/src/lib/streams/reduce_stream.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/reduce_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/reduce_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/replace_stream.test.js
+++ b/packages/osd-opensearch-archiver/src/lib/streams/replace_stream.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/replace_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/replace_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/split_stream.test.js
+++ b/packages/osd-opensearch-archiver/src/lib/streams/split_stream.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/lib/streams/split_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/streams/split_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch-archiver/src/opensearch_archiver.ts
+++ b/packages/osd-opensearch-archiver/src/opensearch_archiver.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/scripts/build.js
+++ b/packages/osd-opensearch/scripts/build.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/artifact.js
+++ b/packages/osd-opensearch/src/artifact.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/artifact.test.js
+++ b/packages/osd-opensearch/src/artifact.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/cli.js
+++ b/packages/osd-opensearch/src/cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/cli_commands/archive.js
+++ b/packages/osd-opensearch/src/cli_commands/archive.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/cli_commands/build_snapshots.js
+++ b/packages/osd-opensearch/src/cli_commands/build_snapshots.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/cli_commands/index.js
+++ b/packages/osd-opensearch/src/cli_commands/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/cli_commands/snapshot.js
+++ b/packages/osd-opensearch/src/cli_commands/snapshot.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/cli_commands/source.js
+++ b/packages/osd-opensearch/src/cli_commands/source.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/cluster.js
+++ b/packages/osd-opensearch/src/cluster.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/custom_snapshots.js
+++ b/packages/osd-opensearch/src/custom_snapshots.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/errors.js
+++ b/packages/osd-opensearch/src/errors.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/index.js
+++ b/packages/osd-opensearch/src/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/install/archive.js
+++ b/packages/osd-opensearch/src/install/archive.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/install/index.js
+++ b/packages/osd-opensearch/src/install/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/install/snapshot.js
+++ b/packages/osd-opensearch/src/install/snapshot.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/install/source.js
+++ b/packages/osd-opensearch/src/install/source.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/integration_tests/__fixtures__/opensearch_bin.js
+++ b/packages/osd-opensearch/src/integration_tests/__fixtures__/opensearch_bin.js
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/integration_tests/cluster.test.js
+++ b/packages/osd-opensearch/src/integration_tests/cluster.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/paths.js
+++ b/packages/osd-opensearch/src/paths.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/settings.test.ts
+++ b/packages/osd-opensearch/src/settings.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/settings.ts
+++ b/packages/osd-opensearch/src/settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/build_snapshot.js
+++ b/packages/osd-opensearch/src/utils/build_snapshot.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/cache.js
+++ b/packages/osd-opensearch/src/utils/cache.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/decompress.js
+++ b/packages/osd-opensearch/src/utils/decompress.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/decompress.test.js
+++ b/packages/osd-opensearch/src/utils/decompress.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/extract_config_files.js
+++ b/packages/osd-opensearch/src/utils/extract_config_files.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/extract_config_files.test.js
+++ b/packages/osd-opensearch/src/utils/extract_config_files.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/find_most_recently_changed.js
+++ b/packages/osd-opensearch/src/utils/find_most_recently_changed.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/find_most_recently_changed.test.js
+++ b/packages/osd-opensearch/src/utils/find_most_recently_changed.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/index.js
+++ b/packages/osd-opensearch/src/utils/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/log.js
+++ b/packages/osd-opensearch/src/utils/log.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/native_realm.js
+++ b/packages/osd-opensearch/src/utils/native_realm.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/native_realm.test.js
+++ b/packages/osd-opensearch/src/utils/native_realm.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/parse_opensearch_log.js
+++ b/packages/osd-opensearch/src/utils/parse_opensearch_log.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-opensearch/src/utils/parse_opensearch_log.test.js
+++ b/packages/osd-opensearch/src/utils/parse_opensearch_log.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/babel.config.js
+++ b/packages/osd-optimizer/babel.config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/index.d.ts
+++ b/packages/osd-optimizer/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/postcss.config.js
+++ b/packages/osd-optimizer/postcss.config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/bar/public/index.ts
+++ b/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/bar/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/bar/public/lib.ts
+++ b/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/bar/public/lib.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/foo/public/async_import.ts
+++ b/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/foo/public/async_import.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/foo/public/ext.ts
+++ b/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/foo/public/ext.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/foo/public/index.ts
+++ b/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/foo/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/foo/public/lib.ts
+++ b/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/foo/public/lib.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/nested/baz/server/index.ts
+++ b/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/nested/baz/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/nested/baz/server/lib.ts
+++ b/packages/osd-optimizer/src/__fixtures__/mock_repo/plugins/nested/baz/server/lib.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/__fixtures__/mock_repo/test_plugins/test_baz/server/index.ts
+++ b/packages/osd-optimizer/src/__fixtures__/mock_repo/test_plugins/test_baz/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/__fixtures__/mock_repo/test_plugins/test_baz/server/lib.ts
+++ b/packages/osd-optimizer/src/__fixtures__/mock_repo/test_plugins/test_baz/server/lib.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/cli.ts
+++ b/packages/osd-optimizer/src/cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/array_helpers.test.ts
+++ b/packages/osd-optimizer/src/common/array_helpers.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/array_helpers.ts
+++ b/packages/osd-optimizer/src/common/array_helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/bundle.test.ts
+++ b/packages/osd-optimizer/src/common/bundle.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/bundle.ts
+++ b/packages/osd-optimizer/src/common/bundle.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/bundle_cache.test.ts
+++ b/packages/osd-optimizer/src/common/bundle_cache.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/bundle_cache.ts
+++ b/packages/osd-optimizer/src/common/bundle_cache.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/bundle_refs.ts
+++ b/packages/osd-optimizer/src/common/bundle_refs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/compiler_messages.ts
+++ b/packages/osd-optimizer/src/common/compiler_messages.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/event_stream_helpers.test.ts
+++ b/packages/osd-optimizer/src/common/event_stream_helpers.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/event_stream_helpers.ts
+++ b/packages/osd-optimizer/src/common/event_stream_helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/index.ts
+++ b/packages/osd-optimizer/src/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/parse_path.test.ts
+++ b/packages/osd-optimizer/src/common/parse_path.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/parse_path.ts
+++ b/packages/osd-optimizer/src/common/parse_path.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/rxjs_helpers.test.ts
+++ b/packages/osd-optimizer/src/common/rxjs_helpers.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/rxjs_helpers.ts
+++ b/packages/osd-optimizer/src/common/rxjs_helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/theme_tags.test.ts
+++ b/packages/osd-optimizer/src/common/theme_tags.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/theme_tags.ts
+++ b/packages/osd-optimizer/src/common/theme_tags.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/ts_helpers.ts
+++ b/packages/osd-optimizer/src/common/ts_helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/worker_config.ts
+++ b/packages/osd-optimizer/src/common/worker_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/common/worker_messages.ts
+++ b/packages/osd-optimizer/src/common/worker_messages.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/index.ts
+++ b/packages/osd-optimizer/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/integration_tests/basic_optimization.test.ts
+++ b/packages/osd-optimizer/src/integration_tests/basic_optimization.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/integration_tests/bundle_cache.test.ts
+++ b/packages/osd-optimizer/src/integration_tests/bundle_cache.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/integration_tests/watch_bundles_for_changes.test.ts
+++ b/packages/osd-optimizer/src/integration_tests/watch_bundles_for_changes.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/limits.ts
+++ b/packages/osd-optimizer/src/limits.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/log_optimizer_state.ts
+++ b/packages/osd-optimizer/src/log_optimizer_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/node/cache.ts
+++ b/packages/osd-optimizer/src/node/cache.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/node/index.ts
+++ b/packages/osd-optimizer/src/node/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/node/polyfill.ts
+++ b/packages/osd-optimizer/src/node/polyfill.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/assign_bundles_to_workers.test.ts
+++ b/packages/osd-optimizer/src/optimizer/assign_bundles_to_workers.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/assign_bundles_to_workers.ts
+++ b/packages/osd-optimizer/src/optimizer/assign_bundles_to_workers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/bundle_cache.ts
+++ b/packages/osd-optimizer/src/optimizer/bundle_cache.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/cache_keys.test.ts
+++ b/packages/osd-optimizer/src/optimizer/cache_keys.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/cache_keys.ts
+++ b/packages/osd-optimizer/src/optimizer/cache_keys.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/filter_by_id.test.ts
+++ b/packages/osd-optimizer/src/optimizer/filter_by_id.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/filter_by_id.ts
+++ b/packages/osd-optimizer/src/optimizer/filter_by_id.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/get_changes.test.ts
+++ b/packages/osd-optimizer/src/optimizer/get_changes.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/get_changes.ts
+++ b/packages/osd-optimizer/src/optimizer/get_changes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/get_mtimes.test.ts
+++ b/packages/osd-optimizer/src/optimizer/get_mtimes.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/get_mtimes.ts
+++ b/packages/osd-optimizer/src/optimizer/get_mtimes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/get_output_stats.ts
+++ b/packages/osd-optimizer/src/optimizer/get_output_stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/get_plugin_bundles.test.ts
+++ b/packages/osd-optimizer/src/optimizer/get_plugin_bundles.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/get_plugin_bundles.ts
+++ b/packages/osd-optimizer/src/optimizer/get_plugin_bundles.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/handle_optimizer_completion.test.ts
+++ b/packages/osd-optimizer/src/optimizer/handle_optimizer_completion.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/handle_optimizer_completion.ts
+++ b/packages/osd-optimizer/src/optimizer/handle_optimizer_completion.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/index.ts
+++ b/packages/osd-optimizer/src/optimizer/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/observe_stdio.test.ts
+++ b/packages/osd-optimizer/src/optimizer/observe_stdio.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/observe_stdio.ts
+++ b/packages/osd-optimizer/src/optimizer/observe_stdio.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/observe_worker.ts
+++ b/packages/osd-optimizer/src/optimizer/observe_worker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/opensearch_dashboards_platform_plugins.test.ts
+++ b/packages/osd-optimizer/src/optimizer/opensearch_dashboards_platform_plugins.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/opensearch_dashboards_platform_plugins.ts
+++ b/packages/osd-optimizer/src/optimizer/opensearch_dashboards_platform_plugins.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/optimizer_config.test.ts
+++ b/packages/osd-optimizer/src/optimizer/optimizer_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/optimizer_config.ts
+++ b/packages/osd-optimizer/src/optimizer/optimizer_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/optimizer_state.ts
+++ b/packages/osd-optimizer/src/optimizer/optimizer_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/run_workers.ts
+++ b/packages/osd-optimizer/src/optimizer/run_workers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/watch_bundles_for_changes.ts
+++ b/packages/osd-optimizer/src/optimizer/watch_bundles_for_changes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/optimizer/watcher.ts
+++ b/packages/osd-optimizer/src/optimizer/watcher.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/report_optimizer_stats.ts
+++ b/packages/osd-optimizer/src/report_optimizer_stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/run_optimizer.ts
+++ b/packages/osd-optimizer/src/run_optimizer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/worker/entry_point_creator.ts
+++ b/packages/osd-optimizer/src/worker/entry_point_creator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/worker/run_compilers.ts
+++ b/packages/osd-optimizer/src/worker/run_compilers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/worker/run_worker.ts
+++ b/packages/osd-optimizer/src/worker/run_worker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/worker/theme_loader.ts
+++ b/packages/osd-optimizer/src/worker/theme_loader.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/worker/webpack.config.ts
+++ b/packages/osd-optimizer/src/worker/webpack.config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-optimizer/src/worker/webpack_helpers.ts
+++ b/packages/osd-optimizer/src/worker/webpack_helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-generator/scripts/build.js
+++ b/packages/osd-plugin-generator/scripts/build.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-generator/src/ask_questions.ts
+++ b/packages/osd-plugin-generator/src/ask_questions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-generator/src/casing.test.ts
+++ b/packages/osd-plugin-generator/src/casing.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-generator/src/casing.ts
+++ b/packages/osd-plugin-generator/src/casing.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-generator/src/cli.ts
+++ b/packages/osd-plugin-generator/src/cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-generator/src/index.ts
+++ b/packages/osd-plugin-generator/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-generator/src/integration_tests/generate_plugin.test.ts
+++ b/packages/osd-plugin-generator/src/integration_tests/generate_plugin.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-generator/src/plugin_types.ts
+++ b/packages/osd-plugin-generator/src/plugin_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-generator/src/render_template.ts
+++ b/packages/osd-plugin-generator/src/render_template.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/build_context.ts
+++ b/packages/osd-plugin-helpers/src/build_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/cli.ts
+++ b/packages/osd-plugin-helpers/src/cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/config.ts
+++ b/packages/osd-plugin-helpers/src/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/find_opensearch_dashboards_json.ts
+++ b/packages/osd-plugin-helpers/src/find_opensearch_dashboards_json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/index.ts
+++ b/packages/osd-plugin-helpers/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/integration_tests/build.test.ts
+++ b/packages/osd-plugin-helpers/src/integration_tests/build.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/load_opensearch_dashboards_platform_plugin.ts
+++ b/packages/osd-plugin-helpers/src/load_opensearch_dashboards_platform_plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/resolve_opensearch_dashboards_version.ts
+++ b/packages/osd-plugin-helpers/src/resolve_opensearch_dashboards_version.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/tasks/clean.ts
+++ b/packages/osd-plugin-helpers/src/tasks/clean.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/tasks/create_archive.ts
+++ b/packages/osd-plugin-helpers/src/tasks/create_archive.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/tasks/index.ts
+++ b/packages/osd-plugin-helpers/src/tasks/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/tasks/optimize.ts
+++ b/packages/osd-plugin-helpers/src/tasks/optimize.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/tasks/write_public_assets.ts
+++ b/packages/osd-plugin-helpers/src/tasks/write_public_assets.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/tasks/write_server_files.ts
+++ b/packages/osd-plugin-helpers/src/tasks/write_server_files.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-plugin-helpers/src/tasks/yarn_install.ts
+++ b/packages/osd-plugin-helpers/src/tasks/yarn_install.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/cli.js
+++ b/packages/osd-pm/cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/index.d.ts
+++ b/packages/osd-pm/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/cli.ts
+++ b/packages/osd-pm/src/cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/commands/bootstrap.ts
+++ b/packages/osd-pm/src/commands/bootstrap.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/commands/clean.ts
+++ b/packages/osd-pm/src/commands/clean.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/commands/index.ts
+++ b/packages/osd-pm/src/commands/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/commands/run.ts
+++ b/packages/osd-pm/src/commands/run.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/commands/watch.ts
+++ b/packages/osd-pm/src/commands/watch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/config.ts
+++ b/packages/osd-pm/src/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/index.ts
+++ b/packages/osd-pm/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/production/build_production_projects.ts
+++ b/packages/osd-pm/src/production/build_production_projects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/production/index.ts
+++ b/packages/osd-pm/src/production/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/run.test.ts
+++ b/packages/osd-pm/src/run.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/run.ts
+++ b/packages/osd-pm/src/run.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/test_helpers/absolute_path_snapshot_serializer.ts
+++ b/packages/osd-pm/src/test_helpers/absolute_path_snapshot_serializer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/test_helpers/index.ts
+++ b/packages/osd-pm/src/test_helpers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/test_helpers/strip_ansi_snapshot_serializer.ts
+++ b/packages/osd-pm/src/test_helpers/strip_ansi_snapshot_serializer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/bootstrap_cache_file.ts
+++ b/packages/osd-pm/src/utils/bootstrap_cache_file.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/child_process.ts
+++ b/packages/osd-pm/src/utils/child_process.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/errors.ts
+++ b/packages/osd-pm/src/utils/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/fs.ts
+++ b/packages/osd-pm/src/utils/fs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/link_project_executables.test.ts
+++ b/packages/osd-pm/src/utils/link_project_executables.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/link_project_executables.ts
+++ b/packages/osd-pm/src/utils/link_project_executables.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/log.ts
+++ b/packages/osd-pm/src/utils/log.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/opensearch_dashboards.ts
+++ b/packages/osd-pm/src/utils/opensearch_dashboards.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/package_json.ts
+++ b/packages/osd-pm/src/utils/package_json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/parallelize.test.ts
+++ b/packages/osd-pm/src/utils/parallelize.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/parallelize.ts
+++ b/packages/osd-pm/src/utils/parallelize.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/project.test.ts
+++ b/packages/osd-pm/src/utils/project.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/project.ts
+++ b/packages/osd-pm/src/utils/project.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/project_checksums.ts
+++ b/packages/osd-pm/src/utils/project_checksums.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/projects.test.ts
+++ b/packages/osd-pm/src/utils/projects.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/projects.ts
+++ b/packages/osd-pm/src/utils/projects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/projects_tree.test.ts
+++ b/packages/osd-pm/src/utils/projects_tree.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/projects_tree.ts
+++ b/packages/osd-pm/src/utils/projects_tree.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/scripts.ts
+++ b/packages/osd-pm/src/utils/scripts.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/validate_dependencies.ts
+++ b/packages/osd-pm/src/utils/validate_dependencies.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/watch.test.ts
+++ b/packages/osd-pm/src/utils/watch.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/watch.ts
+++ b/packages/osd-pm/src/utils/watch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/workspaces.ts
+++ b/packages/osd-pm/src/utils/workspaces.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/src/utils/yarn_lock.ts
+++ b/packages/osd-pm/src/utils/yarn_lock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-pm/webpack.config.js
+++ b/packages/osd-pm/webpack.config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/cli.ts
+++ b/packages/osd-release-notes/src/cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/formats/asciidoc.ts
+++ b/packages/osd-release-notes/src/formats/asciidoc.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/formats/csv.ts
+++ b/packages/osd-release-notes/src/formats/csv.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/formats/format.ts
+++ b/packages/osd-release-notes/src/formats/format.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/formats/index.ts
+++ b/packages/osd-release-notes/src/formats/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/index.ts
+++ b/packages/osd-release-notes/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/classify_pr.ts
+++ b/packages/osd-release-notes/src/lib/classify_pr.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/get_fix_references.test.ts
+++ b/packages/osd-release-notes/src/lib/get_fix_references.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/get_fix_references.ts
+++ b/packages/osd-release-notes/src/lib/get_fix_references.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/get_note_from_description.test.ts
+++ b/packages/osd-release-notes/src/lib/get_note_from_description.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/get_note_from_description.ts
+++ b/packages/osd-release-notes/src/lib/get_note_from_description.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/index.ts
+++ b/packages/osd-release-notes/src/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/irrelevant_pr_summary.ts
+++ b/packages/osd-release-notes/src/lib/irrelevant_pr_summary.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/is_pr_relevant.ts
+++ b/packages/osd-release-notes/src/lib/is_pr_relevant.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/pr_api.ts
+++ b/packages/osd-release-notes/src/lib/pr_api.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/streams.ts
+++ b/packages/osd-release-notes/src/lib/streams.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/type_helpers.ts
+++ b/packages/osd-release-notes/src/lib/type_helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/version.test.ts
+++ b/packages/osd-release-notes/src/lib/version.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/lib/version.ts
+++ b/packages/osd-release-notes/src/lib/version.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-release-notes/src/release_notes_config.ts
+++ b/packages/osd-release-notes/src/release_notes_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-spec-to-console/bin/spec_to_console.js
+++ b/packages/osd-spec-to-console/bin/spec_to_console.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-spec-to-console/index.js
+++ b/packages/osd-spec-to-console/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-spec-to-console/lib/convert.js
+++ b/packages/osd-spec-to-console/lib/convert.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-spec-to-console/lib/convert.test.js
+++ b/packages/osd-spec-to-console/lib/convert.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-spec-to-console/lib/convert/methods.js
+++ b/packages/osd-spec-to-console/lib/convert/methods.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-spec-to-console/lib/convert/params.js
+++ b/packages/osd-spec-to-console/lib/convert/params.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-spec-to-console/lib/convert/parts.js
+++ b/packages/osd-spec-to-console/lib/convert/parts.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-spec-to-console/lib/convert/paths.js
+++ b/packages/osd-spec-to-console/lib/convert/paths.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-spec-to-console/lib/replace_pattern.js
+++ b/packages/osd-spec-to-console/lib/replace_pattern.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/assert_never.ts
+++ b/packages/osd-std/src/assert_never.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/deep_freeze.test.ts
+++ b/packages/osd-std/src/deep_freeze.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/deep_freeze.ts
+++ b/packages/osd-std/src/deep_freeze.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/get.test.ts
+++ b/packages/osd-std/src/get.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/get.ts
+++ b/packages/osd-std/src/get.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/get_flattened_object.test.ts
+++ b/packages/osd-std/src/get_flattened_object.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/get_flattened_object.ts
+++ b/packages/osd-std/src/get_flattened_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/index.ts
+++ b/packages/osd-std/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/map_to_object.ts
+++ b/packages/osd-std/src/map_to_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/map_utils.test.ts
+++ b/packages/osd-std/src/map_utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/map_utils.ts
+++ b/packages/osd-std/src/map_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/merge.test.ts
+++ b/packages/osd-std/src/merge.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/merge.ts
+++ b/packages/osd-std/src/merge.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/pick.ts
+++ b/packages/osd-std/src/pick.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/promise.test.ts
+++ b/packages/osd-std/src/promise.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/promise.ts
+++ b/packages/osd-std/src/promise.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/rxjs_7.test.ts
+++ b/packages/osd-std/src/rxjs_7.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/rxjs_7.ts
+++ b/packages/osd-std/src/rxjs_7.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/unset.test.ts
+++ b/packages/osd-std/src/unset.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/unset.ts
+++ b/packages/osd-std/src/unset.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/url.test.ts
+++ b/packages/osd-std/src/url.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-std/src/url.ts
+++ b/packages/osd-std/src/url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-storybook/index.ts
+++ b/packages/osd-storybook/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-storybook/lib/constants.ts
+++ b/packages/osd-storybook/lib/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-storybook/lib/default_config.ts
+++ b/packages/osd-storybook/lib/default_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-storybook/lib/register.ts
+++ b/packages/osd-storybook/lib/register.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-storybook/lib/run_storybook_cli.ts
+++ b/packages/osd-storybook/lib/run_storybook_cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-storybook/preset.js
+++ b/packages/osd-storybook/preset.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-storybook/typings.d.ts
+++ b/packages/osd-storybook/typings.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-storybook/webpack.config.ts
+++ b/packages/osd-storybook/webpack.config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/babel.config.js
+++ b/packages/osd-telemetry-tools/babel.config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/cli/run_telemetry_check.ts
+++ b/packages/osd-telemetry-tools/src/cli/run_telemetry_check.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/cli/run_telemetry_extract.ts
+++ b/packages/osd-telemetry-tools/src/cli/run_telemetry_extract.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/index.ts
+++ b/packages/osd-telemetry-tools/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_externally_defined_collector.ts
+++ b/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_externally_defined_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_imported_schema.ts
+++ b/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_imported_schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_imported_usage_interface.ts
+++ b/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_imported_usage_interface.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_indexed_interface_with_not_matching_schema.ts
+++ b/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_indexed_interface_with_not_matching_schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_nested_collector.ts
+++ b/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_nested_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_schema_defined_with_spreads_collector.ts
+++ b/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_schema_defined_with_spreads_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_working_collector.ts
+++ b/packages/osd-telemetry-tools/src/tools/__fixture__/parsed_working_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/check_collector__integrity.test.ts
+++ b/packages/osd-telemetry-tools/src/tools/check_collector__integrity.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/check_collector_integrity.ts
+++ b/packages/osd-telemetry-tools/src/tools/check_collector_integrity.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/config.test.ts
+++ b/packages/osd-telemetry-tools/src/tools/config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/config.ts
+++ b/packages/osd-telemetry-tools/src/tools/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/constants.ts
+++ b/packages/osd-telemetry-tools/src/tools/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/extract_collectors.test.ts
+++ b/packages/osd-telemetry-tools/src/tools/extract_collectors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/extract_collectors.ts
+++ b/packages/osd-telemetry-tools/src/tools/extract_collectors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/manage_schema.test.ts
+++ b/packages/osd-telemetry-tools/src/tools/manage_schema.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/manage_schema.ts
+++ b/packages/osd-telemetry-tools/src/tools/manage_schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/serializer.test.ts
+++ b/packages/osd-telemetry-tools/src/tools/serializer.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/serializer.ts
+++ b/packages/osd-telemetry-tools/src/tools/serializer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/tasks/check_compatible_types_task.ts
+++ b/packages/osd-telemetry-tools/src/tools/tasks/check_compatible_types_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/tasks/check_matching_schemas_task.ts
+++ b/packages/osd-telemetry-tools/src/tools/tasks/check_matching_schemas_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/tasks/error_reporter.ts
+++ b/packages/osd-telemetry-tools/src/tools/tasks/error_reporter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/tasks/extract_collectors_task.ts
+++ b/packages/osd-telemetry-tools/src/tools/tasks/extract_collectors_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/tasks/generate_schemas_task.ts
+++ b/packages/osd-telemetry-tools/src/tools/tasks/generate_schemas_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/tasks/index.ts
+++ b/packages/osd-telemetry-tools/src/tools/tasks/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/tasks/parse_configs_task.ts
+++ b/packages/osd-telemetry-tools/src/tools/tasks/parse_configs_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/tasks/task_context.ts
+++ b/packages/osd-telemetry-tools/src/tools/tasks/task_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/tasks/write_to_file_task.ts
+++ b/packages/osd-telemetry-tools/src/tools/tasks/write_to_file_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/ts_parser.test.ts
+++ b/packages/osd-telemetry-tools/src/tools/ts_parser.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/ts_parser.ts
+++ b/packages/osd-telemetry-tools/src/tools/ts_parser.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-telemetry-tools/src/tools/utils.ts
+++ b/packages/osd-telemetry-tools/src/tools/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test-subj-selector/__tests__/index.js
+++ b/packages/osd-test-subj-selector/__tests__/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test-subj-selector/index.d.ts
+++ b/packages/osd-test-subj-selector/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test-subj-selector/index.js
+++ b/packages/osd-test-subj-selector/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/babel.config.js
+++ b/packages/osd-test/babel.config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/index.d.ts
+++ b/packages/osd-test/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/ci_parallel_process_prefix.ts
+++ b/packages/osd-test/src/ci_parallel_process_prefix.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/__fixtures__/index.ts
+++ b/packages/osd-test/src/failed_tests_reporter/__fixtures__/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/add_messages_to_report.test.ts
+++ b/packages/osd-test/src/failed_tests_reporter/add_messages_to_report.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/add_messages_to_report.ts
+++ b/packages/osd-test/src/failed_tests_reporter/add_messages_to_report.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/get_failures.test.ts
+++ b/packages/osd-test/src/failed_tests_reporter/get_failures.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/get_failures.ts
+++ b/packages/osd-test/src/failed_tests_reporter/get_failures.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/github_api.ts
+++ b/packages/osd-test/src/failed_tests_reporter/github_api.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/index.ts
+++ b/packages/osd-test/src/failed_tests_reporter/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/issue_metadata.test.ts
+++ b/packages/osd-test/src/failed_tests_reporter/issue_metadata.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/report_failure.test.ts
+++ b/packages/osd-test/src/failed_tests_reporter/report_failure.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/report_failure.ts
+++ b/packages/osd-test/src/failed_tests_reporter/report_failure.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/report_metadata.test.ts
+++ b/packages/osd-test/src/failed_tests_reporter/report_metadata.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/report_metadata.ts
+++ b/packages/osd-test/src/failed_tests_reporter/report_metadata.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
+++ b/packages/osd-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/failed_tests_reporter/test_report.ts
+++ b/packages/osd-test/src/failed_tests_reporter/test_report.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/__tests__/integration/basic.js
+++ b/packages/osd-test/src/functional_test_runner/__tests__/integration/basic.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/__tests__/integration/failure_hooks.js
+++ b/packages/osd-test/src/functional_test_runner/__tests__/integration/failure_hooks.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/cli.ts
+++ b/packages/osd-test/src/functional_test_runner/cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/fake_mocha_types.d.ts
+++ b/packages/osd-test/src/functional_test_runner/fake_mocha_types.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/functional_test_runner.ts
+++ b/packages/osd-test/src/functional_test_runner/functional_test_runner.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/index.ts
+++ b/packages/osd-test/src/functional_test_runner/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/config/__tests__/read_config_file.js
+++ b/packages/osd-test/src/functional_test_runner/lib/config/__tests__/read_config_file.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/config/config.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/config/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/config/index.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/config/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/config/read_config_file.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/config/read_config_file.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/config/schema.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/config/schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/docker_servers/container_logs.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/docker_servers/container_logs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/docker_servers/container_running.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/docker_servers/container_running.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/docker_servers/define_docker_servers_config.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/docker_servers/define_docker_servers_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/docker_servers/docker_servers_service.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/docker_servers/docker_servers_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/docker_servers/index.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/docker_servers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/failure_metadata.test.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/failure_metadata.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/failure_metadata.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/failure_metadata.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/index.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/lifecycle.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/lifecycle.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/lifecycle_event.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/lifecycle_event.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/lifecycle_phase.test.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/lifecycle_phase.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/lifecycle_phase.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/lifecycle_phase.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/load_tracer.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/load_tracer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/assignment_proxy.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/assignment_proxy.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/decorate_mocha_ui.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/decorate_mocha_ui.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/filter_suites_by_tags.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/filter_suites_by_tags.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/filter_suites_by_tags.test.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/filter_suites_by_tags.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/index.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/load_test_files.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/load_test_files.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/colors.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/colors.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/index.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/ms.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/ms.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/reporter.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/reporter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/symbols.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/symbols.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/write_epilogue.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/reporter/write_epilogue.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/run_tests.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/run_tests.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/setup_mocha.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/setup_mocha.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/wrap_function.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/wrap_function.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/mocha/wrap_runnable_args.js
+++ b/packages/osd-test/src/functional_test_runner/lib/mocha/wrap_runnable_args.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/providers/async_instance.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/providers/async_instance.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/providers/index.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/providers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/providers/provider_collection.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/providers/provider_collection.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/providers/read_provider_spec.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/providers/read_provider_spec.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/providers/verbose_instance.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/providers/verbose_instance.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/suite_tracker.test.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/suite_tracker.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_test_runner/lib/suite_tracker.ts
+++ b/packages/osd-test/src/functional_test_runner/lib/suite_tracker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/cli/index.js
+++ b/packages/osd-test/src/functional_tests/cli/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/cli/run_tests/args.js
+++ b/packages/osd-test/src/functional_tests/cli/run_tests/args.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/cli/run_tests/args.test.js
+++ b/packages/osd-test/src/functional_tests/cli/run_tests/args.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/cli/run_tests/cli.js
+++ b/packages/osd-test/src/functional_tests/cli/run_tests/cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/cli/run_tests/cli.test.js
+++ b/packages/osd-test/src/functional_tests/cli/run_tests/cli.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/cli/start_servers/args.js
+++ b/packages/osd-test/src/functional_tests/cli/start_servers/args.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/cli/start_servers/args.test.js
+++ b/packages/osd-test/src/functional_tests/cli/start_servers/args.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/cli/start_servers/cli.js
+++ b/packages/osd-test/src/functional_tests/cli/start_servers/cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/cli/start_servers/cli.test.js
+++ b/packages/osd-test/src/functional_tests/cli/start_servers/cli.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/lib/auth.js
+++ b/packages/osd-test/src/functional_tests/lib/auth.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/lib/babel_register_for_test_plugins.js
+++ b/packages/osd-test/src/functional_tests/lib/babel_register_for_test_plugins.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/lib/index.js
+++ b/packages/osd-test/src/functional_tests/lib/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/lib/paths.js
+++ b/packages/osd-test/src/functional_tests/lib/paths.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/lib/run_cli.js
+++ b/packages/osd-test/src/functional_tests/lib/run_cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/lib/run_cli.test.js
+++ b/packages/osd-test/src/functional_tests/lib/run_cli.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/lib/run_ftr.js
+++ b/packages/osd-test/src/functional_tests/lib/run_ftr.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/lib/run_opensearch.js
+++ b/packages/osd-test/src/functional_tests/lib/run_opensearch.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/lib/run_opensearch_dashboards_server.js
+++ b/packages/osd-test/src/functional_tests/lib/run_opensearch_dashboards_server.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/tasks.js
+++ b/packages/osd-test/src/functional_tests/tasks.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/functional_tests/test_helpers.js
+++ b/packages/osd-test/src/functional_tests/test_helpers.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/index.ts
+++ b/packages/osd-test/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/junit_report_path.ts
+++ b/packages/osd-test/src/junit_report_path.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/legacy_opensearch/index.js
+++ b/packages/osd-test/src/legacy_opensearch/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/legacy_opensearch/legacy_opensearch_test_cluster.js
+++ b/packages/osd-test/src/legacy_opensearch/legacy_opensearch_test_cluster.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/legacy_opensearch/opensearch_test_config.js
+++ b/packages/osd-test/src/legacy_opensearch/opensearch_test_config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/osd/index.ts
+++ b/packages/osd-test/src/osd/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/osd/osd_test_config.ts
+++ b/packages/osd-test/src/osd/osd_test_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/src/osd/users.ts
+++ b/packages/osd-test/src/osd/users.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-test/types/ftr.d.ts
+++ b/packages/osd-test/types/ftr.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/Gruntfile.js
+++ b/packages/osd-ui-framework/Gruntfile.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/components/index.js
+++ b/packages/osd-ui-framework/components/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/actions/action_types.js
+++ b/packages/osd-ui-framework/doc_site/src/actions/action_types.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/actions/code_viewer_actions.js
+++ b/packages/osd-ui-framework/doc_site/src/actions/code_viewer_actions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/actions/example_nav_actions.js
+++ b/packages/osd-ui-framework/doc_site/src/actions/example_nav_actions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/actions/index.js
+++ b/packages/osd-ui-framework/doc_site/src/actions/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/actions/sandbox_actions.js
+++ b/packages/osd-ui-framework/doc_site/src/actions/sandbox_actions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_code/guide_code.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_code/guide_code.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_code_viewer/guide_code_viewer.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_code_viewer/guide_code_viewer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_demo/guide_demo.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_demo/guide_demo.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_link/guide_link.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_link/guide_link.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_nav/guide_nav.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_nav/guide_nav.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_page/guide_page.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_page/guide_page.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_page/guide_page_container.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_page/guide_page_container.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_page_side_nav/guide_page_side_nav.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_page_side_nav/guide_page_side_nav.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_page_side_nav/guide_page_side_nav_item.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_page_side_nav/guide_page_side_nav_item.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_sandbox/guide_sandbox.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_sandbox/guide_sandbox.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_sandbox/guide_sandbox_code_toggle.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_sandbox/guide_sandbox_code_toggle.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_sandbox/guide_sandbox_code_toggle_container.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_sandbox/guide_sandbox_code_toggle_container.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_section/guide_section.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_section/guide_section.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_section/guide_section_container.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_section/guide_section_container.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_section/guide_section_types.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_section/guide_section_types.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/guide_text/guide_text.js
+++ b/packages/osd-ui-framework/doc_site/src/components/guide_text/guide_text.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/components/index.js
+++ b/packages/osd-ui-framework/doc_site/src/components/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/index.js
+++ b/packages/osd-ui-framework/doc_site/src/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/services/example/create_example.js
+++ b/packages/osd-ui-framework/doc_site/src/services/example/create_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/services/index.js
+++ b/packages/osd-ui-framework/doc_site/src/services/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/services/js_injector/js_injector.js
+++ b/packages/osd-ui-framework/doc_site/src/services/js_injector/js_injector.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/services/routes/routes.js
+++ b/packages/osd-ui-framework/doc_site/src/services/routes/routes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/services/string/render_to_html.js
+++ b/packages/osd-ui-framework/doc_site/src/services/string/render_to_html.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/services/string/slugify.js
+++ b/packages/osd-ui-framework/doc_site/src/services/string/slugify.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/store/configure_store.js
+++ b/packages/osd-ui-framework/doc_site/src/store/configure_store.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/store/index.js
+++ b/packages/osd-ui-framework/doc_site/src/store/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/store/reducers/code_viewer_reducer.js
+++ b/packages/osd-ui-framework/doc_site/src/store/reducers/code_viewer_reducer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/store/reducers/sandbox_reducer.js
+++ b/packages/osd-ui-framework/doc_site/src/store/reducers/sandbox_reducer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/store/reducers/sections_reducer.js
+++ b/packages/osd-ui-framework/doc_site/src/store/reducers/sections_reducer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/app_container.js
+++ b/packages/osd-ui-framework/doc_site/src/views/app_container.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/app_view.js
+++ b/packages/osd-ui-framework/doc_site/src/views/app_view.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/bar/bar.js
+++ b/packages/osd-ui-framework/doc_site/src/views/bar/bar.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/bar/bar_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/bar/bar_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/bar/bar_one_section.js
+++ b/packages/osd-ui-framework/doc_site/src/views/bar/bar_one_section.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/bar/bar_three_sections.js
+++ b/packages/osd-ui-framework/doc_site/src/views/bar/bar_three_sections.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_basic.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_basic.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_danger.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_danger.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_elements.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_elements.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_group.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_group.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_group_united.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_group_united.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_hollow.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_hollow.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_loading.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_loading.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_primary.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_primary.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_secondary.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_secondary.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_warning.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_warning.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/button/button_with_icon.js
+++ b/packages/osd-ui-framework/doc_site/src/views/button/button_with_icon.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/collapse_button/collapse_button.js
+++ b/packages/osd-ui-framework/doc_site/src/views/collapse_button/collapse_button.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/collapse_button/collapse_button_aria.js
+++ b/packages/osd-ui-framework/doc_site/src/views/collapse_button/collapse_button_aria.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/collapse_button/collapse_button_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/collapse_button/collapse_button_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/empty_table_prompt/empty_table_prompt.js
+++ b/packages/osd-ui-framework/doc_site/src/views/empty_table_prompt/empty_table_prompt.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/empty_table_prompt/empty_table_prompt_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/empty_table_prompt/empty_table_prompt_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/empty_table_prompt/table_with_empty_prompt.js
+++ b/packages/osd-ui-framework/doc_site/src/views/empty_table_prompt/table_with_empty_prompt.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/form/check_box.js
+++ b/packages/osd-ui-framework/doc_site/src/views/form/check_box.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/form/form_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/form/form_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/form/label.js
+++ b/packages/osd-ui-framework/doc_site/src/views/form/label.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/form/select.js
+++ b/packages/osd-ui-framework/doc_site/src/views/form/select.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/form/text_area.js
+++ b/packages/osd-ui-framework/doc_site/src/views/form/text_area.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/form/text_area_non_resizable.js
+++ b/packages/osd-ui-framework/doc_site/src/views/form/text_area_non_resizable.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/form/text_input.js
+++ b/packages/osd-ui-framework/doc_site/src/views/form/text_input.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/form_layout/field_group.js
+++ b/packages/osd-ui-framework/doc_site/src/views/form_layout/field_group.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/form_layout/form_layout_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/form_layout/form_layout_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/home/home_view.js
+++ b/packages/osd-ui-framework/doc_site/src/views/home/home_view.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/icon/icon_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/icon/icon_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/info_panel/info_panel_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/info_panel/info_panel_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/link/link_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/link/link_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_breadcrumbs.js
+++ b/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_breadcrumbs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_dropdown.js
+++ b/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_dropdown.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_dropdown_panels.js
+++ b/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_dropdown_panels.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_menu_item_states.js
+++ b/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_menu_item_states.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_search.js
+++ b/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_search.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_search_error.js
+++ b/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_search_error.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_simple.js
+++ b/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_simple.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_tabs.js
+++ b/packages/osd-ui-framework/doc_site/src/views/local_nav/local_nav_tabs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/not_found/not_found_view.js
+++ b/packages/osd-ui-framework/doc_site/src/views/not_found/not_found_view.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/pager/pager_buttons.js
+++ b/packages/osd-ui-framework/doc_site/src/views/pager/pager_buttons.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/pager/pager_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/pager/pager_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/pager/tool_bar_pager.js
+++ b/packages/osd-ui-framework/doc_site/src/views/pager/tool_bar_pager.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/panel/panel_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/panel/panel_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/status_text/status_text_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/status_text/status_text_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/table/fluid_table.js
+++ b/packages/osd-ui-framework/doc_site/src/views/table/fluid_table.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/table/listing_table.js
+++ b/packages/osd-ui-framework/doc_site/src/views/table/listing_table.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/table/listing_table_loading_items.js
+++ b/packages/osd-ui-framework/doc_site/src/views/table/listing_table_loading_items.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/table/listing_table_with_empty_prompt.js
+++ b/packages/osd-ui-framework/doc_site/src/views/table/listing_table_with_empty_prompt.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/table/listing_table_with_no_items.js
+++ b/packages/osd-ui-framework/doc_site/src/views/table/listing_table_with_no_items.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/table/table.js
+++ b/packages/osd-ui-framework/doc_site/src/views/table/table.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/table/table_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/table/table_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/table/table_with_menu_buttons.js
+++ b/packages/osd-ui-framework/doc_site/src/views/table/table_with_menu_buttons.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/tabs/tabs.js
+++ b/packages/osd-ui-framework/doc_site/src/views/tabs/tabs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/tabs/tabs_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/tabs/tabs_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/tool_bar/tool_bar.js
+++ b/packages/osd-ui-framework/doc_site/src/views/tool_bar/tool_bar.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/tool_bar/tool_bar_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/tool_bar/tool_bar_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/tool_bar/tool_bar_footer.js
+++ b/packages/osd-ui-framework/doc_site/src/views/tool_bar/tool_bar_footer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/typography/typography_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/typography/typography_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/vertical_rhythm/vertical_rhythm_example.js
+++ b/packages/osd-ui-framework/doc_site/src/views/vertical_rhythm/vertical_rhythm_example.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/src/views/view/view_sandbox.js
+++ b/packages/osd-ui-framework/doc_site/src/views/view/view_sandbox.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/doc_site/webpack.config.js
+++ b/packages/osd-ui-framework/doc_site/webpack.config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/generator-kui/app/component.js
+++ b/packages/osd-ui-framework/generator-kui/app/component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/generator-kui/app/documentation.js
+++ b/packages/osd-ui-framework/generator-kui/app/documentation.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/generator-kui/component/index.js
+++ b/packages/osd-ui-framework/generator-kui/component/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/generator-kui/documentation/index.js
+++ b/packages/osd-ui-framework/generator-kui/documentation/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/generator-kui/utils.js
+++ b/packages/osd-ui-framework/generator-kui/utils.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/bar/bar.js
+++ b/packages/osd-ui-framework/src/components/bar/bar.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/bar/bar.test.js
+++ b/packages/osd-ui-framework/src/components/bar/bar.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/bar/bar_section.js
+++ b/packages/osd-ui-framework/src/components/bar/bar_section.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/bar/bar_section.test.js
+++ b/packages/osd-ui-framework/src/components/bar/bar_section.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/bar/index.js
+++ b/packages/osd-ui-framework/src/components/bar/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/button/button.js
+++ b/packages/osd-ui-framework/src/components/button/button.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/button/button.test.js
+++ b/packages/osd-ui-framework/src/components/button/button.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/button/button_group/button_group.js
+++ b/packages/osd-ui-framework/src/components/button/button_group/button_group.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/button/button_group/button_group.test.js
+++ b/packages/osd-ui-framework/src/components/button/button_group/button_group.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/button/button_icon/button_icon.js
+++ b/packages/osd-ui-framework/src/components/button/button_icon/button_icon.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/button/button_icon/button_icon.test.js
+++ b/packages/osd-ui-framework/src/components/button/button_icon/button_icon.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/button/index.js
+++ b/packages/osd-ui-framework/src/components/button/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/button/link_button.test.js
+++ b/packages/osd-ui-framework/src/components/button/link_button.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/button/submit_button.test.js
+++ b/packages/osd-ui-framework/src/components/button/submit_button.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/collapse_button/collapse_button.js
+++ b/packages/osd-ui-framework/src/components/collapse_button/collapse_button.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/collapse_button/collapse_button.test.js
+++ b/packages/osd-ui-framework/src/components/collapse_button/collapse_button.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/collapse_button/index.js
+++ b/packages/osd-ui-framework/src/components/collapse_button/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt.js
+++ b/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt.test.js
+++ b/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_actions.js
+++ b/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_actions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_actions.test.js
+++ b/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_actions.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_message.js
+++ b/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_message.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_message.test.js
+++ b/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_message.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_panel.js
+++ b/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_panel.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_panel.test.js
+++ b/packages/osd-ui-framework/src/components/empty_table_prompt/empty_table_prompt_panel.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/empty_table_prompt/index.js
+++ b/packages/osd-ui-framework/src/components/empty_table_prompt/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/check_box/check_box.js
+++ b/packages/osd-ui-framework/src/components/form/check_box/check_box.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/check_box/check_box.test.js
+++ b/packages/osd-ui-framework/src/components/form/check_box/check_box.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/check_box/check_box_label.js
+++ b/packages/osd-ui-framework/src/components/form/check_box/check_box_label.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/check_box/check_box_label.test.js
+++ b/packages/osd-ui-framework/src/components/form/check_box/check_box_label.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/check_box/index.js
+++ b/packages/osd-ui-framework/src/components/form/check_box/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/index.js
+++ b/packages/osd-ui-framework/src/components/form/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/label/index.js
+++ b/packages/osd-ui-framework/src/components/form/label/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/label/label.js
+++ b/packages/osd-ui-framework/src/components/form/label/label.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/label/label.test.js
+++ b/packages/osd-ui-framework/src/components/form/label/label.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/select/index.js
+++ b/packages/osd-ui-framework/src/components/form/select/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/select/select.js
+++ b/packages/osd-ui-framework/src/components/form/select/select.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/select/select.test.js
+++ b/packages/osd-ui-framework/src/components/form/select/select.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/text_area/index.js
+++ b/packages/osd-ui-framework/src/components/form/text_area/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/text_area/text_area.js
+++ b/packages/osd-ui-framework/src/components/form/text_area/text_area.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/text_area/text_area.test.js
+++ b/packages/osd-ui-framework/src/components/form/text_area/text_area.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/text_input/index.js
+++ b/packages/osd-ui-framework/src/components/form/text_input/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/text_input/text_input.js
+++ b/packages/osd-ui-framework/src/components/form/text_input/text_input.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form/text_input/text_input.test.js
+++ b/packages/osd-ui-framework/src/components/form/text_input/text_input.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form_layout/field_group.js
+++ b/packages/osd-ui-framework/src/components/form_layout/field_group.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form_layout/field_group.test.js
+++ b/packages/osd-ui-framework/src/components/form_layout/field_group.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form_layout/field_group_section.js
+++ b/packages/osd-ui-framework/src/components/form_layout/field_group_section.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form_layout/field_group_section.test.js
+++ b/packages/osd-ui-framework/src/components/form_layout/field_group_section.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/form_layout/index.js
+++ b/packages/osd-ui-framework/src/components/form_layout/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/index.js
+++ b/packages/osd-ui-framework/src/components/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/index.js
+++ b/packages/osd-ui-framework/src/components/local_nav/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_nav.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_nav.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_nav.test.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_nav.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_nav_row.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_nav_row.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_nav_row.test.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_nav_row.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_nav_row_section.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_nav_row_section.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_nav_row_section.test.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_nav_row_section.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_tab.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_tab.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_tab.test.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_tab.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_tabs.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_tabs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_tabs.test.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_tabs.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_title.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_title.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/local_nav/local_title.test.js
+++ b/packages/osd-ui-framework/src/components/local_nav/local_title.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/pager/index.js
+++ b/packages/osd-ui-framework/src/components/pager/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/pager/pager.js
+++ b/packages/osd-ui-framework/src/components/pager/pager.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/pager/pager.test.js
+++ b/packages/osd-ui-framework/src/components/pager/pager.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/pager/pager_button_group.js
+++ b/packages/osd-ui-framework/src/components/pager/pager_button_group.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/pager/pager_button_group.test.js
+++ b/packages/osd-ui-framework/src/components/pager/pager_button_group.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/controlled_table.js
+++ b/packages/osd-ui-framework/src/components/table/controlled_table.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/controlled_table.test.js
+++ b/packages/osd-ui-framework/src/components/table/controlled_table.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/index.js
+++ b/packages/osd-ui-framework/src/components/table/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/listing_table/index.js
+++ b/packages/osd-ui-framework/src/components/table/listing_table/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/listing_table/listing_table.js
+++ b/packages/osd-ui-framework/src/components/table/listing_table/listing_table.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/listing_table/listing_table.test.js
+++ b/packages/osd-ui-framework/src/components/table/listing_table/listing_table.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/listing_table/listing_table_create_button.js
+++ b/packages/osd-ui-framework/src/components/table/listing_table/listing_table_create_button.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/listing_table/listing_table_delete_button.js
+++ b/packages/osd-ui-framework/src/components/table/listing_table/listing_table_delete_button.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/listing_table/listing_table_loading_prompt.js
+++ b/packages/osd-ui-framework/src/components/table/listing_table/listing_table_loading_prompt.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/listing_table/listing_table_no_matches_prompt.js
+++ b/packages/osd-ui-framework/src/components/table/listing_table/listing_table_no_matches_prompt.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/listing_table/listing_table_row.js
+++ b/packages/osd-ui-framework/src/components/table/listing_table/listing_table_row.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/listing_table/listing_table_tool_bar.js
+++ b/packages/osd-ui-framework/src/components/table/listing_table/listing_table_tool_bar.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/listing_table/listing_table_tool_bar_footer.js
+++ b/packages/osd-ui-framework/src/components/table/listing_table/listing_table_tool_bar_footer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table.js
+++ b/packages/osd-ui-framework/src/components/table/table.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table.test.js
+++ b/packages/osd-ui-framework/src/components/table/table.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_body.js
+++ b/packages/osd-ui-framework/src/components/table/table_body.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_header.js
+++ b/packages/osd-ui-framework/src/components/table/table_header.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_header_cell.js
+++ b/packages/osd-ui-framework/src/components/table/table_header_cell.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_header_cell.test.js
+++ b/packages/osd-ui-framework/src/components/table/table_header_cell.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_header_check_box_cell.js
+++ b/packages/osd-ui-framework/src/components/table/table_header_check_box_cell.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_header_check_box_cell.test.js
+++ b/packages/osd-ui-framework/src/components/table/table_header_check_box_cell.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_info.js
+++ b/packages/osd-ui-framework/src/components/table/table_info.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_info.test.js
+++ b/packages/osd-ui-framework/src/components/table/table_info.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_row.js
+++ b/packages/osd-ui-framework/src/components/table/table_row.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_row.test.js
+++ b/packages/osd-ui-framework/src/components/table/table_row.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_row_cell.js
+++ b/packages/osd-ui-framework/src/components/table/table_row_cell.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_row_cell.test.js
+++ b/packages/osd-ui-framework/src/components/table/table_row_cell.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_row_check_box_cell.js
+++ b/packages/osd-ui-framework/src/components/table/table_row_check_box_cell.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/table/table_row_check_box_cell.test.js
+++ b/packages/osd-ui-framework/src/components/table/table_row_check_box_cell.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tabs/index.js
+++ b/packages/osd-ui-framework/src/components/tabs/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tabs/tab.js
+++ b/packages/osd-ui-framework/src/components/tabs/tab.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tabs/tab.test.js
+++ b/packages/osd-ui-framework/src/components/tabs/tab.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tabs/tabs.js
+++ b/packages/osd-ui-framework/src/components/tabs/tabs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tabs/tabs.test.js
+++ b/packages/osd-ui-framework/src/components/tabs/tabs.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/index.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar.test.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar_footer.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar_footer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar_footer.test.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar_footer.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar_footer_section.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar_footer_section.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar_footer_section.test.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar_footer_section.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar_search_box.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar_search_box.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar_search_box.test.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar_search_box.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar_section.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar_section.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar_section.test.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar_section.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar_text.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar_text.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/tool_bar/tool_bar_text.test.js
+++ b/packages/osd-ui-framework/src/components/tool_bar/tool_bar_text.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/typography/typography.js
+++ b/packages/osd-ui-framework/src/components/typography/typography.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/components/typography/typography.test.js
+++ b/packages/osd-ui-framework/src/components/typography/typography.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/accessibility/accessible_click_keys.js
+++ b/packages/osd-ui-framework/src/services/accessibility/accessible_click_keys.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/accessibility/cascading_menu_key_codes.js
+++ b/packages/osd-ui-framework/src/services/accessibility/cascading_menu_key_codes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/accessibility/combo_box_key_codes.js
+++ b/packages/osd-ui-framework/src/services/accessibility/combo_box_key_codes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/accessibility/html_id_generator.js
+++ b/packages/osd-ui-framework/src/services/accessibility/html_id_generator.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/accessibility/html_id_generator.test.js
+++ b/packages/osd-ui-framework/src/services/accessibility/html_id_generator.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/accessibility/index.js
+++ b/packages/osd-ui-framework/src/services/accessibility/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/alignment.js
+++ b/packages/osd-ui-framework/src/services/alignment.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/index.js
+++ b/packages/osd-ui-framework/src/services/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/key_codes.js
+++ b/packages/osd-ui-framework/src/services/key_codes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/sort/index.js
+++ b/packages/osd-ui-framework/src/services/sort/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/sort/sortable_properties.js
+++ b/packages/osd-ui-framework/src/services/sort/sortable_properties.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/services/sort/sortable_properties.test.js
+++ b/packages/osd-ui-framework/src/services/sort/sortable_properties.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/test/find_test_subject.js
+++ b/packages/osd-ui-framework/src/test/find_test_subject.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/test/index.js
+++ b/packages/osd-ui-framework/src/test/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/test/required_props.js
+++ b/packages/osd-ui-framework/src/test/required_props.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-framework/src/test/take_mounted_snapshot.js
+++ b/packages/osd-ui-framework/src/test/take_mounted_snapshot.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-shared-deps/entry.js
+++ b/packages/osd-ui-shared-deps/entry.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-shared-deps/index.d.ts
+++ b/packages/osd-ui-shared-deps/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-shared-deps/index.js
+++ b/packages/osd-ui-shared-deps/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-shared-deps/polyfills.js
+++ b/packages/osd-ui-shared-deps/polyfills.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-shared-deps/public_path_loader.js
+++ b/packages/osd-ui-shared-deps/public_path_loader.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-shared-deps/public_path_module_creator.js
+++ b/packages/osd-ui-shared-deps/public_path_module_creator.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-shared-deps/scripts/build.js
+++ b/packages/osd-ui-shared-deps/scripts/build.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-shared-deps/theme.ts
+++ b/packages/osd-ui-shared-deps/theme.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-ui-shared-deps/webpack.config.js
+++ b/packages/osd-ui-shared-deps/webpack.config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utility-types/index.ts
+++ b/packages/osd-utility-types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utility-types/test-d/public_contract.ts
+++ b/packages/osd-utility-types/test-d/public_contract.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utility-types/test-d/public_keys.ts
+++ b/packages/osd-utility-types/test-d/public_keys.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utility-types/test-d/shallow_promise.ts
+++ b/packages/osd-utility-types/test-d/shallow_promise.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utility-types/test-d/union_to_intersection.ts
+++ b/packages/osd-utility-types/test-d/union_to_intersection.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utility-types/test-d/unwrap_observable.ts
+++ b/packages/osd-utility-types/test-d/unwrap_observable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utility-types/test-d/unwrap_promise.ts
+++ b/packages/osd-utility-types/test-d/unwrap_promise.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utility-types/test-d/values.ts
+++ b/packages/osd-utility-types/test-d/values.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utils/src/index.ts
+++ b/packages/osd-utils/src/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utils/src/package_json/index.test.ts
+++ b/packages/osd-utils/src/package_json/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utils/src/package_json/index.ts
+++ b/packages/osd-utils/src/package_json/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utils/src/path/index.test.ts
+++ b/packages/osd-utils/src/path/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utils/src/path/index.ts
+++ b/packages/osd-utils/src/path/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/packages/osd-utils/src/repo_root.ts
+++ b/packages/osd-utils/src/repo_root.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/preinstall_check.js
+++ b/preinstall_check.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/backport.js
+++ b/scripts/backport.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/build_opensearch_dashboards_platform_plugins.js
+++ b/scripts/build_opensearch_dashboards_platform_plugins.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/build_plugin_list_docs.js
+++ b/scripts/build_plugin_list_docs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/build_ts_refs.js
+++ b/scripts/build_ts_refs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/check_file_casing.js
+++ b/scripts/check_file_casing.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/check_licenses.js
+++ b/scripts/check_licenses.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/check_lockfile_symlinks.js
+++ b/scripts/check_lockfile_symlinks.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/check_published_api_changes.js
+++ b/scripts/check_published_api_changes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/check_ts_projects.js
+++ b/scripts/check_ts_projects.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/eslint.js
+++ b/scripts/eslint.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/functional_test_runner.js
+++ b/scripts/functional_test_runner.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/functional_tests.js
+++ b/scripts/functional_tests.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/functional_tests_server.js
+++ b/scripts/functional_tests_server.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/generate_plugin.js
+++ b/scripts/generate_plugin.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/i18n_check.js
+++ b/scripts/i18n_check.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/i18n_extract.js
+++ b/scripts/i18n_extract.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/i18n_integrate.js
+++ b/scripts/i18n_integrate.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/jest.js
+++ b/scripts/jest.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/jest_integration.js
+++ b/scripts/jest_integration.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/makelogs.js
+++ b/scripts/makelogs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/mocha.js
+++ b/scripts/mocha.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/notice.js
+++ b/scripts/notice.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/opensearch.js
+++ b/scripts/opensearch.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/opensearch_archiver.js
+++ b/scripts/opensearch_archiver.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/opensearch_dashboards.js
+++ b/scripts/opensearch_dashboards.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/opensearch_dashboards_keystore.js
+++ b/scripts/opensearch_dashboards_keystore.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/opensearch_dashboards_plugin.js
+++ b/scripts/opensearch_dashboards_plugin.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/osd.js
+++ b/scripts/osd.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/plugin_helpers.js
+++ b/scripts/plugin_helpers.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/precommit_hook.js
+++ b/scripts/precommit_hook.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/register_git_hook.js
+++ b/scripts/register_git_hook.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/release_notes.js
+++ b/scripts/release_notes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/report_failed_tests.js
+++ b/scripts/report_failed_tests.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/sasslint.js
+++ b/scripts/sasslint.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/spec_to_console.js
+++ b/scripts/spec_to_console.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/storybook.js
+++ b/scripts/storybook.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/telemetry_check.js
+++ b/scripts/telemetry_check.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/telemetry_extract.js
+++ b/scripts/telemetry_extract.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/test_hardening.js
+++ b/scripts/test_hardening.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/type_check.js
+++ b/scripts/type_check.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/scripts/update_prs.js
+++ b/scripts/update_prs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/apm.js
+++ b/src/apm.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/cluster/binder.ts
+++ b/src/cli/cluster/binder.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/cluster/binder_for.ts
+++ b/src/cli/cluster/binder_for.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/cluster/cluster.mock.ts
+++ b/src/cli/cluster/cluster.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/cluster/cluster_manager.test.mocks.ts
+++ b/src/cli/cluster/cluster_manager.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/cluster/cluster_manager.test.ts
+++ b/src/cli/cluster/cluster_manager.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/cluster/cluster_manager.ts
+++ b/src/cli/cluster/cluster_manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/cluster/log.ts
+++ b/src/cli/cluster/log.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/cluster/run_osd_optimizer.ts
+++ b/src/cli/cluster/run_osd_optimizer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/cluster/worker.test.ts
+++ b/src/cli/cluster/worker.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/cluster/worker.ts
+++ b/src/cli/cluster/worker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/command.js
+++ b/src/cli/command.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/dev.js
+++ b/src/cli/dev.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/dist.js
+++ b/src/cli/dist.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/help.js
+++ b/src/cli/help.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/repl/index.js
+++ b/src/cli/repl/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/repl/repl.test.js
+++ b/src/cli/repl/repl.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/serve/integration_tests/invalid_config.test.ts
+++ b/src/cli/serve/integration_tests/invalid_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/serve/integration_tests/reload_logging_config.test.ts
+++ b/src/cli/serve/integration_tests/reload_logging_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/serve/read_keystore.js
+++ b/src/cli/serve/read_keystore.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/serve/read_keystore.test.js
+++ b/src/cli/serve/read_keystore.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/add.js
+++ b/src/cli_keystore/add.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/add.test.js
+++ b/src/cli_keystore/add.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/cli_keystore.js
+++ b/src/cli_keystore/cli_keystore.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/create.js
+++ b/src/cli_keystore/create.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/create.test.js
+++ b/src/cli_keystore/create.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/dev.js
+++ b/src/cli_keystore/dev.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/dist.js
+++ b/src/cli_keystore/dist.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/get_keystore.js
+++ b/src/cli_keystore/get_keystore.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/get_keystore.test.js
+++ b/src/cli_keystore/get_keystore.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/list.js
+++ b/src/cli_keystore/list.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/list.test.js
+++ b/src/cli_keystore/list.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/remove.js
+++ b/src/cli_keystore/remove.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/remove.test.js
+++ b/src/cli_keystore/remove.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/utils/index.js
+++ b/src/cli_keystore/utils/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/utils/prompt.js
+++ b/src/cli_keystore/utils/prompt.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_keystore/utils/prompt.test.js
+++ b/src/cli_keystore/utils/prompt.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/cli.js
+++ b/src/cli_plugin/cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/dev.js
+++ b/src/cli_plugin/dev.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/dist.js
+++ b/src/cli_plugin/dist.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/cleanup.js
+++ b/src/cli_plugin/install/cleanup.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/cleanup.test.js
+++ b/src/cli_plugin/install/cleanup.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/download.js
+++ b/src/cli_plugin/install/download.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/download.test.js
+++ b/src/cli_plugin/install/download.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/downloaders/file.js
+++ b/src/cli_plugin/install/downloaders/file.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/downloaders/http.js
+++ b/src/cli_plugin/install/downloaders/http.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/index.js
+++ b/src/cli_plugin/install/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/index.test.js
+++ b/src/cli_plugin/install/index.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/install.js
+++ b/src/cli_plugin/install/install.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/opensearch_dashboards.js
+++ b/src/cli_plugin/install/opensearch_dashboards.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/opensearch_dashboards.test.js
+++ b/src/cli_plugin/install/opensearch_dashboards.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/pack.js
+++ b/src/cli_plugin/install/pack.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/pack.test.js
+++ b/src/cli_plugin/install/pack.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/progress.js
+++ b/src/cli_plugin/install/progress.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/progress.test.js
+++ b/src/cli_plugin/install/progress.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/rename.js
+++ b/src/cli_plugin/install/rename.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/rename.test.js
+++ b/src/cli_plugin/install/rename.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/settings.js
+++ b/src/cli_plugin/install/settings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/settings.test.js
+++ b/src/cli_plugin/install/settings.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/zip.js
+++ b/src/cli_plugin/install/zip.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/install/zip.test.js
+++ b/src/cli_plugin/install/zip.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/lib/errors.js
+++ b/src/cli_plugin/lib/errors.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/lib/log_warnings.js
+++ b/src/cli_plugin/lib/log_warnings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/lib/logger.js
+++ b/src/cli_plugin/lib/logger.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/lib/logger.test.js
+++ b/src/cli_plugin/lib/logger.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/list/index.js
+++ b/src/cli_plugin/list/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/list/list.js
+++ b/src/cli_plugin/list/list.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/list/list.test.js
+++ b/src/cli_plugin/list/list.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/remove/index.js
+++ b/src/cli_plugin/remove/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/remove/remove.js
+++ b/src/cli_plugin/remove/remove.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/remove/remove.test.js
+++ b/src/cli_plugin/remove/remove.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/remove/settings.js
+++ b/src/cli_plugin/remove/settings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/cli_plugin/remove/settings.test.js
+++ b/src/cli_plugin/remove/settings.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/apm_system.test.ts
+++ b/src/core/public/apm_system.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/apm_system.ts
+++ b/src/core/public/apm_system.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/application_leave.test.ts
+++ b/src/core/public/application/application_leave.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/application_leave.tsx
+++ b/src/core/public/application/application_leave.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/application_service.mock.ts
+++ b/src/core/public/application/application_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/application_service.test.mocks.ts
+++ b/src/core/public/application/application_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/application_service.test.ts
+++ b/src/core/public/application/application_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/application_service.tsx
+++ b/src/core/public/application/application_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/capabilities/capabilities_service.mock.ts
+++ b/src/core/public/application/capabilities/capabilities_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/capabilities/capabilities_service.test.ts
+++ b/src/core/public/application/capabilities/capabilities_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/capabilities/capabilities_service.tsx
+++ b/src/core/public/application/capabilities/capabilities_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/capabilities/index.ts
+++ b/src/core/public/application/capabilities/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/index.ts
+++ b/src/core/public/application/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/integration_tests/application_service.test.tsx
+++ b/src/core/public/application/integration_tests/application_service.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/integration_tests/router.test.tsx
+++ b/src/core/public/application/integration_tests/router.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/integration_tests/utils.tsx
+++ b/src/core/public/application/integration_tests/utils.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/scoped_history.mock.ts
+++ b/src/core/public/application/scoped_history.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/scoped_history.test.ts
+++ b/src/core/public/application/scoped_history.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/scoped_history.ts
+++ b/src/core/public/application/scoped_history.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/test_types.ts
+++ b/src/core/public/application/test_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/types.ts
+++ b/src/core/public/application/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/ui/app_container.test.tsx
+++ b/src/core/public/application/ui/app_container.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/ui/app_container.tsx
+++ b/src/core/public/application/ui/app_container.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/ui/app_not_found_screen.tsx
+++ b/src/core/public/application/ui/app_not_found_screen.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/ui/app_router.tsx
+++ b/src/core/public/application/ui/app_router.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/ui/index.ts
+++ b/src/core/public/application/ui/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/utils/append_app_path.test.ts
+++ b/src/core/public/application/utils/append_app_path.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/utils/append_app_path.ts
+++ b/src/core/public/application/utils/append_app_path.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/utils/get_app_info.test.ts
+++ b/src/core/public/application/utils/get_app_info.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/utils/get_app_info.ts
+++ b/src/core/public/application/utils/get_app_info.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/utils/index.ts
+++ b/src/core/public/application/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/utils/parse_app_url.test.ts
+++ b/src/core/public/application/utils/parse_app_url.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/utils/parse_app_url.ts
+++ b/src/core/public/application/utils/parse_app_url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/utils/relative_to_absolute.test.ts
+++ b/src/core/public/application/utils/relative_to_absolute.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/utils/relative_to_absolute.ts
+++ b/src/core/public/application/utils/relative_to_absolute.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/utils/remove_slashes.test.ts
+++ b/src/core/public/application/utils/remove_slashes.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/application/utils/remove_slashes.ts
+++ b/src/core/public/application/utils/remove_slashes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/chrome_service.mock.ts
+++ b/src/core/public/chrome/chrome_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/chrome_service.test.ts
+++ b/src/core/public/chrome/chrome_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/constants.ts
+++ b/src/core/public/chrome/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/doc_title/doc_title_service.test.ts
+++ b/src/core/public/chrome/doc_title/doc_title_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/doc_title/doc_title_service.ts
+++ b/src/core/public/chrome/doc_title/doc_title_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/doc_title/index.ts
+++ b/src/core/public/chrome/doc_title/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/index.ts
+++ b/src/core/public/chrome/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/nav_controls/index.ts
+++ b/src/core/public/chrome/nav_controls/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/nav_controls/nav_controls_service.test.ts
+++ b/src/core/public/chrome/nav_controls/nav_controls_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/nav_controls/nav_controls_service.ts
+++ b/src/core/public/chrome/nav_controls/nav_controls_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/nav_links/index.ts
+++ b/src/core/public/chrome/nav_links/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/nav_links/nav_link.ts
+++ b/src/core/public/chrome/nav_links/nav_link.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/nav_links/nav_links_service.test.ts
+++ b/src/core/public/chrome/nav_links/nav_links_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/nav_links/nav_links_service.ts
+++ b/src/core/public/chrome/nav_links/nav_links_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/nav_links/to_nav_link.test.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/nav_links/to_nav_link.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/recently_accessed/create_log_key.test.ts
+++ b/src/core/public/chrome/recently_accessed/create_log_key.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/recently_accessed/create_log_key.ts
+++ b/src/core/public/chrome/recently_accessed/create_log_key.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/recently_accessed/index.ts
+++ b/src/core/public/chrome/recently_accessed/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/recently_accessed/persisted_log.test.ts
+++ b/src/core/public/chrome/recently_accessed/persisted_log.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/recently_accessed/persisted_log.ts
+++ b/src/core/public/chrome/recently_accessed/persisted_log.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/recently_accessed/recently_accessed_service.test.ts
+++ b/src/core/public/chrome/recently_accessed/recently_accessed_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/recently_accessed/recently_accessed_service.ts
+++ b/src/core/public/chrome/recently_accessed/recently_accessed_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.test.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header_action_menu.test.tsx
+++ b/src/core/public/chrome/ui/header/header_action_menu.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header_action_menu.tsx
+++ b/src/core/public/chrome/ui/header/header_action_menu.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header_badge.tsx
+++ b/src/core/public/chrome/ui/header/header_badge.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.test.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header_extension.test.tsx
+++ b/src/core/public/chrome/ui/header/header_extension.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header_extension.tsx
+++ b/src/core/public/chrome/ui/header/header_extension.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header_help_menu.tsx
+++ b/src/core/public/chrome/ui/header/header_help_menu.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header_logo.tsx
+++ b/src/core/public/chrome/ui/header/header_logo.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/header_nav_controls.tsx
+++ b/src/core/public/chrome/ui/header/header_nav_controls.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/index.ts
+++ b/src/core/public/chrome/ui/header/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/nav_link.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/recent_links.tsx
+++ b/src/core/public/chrome/ui/header/recent_links.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/header/types.ts
+++ b/src/core/public/chrome/ui/header/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/index.ts
+++ b/src/core/public/chrome/ui/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/loading_indicator.test.tsx
+++ b/src/core/public/chrome/ui/loading_indicator.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/chrome/ui/loading_indicator.tsx
+++ b/src/core/public/chrome/ui/loading_indicator.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/context/context_service.mock.ts
+++ b/src/core/public/context/context_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/context/context_service.test.mocks.ts
+++ b/src/core/public/context/context_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/context/context_service.test.ts
+++ b/src/core/public/context/context_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/context/context_service.ts
+++ b/src/core/public/context/context_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/context/index.ts
+++ b/src/core/public/context/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/core_app.mock.ts
+++ b/src/core/public/core_app/core_app.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/core_app.ts
+++ b/src/core/public/core_app/core_app.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/errors/error_application.test.ts
+++ b/src/core/public/core_app/errors/error_application.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/errors/error_application.tsx
+++ b/src/core/public/core_app/errors/error_application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/errors/index.ts
+++ b/src/core/public/core_app/errors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/errors/url_overflow.test.ts
+++ b/src/core/public/core_app/errors/url_overflow.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/errors/url_overflow.tsx
+++ b/src/core/public/core_app/errors/url_overflow.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/errors/url_overflow_ui.tsx
+++ b/src/core/public/core_app/errors/url_overflow_ui.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/index.ts
+++ b/src/core/public/core_app/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/components/index.ts
+++ b/src/core/public/core_app/status/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/components/metric_tiles.test.tsx
+++ b/src/core/public/core_app/status/components/metric_tiles.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/components/metric_tiles.tsx
+++ b/src/core/public/core_app/status/components/metric_tiles.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/components/server_status.test.tsx
+++ b/src/core/public/core_app/status/components/server_status.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/components/server_status.tsx
+++ b/src/core/public/core_app/status/components/server_status.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/components/status_table.test.tsx
+++ b/src/core/public/core_app/status/components/status_table.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/components/status_table.tsx
+++ b/src/core/public/core_app/status/components/status_table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/index.ts
+++ b/src/core/public/core_app/status/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/lib/format_number.test.ts
+++ b/src/core/public/core_app/status/lib/format_number.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/lib/format_number.ts
+++ b/src/core/public/core_app/status/lib/format_number.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/lib/index.ts
+++ b/src/core/public/core_app/status/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/lib/load_status.test.ts
+++ b/src/core/public/core_app/status/lib/load_status.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/lib/load_status.ts
+++ b/src/core/public/core_app/status/lib/load_status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/render_app.tsx
+++ b/src/core/public/core_app/status/render_app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_app/status/status_app.tsx
+++ b/src/core/public/core_app/status/status_app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_system.test.mocks.ts
+++ b/src/core/public/core_system.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_system.test.ts
+++ b/src/core/public/core_system.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/core_system.ts
+++ b/src/core/public/core_system.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/doc_links/doc_links_service.mock.ts
+++ b/src/core/public/doc_links/doc_links_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/doc_links/doc_links_service.test.ts
+++ b/src/core/public/doc_links/doc_links_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/doc_links/index.ts
+++ b/src/core/public/doc_links/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/fatal_errors/fatal_errors_screen.test.tsx
+++ b/src/core/public/fatal_errors/fatal_errors_screen.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/fatal_errors/fatal_errors_screen.tsx
+++ b/src/core/public/fatal_errors/fatal_errors_screen.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/fatal_errors/fatal_errors_service.mock.ts
+++ b/src/core/public/fatal_errors/fatal_errors_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/fatal_errors/fatal_errors_service.test.mocks.ts
+++ b/src/core/public/fatal_errors/fatal_errors_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/fatal_errors/fatal_errors_service.test.ts
+++ b/src/core/public/fatal_errors/fatal_errors_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/fatal_errors/fatal_errors_service.tsx
+++ b/src/core/public/fatal_errors/fatal_errors_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/fatal_errors/get_error_info.test.ts
+++ b/src/core/public/fatal_errors/get_error_info.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/fatal_errors/get_error_info.ts
+++ b/src/core/public/fatal_errors/get_error_info.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/fatal_errors/index.ts
+++ b/src/core/public/fatal_errors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/anonymous_paths_service.test.ts
+++ b/src/core/public/http/anonymous_paths_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/anonymous_paths_service.ts
+++ b/src/core/public/http/anonymous_paths_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/base_path.test.ts
+++ b/src/core/public/http/base_path.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/base_path.ts
+++ b/src/core/public/http/base_path.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/fetch.test.ts
+++ b/src/core/public/http/fetch.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/fetch.ts
+++ b/src/core/public/http/fetch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/http_fetch_error.ts
+++ b/src/core/public/http/http_fetch_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/http_intercept_controller.ts
+++ b/src/core/public/http/http_intercept_controller.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/http_intercept_halt_error.ts
+++ b/src/core/public/http/http_intercept_halt_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/http_service.mock.ts
+++ b/src/core/public/http/http_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/http_service.test.mocks.ts
+++ b/src/core/public/http/http_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/http_service.test.ts
+++ b/src/core/public/http/http_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/http_service.ts
+++ b/src/core/public/http/http_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/index.ts
+++ b/src/core/public/http/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/intercept.ts
+++ b/src/core/public/http/intercept.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/loading_count_service.mock.ts
+++ b/src/core/public/http/loading_count_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/loading_count_service.test.ts
+++ b/src/core/public/http/loading_count_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/loading_count_service.ts
+++ b/src/core/public/http/loading_count_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/http/types.ts
+++ b/src/core/public/http/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/i18n/i18n_eui_mapping.tsx
+++ b/src/core/public/i18n/i18n_eui_mapping.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/i18n/i18n_service.mock.ts
+++ b/src/core/public/i18n/i18n_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/i18n/i18n_service.test.tsx
+++ b/src/core/public/i18n/i18n_service.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/i18n/i18n_service.tsx
+++ b/src/core/public/i18n/i18n_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/i18n/index.ts
+++ b/src/core/public/i18n/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/injected_metadata/index.ts
+++ b/src/core/public/injected_metadata/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/injected_metadata/injected_metadata_service.mock.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/injected_metadata/injected_metadata_service.test.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/injected_metadata/injected_metadata_service.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/index.ts
+++ b/src/core/public/integrations/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/integrations_service.mock.ts
+++ b/src/core/public/integrations/integrations_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/integrations_service.test.mocks.ts
+++ b/src/core/public/integrations/integrations_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/integrations_service.test.ts
+++ b/src/core/public/integrations/integrations_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/integrations_service.ts
+++ b/src/core/public/integrations/integrations_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/moment/index.ts
+++ b/src/core/public/integrations/moment/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/moment/moment_service.test.mocks.ts
+++ b/src/core/public/integrations/moment/moment_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/moment/moment_service.test.ts
+++ b/src/core/public/integrations/moment/moment_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/moment/moment_service.ts
+++ b/src/core/public/integrations/moment/moment_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/styles/index.ts
+++ b/src/core/public/integrations/styles/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/styles/styles_service.test.ts
+++ b/src/core/public/integrations/styles/styles_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/integrations/styles/styles_service.ts
+++ b/src/core/public/integrations/styles/styles_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/mocks.ts
+++ b/src/core/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/index.ts
+++ b/src/core/public/notifications/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/notifications_service.mock.ts
+++ b/src/core/public/notifications/notifications_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/notifications_service.ts
+++ b/src/core/public/notifications/notifications_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/toasts/error_toast.test.tsx
+++ b/src/core/public/notifications/toasts/error_toast.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/toasts/error_toast.tsx
+++ b/src/core/public/notifications/toasts/error_toast.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/toasts/global_toast_list.test.tsx
+++ b/src/core/public/notifications/toasts/global_toast_list.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/toasts/global_toast_list.tsx
+++ b/src/core/public/notifications/toasts/global_toast_list.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/toasts/index.ts
+++ b/src/core/public/notifications/toasts/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/toasts/toasts_api.test.ts
+++ b/src/core/public/notifications/toasts/toasts_api.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/toasts/toasts_api.tsx
+++ b/src/core/public/notifications/toasts/toasts_api.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/toasts/toasts_service.mock.ts
+++ b/src/core/public/notifications/toasts/toasts_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/toasts/toasts_service.test.mocks.ts
+++ b/src/core/public/notifications/toasts/toasts_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/toasts/toasts_service.test.tsx
+++ b/src/core/public/notifications/toasts/toasts_service.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/notifications/toasts/toasts_service.tsx
+++ b/src/core/public/notifications/toasts/toasts_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/osd_bootstrap.test.mocks.ts
+++ b/src/core/public/osd_bootstrap.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/osd_bootstrap.test.ts
+++ b/src/core/public/osd_bootstrap.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/osd_bootstrap.ts
+++ b/src/core/public/osd_bootstrap.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/banners/banners_list.test.tsx
+++ b/src/core/public/overlays/banners/banners_list.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/banners/banners_list.tsx
+++ b/src/core/public/overlays/banners/banners_list.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/banners/banners_service.mock.ts
+++ b/src/core/public/overlays/banners/banners_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/banners/banners_service.test.ts
+++ b/src/core/public/overlays/banners/banners_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/banners/banners_service.tsx
+++ b/src/core/public/overlays/banners/banners_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/banners/index.ts
+++ b/src/core/public/overlays/banners/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/banners/priority_map.test.ts
+++ b/src/core/public/overlays/banners/priority_map.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/banners/priority_map.ts
+++ b/src/core/public/overlays/banners/priority_map.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/banners/user_banner_service.test.ts
+++ b/src/core/public/overlays/banners/user_banner_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/banners/user_banner_service.tsx
+++ b/src/core/public/overlays/banners/user_banner_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/flyout/flyout_service.mock.ts
+++ b/src/core/public/overlays/flyout/flyout_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/flyout/flyout_service.test.tsx
+++ b/src/core/public/overlays/flyout/flyout_service.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/flyout/flyout_service.tsx
+++ b/src/core/public/overlays/flyout/flyout_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/flyout/index.ts
+++ b/src/core/public/overlays/flyout/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/index.ts
+++ b/src/core/public/overlays/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/modal/index.ts
+++ b/src/core/public/overlays/modal/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/modal/modal_service.mock.ts
+++ b/src/core/public/overlays/modal/modal_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/modal/modal_service.test.tsx
+++ b/src/core/public/overlays/modal/modal_service.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/modal/modal_service.tsx
+++ b/src/core/public/overlays/modal/modal_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/overlay.test.mocks.ts
+++ b/src/core/public/overlays/overlay.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/overlay_service.mock.ts
+++ b/src/core/public/overlays/overlay_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/overlay_service.ts
+++ b/src/core/public/overlays/overlay_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/overlays/types.ts
+++ b/src/core/public/overlays/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/plugins/index.ts
+++ b/src/core/public/plugins/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/plugins/plugin.test.mocks.ts
+++ b/src/core/public/plugins/plugin.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/plugins/plugin.test.ts
+++ b/src/core/public/plugins/plugin.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/plugins/plugin.ts
+++ b/src/core/public/plugins/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/plugins/plugin_context.ts
+++ b/src/core/public/plugins/plugin_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/plugins/plugin_reader.test.ts
+++ b/src/core/public/plugins/plugin_reader.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/plugins/plugin_reader.ts
+++ b/src/core/public/plugins/plugin_reader.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/plugins/plugins_service.mock.ts
+++ b/src/core/public/plugins/plugins_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/plugins/plugins_service.test.mocks.ts
+++ b/src/core/public/plugins/plugins_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/plugins/plugins_service.test.ts
+++ b/src/core/public/plugins/plugins_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/plugins/plugins_service.ts
+++ b/src/core/public/plugins/plugins_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/rendering/app_containers.test.tsx
+++ b/src/core/public/rendering/app_containers.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/rendering/app_containers.tsx
+++ b/src/core/public/rendering/app_containers.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/rendering/index.ts
+++ b/src/core/public/rendering/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/rendering/rendering_service.mock.ts
+++ b/src/core/public/rendering/rendering_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/rendering/rendering_service.test.tsx
+++ b/src/core/public/rendering/rendering_service.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/rendering/rendering_service.tsx
+++ b/src/core/public/rendering/rendering_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/saved_objects/index.ts
+++ b/src/core/public/saved_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/saved_objects/saved_objects_client.test.ts
+++ b/src/core/public/saved_objects/saved_objects_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/public/saved_objects/saved_objects_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/saved_objects/saved_objects_service.ts
+++ b/src/core/public/saved_objects/saved_objects_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/saved_objects/simple_saved_object.test.ts
+++ b/src/core/public/saved_objects/simple_saved_object.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/saved_objects/simple_saved_object.ts
+++ b/src/core/public/saved_objects/simple_saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/types.ts
+++ b/src/core/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/ui_settings/index.ts
+++ b/src/core/public/ui_settings/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/ui_settings/types.ts
+++ b/src/core/public/ui_settings/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/ui_settings/ui_settings_api.test.ts
+++ b/src/core/public/ui_settings/ui_settings_api.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/ui_settings/ui_settings_api.ts
+++ b/src/core/public/ui_settings/ui_settings_api.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/ui_settings/ui_settings_client.test.ts
+++ b/src/core/public/ui_settings/ui_settings_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/ui_settings/ui_settings_client.ts
+++ b/src/core/public/ui_settings/ui_settings_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/ui_settings/ui_settings_service.mock.ts
+++ b/src/core/public/ui_settings/ui_settings_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/ui_settings/ui_settings_service.test.ts
+++ b/src/core/public/ui_settings/ui_settings_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/ui_settings/ui_settings_service.ts
+++ b/src/core/public/ui_settings/ui_settings_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/utils/crypto/index.ts
+++ b/src/core/public/utils/crypto/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/utils/crypto/sha256.ts
+++ b/src/core/public/utils/crypto/sha256.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/utils/index.ts
+++ b/src/core/public/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/utils/mount.test.tsx
+++ b/src/core/public/utils/mount.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/utils/mount.tsx
+++ b/src/core/public/utils/mount.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/utils/share_weak_replay.test.ts
+++ b/src/core/public/utils/share_weak_replay.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/public/utils/share_weak_replay.ts
+++ b/src/core/public/utils/share_weak_replay.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/audit_trail/audit_trail_service.mock.ts
+++ b/src/core/server/audit_trail/audit_trail_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/audit_trail/audit_trail_service.test.ts
+++ b/src/core/server/audit_trail/audit_trail_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/audit_trail/audit_trail_service.ts
+++ b/src/core/server/audit_trail/audit_trail_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/audit_trail/index.ts
+++ b/src/core/server/audit_trail/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/audit_trail/types.ts
+++ b/src/core/server/audit_trail/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/bootstrap.ts
+++ b/src/core/server/bootstrap.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/capabilities_service.mock.ts
+++ b/src/core/server/capabilities/capabilities_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/capabilities_service.test.ts
+++ b/src/core/server/capabilities/capabilities_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/capabilities_service.ts
+++ b/src/core/server/capabilities/capabilities_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/index.ts
+++ b/src/core/server/capabilities/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/integration_tests/capabilities_service.test.ts
+++ b/src/core/server/capabilities/integration_tests/capabilities_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/merge_capabilities.test.ts
+++ b/src/core/server/capabilities/merge_capabilities.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/merge_capabilities.ts
+++ b/src/core/server/capabilities/merge_capabilities.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/resolve_capabilities.test.ts
+++ b/src/core/server/capabilities/resolve_capabilities.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/resolve_capabilities.ts
+++ b/src/core/server/capabilities/resolve_capabilities.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/routes/index.ts
+++ b/src/core/server/capabilities/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/routes/resolve_capabilities.ts
+++ b/src/core/server/capabilities/routes/resolve_capabilities.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/capabilities/types.ts
+++ b/src/core/server/capabilities/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/config/deprecation/core_deprecations.test.ts
+++ b/src/core/server/config/deprecation/core_deprecations.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/config/deprecation/core_deprecations.ts
+++ b/src/core/server/config/deprecation/core_deprecations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/config/deprecation/index.ts
+++ b/src/core/server/config/deprecation/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/config/index.ts
+++ b/src/core/server/config/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/config/integration_tests/config_deprecation.test.mocks.ts
+++ b/src/core/server/config/integration_tests/config_deprecation.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/config/integration_tests/config_deprecation.test.ts
+++ b/src/core/server/config/integration_tests/config_deprecation.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/config/mocks.ts
+++ b/src/core/server/config/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/context/context_service.mock.ts
+++ b/src/core/server/context/context_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/context/context_service.test.mocks.ts
+++ b/src/core/server/context/context_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/context/context_service.test.ts
+++ b/src/core/server/context/context_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/context/context_service.ts
+++ b/src/core/server/context/context_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/context/index.ts
+++ b/src/core/server/context/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_app/core_app.test.ts
+++ b/src/core/server/core_app/core_app.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_app/core_app.ts
+++ b/src/core/server/core_app/core_app.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_app/index.ts
+++ b/src/core/server/core_app/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_app/integration_tests/default_route_provider_config.test.ts
+++ b/src/core/server/core_app/integration_tests/default_route_provider_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_app/integration_tests/static_assets.test.ts
+++ b/src/core/server/core_app/integration_tests/static_assets.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_context.mock.ts
+++ b/src/core/server/core_context.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_context.ts
+++ b/src/core/server/core_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_route_handler_context.test.ts
+++ b/src/core/server/core_route_handler_context.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_route_handler_context.ts
+++ b/src/core/server/core_route_handler_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_usage_data/core_usage_data_service.mock.ts
+++ b/src/core/server/core_usage_data/core_usage_data_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_usage_data/core_usage_data_service.test.ts
+++ b/src/core/server/core_usage_data/core_usage_data_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_usage_data/core_usage_data_service.ts
+++ b/src/core/server/core_usage_data/core_usage_data_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_usage_data/index.ts
+++ b/src/core/server/core_usage_data/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_usage_data/is_configured.test.ts
+++ b/src/core/server/core_usage_data/is_configured.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_usage_data/is_configured.ts
+++ b/src/core/server/core_usage_data/is_configured.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/core_usage_data/types.ts
+++ b/src/core/server/core_usage_data/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/csp/config.ts
+++ b/src/core/server/csp/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/csp/csp_config.test.ts
+++ b/src/core/server/csp/csp_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/csp/csp_config.ts
+++ b/src/core/server/csp/csp_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/csp/index.ts
+++ b/src/core/server/csp/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/dev/dev_config.ts
+++ b/src/core/server/dev/dev_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/dev/index.ts
+++ b/src/core/server/dev/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/create_data_folder.test.ts
+++ b/src/core/server/environment/create_data_folder.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/create_data_folder.ts
+++ b/src/core/server/environment/create_data_folder.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/environment_service.mock.ts
+++ b/src/core/server/environment/environment_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/environment_service.test.ts
+++ b/src/core/server/environment/environment_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/environment_service.ts
+++ b/src/core/server/environment/environment_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/fs.ts
+++ b/src/core/server/environment/fs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/index.ts
+++ b/src/core/server/environment/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/pid_config.ts
+++ b/src/core/server/environment/pid_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/resolve_uuid.test.ts
+++ b/src/core/server/environment/resolve_uuid.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/resolve_uuid.ts
+++ b/src/core/server/environment/resolve_uuid.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/write_pid_file.test.ts
+++ b/src/core/server/environment/write_pid_file.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/environment/write_pid_file.ts
+++ b/src/core/server/environment/write_pid_file.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/errors.ts
+++ b/src/core/server/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/auth_headers_storage.test.ts
+++ b/src/core/server/http/auth_headers_storage.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/auth_headers_storage.ts
+++ b/src/core/server/http/auth_headers_storage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/auth_state_storage.ts
+++ b/src/core/server/http/auth_state_storage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/base_path_proxy_server.ts
+++ b/src/core/server/http/base_path_proxy_server.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/base_path_service.test.ts
+++ b/src/core/server/http/base_path_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/base_path_service.ts
+++ b/src/core/server/http/base_path_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/cookie_session_storage.mocks.ts
+++ b/src/core/server/http/cookie_session_storage.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/cookie_session_storage.test.ts
+++ b/src/core/server/http/cookie_session_storage.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/cookie_session_storage.ts
+++ b/src/core/server/http/cookie_session_storage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/http_config.test.ts
+++ b/src/core/server/http/http_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/http_config.ts
+++ b/src/core/server/http/http_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/http_server.mocks.ts
+++ b/src/core/server/http/http_server.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/http_server.test.ts
+++ b/src/core/server/http/http_server.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/http_server.ts
+++ b/src/core/server/http/http_server.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/http_service.mock.ts
+++ b/src/core/server/http/http_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/http_service.test.mocks.ts
+++ b/src/core/server/http/http_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/http_service.test.ts
+++ b/src/core/server/http/http_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/http_service.ts
+++ b/src/core/server/http/http_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/http_tools.test.ts
+++ b/src/core/server/http/http_tools.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/http_tools.ts
+++ b/src/core/server/http/http_tools.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/https_redirect_server.test.ts
+++ b/src/core/server/http/https_redirect_server.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/https_redirect_server.ts
+++ b/src/core/server/http/https_redirect_server.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/index.ts
+++ b/src/core/server/http/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/integration_tests/core_service.test.mocks.ts
+++ b/src/core/server/http/integration_tests/core_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/integration_tests/core_services.test.ts
+++ b/src/core/server/http/integration_tests/core_services.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/integration_tests/lifecycle.test.ts
+++ b/src/core/server/http/integration_tests/lifecycle.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/integration_tests/lifecycle_handlers.test.ts
+++ b/src/core/server/http/integration_tests/lifecycle_handlers.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/integration_tests/request.test.ts
+++ b/src/core/server/http/integration_tests/request.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/integration_tests/router.test.ts
+++ b/src/core/server/http/integration_tests/router.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/lifecycle/auth.ts
+++ b/src/core/server/http/lifecycle/auth.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/lifecycle/on_post_auth.ts
+++ b/src/core/server/http/lifecycle/on_post_auth.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/lifecycle/on_pre_auth.ts
+++ b/src/core/server/http/lifecycle/on_pre_auth.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/lifecycle/on_pre_response.ts
+++ b/src/core/server/http/lifecycle/on_pre_response.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/lifecycle/on_pre_routing.ts
+++ b/src/core/server/http/lifecycle/on_pre_routing.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/lifecycle_handlers.test.ts
+++ b/src/core/server/http/lifecycle_handlers.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/lifecycle_handlers.ts
+++ b/src/core/server/http/lifecycle_handlers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/prototype_pollution/index.ts
+++ b/src/core/server/http/prototype_pollution/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/prototype_pollution/validate_object.test.ts
+++ b/src/core/server/http/prototype_pollution/validate_object.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/prototype_pollution/validate_object.ts
+++ b/src/core/server/http/prototype_pollution/validate_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/error_wrapper.test.ts
+++ b/src/core/server/http/router/error_wrapper.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/error_wrapper.ts
+++ b/src/core/server/http/router/error_wrapper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/headers.ts
+++ b/src/core/server/http/router/headers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/index.ts
+++ b/src/core/server/http/router/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/request.test.ts
+++ b/src/core/server/http/router/request.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/response.ts
+++ b/src/core/server/http/router/response.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/response_adapter.ts
+++ b/src/core/server/http/router/response_adapter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/route.ts
+++ b/src/core/server/http/router/route.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/router.mock.ts
+++ b/src/core/server/http/router/router.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/router.test.ts
+++ b/src/core/server/http/router/router.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/router.ts
+++ b/src/core/server/http/router/router.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/socket.test.ts
+++ b/src/core/server/http/router/socket.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/socket.ts
+++ b/src/core/server/http/router/socket.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/validator/index.ts
+++ b/src/core/server/http/router/validator/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/validator/validator.test.ts
+++ b/src/core/server/http/router/validator/validator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/validator/validator.ts
+++ b/src/core/server/http/router/validator/validator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/router/validator/validator_error.ts
+++ b/src/core/server/http/router/validator/validator_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/session_storage.ts
+++ b/src/core/server/http/session_storage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/ssl_config.test.mocks.ts
+++ b/src/core/server/http/ssl_config.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/ssl_config.test.ts
+++ b/src/core/server/http/ssl_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/ssl_config.ts
+++ b/src/core/server/http/ssl_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/test_utils.ts
+++ b/src/core/server/http/test_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http/types.ts
+++ b/src/core/server/http/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http_resources/http_resources_service.mock.ts
+++ b/src/core/server/http_resources/http_resources_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http_resources/http_resources_service.test.ts
+++ b/src/core/server/http_resources/http_resources_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http_resources/http_resources_service.ts
+++ b/src/core/server/http_resources/http_resources_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http_resources/index.ts
+++ b/src/core/server/http_resources/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http_resources/integration_tests/http_resources_service.test.ts
+++ b/src/core/server/http_resources/integration_tests/http_resources_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/http_resources/types.ts
+++ b/src/core/server/http_resources/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/internal_types.ts
+++ b/src/core/server/internal_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/cli.js
+++ b/src/core/server/legacy/cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/cluster_manager.js
+++ b/src/core/server/legacy/cluster_manager.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/config/ensure_valid_configuration.test.ts
+++ b/src/core/server/legacy/config/ensure_valid_configuration.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/config/ensure_valid_configuration.ts
+++ b/src/core/server/legacy/config/ensure_valid_configuration.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/config/get_unused_config_keys.test.ts
+++ b/src/core/server/legacy/config/get_unused_config_keys.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/config/get_unused_config_keys.ts
+++ b/src/core/server/legacy/config/get_unused_config_keys.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/config/index.ts
+++ b/src/core/server/legacy/config/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/index.ts
+++ b/src/core/server/legacy/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/integration_tests/legacy_service.test.ts
+++ b/src/core/server/legacy/integration_tests/legacy_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/integration_tests/logging.test.ts
+++ b/src/core/server/legacy/integration_tests/logging.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/legacy_service.mock.ts
+++ b/src/core/server/legacy/legacy_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/legacy_service.test.ts
+++ b/src/core/server/legacy/legacy_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/legacy_service.ts
+++ b/src/core/server/legacy/legacy_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/logging/appenders/legacy_appender.test.ts
+++ b/src/core/server/legacy/logging/appenders/legacy_appender.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/logging/appenders/legacy_appender.ts
+++ b/src/core/server/legacy/logging/appenders/legacy_appender.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/logging/legacy_logging_server.test.ts
+++ b/src/core/server/legacy/logging/legacy_logging_server.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/logging/legacy_logging_server.ts
+++ b/src/core/server/legacy/logging/legacy_logging_server.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/merge_vars.test.ts
+++ b/src/core/server/legacy/merge_vars.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/merge_vars.ts
+++ b/src/core/server/legacy/merge_vars.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/legacy/types.ts
+++ b/src/core/server/legacy/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/appenders/appenders.test.mocks.ts
+++ b/src/core/server/logging/appenders/appenders.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/appenders/appenders.test.ts
+++ b/src/core/server/logging/appenders/appenders.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/appenders/appenders.ts
+++ b/src/core/server/logging/appenders/appenders.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/appenders/buffer/buffer_appender.test.ts
+++ b/src/core/server/logging/appenders/buffer/buffer_appender.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/appenders/buffer/buffer_appender.ts
+++ b/src/core/server/logging/appenders/buffer/buffer_appender.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/appenders/console/console_appender.test.ts
+++ b/src/core/server/logging/appenders/console/console_appender.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/appenders/console/console_appender.ts
+++ b/src/core/server/logging/appenders/console/console_appender.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/appenders/file/file_appender.test.mocks.ts
+++ b/src/core/server/logging/appenders/file/file_appender.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/appenders/file/file_appender.test.ts
+++ b/src/core/server/logging/appenders/file/file_appender.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/appenders/file/file_appender.ts
+++ b/src/core/server/logging/appenders/file/file_appender.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/index.ts
+++ b/src/core/server/logging/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/integration_tests/logging.test.ts
+++ b/src/core/server/logging/integration_tests/logging.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/integration_tests/utils.ts
+++ b/src/core/server/logging/integration_tests/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/conversions/date.ts
+++ b/src/core/server/logging/layouts/conversions/date.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/conversions/index.ts
+++ b/src/core/server/logging/layouts/conversions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/conversions/level.ts
+++ b/src/core/server/logging/layouts/conversions/level.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/conversions/logger.ts
+++ b/src/core/server/logging/layouts/conversions/logger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/conversions/message.ts
+++ b/src/core/server/logging/layouts/conversions/message.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/conversions/meta.ts
+++ b/src/core/server/logging/layouts/conversions/meta.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/conversions/pid.ts
+++ b/src/core/server/logging/layouts/conversions/pid.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/conversions/type.ts
+++ b/src/core/server/logging/layouts/conversions/type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/json_layout.test.ts
+++ b/src/core/server/logging/layouts/json_layout.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/json_layout.ts
+++ b/src/core/server/logging/layouts/json_layout.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/layouts.test.ts
+++ b/src/core/server/logging/layouts/layouts.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/layouts.ts
+++ b/src/core/server/logging/layouts/layouts.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/pattern_layout.test.ts
+++ b/src/core/server/logging/layouts/pattern_layout.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/layouts/pattern_layout.ts
+++ b/src/core/server/logging/layouts/pattern_layout.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logger.mock.ts
+++ b/src/core/server/logging/logger.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logger.test.ts
+++ b/src/core/server/logging/logger.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logger.ts
+++ b/src/core/server/logging/logger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logger_adapter.test.ts
+++ b/src/core/server/logging/logger_adapter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logger_adapter.ts
+++ b/src/core/server/logging/logger_adapter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logging_config.test.ts
+++ b/src/core/server/logging/logging_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logging_config.ts
+++ b/src/core/server/logging/logging_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logging_service.mock.ts
+++ b/src/core/server/logging/logging_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logging_service.test.ts
+++ b/src/core/server/logging/logging_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logging_service.ts
+++ b/src/core/server/logging/logging_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logging_system.mock.ts
+++ b/src/core/server/logging/logging_system.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logging_system.test.ts
+++ b/src/core/server/logging/logging_system.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/logging/logging_system.ts
+++ b/src/core/server/logging/logging_system.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/cgroup.test.ts
+++ b/src/core/server/metrics/collectors/cgroup.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/cgroup.ts
+++ b/src/core/server/metrics/collectors/cgroup.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/collector.mock.ts
+++ b/src/core/server/metrics/collectors/collector.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/index.ts
+++ b/src/core/server/metrics/collectors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/mocks.ts
+++ b/src/core/server/metrics/collectors/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/os.test.mocks.ts
+++ b/src/core/server/metrics/collectors/os.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/os.test.ts
+++ b/src/core/server/metrics/collectors/os.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/os.ts
+++ b/src/core/server/metrics/collectors/os.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/process.test.ts
+++ b/src/core/server/metrics/collectors/process.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/process.ts
+++ b/src/core/server/metrics/collectors/process.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/server.ts
+++ b/src/core/server/metrics/collectors/server.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/collectors/types.ts
+++ b/src/core/server/metrics/collectors/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/index.ts
+++ b/src/core/server/metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/integration_tests/server_collector.test.ts
+++ b/src/core/server/metrics/integration_tests/server_collector.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/metrics_service.mock.ts
+++ b/src/core/server/metrics/metrics_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/metrics_service.test.mocks.ts
+++ b/src/core/server/metrics/metrics_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/metrics_service.test.ts
+++ b/src/core/server/metrics/metrics_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/metrics_service.ts
+++ b/src/core/server/metrics/metrics_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/ops_config.ts
+++ b/src/core/server/metrics/ops_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/ops_metrics_collector.test.mocks.ts
+++ b/src/core/server/metrics/ops_metrics_collector.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/ops_metrics_collector.test.ts
+++ b/src/core/server/metrics/ops_metrics_collector.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/ops_metrics_collector.ts
+++ b/src/core/server/metrics/ops_metrics_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/metrics/types.ts
+++ b/src/core/server/metrics/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/client_config.test.ts
+++ b/src/core/server/opensearch/client/client_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/client_config.ts
+++ b/src/core/server/opensearch/client/client_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/cluster_client.test.mocks.ts
+++ b/src/core/server/opensearch/client/cluster_client.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/cluster_client.test.ts
+++ b/src/core/server/opensearch/client/cluster_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/cluster_client.ts
+++ b/src/core/server/opensearch/client/cluster_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/configure_client.test.mocks.ts
+++ b/src/core/server/opensearch/client/configure_client.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/configure_client.test.ts
+++ b/src/core/server/opensearch/client/configure_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/configure_client.ts
+++ b/src/core/server/opensearch/client/configure_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/errors.test.ts
+++ b/src/core/server/opensearch/client/errors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/errors.ts
+++ b/src/core/server/opensearch/client/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/index.ts
+++ b/src/core/server/opensearch/client/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/mocks.test.ts
+++ b/src/core/server/opensearch/client/mocks.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/mocks.ts
+++ b/src/core/server/opensearch/client/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/retry_call_cluster.test.ts
+++ b/src/core/server/opensearch/client/retry_call_cluster.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/retry_call_cluster.ts
+++ b/src/core/server/opensearch/client/retry_call_cluster.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/scoped_cluster_client.test.ts
+++ b/src/core/server/opensearch/client/scoped_cluster_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/scoped_cluster_client.ts
+++ b/src/core/server/opensearch/client/scoped_cluster_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/client/types.ts
+++ b/src/core/server/opensearch/client/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/default_headers.ts
+++ b/src/core/server/opensearch/default_headers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/index.ts
+++ b/src/core/server/opensearch/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/api_types.ts
+++ b/src/core/server/opensearch/legacy/api_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/cluster_client.test.mocks.ts
+++ b/src/core/server/opensearch/legacy/cluster_client.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/cluster_client.test.ts
+++ b/src/core/server/opensearch/legacy/cluster_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/cluster_client.ts
+++ b/src/core/server/opensearch/legacy/cluster_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/errors.test.ts
+++ b/src/core/server/opensearch/legacy/errors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/errors.ts
+++ b/src/core/server/opensearch/legacy/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/index.ts
+++ b/src/core/server/opensearch/legacy/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/mocks.ts
+++ b/src/core/server/opensearch/legacy/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/opensearch_client_config.test.ts
+++ b/src/core/server/opensearch/legacy/opensearch_client_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/opensearch_client_config.ts
+++ b/src/core/server/opensearch/legacy/opensearch_client_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/scoped_cluster_client.test.ts
+++ b/src/core/server/opensearch/legacy/scoped_cluster_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/legacy/scoped_cluster_client.ts
+++ b/src/core/server/opensearch/legacy/scoped_cluster_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/opensearch_config.test.mocks.ts
+++ b/src/core/server/opensearch/opensearch_config.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/opensearch_config.test.ts
+++ b/src/core/server/opensearch/opensearch_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/opensearch_config.ts
+++ b/src/core/server/opensearch/opensearch_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/opensearch_service.mock.ts
+++ b/src/core/server/opensearch/opensearch_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/opensearch_service.test.mocks.ts
+++ b/src/core/server/opensearch/opensearch_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/opensearch_service.test.ts
+++ b/src/core/server/opensearch/opensearch_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/opensearch_service.ts
+++ b/src/core/server/opensearch/opensearch_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/status.test.ts
+++ b/src/core/server/opensearch/status.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/status.ts
+++ b/src/core/server/opensearch/status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/types.ts
+++ b/src/core/server/opensearch/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/version_check/ensure_opensearch_version.test.ts
+++ b/src/core/server/opensearch/version_check/ensure_opensearch_version.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/version_check/ensure_opensearch_version.ts
+++ b/src/core/server/opensearch/version_check/ensure_opensearch_version.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.test.ts
+++ b/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.ts
+++ b/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch_dashboards_config.test.ts
+++ b/src/core/server/opensearch_dashboards_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/discovery/index.ts
+++ b/src/core/server/plugins/discovery/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/discovery/is_camel_case.test.ts
+++ b/src/core/server/plugins/discovery/is_camel_case.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/discovery/is_camel_case.ts
+++ b/src/core/server/plugins/discovery/is_camel_case.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/discovery/plugin_discovery_error.ts
+++ b/src/core/server/plugins/discovery/plugin_discovery_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/discovery/plugin_manifest_parser.test.mocks.ts
+++ b/src/core/server/plugins/discovery/plugin_manifest_parser.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/discovery/plugin_manifest_parser.test.ts
+++ b/src/core/server/plugins/discovery/plugin_manifest_parser.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/discovery/plugin_manifest_parser.ts
+++ b/src/core/server/plugins/discovery/plugin_manifest_parser.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/discovery/plugins_discovery.test.mocks.ts
+++ b/src/core/server/plugins/discovery/plugins_discovery.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/discovery/plugins_discovery.test.ts
+++ b/src/core/server/plugins/discovery/plugins_discovery.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/discovery/plugins_discovery.ts
+++ b/src/core/server/plugins/discovery/plugins_discovery.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/index.ts
+++ b/src/core/server/plugins/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/integration_tests/plugins_service.test.mocks.ts
+++ b/src/core/server/plugins/integration_tests/plugins_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/integration_tests/plugins_service.test.ts
+++ b/src/core/server/plugins/integration_tests/plugins_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugin.test.ts
+++ b/src/core/server/plugins/plugin.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugin.ts
+++ b/src/core/server/plugins/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugin_context.test.ts
+++ b/src/core/server/plugins/plugin_context.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugin_context.ts
+++ b/src/core/server/plugins/plugin_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugins_config.test.ts
+++ b/src/core/server/plugins/plugins_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugins_config.ts
+++ b/src/core/server/plugins/plugins_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugins_service.mock.ts
+++ b/src/core/server/plugins/plugins_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugins_service.test.mocks.ts
+++ b/src/core/server/plugins/plugins_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugins_service.test.ts
+++ b/src/core/server/plugins/plugins_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugins_service.ts
+++ b/src/core/server/plugins/plugins_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugins_system.test.mocks.ts
+++ b/src/core/server/plugins/plugins_system.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugins_system.test.ts
+++ b/src/core/server/plugins/plugins_system.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/plugins_system.ts
+++ b/src/core/server/plugins/plugins_system.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/plugins/types.ts
+++ b/src/core/server/plugins/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/__mocks__/params.ts
+++ b/src/core/server/rendering/__mocks__/params.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/__mocks__/rendering_service.ts
+++ b/src/core/server/rendering/__mocks__/rendering_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/index.ts
+++ b/src/core/server/rendering/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/rendering_service.mock.ts
+++ b/src/core/server/rendering/rendering_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/rendering_service.test.ts
+++ b/src/core/server/rendering/rendering_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/views/fonts.tsx
+++ b/src/core/server/rendering/views/fonts.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/views/index.ts
+++ b/src/core/server/rendering/views/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/views/styles.tsx
+++ b/src/core/server/rendering/views/styles.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/views/template.test.tsx
+++ b/src/core/server/rendering/views/template.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/rendering/views/template.tsx
+++ b/src/core/server/rendering/views/template.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/root/index.test.mocks.ts
+++ b/src/core/server/root/index.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/root/index.test.ts
+++ b/src/core/server/root/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/root/index.ts
+++ b/src/core/server/root/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/export/index.ts
+++ b/src/core/server/saved_objects/export/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/export/inject_nested_depdendencies.test.ts
+++ b/src/core/server/saved_objects/export/inject_nested_depdendencies.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/export/inject_nested_depdendencies.ts
+++ b/src/core/server/saved_objects/export/inject_nested_depdendencies.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/export/sort_objects.test.ts
+++ b/src/core/server/saved_objects/export/sort_objects.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/export/sort_objects.ts
+++ b/src/core/server/saved_objects/export/sort_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/__mocks__/index.ts
+++ b/src/core/server/saved_objects/import/__mocks__/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/check_conflicts.test.ts
+++ b/src/core/server/saved_objects/import/check_conflicts.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/check_conflicts.ts
+++ b/src/core/server/saved_objects/import/check_conflicts.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/check_origin_conflicts.test.ts
+++ b/src/core/server/saved_objects/import/check_origin_conflicts.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/check_origin_conflicts.ts
+++ b/src/core/server/saved_objects/import/check_origin_conflicts.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/collect_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/collect_saved_objects.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/collect_saved_objects.ts
+++ b/src/core/server/saved_objects/import/collect_saved_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/create_limit_stream.test.ts
+++ b/src/core/server/saved_objects/import/create_limit_stream.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/create_limit_stream.ts
+++ b/src/core/server/saved_objects/import/create_limit_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/create_objects_filter.test.ts
+++ b/src/core/server/saved_objects/import/create_objects_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/create_objects_filter.ts
+++ b/src/core/server/saved_objects/import/create_objects_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/create_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/create_saved_objects.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/extract_errors.test.ts
+++ b/src/core/server/saved_objects/import/extract_errors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/extract_errors.ts
+++ b/src/core/server/saved_objects/import/extract_errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/get_non_unique_entries.test.ts
+++ b/src/core/server/saved_objects/import/get_non_unique_entries.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/get_non_unique_entries.ts
+++ b/src/core/server/saved_objects/import/get_non_unique_entries.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/index.ts
+++ b/src/core/server/saved_objects/import/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/regenerate_ids.test.ts
+++ b/src/core/server/saved_objects/import/regenerate_ids.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/regenerate_ids.ts
+++ b/src/core/server/saved_objects/import/regenerate_ids.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/resolve_import_errors.test.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/split_overwrites.test.ts
+++ b/src/core/server/saved_objects/import/split_overwrites.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/split_overwrites.ts
+++ b/src/core/server/saved_objects/import/split_overwrites.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/types.ts
+++ b/src/core/server/saved_objects/import/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/validate_references.test.ts
+++ b/src/core/server/saved_objects/import/validate_references.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/validate_references.ts
+++ b/src/core/server/saved_objects/import/validate_references.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/validate_retries.test.ts
+++ b/src/core/server/saved_objects/import/validate_retries.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/import/validate_retries.ts
+++ b/src/core/server/saved_objects/import/validate_retries.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/index.ts
+++ b/src/core/server/saved_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/mappings/index.ts
+++ b/src/core/server/saved_objects/mappings/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/mappings/lib/get_property.test.ts
+++ b/src/core/server/saved_objects/mappings/lib/get_property.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/mappings/lib/get_property.ts
+++ b/src/core/server/saved_objects/mappings/lib/get_property.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/mappings/lib/get_root_properties.ts
+++ b/src/core/server/saved_objects/mappings/lib/get_root_properties.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/mappings/lib/get_root_properties_objects.test.ts
+++ b/src/core/server/saved_objects/mappings/lib/get_root_properties_objects.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/mappings/lib/get_root_properties_objects.ts
+++ b/src/core/server/saved_objects/mappings/lib/get_root_properties_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/mappings/lib/get_types.ts
+++ b/src/core/server/saved_objects/mappings/lib/get_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/mappings/lib/index.ts
+++ b/src/core/server/saved_objects/mappings/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/mappings/types.ts
+++ b/src/core/server/saved_objects/mappings/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/build_active_mappings.test.ts
+++ b/src/core/server/saved_objects/migrations/core/build_active_mappings.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
+++ b/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/build_index_map.test.ts
+++ b/src/core/server/saved_objects/migrations/core/build_index_map.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/build_index_map.ts
+++ b/src/core/server/saved_objects/migrations/core/build_index_map.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/call_cluster.ts
+++ b/src/core/server/saved_objects/migrations/core/call_cluster.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/document_migrator.test.ts
+++ b/src/core/server/saved_objects/migrations/core/document_migrator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/document_migrator.ts
+++ b/src/core/server/saved_objects/migrations/core/document_migrator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/index.ts
+++ b/src/core/server/saved_objects/migrations/core/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
+++ b/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/index_migrator.ts
+++ b/src/core/server/saved_objects/migrations/core/index_migrator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/migrate_raw_docs.test.ts
+++ b/src/core/server/saved_objects/migrations/core/migrate_raw_docs.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/migrate_raw_docs.ts
+++ b/src/core/server/saved_objects/migrations/core/migrate_raw_docs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/migration_context.test.ts
+++ b/src/core/server/saved_objects/migrations/core/migration_context.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/migration_context.ts
+++ b/src/core/server/saved_objects/migrations/core/migration_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/migration_coordinator.test.ts
+++ b/src/core/server/saved_objects/migrations/core/migration_coordinator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/migration_coordinator.ts
+++ b/src/core/server/saved_objects/migrations/core/migration_coordinator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/migration_logger.ts
+++ b/src/core/server/saved_objects/migrations/core/migration_logger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/migration_opensearch_client.test.mock.ts
+++ b/src/core/server/saved_objects/migrations/core/migration_opensearch_client.test.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/migration_opensearch_client.test.ts
+++ b/src/core/server/saved_objects/migrations/core/migration_opensearch_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/migration_opensearch_client.ts
+++ b/src/core/server/saved_objects/migrations/core/migration_opensearch_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/opensearch_index.test.ts
+++ b/src/core/server/saved_objects/migrations/core/opensearch_index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/core/opensearch_index.ts
+++ b/src/core/server/saved_objects/migrations/core/opensearch_index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/index.ts
+++ b/src/core/server/saved_objects/migrations/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/mocks.ts
+++ b/src/core/server/saved_objects/migrations/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/opensearch_dashboards/__mocks__/opensearch_dashboards_migrator.ts
+++ b/src/core/server/saved_objects/migrations/opensearch_dashboards/__mocks__/opensearch_dashboards_migrator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/opensearch_dashboards/index.ts
+++ b/src/core/server/saved_objects/migrations/opensearch_dashboards/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.mock.ts
+++ b/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.test.ts
+++ b/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.ts
+++ b/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/migrations/types.ts
+++ b/src/core/server/saved_objects/migrations/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/opensearch_query.js
+++ b/src/core/server/saved_objects/opensearch_query.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/bulk_create.ts
+++ b/src/core/server/saved_objects/routes/bulk_create.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/bulk_get.ts
+++ b/src/core/server/saved_objects/routes/bulk_get.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/bulk_update.ts
+++ b/src/core/server/saved_objects/routes/bulk_update.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/create.ts
+++ b/src/core/server/saved_objects/routes/create.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/delete.ts
+++ b/src/core/server/saved_objects/routes/delete.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/export.ts
+++ b/src/core/server/saved_objects/routes/export.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/find.ts
+++ b/src/core/server/saved_objects/routes/find.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/get.ts
+++ b/src/core/server/saved_objects/routes/get.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/import.ts
+++ b/src/core/server/saved_objects/routes/import.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/index.ts
+++ b/src/core/server/saved_objects/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/bulk_create.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/bulk_create.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/bulk_get.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/bulk_get.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/bulk_update.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/bulk_update.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/create.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/create.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/delete.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/delete.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/export.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/export.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/find.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/find.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/get.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/get.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/import.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/import.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/log_legacy_import.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/log_legacy_import.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/migrate.test.mocks.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/migrate.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/migrate.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/migrate.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/resolve_import_errors.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/resolve_import_errors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/integration_tests/update.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/update.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/log_legacy_import.ts
+++ b/src/core/server/saved_objects/routes/log_legacy_import.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/migrate.ts
+++ b/src/core/server/saved_objects/routes/migrate.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/routes/resolve_import_errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/test_utils.ts
+++ b/src/core/server/saved_objects/routes/test_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/update.ts
+++ b/src/core/server/saved_objects/routes/update.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/utils.test.ts
+++ b/src/core/server/saved_objects/routes/utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/routes/utils.ts
+++ b/src/core/server/saved_objects/routes/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/saved_objects_config.ts
+++ b/src/core/server/saved_objects/saved_objects_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/server/saved_objects/saved_objects_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/saved_objects_service.test.mocks.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/saved_objects_service.test.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/saved_objects_service.ts
+++ b/src/core/server/saved_objects/saved_objects_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/saved_objects_type_registry.mock.ts
+++ b/src/core/server/saved_objects/saved_objects_type_registry.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/saved_objects_type_registry.test.ts
+++ b/src/core/server/saved_objects/saved_objects_type_registry.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/saved_objects_type_registry.ts
+++ b/src/core/server/saved_objects/saved_objects_type_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/serialization/index.ts
+++ b/src/core/server/saved_objects/serialization/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/serialization/serializer.test.ts
+++ b/src/core/server/saved_objects/serialization/serializer.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/serialization/serializer.ts
+++ b/src/core/server/saved_objects/serialization/serializer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/serialization/types.ts
+++ b/src/core/server/saved_objects/serialization/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/index.ts
+++ b/src/core/server/saved_objects/service/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/decorate_opensearch_error.test.ts
+++ b/src/core/server/saved_objects/service/lib/decorate_opensearch_error.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/decorate_opensearch_error.ts
+++ b/src/core/server/saved_objects/service/lib/decorate_opensearch_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/errors.test.ts
+++ b/src/core/server/saved_objects/service/lib/errors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/errors.ts
+++ b/src/core/server/saved_objects/service/lib/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/filter_utils.test.ts
+++ b/src/core/server/saved_objects/service/lib/filter_utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/filter_utils.ts
+++ b/src/core/server/saved_objects/service/lib/filter_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/included_fields.test.ts
+++ b/src/core/server/saved_objects/service/lib/included_fields.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/included_fields.ts
+++ b/src/core/server/saved_objects/service/lib/included_fields.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/index.ts
+++ b/src/core/server/saved_objects/service/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/priority_collection.test.ts
+++ b/src/core/server/saved_objects/service/lib/priority_collection.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/priority_collection.ts
+++ b/src/core/server/saved_objects/service/lib/priority_collection.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/repository.mock.ts
+++ b/src/core/server/saved_objects/service/lib/repository.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/repository.test.js
+++ b/src/core/server/saved_objects/service/lib/repository.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/repository_create_repository.test.ts
+++ b/src/core/server/saved_objects/service/lib/repository_create_repository.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/repository_opensearch_client.test.mock.ts
+++ b/src/core/server/saved_objects/service/lib/repository_opensearch_client.test.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/repository_opensearch_client.test.ts
+++ b/src/core/server/saved_objects/service/lib/repository_opensearch_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/repository_opensearch_client.ts
+++ b/src/core/server/saved_objects/service/lib/repository_opensearch_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/scoped_client_provider.mock.ts
+++ b/src/core/server/saved_objects/service/lib/scoped_client_provider.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/scoped_client_provider.test.js
+++ b/src/core/server/saved_objects/service/lib/scoped_client_provider.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/scoped_client_provider.ts
+++ b/src/core/server/saved_objects/service/lib/scoped_client_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/search_dsl/index.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.test.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.test.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/search_dsl/sorting_params.test.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/sorting_params.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/search_dsl/sorting_params.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/sorting_params.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/utils.test.ts
+++ b/src/core/server/saved_objects/service/lib/utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/lib/utils.ts
+++ b/src/core/server/saved_objects/service/lib/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/saved_objects_client.mock.ts
+++ b/src/core/server/saved_objects/service/saved_objects_client.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/saved_objects_client.test.js
+++ b/src/core/server/saved_objects/service/saved_objects_client.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/service/saved_objects_client.ts
+++ b/src/core/server/saved_objects/service/saved_objects_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/status.test.ts
+++ b/src/core/server/saved_objects/status.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/status.ts
+++ b/src/core/server/saved_objects/status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/types.ts
+++ b/src/core/server/saved_objects/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/version/base64.ts
+++ b/src/core/server/saved_objects/version/base64.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/version/decode_request_version.test.ts
+++ b/src/core/server/saved_objects/version/decode_request_version.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/version/decode_request_version.ts
+++ b/src/core/server/saved_objects/version/decode_request_version.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/version/decode_version.test.ts
+++ b/src/core/server/saved_objects/version/decode_version.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/version/decode_version.ts
+++ b/src/core/server/saved_objects/version/decode_version.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/version/encode_hit_version.test.ts
+++ b/src/core/server/saved_objects/version/encode_hit_version.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/version/encode_hit_version.ts
+++ b/src/core/server/saved_objects/version/encode_hit_version.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/version/encode_version.test.ts
+++ b/src/core/server/saved_objects/version/encode_version.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/version/encode_version.ts
+++ b/src/core/server/saved_objects/version/encode_version.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/saved_objects/version/index.ts
+++ b/src/core/server/saved_objects/version/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/server.test.mocks.ts
+++ b/src/core/server/server.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/server.test.ts
+++ b/src/core/server/server.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/server.ts
+++ b/src/core/server/server.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/get_summary_status.test.ts
+++ b/src/core/server/status/get_summary_status.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/get_summary_status.ts
+++ b/src/core/server/status/get_summary_status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/index.ts
+++ b/src/core/server/status/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/legacy_status.test.ts
+++ b/src/core/server/status/legacy_status.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/legacy_status.ts
+++ b/src/core/server/status/legacy_status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/plugins_status.test.ts
+++ b/src/core/server/status/plugins_status.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/plugins_status.ts
+++ b/src/core/server/status/plugins_status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/routes/index.ts
+++ b/src/core/server/status/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/routes/integration_tests/status.test.ts
+++ b/src/core/server/status/routes/integration_tests/status.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/routes/status.ts
+++ b/src/core/server/status/routes/status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/status_config.ts
+++ b/src/core/server/status/status_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/status_service.mock.ts
+++ b/src/core/server/status/status_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/status_service.test.ts
+++ b/src/core/server/status/status_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/status_service.ts
+++ b/src/core/server/status/status_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/test_utils.ts
+++ b/src/core/server/status/test_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/status/types.ts
+++ b/src/core/server/status/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/test_utils.ts
+++ b/src/core/server/test_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/types.ts
+++ b/src/core/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/create_or_upgrade_saved_config.test.mock.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/create_or_upgrade_saved_config.test.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/create_or_upgrade_saved_config.test.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/create_or_upgrade_saved_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/create_or_upgrade_saved_config.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/create_or_upgrade_saved_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/get_upgradeable_config.test.mock.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/get_upgradeable_config.test.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/get_upgradeable_config.test.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/get_upgradeable_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/get_upgradeable_config.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/get_upgradeable_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/index.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/integration_tests/create_or_upgrade.test.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/integration_tests/create_or_upgrade.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/is_config_version_upgradeable.test.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/is_config_version_upgradeable.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/is_config_version_upgradeable.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/is_config_version_upgradeable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/index.ts
+++ b/src/core/server/ui_settings/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/integration_tests/doc_exists.ts
+++ b/src/core/server/ui_settings/integration_tests/doc_exists.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/integration_tests/doc_missing.ts
+++ b/src/core/server/ui_settings/integration_tests/doc_missing.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/integration_tests/doc_missing_and_index_read_only.ts
+++ b/src/core/server/ui_settings/integration_tests/doc_missing_and_index_read_only.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/integration_tests/index.test.ts
+++ b/src/core/server/ui_settings/integration_tests/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/integration_tests/lib/chance.ts
+++ b/src/core/server/ui_settings/integration_tests/lib/chance.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/integration_tests/lib/index.ts
+++ b/src/core/server/ui_settings/integration_tests/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/integration_tests/lib/servers.ts
+++ b/src/core/server/ui_settings/integration_tests/lib/servers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/integration_tests/routes.test.ts
+++ b/src/core/server/ui_settings/integration_tests/routes.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/routes/delete.ts
+++ b/src/core/server/ui_settings/routes/delete.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/routes/get.ts
+++ b/src/core/server/ui_settings/routes/get.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/routes/index.ts
+++ b/src/core/server/ui_settings/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/routes/set.ts
+++ b/src/core/server/ui_settings/routes/set.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/routes/set_many.ts
+++ b/src/core/server/ui_settings/routes/set_many.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/saved_objects/index.ts
+++ b/src/core/server/ui_settings/saved_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/saved_objects/migrations.test.ts
+++ b/src/core/server/ui_settings/saved_objects/migrations.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/saved_objects/migrations.ts
+++ b/src/core/server/ui_settings/saved_objects/migrations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/saved_objects/ui_settings.ts
+++ b/src/core/server/ui_settings/saved_objects/ui_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/accessibility.test.ts
+++ b/src/core/server/ui_settings/settings/accessibility.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/accessibility.ts
+++ b/src/core/server/ui_settings/settings/accessibility.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/date_formats.test.ts
+++ b/src/core/server/ui_settings/settings/date_formats.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/date_formats.ts
+++ b/src/core/server/ui_settings/settings/date_formats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/index.test.ts
+++ b/src/core/server/ui_settings/settings/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/index.ts
+++ b/src/core/server/ui_settings/settings/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/misc.test.ts
+++ b/src/core/server/ui_settings/settings/misc.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/misc.ts
+++ b/src/core/server/ui_settings/settings/misc.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/navigation.test.ts
+++ b/src/core/server/ui_settings/settings/navigation.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/navigation.ts
+++ b/src/core/server/ui_settings/settings/navigation.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/notifications.test.ts
+++ b/src/core/server/ui_settings/settings/notifications.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/notifications.ts
+++ b/src/core/server/ui_settings/settings/notifications.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/state.test.ts
+++ b/src/core/server/ui_settings/settings/state.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/state.ts
+++ b/src/core/server/ui_settings/settings/state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/theme.test.ts
+++ b/src/core/server/ui_settings/settings/theme.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/settings/theme.ts
+++ b/src/core/server/ui_settings/settings/theme.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/types.ts
+++ b/src/core/server/ui_settings/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/ui_settings_client.test.ts
+++ b/src/core/server/ui_settings/ui_settings_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/ui_settings_client.ts
+++ b/src/core/server/ui_settings/ui_settings_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/ui_settings_config.ts
+++ b/src/core/server/ui_settings/ui_settings_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/ui_settings_errors.ts
+++ b/src/core/server/ui_settings/ui_settings_errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/ui_settings_service.mock.ts
+++ b/src/core/server/ui_settings/ui_settings_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/ui_settings_service.test.mock.ts
+++ b/src/core/server/ui_settings/ui_settings_service.test.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/ui_settings_service.test.ts
+++ b/src/core/server/ui_settings/ui_settings_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/ui_settings/ui_settings_service.ts
+++ b/src/core/server/ui_settings/ui_settings_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/crypto/__fixtures__/index.ts
+++ b/src/core/server/utils/crypto/__fixtures__/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/crypto/index.ts
+++ b/src/core/server/utils/crypto/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/crypto/pkcs12.test.ts
+++ b/src/core/server/utils/crypto/pkcs12.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/crypto/pkcs12.ts
+++ b/src/core/server/utils/crypto/pkcs12.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/from_root.ts
+++ b/src/core/server/utils/from_root.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/index.ts
+++ b/src/core/server/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/package_json.ts
+++ b/src/core/server/utils/package_json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/concat_stream.test.ts
+++ b/src/core/server/utils/streams/concat_stream.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/concat_stream.ts
+++ b/src/core/server/utils/streams/concat_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/concat_stream_providers.test.ts
+++ b/src/core/server/utils/streams/concat_stream_providers.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/concat_stream_providers.ts
+++ b/src/core/server/utils/streams/concat_stream_providers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/filter_stream.test.ts
+++ b/src/core/server/utils/streams/filter_stream.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/filter_stream.ts
+++ b/src/core/server/utils/streams/filter_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/index.ts
+++ b/src/core/server/utils/streams/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/intersperse_stream.test.ts
+++ b/src/core/server/utils/streams/intersperse_stream.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/intersperse_stream.ts
+++ b/src/core/server/utils/streams/intersperse_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/list_stream.test.ts
+++ b/src/core/server/utils/streams/list_stream.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/list_stream.ts
+++ b/src/core/server/utils/streams/list_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/map_stream.test.ts
+++ b/src/core/server/utils/streams/map_stream.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/map_stream.ts
+++ b/src/core/server/utils/streams/map_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/promise_from_streams.test.ts
+++ b/src/core/server/utils/streams/promise_from_streams.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/promise_from_streams.ts
+++ b/src/core/server/utils/streams/promise_from_streams.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/reduce_stream.test.ts
+++ b/src/core/server/utils/streams/reduce_stream.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/reduce_stream.ts
+++ b/src/core/server/utils/streams/reduce_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/replace_stream.test.ts
+++ b/src/core/server/utils/streams/replace_stream.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/replace_stream.ts
+++ b/src/core/server/utils/streams/replace_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/split_stream.test.ts
+++ b/src/core/server/utils/streams/split_stream.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/server/utils/streams/split_stream.ts
+++ b/src/core/server/utils/streams/split_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/test_helpers/http_test_setup.ts
+++ b/src/core/test_helpers/http_test_setup.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/test_helpers/osd_server.ts
+++ b/src/core/test_helpers/osd_server.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/test_helpers/strip_ansi_snapshot_serializer.ts
+++ b/src/core/test_helpers/strip_ansi_snapshot_serializer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/types/app_category.ts
+++ b/src/core/types/app_category.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/types/capabilities.ts
+++ b/src/core/types/capabilities.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/types/core_service.ts
+++ b/src/core/types/core_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/types/custom_branding.ts
+++ b/src/core/types/custom_branding.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/types/saved_objects.ts
+++ b/src/core/types/saved_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/types/serializable.ts
+++ b/src/core/types/serializable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/types/status.ts
+++ b/src/core/types/status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/types/ui_settings.ts
+++ b/src/core/types/ui_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/typings.ts
+++ b/src/core/typings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/utils/context.mock.ts
+++ b/src/core/utils/context.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/utils/context.test.ts
+++ b/src/core/utils/context.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/utils/context.ts
+++ b/src/core/utils/context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/utils/default_app_categories.ts
+++ b/src/core/utils/default_app_categories.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/__tests__/file.js
+++ b/src/dev/__tests__/file.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/__tests__/node_versions_must_match.js
+++ b/src/dev/__tests__/node_versions_must_match.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/args.test.ts
+++ b/src/dev/build/args.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/args.ts
+++ b/src/dev/build/args.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/cli.ts
+++ b/src/dev/build/cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/__fixtures__/log_on_sigint.js
+++ b/src/dev/build/lib/__fixtures__/log_on_sigint.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/__mocks__/get_build_number.ts
+++ b/src/dev/build/lib/__mocks__/get_build_number.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/build.test.ts
+++ b/src/dev/build/lib/build.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/build.ts
+++ b/src/dev/build/lib/build.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/config.test.ts
+++ b/src/dev/build/lib/config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/config.ts
+++ b/src/dev/build/lib/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/download.ts
+++ b/src/dev/build/lib/download.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/errors.test.ts
+++ b/src/dev/build/lib/errors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/errors.ts
+++ b/src/dev/build/lib/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/exec.test.ts
+++ b/src/dev/build/lib/exec.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/exec.ts
+++ b/src/dev/build/lib/exec.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/fs.ts
+++ b/src/dev/build/lib/fs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/get_build_number.ts
+++ b/src/dev/build/lib/get_build_number.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/index.ts
+++ b/src/dev/build/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/integration_tests/download.test.ts
+++ b/src/dev/build/lib/integration_tests/download.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/integration_tests/fs.test.ts
+++ b/src/dev/build/lib/integration_tests/fs.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/integration_tests/scan_copy.test.ts
+++ b/src/dev/build/lib/integration_tests/scan_copy.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/integration_tests/watch_stdio_for_line.test.ts
+++ b/src/dev/build/lib/integration_tests/watch_stdio_for_line.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/platform.test.ts
+++ b/src/dev/build/lib/platform.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/platform.ts
+++ b/src/dev/build/lib/platform.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/runner.test.ts
+++ b/src/dev/build/lib/runner.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/runner.ts
+++ b/src/dev/build/lib/runner.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/scan.ts
+++ b/src/dev/build/lib/scan.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/scan_copy.ts
+++ b/src/dev/build/lib/scan_copy.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/scan_delete.test.ts
+++ b/src/dev/build/lib/scan_delete.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/scan_delete.ts
+++ b/src/dev/build/lib/scan_delete.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/version_info.test.ts
+++ b/src/dev/build/lib/version_info.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/version_info.ts
+++ b/src/dev/build/lib/version_info.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/lib/watch_stdio_for_line.ts
+++ b/src/dev/build/lib/watch_stdio_for_line.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/bin/copy_bin_scripts_task.ts
+++ b/src/dev/build/tasks/bin/copy_bin_scripts_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/bin/index.ts
+++ b/src/dev/build/tasks/bin/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/build_opensearch_dashboards_platform_plugins.ts
+++ b/src/dev/build/tasks/build_opensearch_dashboards_platform_plugins.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/build_packages_task.ts
+++ b/src/dev/build/tasks/build_packages_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/clean_tasks.ts
+++ b/src/dev/build/tasks/clean_tasks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/copy_source_task.ts
+++ b/src/dev/build/tasks/copy_source_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/create_archives_sources_task.ts
+++ b/src/dev/build/tasks/create_archives_sources_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/create_archives_task.ts
+++ b/src/dev/build/tasks/create_archives_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/create_empty_dirs_and_files_task.ts
+++ b/src/dev/build/tasks/create_empty_dirs_and_files_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/create_package_json_task.ts
+++ b/src/dev/build/tasks/create_package_json_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/create_readme_task.ts
+++ b/src/dev/build/tasks/create_readme_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/index.ts
+++ b/src/dev/build/tasks/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/install_chromium.js
+++ b/src/dev/build/tasks/install_chromium.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/install_dependencies_task.ts
+++ b/src/dev/build/tasks/install_dependencies_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/license_file_task.ts
+++ b/src/dev/build/tasks/license_file_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/nodejs/clean_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/clean_node_builds_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/nodejs/extract_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/extract_node_builds_task.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/nodejs/extract_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/extract_node_builds_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/nodejs/index.ts
+++ b/src/dev/build/tasks/nodejs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/nodejs/node_download_info.ts
+++ b/src/dev/build/tasks/nodejs/node_download_info.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/nodejs/node_shasums.test.ts
+++ b/src/dev/build/tasks/nodejs/node_shasums.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/nodejs/node_shasums.ts
+++ b/src/dev/build/tasks/nodejs/node_shasums.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/notice_file_task.ts
+++ b/src/dev/build/tasks/notice_file_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
+++ b/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/os_packages/docker_generator/bundle_dockerfiles.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/bundle_dockerfiles.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/os_packages/docker_generator/index.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/os_packages/docker_generator/template_context.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/template_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/build_docker_sh.template.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/build_docker_sh.template.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/dockerfile.template.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/dockerfile.template.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/index.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/opensearch_dashboards_yml.template.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/opensearch_dashboards_yml.template.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/os_packages/index.ts
+++ b/src/dev/build/tasks/os_packages/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/os_packages/run_fpm.ts
+++ b/src/dev/build/tasks/os_packages/run_fpm.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/patch_native_modules_task.ts
+++ b/src/dev/build/tasks/patch_native_modules_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/path_length_task.ts
+++ b/src/dev/build/tasks/path_length_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/transpile_babel_task.ts
+++ b/src/dev/build/tasks/transpile_babel_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/uuid_verification_task.ts
+++ b/src/dev/build/tasks/uuid_verification_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/verify_env_task.ts
+++ b/src/dev/build/tasks/verify_env_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/build/tasks/write_sha_sums_task.ts
+++ b/src/dev/build/tasks/write_sha_sums_task.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/ci_setup/get_percy_env.js
+++ b/src/dev/ci_setup/get_percy_env.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/constants.ts
+++ b/src/dev/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/eslint/index.ts
+++ b/src/dev/eslint/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/eslint/lint_files.ts
+++ b/src/dev/eslint/lint_files.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/eslint/pick_files_to_lint.ts
+++ b/src/dev/eslint/pick_files_to_lint.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/file.ts
+++ b/src/dev/file.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/globs.js
+++ b/src/dev/globs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/config.ts
+++ b/src/dev/i18n/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/constants.ts
+++ b/src/dev/i18n/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/extract_default_translations.js
+++ b/src/dev/i18n/extract_default_translations.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/extract_default_translations.test.js
+++ b/src/dev/i18n/extract_default_translations.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/extractors/code.js
+++ b/src/dev/i18n/extractors/code.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/extractors/code.test.js
+++ b/src/dev/i18n/extractors/code.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/extractors/html.js
+++ b/src/dev/i18n/extractors/html.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/extractors/html.test.js
+++ b/src/dev/i18n/extractors/html.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/extractors/i18n_call.js
+++ b/src/dev/i18n/extractors/i18n_call.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/extractors/i18n_call.test.js
+++ b/src/dev/i18n/extractors/i18n_call.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/extractors/index.js
+++ b/src/dev/i18n/extractors/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/extractors/react.js
+++ b/src/dev/i18n/extractors/react.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/extractors/react.test.js
+++ b/src/dev/i18n/extractors/react.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/index.ts
+++ b/src/dev/i18n/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/integrate_locale_files.test.mocks.ts
+++ b/src/dev/i18n/integrate_locale_files.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/integrate_locale_files.test.ts
+++ b/src/dev/i18n/integrate_locale_files.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/integrate_locale_files.ts
+++ b/src/dev/i18n/integrate_locale_files.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/serializers/index.ts
+++ b/src/dev/i18n/serializers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/serializers/json.test.ts
+++ b/src/dev/i18n/serializers/json.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/serializers/json.ts
+++ b/src/dev/i18n/serializers/json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/serializers/json5.test.ts
+++ b/src/dev/i18n/serializers/json5.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/serializers/json5.ts
+++ b/src/dev/i18n/serializers/json5.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/tasks/check_compatibility.ts
+++ b/src/dev/i18n/tasks/check_compatibility.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/tasks/check_configs.ts
+++ b/src/dev/i18n/tasks/check_configs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/tasks/extract_default_translations.ts
+++ b/src/dev/i18n/tasks/extract_default_translations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/tasks/extract_untracked_translations.ts
+++ b/src/dev/i18n/tasks/extract_untracked_translations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/tasks/index.ts
+++ b/src/dev/i18n/tasks/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/tasks/merge_configs.ts
+++ b/src/dev/i18n/tasks/merge_configs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/utils/index.ts
+++ b/src/dev/i18n/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/utils/intl_types.ts
+++ b/src/dev/i18n/utils/intl_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/utils/utils.js
+++ b/src/dev/i18n/utils/utils.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/utils/utils.test.js
+++ b/src/dev/i18n/utils/utils.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/utils/verify_icu_message.test.ts
+++ b/src/dev/i18n/utils/verify_icu_message.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/i18n/utils/verify_icu_message.ts
+++ b/src/dev/i18n/utils/verify_icu_message.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/index.js
+++ b/src/dev/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/index.ts
+++ b/src/dev/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/babel_transform.js
+++ b/src/dev/jest/babel_transform.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/cli.js
+++ b/src/dev/jest/cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/config.integration.js
+++ b/src/dev/jest/config.integration.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/config.js
+++ b/src/dev/jest/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/integration_tests/__fixtures__/test.js
+++ b/src/dev/jest/integration_tests/__fixtures__/test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/integration_tests/junit_reporter.test.js
+++ b/src/dev/jest/integration_tests/junit_reporter.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/junit_reporter.js
+++ b/src/dev/jest/junit_reporter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/mocks/css_module_mock.js
+++ b/src/dev/jest/mocks/css_module_mock.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/mocks/file_mock.js
+++ b/src/dev/jest/mocks/file_mock.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/mocks/style_mock.js
+++ b/src/dev/jest/mocks/style_mock.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/mocks/worker_module_mock.js
+++ b/src/dev/jest/mocks/worker_module_mock.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/setup/after_env.integration.js
+++ b/src/dev/jest/setup/after_env.integration.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/setup/babel_polyfill.js
+++ b/src/dev/jest/setup/babel_polyfill.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/setup/enzyme.js
+++ b/src/dev/jest/setup/enzyme.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/setup/mocks.js
+++ b/src/dev/jest/setup/mocks.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/setup/polyfills.js
+++ b/src/dev/jest/setup/polyfills.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/jest/setup/react_testing_library.js
+++ b/src/dev/jest/setup/react_testing_library.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/license_checker/__tests__/valid.js
+++ b/src/dev/license_checker/__tests__/valid.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/license_checker/index.ts
+++ b/src/dev/license_checker/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/license_checker/run_check_licenses_cli.ts
+++ b/src/dev/license_checker/run_check_licenses_cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/license_checker/valid.ts
+++ b/src/dev/license_checker/valid.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/mocha/__tests__/fixtures/project/test.js
+++ b/src/dev/mocha/__tests__/fixtures/project/test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/mocha/__tests__/junit_report_generation.js
+++ b/src/dev/mocha/__tests__/junit_report_generation.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/mocha/auto_junit_reporter.js
+++ b/src/dev/mocha/auto_junit_reporter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/mocha/index.js
+++ b/src/dev/mocha/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/mocha/junit_report_generation.js
+++ b/src/dev/mocha/junit_report_generation.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/mocha/log_cache.js
+++ b/src/dev/mocha/log_cache.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/mocha/run_mocha_cli.js
+++ b/src/dev/mocha/run_mocha_cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/mocha/server_junit_reporter.js
+++ b/src/dev/mocha/server_junit_reporter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/notice/bundled_notices.js
+++ b/src/dev/notice/bundled_notices.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/notice/cli.js
+++ b/src/dev/notice/cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/notice/generate_build_notice_text.js
+++ b/src/dev/notice/generate_build_notice_text.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/notice/generate_build_notice_text.test.js
+++ b/src/dev/notice/generate_build_notice_text.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/notice/generate_node_notice_text.js
+++ b/src/dev/notice/generate_node_notice_text.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/notice/generate_notice_from_source.ts
+++ b/src/dev/notice/generate_notice_from_source.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/notice/generate_package_notice_text.js
+++ b/src/dev/notice/generate_package_notice_text.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/notice/index.ts
+++ b/src/dev/notice/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/npm/index.ts
+++ b/src/dev/npm/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/npm/installed_packages.ts
+++ b/src/dev/npm/installed_packages.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/npm/integration_tests/__fixtures__/fixture1/index.js
+++ b/src/dev/npm/integration_tests/__fixtures__/fixture1/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/npm/integration_tests/installed_packages.test.ts
+++ b/src/dev/npm/integration_tests/installed_packages.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/precommit_hook/casing_check_config.js
+++ b/src/dev/precommit_hook/casing_check_config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
@@ -105,7 +108,7 @@ export const IGNORE_DIRECTORY_GLOBS = [
   'src/babel-*',
   'packages/*',
   'packages/osd-ui-framework/generator-kui',
-  'src/legacy/ui/public/flot-charts',
+  'src/legacy/core_plugins/opensearch-dashboards/public/context/query_parameters',
   'test/functional/fixtures/opensearch_archiver/visualize_source-filters',
   'packages/osd-pm/src/utils/__fixtures__/*',
 ];

--- a/src/dev/precommit_hook/check_file_casing.js
+++ b/src/dev/precommit_hook/check_file_casing.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/precommit_hook/get_files_for_commit.js
+++ b/src/dev/precommit_hook/get_files_for_commit.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/precommit_hook/index.js
+++ b/src/dev/precommit_hook/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/prs/github_api.ts
+++ b/src/dev/prs/github_api.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/prs/helpers.ts
+++ b/src/dev/prs/helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/prs/pr.ts
+++ b/src/dev/prs/pr.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/prs/run_update_prs_cli.ts
+++ b/src/dev/prs/run_update_prs_cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/run_check_file_casing.js
+++ b/src/dev/run_check_file_casing.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/run_check_lockfile_symlinks.js
+++ b/src/dev/run_check_lockfile_symlinks.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/run_check_published_api_changes.ts
+++ b/src/dev/run_check_published_api_changes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/run_eslint.js
+++ b/src/dev/run_eslint.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/run_i18n_check.ts
+++ b/src/dev/run_i18n_check.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/run_i18n_extract.ts
+++ b/src/dev/run_i18n_extract.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/run_i18n_integrate.ts
+++ b/src/dev/run_i18n_integrate.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/run_precommit_hook.js
+++ b/src/dev/run_precommit_hook.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/run_sasslint.js
+++ b/src/dev/run_sasslint.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/sasslint/index.js
+++ b/src/dev/sasslint/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/sasslint/lint_files.js
+++ b/src/dev/sasslint/lint_files.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/sasslint/pick_files_to_lint.js
+++ b/src/dev/sasslint/pick_files_to_lint.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/storybook/aliases.ts
+++ b/src/dev/storybook/aliases.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/storybook/commands/clean.ts
+++ b/src/dev/storybook/commands/clean.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/storybook/run_storybook_cli.ts
+++ b/src/dev/storybook/run_storybook_cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/typescript/build_refs.ts
+++ b/src/dev/typescript/build_refs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/typescript/exec_in_projects.ts
+++ b/src/dev/typescript/exec_in_projects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/typescript/get_ts_project_for_absolute_path.ts
+++ b/src/dev/typescript/get_ts_project_for_absolute_path.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/typescript/index.ts
+++ b/src/dev/typescript/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/typescript/project.ts
+++ b/src/dev/typescript/project.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/typescript/projects.ts
+++ b/src/dev/typescript/projects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/typescript/run_check_ts_projects_cli.ts
+++ b/src/dev/typescript/run_check_ts_projects_cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/typescript/run_type_check_cli.ts
+++ b/src/dev/typescript/run_type_check_cli.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/dev/xml.ts
+++ b/src/dev/xml.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/docs/cli.js
+++ b/src/docs/cli.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/docs/docs_repo.js
+++ b/src/docs/docs_repo.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/agg_resp/date_histogram.js
+++ b/src/fixtures/agg_resp/date_histogram.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/agg_resp/geohash_grid.js
+++ b/src/fixtures/agg_resp/geohash_grid.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/agg_resp/range.js
+++ b/src/fixtures/agg_resp/range.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/fake_chart_events.js
+++ b/src/fixtures/fake_chart_events.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/fake_hierarchical_data.ts
+++ b/src/fixtures/fake_hierarchical_data.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/fake_row.js
+++ b/src/fixtures/fake_row.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/field_mapping.js
+++ b/src/fixtures/field_mapping.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/hits.js
+++ b/src/fixtures/hits.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/logstash_fields.js
+++ b/src/fixtures/logstash_fields.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/mapping_with_dupes.js
+++ b/src/fixtures/mapping_with_dupes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/mock_index_patterns.js
+++ b/src/fixtures/mock_index_patterns.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/mock_state.js
+++ b/src/fixtures/mock_state.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/mock_ui_state.js
+++ b/src/fixtures/mock_ui_state.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/real_hits.js
+++ b/src/fixtures/real_hits.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/search_response.js
+++ b/src/fixtures/search_response.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/stubbed_logstash_index_pattern.js
+++ b/src/fixtures/stubbed_logstash_index_pattern.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/stubbed_saved_object_index_pattern.ts
+++ b/src/fixtures/stubbed_saved_object_index_pattern.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/stubbed_search_source.js
+++ b/src/fixtures/stubbed_search_source.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/telemetry_collectors/constants.ts
+++ b/src/fixtures/telemetry_collectors/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/telemetry_collectors/externally_defined_collector.ts
+++ b/src/fixtures/telemetry_collectors/externally_defined_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/telemetry_collectors/file_with_no_collector.ts
+++ b/src/fixtures/telemetry_collectors/file_with_no_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/telemetry_collectors/imported_schema.ts
+++ b/src/fixtures/telemetry_collectors/imported_schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/telemetry_collectors/imported_usage_interface.ts
+++ b/src/fixtures/telemetry_collectors/imported_usage_interface.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/telemetry_collectors/indexed_interface_with_not_matching_schema.ts
+++ b/src/fixtures/telemetry_collectors/indexed_interface_with_not_matching_schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/telemetry_collectors/nested_collector.ts
+++ b/src/fixtures/telemetry_collectors/nested_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/telemetry_collectors/schema_defined_with_spreads_collector.ts
+++ b/src/fixtures/telemetry_collectors/schema_defined_with_spreads_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/telemetry_collectors/unmapped_collector.ts
+++ b/src/fixtures/telemetry_collectors/unmapped_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/fixtures/telemetry_collectors/working_collector.ts
+++ b/src/fixtures/telemetry_collectors/working_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/core_plugins/opensearch-dashboards/public/context/query_parameters/state.js
+++ b/src/legacy/core_plugins/opensearch-dashboards/public/context/query_parameters/state.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/config/complete.js
+++ b/src/legacy/server/config/complete.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/config/complete.test.js
+++ b/src/legacy/server/config/complete.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/config/config.js
+++ b/src/legacy/server/config/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/config/config.test.js
+++ b/src/legacy/server/config/config.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/config/index.js
+++ b/src/legacy/server/config/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/config/override.test.ts
+++ b/src/legacy/server/config/override.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/config/override.ts
+++ b/src/legacy/server/config/override.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/config/schema.test.js
+++ b/src/legacy/server/config/schema.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/core/index.ts
+++ b/src/legacy/server/core/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/http/index.js
+++ b/src/legacy/server/http/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/http/integration_tests/max_payload_size.test.js
+++ b/src/legacy/server/http/integration_tests/max_payload_size.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/http/register_hapi_plugins.js
+++ b/src/legacy/server/http/register_hapi_plugins.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/http/setup_base_path_provider.js
+++ b/src/legacy/server/http/setup_base_path_provider.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/i18n/constants.ts
+++ b/src/legacy/server/i18n/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/i18n/get_translations_path.ts
+++ b/src/legacy/server/i18n/get_translations_path.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/i18n/index.ts
+++ b/src/legacy/server/i18n/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/i18n/localization/file_integrity.test.mocks.ts
+++ b/src/legacy/server/i18n/localization/file_integrity.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/i18n/localization/file_integrity.test.ts
+++ b/src/legacy/server/i18n/localization/file_integrity.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/i18n/localization/file_integrity.ts
+++ b/src/legacy/server/i18n/localization/file_integrity.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/i18n/localization/index.ts
+++ b/src/legacy/server/i18n/localization/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/i18n/localization/telemetry_localization_collector.test.ts
+++ b/src/legacy/server/i18n/localization/telemetry_localization_collector.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/i18n/localization/telemetry_localization_collector.ts
+++ b/src/legacy/server/i18n/localization/telemetry_localization_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/keystore/errors.js
+++ b/src/legacy/server/keystore/errors.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/keystore/index.js
+++ b/src/legacy/server/keystore/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/keystore/keystore.js
+++ b/src/legacy/server/keystore/keystore.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/keystore/keystore.test.js
+++ b/src/legacy/server/keystore/keystore.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/apply_filters_to_keys.js
+++ b/src/legacy/server/logging/apply_filters_to_keys.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/apply_filters_to_keys.test.js
+++ b/src/legacy/server/logging/apply_filters_to_keys.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/configuration.js
+++ b/src/legacy/server/logging/configuration.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/index.js
+++ b/src/legacy/server/logging/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/log_format.js
+++ b/src/legacy/server/logging/log_format.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/log_format_json.js
+++ b/src/legacy/server/logging/log_format_json.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/log_format_json.test.js
+++ b/src/legacy/server/logging/log_format_json.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/log_format_string.js
+++ b/src/legacy/server/logging/log_format_string.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/log_format_string.test.js
+++ b/src/legacy/server/logging/log_format_string.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/log_interceptor.js
+++ b/src/legacy/server/logging/log_interceptor.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/log_interceptor.test.js
+++ b/src/legacy/server/logging/log_interceptor.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/log_reporter.js
+++ b/src/legacy/server/logging/log_reporter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/log_with_metadata.js
+++ b/src/legacy/server/logging/log_with_metadata.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/rotate/index.ts
+++ b/src/legacy/server/logging/rotate/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/rotate/log_rotator.test.ts
+++ b/src/legacy/server/logging/rotate/log_rotator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/logging/rotate/log_rotator.ts
+++ b/src/legacy/server/logging/rotate/log_rotator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/osd_server.d.ts
+++ b/src/legacy/server/osd_server.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/osd_server.js
+++ b/src/legacy/server/osd_server.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/server/warnings/index.js
+++ b/src/legacy/server/warnings/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/ui/apm/index.js
+++ b/src/legacy/ui/apm/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/ui/index.js
+++ b/src/legacy/ui/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/ui/public/documentation_links/documentation_links.ts
+++ b/src/legacy/ui/public/documentation_links/documentation_links.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/ui/ui_mixin.js
+++ b/src/legacy/ui/ui_mixin.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/ui/ui_render/bootstrap/app_bootstrap.js
+++ b/src/legacy/ui/ui_render/bootstrap/app_bootstrap.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/ui/ui_render/bootstrap/app_bootstrap.test.js
+++ b/src/legacy/ui/ui_render/bootstrap/app_bootstrap.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/ui/ui_render/bootstrap/index.js
+++ b/src/legacy/ui/ui_render/bootstrap/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/ui/ui_render/bootstrap/osd_bundles_loader_source.js
+++ b/src/legacy/ui/ui_render/bootstrap/osd_bundles_loader_source.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/ui/ui_render/index.js
+++ b/src/legacy/ui/ui_render/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/ui/ui_render/ui_render_mixin.js
+++ b/src/legacy/ui/ui_render/ui_render_mixin.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/utils/__tests__/unset.js
+++ b/src/legacy/utils/__tests__/unset.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/utils/artifact_type.ts
+++ b/src/legacy/utils/artifact_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/utils/deep_clone_with_buffers.test.ts
+++ b/src/legacy/utils/deep_clone_with_buffers.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/utils/deep_clone_with_buffers.ts
+++ b/src/legacy/utils/deep_clone_with_buffers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/utils/index.d.ts
+++ b/src/legacy/utils/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/utils/index.js
+++ b/src/legacy/utils/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/utils/unset.js
+++ b/src/legacy/utils/unset.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/legacy/utils/version.js
+++ b/src/legacy/utils/version.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/bundles_route/__fixtures__/outside_output.js
+++ b/src/optimize/bundles_route/__fixtures__/outside_output.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/bundles_route/__fixtures__/plugin/foo/plugin.js
+++ b/src/optimize/bundles_route/__fixtures__/plugin/foo/plugin.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/bundles_route/bundles_route.test.ts
+++ b/src/optimize/bundles_route/bundles_route.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/bundles_route/bundles_route.ts
+++ b/src/optimize/bundles_route/bundles_route.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/bundles_route/dynamic_asset_response.ts
+++ b/src/optimize/bundles_route/dynamic_asset_response.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/bundles_route/file_hash.ts
+++ b/src/optimize/bundles_route/file_hash.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/bundles_route/file_hash_cache.ts
+++ b/src/optimize/bundles_route/file_hash_cache.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/bundles_route/index.ts
+++ b/src/optimize/bundles_route/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/bundles_route/proxy_bundles_route.ts
+++ b/src/optimize/bundles_route/proxy_bundles_route.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/index.ts
+++ b/src/optimize/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/np_ui_plugin_public_dirs.ts
+++ b/src/optimize/np_ui_plugin_public_dirs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/optimize/optimize_mixin.ts
+++ b/src/optimize/optimize_mixin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/component_registry.test.tsx
+++ b/src/plugins/advanced_settings/public/component_registry/component_registry.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/component_registry.ts
+++ b/src/plugins/advanced_settings/public/component_registry/component_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/index.ts
+++ b/src/plugins/advanced_settings/public/component_registry/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/page_footer/index.ts
+++ b/src/plugins/advanced_settings/public/component_registry/page_footer/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/page_footer/page_footer.test.tsx
+++ b/src/plugins/advanced_settings/public/component_registry/page_footer/page_footer.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/page_footer/page_footer.ts
+++ b/src/plugins/advanced_settings/public/component_registry/page_footer/page_footer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/page_subtitle/index.ts
+++ b/src/plugins/advanced_settings/public/component_registry/page_subtitle/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/page_subtitle/page_subtitle.test.tsx
+++ b/src/plugins/advanced_settings/public/component_registry/page_subtitle/page_subtitle.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/page_subtitle/page_subtitle.ts
+++ b/src/plugins/advanced_settings/public/component_registry/page_subtitle/page_subtitle.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/page_title/index.ts
+++ b/src/plugins/advanced_settings/public/component_registry/page_title/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/page_title/page_title.test.tsx
+++ b/src/plugins/advanced_settings/public/component_registry/page_title/page_title.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/component_registry/page_title/page_title.tsx
+++ b/src/plugins/advanced_settings/public/component_registry/page_title/page_title.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/index.ts
+++ b/src/plugins/advanced_settings/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/advanced_settings.test.tsx
+++ b/src/plugins/advanced_settings/public/management_app/advanced_settings.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/advanced_settings.tsx
+++ b/src/plugins/advanced_settings/public/management_app/advanced_settings.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/advanced_settings_voice_announcement/advanced_settings_voice_announcement.test.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/advanced_settings_voice_announcement/advanced_settings_voice_announcement.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/advanced_settings_voice_announcement/advanced_settings_voice_announcement.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/advanced_settings_voice_announcement/advanced_settings_voice_announcement.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/advanced_settings_voice_announcement/index.ts
+++ b/src/plugins/advanced_settings/public/management_app/components/advanced_settings_voice_announcement/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/call_outs/call_outs.test.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/call_outs/call_outs.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/call_outs/call_outs.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/call_outs/call_outs.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/call_outs/index.ts
+++ b/src/plugins/advanced_settings/public/management_app/components/call_outs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/field/field.test.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/field/field.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/field/field.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/field/field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/field/index.ts
+++ b/src/plugins/advanced_settings/public/management_app/components/field/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/form/form.test.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/form/form.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/form/form.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/form/form.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/form/index.ts
+++ b/src/plugins/advanced_settings/public/management_app/components/form/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/search/index.ts
+++ b/src/plugins/advanced_settings/public/management_app/components/search/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/search/search.test.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/search/search.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/components/search/search.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/search/search.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/default_category.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/default_category.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/get_aria_name.test.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/get_aria_name.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/get_aria_name.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/get_aria_name.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/get_category_name.test.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/get_category_name.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/get_category_name.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/get_category_name.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/get_val_type.test.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/get_val_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/get_val_type.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/get_val_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/index.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/is_default_value.test.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/is_default_value.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/is_default_value.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/is_default_value.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/to_editable_config.test.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/to_editable_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/lib/to_editable_config.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/to_editable_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/mount_management_section.tsx
+++ b/src/plugins/advanced_settings/public/management_app/mount_management_section.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/management_app/types.ts
+++ b/src/plugins/advanced_settings/public/management_app/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/mocks.ts
+++ b/src/plugins/advanced_settings/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/plugin.ts
+++ b/src/plugins/advanced_settings/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/public/types.ts
+++ b/src/plugins/advanced_settings/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/server/capabilities_provider.ts
+++ b/src/plugins/advanced_settings/server/capabilities_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/server/index.ts
+++ b/src/plugins/advanced_settings/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/advanced_settings/server/plugin.ts
+++ b/src/plugins/advanced_settings/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/apm_oss/common/index_pattern_constants.ts
+++ b/src/plugins/apm_oss/common/index_pattern_constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/apm_oss/public/index.ts
+++ b/src/plugins/apm_oss/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/apm_oss/public/plugin.ts
+++ b/src/plugins/apm_oss/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/apm_oss/public/types.ts
+++ b/src/plugins/apm_oss/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/apm_oss/server/index.ts
+++ b/src/plugins/apm_oss/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/apm_oss/server/mocks.ts
+++ b/src/plugins/apm_oss/server/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/apm_oss/server/plugin.ts
+++ b/src/plugins/apm_oss/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/apm_oss/server/tutorial/envs/on_prem.ts
+++ b/src/plugins/apm_oss/server/tutorial/envs/on_prem.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/apm_oss/server/tutorial/index.ts
+++ b/src/plugins/apm_oss/server/tutorial/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/apm_oss/server/tutorial/instructions/apm_agent_instructions.ts
+++ b/src/plugins/apm_oss/server/tutorial/instructions/apm_agent_instructions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/apm_oss/server/tutorial/instructions/apm_server_instructions.ts
+++ b/src/plugins/apm_oss/server/tutorial/instructions/apm_server_instructions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/batch.ts
+++ b/src/plugins/bfetch/common/batch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/buffer/create_batched_function.ts
+++ b/src/plugins/bfetch/common/buffer/create_batched_function.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/buffer/index.ts
+++ b/src/plugins/bfetch/common/buffer/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/buffer/item_buffer.ts
+++ b/src/plugins/bfetch/common/buffer/item_buffer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/buffer/tests/create_batched_function.test.ts
+++ b/src/plugins/bfetch/common/buffer/tests/create_batched_function.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/buffer/tests/item_buffer.test.ts
+++ b/src/plugins/bfetch/common/buffer/tests/item_buffer.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/buffer/tests/run_item_buffer_tests.ts
+++ b/src/plugins/bfetch/common/buffer/tests/run_item_buffer_tests.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/buffer/tests/timed_item_buffer.test.ts
+++ b/src/plugins/bfetch/common/buffer/tests/timed_item_buffer.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/buffer/timed_item_buffer.ts
+++ b/src/plugins/bfetch/common/buffer/timed_item_buffer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/index.ts
+++ b/src/plugins/bfetch/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/streaming/index.ts
+++ b/src/plugins/bfetch/common/streaming/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/streaming/types.ts
+++ b/src/plugins/bfetch/common/streaming/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/types.ts
+++ b/src/plugins/bfetch/common/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/util/index.ts
+++ b/src/plugins/bfetch/common/util/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/util/normalize_error.ts
+++ b/src/plugins/bfetch/common/util/normalize_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/common/util/remove_leading_slash.ts
+++ b/src/plugins/bfetch/common/util/remove_leading_slash.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/batching/create_streaming_batched_function.test.ts
+++ b/src/plugins/bfetch/public/batching/create_streaming_batched_function.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/batching/create_streaming_batched_function.ts
+++ b/src/plugins/bfetch/public/batching/create_streaming_batched_function.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/index.ts
+++ b/src/plugins/bfetch/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/mocks.ts
+++ b/src/plugins/bfetch/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/plugin.ts
+++ b/src/plugins/bfetch/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/streaming/fetch_streaming.test.ts
+++ b/src/plugins/bfetch/public/streaming/fetch_streaming.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/streaming/fetch_streaming.ts
+++ b/src/plugins/bfetch/public/streaming/fetch_streaming.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/streaming/from_streaming_xhr.test.ts
+++ b/src/plugins/bfetch/public/streaming/from_streaming_xhr.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/streaming/from_streaming_xhr.ts
+++ b/src/plugins/bfetch/public/streaming/from_streaming_xhr.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/streaming/index.ts
+++ b/src/plugins/bfetch/public/streaming/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/streaming/split.test.ts
+++ b/src/plugins/bfetch/public/streaming/split.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/streaming/split.ts
+++ b/src/plugins/bfetch/public/streaming/split.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/test_helpers/xhr.ts
+++ b/src/plugins/bfetch/public/test_helpers/xhr.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/public/types.ts
+++ b/src/plugins/bfetch/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/server/index.ts
+++ b/src/plugins/bfetch/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/server/mocks.ts
+++ b/src/plugins/bfetch/server/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/server/plugin.ts
+++ b/src/plugins/bfetch/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/server/streaming/create_ndjson_stream.ts
+++ b/src/plugins/bfetch/server/streaming/create_ndjson_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/server/streaming/index.ts
+++ b/src/plugins/bfetch/server/streaming/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/bfetch/server/types.ts
+++ b/src/plugins/bfetch/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/common/index.ts
+++ b/src/plugins/charts/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/index.ts
+++ b/src/plugins/charts/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/mocks.ts
+++ b/src/plugins/charts/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/plugin.ts
+++ b/src/plugins/charts/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/colors/color_palette.ts
+++ b/src/plugins/charts/public/services/colors/color_palette.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/colors/colors.test.ts
+++ b/src/plugins/charts/public/services/colors/colors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/colors/colors.ts
+++ b/src/plugins/charts/public/services/colors/colors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/colors/colors_palette.test.ts
+++ b/src/plugins/charts/public/services/colors/colors_palette.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/colors/index.ts
+++ b/src/plugins/charts/public/services/colors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/colors/mapped_colors.test.ts
+++ b/src/plugins/charts/public/services/colors/mapped_colors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/colors/mapped_colors.ts
+++ b/src/plugins/charts/public/services/colors/mapped_colors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/colors/mock.ts
+++ b/src/plugins/charts/public/services/colors/mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/colors/seed_colors.test.ts
+++ b/src/plugins/charts/public/services/colors/seed_colors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/colors/seed_colors.ts
+++ b/src/plugins/charts/public/services/colors/seed_colors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/index.ts
+++ b/src/plugins/charts/public/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/theme/index.ts
+++ b/src/plugins/charts/public/services/theme/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/theme/mock.ts
+++ b/src/plugins/charts/public/services/theme/mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/theme/theme.test.tsx
+++ b/src/plugins/charts/public/services/theme/theme.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/services/theme/theme.ts
+++ b/src/plugins/charts/public/services/theme/theme.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/color_maps/color_maps.ts
+++ b/src/plugins/charts/public/static/color_maps/color_maps.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/color_maps/heatmap_color.test.ts
+++ b/src/plugins/charts/public/static/color_maps/heatmap_color.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/color_maps/heatmap_color.ts
+++ b/src/plugins/charts/public/static/color_maps/heatmap_color.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/color_maps/index.ts
+++ b/src/plugins/charts/public/static/color_maps/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/color_maps/mock.ts
+++ b/src/plugins/charts/public/static/color_maps/mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/color_maps/truncated_color_maps.ts
+++ b/src/plugins/charts/public/static/color_maps/truncated_color_maps.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/basic_options.tsx
+++ b/src/plugins/charts/public/static/components/basic_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/collections.ts
+++ b/src/plugins/charts/public/static/components/collections.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/color_ranges.tsx
+++ b/src/plugins/charts/public/static/components/color_ranges.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/color_schema.tsx
+++ b/src/plugins/charts/public/static/components/color_schema.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/index.ts
+++ b/src/plugins/charts/public/static/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/number_input.tsx
+++ b/src/plugins/charts/public/static/components/number_input.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/range.tsx
+++ b/src/plugins/charts/public/static/components/range.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/required_number_input.tsx
+++ b/src/plugins/charts/public/static/components/required_number_input.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/select.tsx
+++ b/src/plugins/charts/public/static/components/select.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/switch.tsx
+++ b/src/plugins/charts/public/static/components/switch.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/text_input.tsx
+++ b/src/plugins/charts/public/static/components/text_input.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/components/types.ts
+++ b/src/plugins/charts/public/static/components/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/public/static/index.ts
+++ b/src/plugins/charts/public/static/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/server/index.ts
+++ b/src/plugins/charts/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/charts/server/plugin.ts
+++ b/src/plugins/charts/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/common/text_object.ts
+++ b/src/plugins/console/common/text_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/common/types/api_responses.ts
+++ b/src/plugins/console/common/types/api_responses.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/common/types/index.ts
+++ b/src/plugins/console/common/types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/common/types/models.ts
+++ b/src/plugins/console/common/types/models.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/common/types/plugin_config.ts
+++ b/src/plugins/console/common/types/plugin_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/components/console_menu.tsx
+++ b/src/plugins/console/public/application/components/console_menu.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/components/editor_content_spinner.tsx
+++ b/src/plugins/console/public/application/components/editor_content_spinner.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/components/editor_example.tsx
+++ b/src/plugins/console/public/application/components/editor_example.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/components/help_panel.tsx
+++ b/src/plugins/console/public/application/components/help_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/components/index.ts
+++ b/src/plugins/console/public/application/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/components/network_request_status_bar/index.ts
+++ b/src/plugins/console/public/application/components/network_request_status_bar/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/components/network_request_status_bar/network_request_status_bar.tsx
+++ b/src/plugins/console/public/application/components/network_request_status_bar/network_request_status_bar.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/components/settings_modal.tsx
+++ b/src/plugins/console/public/application/components/settings_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/components/something_went_wrong_callout.tsx
+++ b/src/plugins/console/public/application/components/something_went_wrong_callout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/components/top_nav_menu.tsx
+++ b/src/plugins/console/public/application/components/top_nav_menu.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/components/welcome_panel.tsx
+++ b/src/plugins/console/public/application/components/welcome_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/console_history/console_history.tsx
+++ b/src/plugins/console/public/application/containers/console_history/console_history.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/console_history/history_viewer.tsx
+++ b/src/plugins/console/public/application/containers/console_history/history_viewer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/console_history/index.ts
+++ b/src/plugins/console/public/application/containers/console_history/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/index.ts
+++ b/src/plugins/console/public/application/containers/editor/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/apply_editor_settings.ts
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/apply_editor_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.test.mock.tsx
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.test.mock.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.test.tsx
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor_output.tsx
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor_output.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/index.ts
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/keyboard_shortcuts.ts
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/keyboard_shortcuts.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/legacy/console_menu_actions.ts
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_menu_actions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/legacy/index.ts
+++ b/src/plugins/console/public/application/containers/editor/legacy/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/editor/legacy/subscribe_console_resize_checker.ts
+++ b/src/plugins/console/public/application/containers/editor/legacy/subscribe_console_resize_checker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/index.ts
+++ b/src/plugins/console/public/application/containers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/main/get_top_nav.ts
+++ b/src/plugins/console/public/application/containers/main/get_top_nav.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/main/index.ts
+++ b/src/plugins/console/public/application/containers/main/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/main/main.tsx
+++ b/src/plugins/console/public/application/containers/main/main.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/containers/settings.tsx
+++ b/src/plugins/console/public/application/containers/settings.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/contexts/create_use_context.ts
+++ b/src/plugins/console/public/application/contexts/create_use_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/contexts/editor_context/editor_context.tsx
+++ b/src/plugins/console/public/application/contexts/editor_context/editor_context.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/contexts/editor_context/editor_registry.ts
+++ b/src/plugins/console/public/application/contexts/editor_context/editor_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/contexts/editor_context/index.ts
+++ b/src/plugins/console/public/application/contexts/editor_context/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/contexts/index.ts
+++ b/src/plugins/console/public/application/contexts/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/contexts/request_context.tsx
+++ b/src/plugins/console/public/application/contexts/request_context.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/contexts/services_context.mock.ts
+++ b/src/plugins/console/public/application/contexts/services_context.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/contexts/services_context.tsx
+++ b/src/plugins/console/public/application/contexts/services_context.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/factories/index.ts
+++ b/src/plugins/console/public/application/factories/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/factories/token_iterator.ts
+++ b/src/plugins/console/public/application/factories/token_iterator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/index.ts
+++ b/src/plugins/console/public/application/hooks/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_data_init/data_migration.ts
+++ b/src/plugins/console/public/application/hooks/use_data_init/data_migration.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_data_init/index.ts
+++ b/src/plugins/console/public/application/hooks/use_data_init/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_data_init/use_data_init.ts
+++ b/src/plugins/console/public/application/hooks/use_data_init/use_data_init.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_restore_request_from_history/index.ts
+++ b/src/plugins/console/public/application/hooks/use_restore_request_from_history/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_restore_request_from_history/restore_request_from_history.ts
+++ b/src/plugins/console/public/application/hooks/use_restore_request_from_history/restore_request_from_history.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_restore_request_from_history/use_restore_request_from_history.ts
+++ b/src/plugins/console/public/application/hooks/use_restore_request_from_history/use_restore_request_from_history.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_save_current_text_object.ts
+++ b/src/plugins/console/public/application/hooks/use_save_current_text_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/index.ts
+++ b/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/send_request_to_opensearch.ts
+++ b/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/send_request_to_opensearch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/track.ts
+++ b/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/track.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/use_send_current_request_to_opensearch.test.tsx
+++ b/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/use_send_current_request_to_opensearch.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/use_send_current_request_to_opensearch.ts
+++ b/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/use_send_current_request_to_opensearch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/hooks/use_set_input_editor.ts
+++ b/src/plugins/console/public/application/hooks/use_set_input_editor.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/index.tsx
+++ b/src/plugins/console/public/application/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/lib/api.ts
+++ b/src/plugins/console/public/application/lib/api.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/lib/index.ts
+++ b/src/plugins/console/public/application/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/lib/opensearch_host_service.ts
+++ b/src/plugins/console/public/application/lib/opensearch_host_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/index.ts
+++ b/src/plugins/console/public/application/models/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/__tests__/input.test.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/__tests__/input.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/__tests__/output_tokenization.test.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/__tests__/output_tokenization.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/create.ts
+++ b/src/plugins/console/public/application/models/legacy_core_editor/create.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/create_readonly.ts
+++ b/src/plugins/console/public/application/models/legacy_core_editor/create_readonly.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/index.ts
+++ b/src/plugins/console/public/application/models/legacy_core_editor/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/legacy_core_editor.test.mocks.ts
+++ b/src/plugins/console/public/application/models/legacy_core_editor/legacy_core_editor.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/legacy_core_editor.ts
+++ b/src/plugins/console/public/application/models/legacy_core_editor/legacy_core_editor.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/mode/input.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/mode/input.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/mode/input_highlight_rules.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/mode/input_highlight_rules.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/mode/output.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/mode/output.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/mode/output_highlight_rules.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/mode/output_highlight_rules.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/mode/script.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/mode/script.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/mode/worker/index.d.ts
+++ b/src/plugins/console/public/application/models/legacy_core_editor/mode/worker/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/mode/worker/index.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/mode/worker/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/mode/worker/worker.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/mode/worker/worker.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/smart_resize.ts
+++ b/src/plugins/console/public/application/models/legacy_core_editor/smart_resize.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/legacy_core_editor/theme_sense_dark.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/theme_sense_dark.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/sense_editor/__tests__/integration.test.js
+++ b/src/plugins/console/public/application/models/sense_editor/__tests__/integration.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/sense_editor/__tests__/sense_editor.test.js
+++ b/src/plugins/console/public/application/models/sense_editor/__tests__/sense_editor.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/sense_editor/create.ts
+++ b/src/plugins/console/public/application/models/sense_editor/create.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/sense_editor/curl.ts
+++ b/src/plugins/console/public/application/models/sense_editor/curl.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/sense_editor/index.ts
+++ b/src/plugins/console/public/application/models/sense_editor/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/sense_editor/sense_editor.test.mocks.ts
+++ b/src/plugins/console/public/application/models/sense_editor/sense_editor.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/models/sense_editor/sense_editor.ts
+++ b/src/plugins/console/public/application/models/sense_editor/sense_editor.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/stores/editor.ts
+++ b/src/plugins/console/public/application/stores/editor.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/application/stores/request.ts
+++ b/src/plugins/console/public/application/stores/request.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/index.ts
+++ b/src/plugins/console/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/ace_token_provider/index.ts
+++ b/src/plugins/console/public/lib/ace_token_provider/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/ace_token_provider/token_provider.test.ts
+++ b/src/plugins/console/public/lib/ace_token_provider/token_provider.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/ace_token_provider/token_provider.ts
+++ b/src/plugins/console/public/lib/ace_token_provider/token_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/__jest__/url_autocomplete.test.js
+++ b/src/plugins/console/public/lib/autocomplete/__jest__/url_autocomplete.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/__jest__/url_params.test.js
+++ b/src/plugins/console/public/lib/autocomplete/__jest__/url_params.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/autocomplete.ts
+++ b/src/plugins/console/public/lib/autocomplete/autocomplete.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/body_completer.js
+++ b/src/plugins/console/public/lib/autocomplete/body_completer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/accept_endpoint_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/accept_endpoint_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/autocomplete_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/autocomplete_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/conditional_proxy.js
+++ b/src/plugins/console/public/lib/autocomplete/components/conditional_proxy.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/constant_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/constant_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/field_autocomplete_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/field_autocomplete_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/full_request_component.ts
+++ b/src/plugins/console/public/lib/autocomplete/components/full_request_component.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/global_only_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/global_only_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/id_autocomplete_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/id_autocomplete_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/index.js
+++ b/src/plugins/console/public/lib/autocomplete/components/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/index_autocomplete_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/index_autocomplete_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/list_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/list_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/object_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/object_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/shared_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/shared_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/simple_param_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/simple_param_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/template_autocomplete_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/template_autocomplete_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/type_autocomplete_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/type_autocomplete_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/url_pattern_matcher.js
+++ b/src/plugins/console/public/lib/autocomplete/components/url_pattern_matcher.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/components/username_autocomplete_component.js
+++ b/src/plugins/console/public/lib/autocomplete/components/username_autocomplete_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/engine.js
+++ b/src/plugins/console/public/lib/autocomplete/engine.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/get_endpoint_from_position.ts
+++ b/src/plugins/console/public/lib/autocomplete/get_endpoint_from_position.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/autocomplete/url_params.js
+++ b/src/plugins/console/public/lib/autocomplete/url_params.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/curl_parsing/__tests__/curl_parsing.test.js
+++ b/src/plugins/console/public/lib/curl_parsing/__tests__/curl_parsing.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/curl_parsing/curl.js
+++ b/src/plugins/console/public/lib/curl_parsing/curl.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/local_storage_object_client/create.ts
+++ b/src/plugins/console/public/lib/local_storage_object_client/create.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/local_storage_object_client/index.ts
+++ b/src/plugins/console/public/lib/local_storage_object_client/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/local_storage_object_client/local_storage_object_client.ts
+++ b/src/plugins/console/public/lib/local_storage_object_client/local_storage_object_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/mappings/__tests__/mapping.test.js
+++ b/src/plugins/console/public/lib/mappings/__tests__/mapping.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/mappings/mappings.js
+++ b/src/plugins/console/public/lib/mappings/mappings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/opensearch/__tests__/content_type.test.js
+++ b/src/plugins/console/public/lib/opensearch/__tests__/content_type.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/opensearch/index.ts
+++ b/src/plugins/console/public/lib/opensearch/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/opensearch/opensearch.ts
+++ b/src/plugins/console/public/lib/opensearch/opensearch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/osd/__tests__/kb.test.js
+++ b/src/plugins/console/public/lib/osd/__tests__/kb.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/osd/api.js
+++ b/src/plugins/console/public/lib/osd/api.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/osd/index.js
+++ b/src/plugins/console/public/lib/osd/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/osd/osd.js
+++ b/src/plugins/console/public/lib/osd/osd.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/row_parser.ts
+++ b/src/plugins/console/public/lib/row_parser.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/token_iterator/index.ts
+++ b/src/plugins/console/public/lib/token_iterator/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/token_iterator/token_iterator.test.ts
+++ b/src/plugins/console/public/lib/token_iterator/token_iterator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/token_iterator/token_iterator.ts
+++ b/src/plugins/console/public/lib/token_iterator/token_iterator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/utils/__tests__/utils.test.js
+++ b/src/plugins/console/public/lib/utils/__tests__/utils.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/lib/utils/index.ts
+++ b/src/plugins/console/public/lib/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/services/history.mock.ts
+++ b/src/plugins/console/public/services/history.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/services/history.ts
+++ b/src/plugins/console/public/services/history.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/services/index.ts
+++ b/src/plugins/console/public/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/services/settings.mock.ts
+++ b/src/plugins/console/public/services/settings.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/services/settings.ts
+++ b/src/plugins/console/public/services/settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/services/storage.mock.ts
+++ b/src/plugins/console/public/services/storage.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/services/storage.ts
+++ b/src/plugins/console/public/services/storage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/services/tracker.ts
+++ b/src/plugins/console/public/services/tracker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/shared_imports.ts
+++ b/src/plugins/console/public/shared_imports.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/types/common.ts
+++ b/src/plugins/console/public/types/common.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/types/core_editor.ts
+++ b/src/plugins/console/public/types/core_editor.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/types/index.ts
+++ b/src/plugins/console/public/types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/types/plugin_dependencies.ts
+++ b/src/plugins/console/public/types/plugin_dependencies.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/types/token.ts
+++ b/src/plugins/console/public/types/token.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/public/types/tokens_provider.ts
+++ b/src/plugins/console/public/types/tokens_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/__tests__/opensearch_proxy_config.js
+++ b/src/plugins/console/server/__tests__/opensearch_proxy_config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/__tests__/proxy_config.js
+++ b/src/plugins/console/server/__tests__/proxy_config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/__tests__/proxy_config_collection.js
+++ b/src/plugins/console/server/__tests__/proxy_config_collection.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/__tests__/set_headers.js
+++ b/src/plugins/console/server/__tests__/set_headers.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/__tests__/wildcard_matcher.js
+++ b/src/plugins/console/server/__tests__/wildcard_matcher.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/config.ts
+++ b/src/plugins/console/server/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/index.ts
+++ b/src/plugins/console/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/index.ts
+++ b/src/plugins/console/server/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/opensearch_proxy_config.ts
+++ b/src/plugins/console/server/lib/opensearch_proxy_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/proxy_config.ts
+++ b/src/plugins/console/server/lib/proxy_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/proxy_config_collection.ts
+++ b/src/plugins/console/server/lib/proxy_config_collection.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/proxy_request.test.ts
+++ b/src/plugins/console/server/lib/proxy_request.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/proxy_request.ts
+++ b/src/plugins/console/server/lib/proxy_request.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/set_headers.ts
+++ b/src/plugins/console/server/lib/set_headers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/index.ts
+++ b/src/plugins/console/server/lib/spec_definitions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/aggregations.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/aggregations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/aliases.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/aliases.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/document.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/document.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/filter.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/globals.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/globals.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/index.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/ingest.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/ingest.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/mappings.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/mappings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/query/dsl.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/query/dsl.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/query/index.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/query/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/query/templates.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/query/templates.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/reindex.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/reindex.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/search.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/search.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/settings.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/spec_definitions/js/shared.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/shared.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/lib/wildcard_matcher.ts
+++ b/src/plugins/console/server/lib/wildcard_matcher.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/plugin.ts
+++ b/src/plugins/console/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/opensearch_config/index.ts
+++ b/src/plugins/console/server/routes/api/console/opensearch_config/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/create_handler.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/proxy/index.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/proxy/tests/body.test.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/tests/body.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/proxy/tests/headers.test.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/tests/headers.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/proxy/tests/mocks.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/tests/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/proxy/tests/params.test.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/tests/params.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/proxy/tests/proxy_fallback.test.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/tests/proxy_fallback.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/proxy/tests/query_string.test.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/tests/query_string.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/proxy/tests/route_validation.test.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/tests/route_validation.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/proxy/tests/stubs.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/tests/stubs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/proxy/validation_config.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/validation_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/api/console/spec_definitions/index.ts
+++ b/src/plugins/console/server/routes/api/console/spec_definitions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/routes/index.ts
+++ b/src/plugins/console/server/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/services/index.ts
+++ b/src/plugins/console/server/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/services/opensearch_legacy_config_service.ts
+++ b/src/plugins/console/server/services/opensearch_legacy_config_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/services/spec_definitions_service.ts
+++ b/src/plugins/console/server/services/spec_definitions_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/console/server/types.ts
+++ b/src/plugins/console/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/common/bwc/types.ts
+++ b/src/plugins/dashboard/common/bwc/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/common/embeddable/types.ts
+++ b/src/plugins/dashboard/common/embeddable/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/common/index.ts
+++ b/src/plugins/dashboard/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/common/migrate_to_730_panels.test.ts
+++ b/src/plugins/dashboard/common/migrate_to_730_panels.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/common/migrate_to_730_panels.ts
+++ b/src/plugins/dashboard/common/migrate_to_730_panels.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/common/types.ts
+++ b/src/plugins/dashboard/common/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/config.ts
+++ b/src/plugins/dashboard/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/add_to_library_action.test.tsx
+++ b/src/plugins/dashboard/public/application/actions/add_to_library_action.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/add_to_library_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/add_to_library_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/clone_panel_action.test.tsx
+++ b/src/plugins/dashboard/public/application/actions/clone_panel_action.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/clone_panel_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/clone_panel_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/expand_panel_action.test.tsx
+++ b/src/plugins/dashboard/public/application/actions/expand_panel_action.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/expand_panel_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/expand_panel_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/index.ts
+++ b/src/plugins/dashboard/public/application/actions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/library_notification_action.test.tsx
+++ b/src/plugins/dashboard/public/application/actions/library_notification_action.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/library_notification_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/library_notification_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/open_replace_panel_flyout.tsx
+++ b/src/plugins/dashboard/public/application/actions/open_replace_panel_flyout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/replace_panel_action.test.tsx
+++ b/src/plugins/dashboard/public/application/actions/replace_panel_action.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/replace_panel_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/replace_panel_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/replace_panel_flyout.tsx
+++ b/src/plugins/dashboard/public/application/actions/replace_panel_flyout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/unlink_from_library_action.test.tsx
+++ b/src/plugins/dashboard/public/application/actions/unlink_from_library_action.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/actions/unlink_from_library_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/unlink_from_library_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/application.ts
+++ b/src/plugins/dashboard/public/application/application.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/dashboard_app.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/dashboard_empty_screen.test.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_empty_screen.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/dashboard_empty_screen.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_empty_screen.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/dashboard_empty_screen_constants.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_empty_screen_constants.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/dashboard_state.test.ts
+++ b/src/plugins/dashboard/public/application/dashboard_state.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/dashboard_state_manager.ts
+++ b/src/plugins/dashboard/public/application/dashboard_state_manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/dashboard_strings.ts
+++ b/src/plugins/dashboard/public/application/dashboard_strings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_constants.ts
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.test.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container_by_value_renderer.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container_by_value_renderer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container_factory.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container_factory.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid.test.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/grid/index.ts
+++ b/src/plugins/dashboard/public/application/embeddable/grid/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/index.ts
+++ b/src/plugins/dashboard/public/application/embeddable/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/panel/create_panel_state.test.ts
+++ b/src/plugins/dashboard/public/application/embeddable/panel/create_panel_state.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/panel/create_panel_state.ts
+++ b/src/plugins/dashboard/public/application/embeddable/panel/create_panel_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/panel/dashboard_panel_placement.ts
+++ b/src/plugins/dashboard/public/application/embeddable/panel/dashboard_panel_placement.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/panel/index.ts
+++ b/src/plugins/dashboard/public/application/embeddable/panel/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/placeholder/index.ts
+++ b/src/plugins/dashboard/public/application/embeddable/placeholder/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/placeholder/placeholder_embeddable.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/placeholder/placeholder_embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/placeholder/placeholder_embeddable_factory.ts
+++ b/src/plugins/dashboard/public/application/embeddable/placeholder/placeholder_embeddable_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/types.ts
+++ b/src/plugins/dashboard/public/application/embeddable/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.test.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/viewport/dashboard_viewport.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/help_menu/help_menu_util.ts
+++ b/src/plugins/dashboard/public/application/help_menu/help_menu_util.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/index.ts
+++ b/src/plugins/dashboard/public/application/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/legacy_app.js
+++ b/src/plugins/dashboard/public/application/legacy_app.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters.test.ts
+++ b/src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters.ts
+++ b/src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/filter_utils.ts
+++ b/src/plugins/dashboard/public/application/lib/filter_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/get_app_state_defaults.ts
+++ b/src/plugins/dashboard/public/application/lib/get_app_state_defaults.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/index.ts
+++ b/src/plugins/dashboard/public/application/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/migrate_app_state.test.ts
+++ b/src/plugins/dashboard/public/application/lib/migrate_app_state.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/migrate_app_state.ts
+++ b/src/plugins/dashboard/public/application/lib/migrate_app_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/migrate_legacy_query.ts
+++ b/src/plugins/dashboard/public/application/lib/migrate_legacy_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/save_dashboard.ts
+++ b/src/plugins/dashboard/public/application/lib/save_dashboard.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/update_saved_dashboard.ts
+++ b/src/plugins/dashboard/public/application/lib/update_saved_dashboard.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/url.test.ts
+++ b/src/plugins/dashboard/public/application/lib/url.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/lib/url.ts
+++ b/src/plugins/dashboard/public/application/lib/url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/listing/dashboard_listing.js
+++ b/src/plugins/dashboard/public/application/listing/dashboard_listing.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/listing/dashboard_listing.test.js
+++ b/src/plugins/dashboard/public/application/listing/dashboard_listing.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/test_helpers/get_sample_dashboard_input.ts
+++ b/src/plugins/dashboard/public/application/test_helpers/get_sample_dashboard_input.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/test_helpers/get_saved_dashboard_mock.ts
+++ b/src/plugins/dashboard/public/application/test_helpers/get_saved_dashboard_mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/test_helpers/index.ts
+++ b/src/plugins/dashboard/public/application/test_helpers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/tests/dashboard_container.test.tsx
+++ b/src/plugins/dashboard/public/application/tests/dashboard_container.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/top_nav/clone_modal.test.js
+++ b/src/plugins/dashboard/public/application/top_nav/clone_modal.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/top_nav/clone_modal.tsx
+++ b/src/plugins/dashboard/public/application/top_nav/clone_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/top_nav/get_top_nav_config.ts
+++ b/src/plugins/dashboard/public/application/top_nav/get_top_nav_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/top_nav/options.tsx
+++ b/src/plugins/dashboard/public/application/top_nav/options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/top_nav/save_modal.test.js
+++ b/src/plugins/dashboard/public/application/top_nav/save_modal.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/top_nav/save_modal.tsx
+++ b/src/plugins/dashboard/public/application/top_nav/save_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/top_nav/show_clone_modal.tsx
+++ b/src/plugins/dashboard/public/application/top_nav/show_clone_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/top_nav/show_options_popover.tsx
+++ b/src/plugins/dashboard/public/application/top_nav/show_options_popover.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/application/top_nav/top_nav_ids.ts
+++ b/src/plugins/dashboard/public/application/top_nav/top_nav_ids.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/attribute_service/attribute_service.mock.tsx
+++ b/src/plugins/dashboard/public/attribute_service/attribute_service.mock.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/attribute_service/attribute_service.test.ts
+++ b/src/plugins/dashboard/public/attribute_service/attribute_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/attribute_service/attribute_service.tsx
+++ b/src/plugins/dashboard/public/attribute_service/attribute_service.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/attribute_service/index.ts
+++ b/src/plugins/dashboard/public/attribute_service/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/dashboard_constants.ts
+++ b/src/plugins/dashboard/public/dashboard_constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/embeddable_plugin.ts
+++ b/src/plugins/dashboard/public/embeddable_plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/embeddable_plugin_test_samples.ts
+++ b/src/plugins/dashboard/public/embeddable_plugin_test_samples.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/index.ts
+++ b/src/plugins/dashboard/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/mocks.tsx
+++ b/src/plugins/dashboard/public/mocks.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/saved_dashboards/index.ts
+++ b/src/plugins/dashboard/public/saved_dashboards/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/saved_dashboards/saved_dashboard.ts
+++ b/src/plugins/dashboard/public/saved_dashboards/saved_dashboard.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/saved_dashboards/saved_dashboard_references.test.ts
+++ b/src/plugins/dashboard/public/saved_dashboards/saved_dashboard_references.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/saved_dashboards/saved_dashboard_references.ts
+++ b/src/plugins/dashboard/public/saved_dashboards/saved_dashboard_references.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/saved_dashboards/saved_dashboards.ts
+++ b/src/plugins/dashboard/public/saved_dashboards/saved_dashboards.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/ui_actions_plugin.ts
+++ b/src/plugins/dashboard/public/ui_actions_plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/url_generator.test.ts
+++ b/src/plugins/dashboard/public/url_generator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/url_generator.ts
+++ b/src/plugins/dashboard/public/url_generator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/url_utils/url_helper.test.ts
+++ b/src/plugins/dashboard/public/url_utils/url_helper.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/public/url_utils/url_helper.ts
+++ b/src/plugins/dashboard/public/url_utils/url_helper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/capabilities_provider.ts
+++ b/src/plugins/dashboard/server/capabilities_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/index.ts
+++ b/src/plugins/dashboard/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/plugin.ts
+++ b/src/plugins/dashboard/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/saved_objects/dashboard.ts
+++ b/src/plugins/dashboard/server/saved_objects/dashboard.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/saved_objects/dashboard_migrations.test.ts
+++ b/src/plugins/dashboard/server/saved_objects/dashboard_migrations.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/saved_objects/dashboard_migrations.ts
+++ b/src/plugins/dashboard/server/saved_objects/dashboard_migrations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/saved_objects/index.ts
+++ b/src/plugins/dashboard/server/saved_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/saved_objects/is_dashboard_doc.ts
+++ b/src/plugins/dashboard/server/saved_objects/is_dashboard_doc.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/saved_objects/migrate_match_all_query.test.ts
+++ b/src/plugins/dashboard/server/saved_objects/migrate_match_all_query.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/saved_objects/migrate_match_all_query.ts
+++ b/src/plugins/dashboard/server/saved_objects/migrate_match_all_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/saved_objects/migrations_730.test.ts
+++ b/src/plugins/dashboard/server/saved_objects/migrations_730.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/saved_objects/migrations_730.ts
+++ b/src/plugins/dashboard/server/saved_objects/migrations_730.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/saved_objects/move_filters_to_query.test.ts
+++ b/src/plugins/dashboard/server/saved_objects/move_filters_to_query.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/saved_objects/move_filters_to_query.ts
+++ b/src/plugins/dashboard/server/saved_objects/move_filters_to_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dashboard/server/types.ts
+++ b/src/plugins/dashboard/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/constants.ts
+++ b/src/plugins/data/common/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/constants/base_formatters.ts
+++ b/src/plugins/data/common/field_formats/constants/base_formatters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/constants/color_default.ts
+++ b/src/plugins/data/common/field_formats/constants/color_default.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/content_types/html_content_type.ts
+++ b/src/plugins/data/common/field_formats/content_types/html_content_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/content_types/index.ts
+++ b/src/plugins/data/common/field_formats/content_types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/content_types/text_content_type.ts
+++ b/src/plugins/data/common/field_formats/content_types/text_content_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/boolean.test.ts
+++ b/src/plugins/data/common/field_formats/converters/boolean.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/boolean.ts
+++ b/src/plugins/data/common/field_formats/converters/boolean.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/bytes.test.ts
+++ b/src/plugins/data/common/field_formats/converters/bytes.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/bytes.ts
+++ b/src/plugins/data/common/field_formats/converters/bytes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/color.test.ts
+++ b/src/plugins/data/common/field_formats/converters/color.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/color.ts
+++ b/src/plugins/data/common/field_formats/converters/color.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/custom.ts
+++ b/src/plugins/data/common/field_formats/converters/custom.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/date_nanos_shared.test.ts
+++ b/src/plugins/data/common/field_formats/converters/date_nanos_shared.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/date_nanos_shared.ts
+++ b/src/plugins/data/common/field_formats/converters/date_nanos_shared.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/duration.test.ts
+++ b/src/plugins/data/common/field_formats/converters/duration.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/duration.ts
+++ b/src/plugins/data/common/field_formats/converters/duration.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/index.ts
+++ b/src/plugins/data/common/field_formats/converters/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/ip.test.ts
+++ b/src/plugins/data/common/field_formats/converters/ip.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/ip.ts
+++ b/src/plugins/data/common/field_formats/converters/ip.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/number.test.ts
+++ b/src/plugins/data/common/field_formats/converters/number.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/number.ts
+++ b/src/plugins/data/common/field_formats/converters/number.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/numeral.ts
+++ b/src/plugins/data/common/field_formats/converters/numeral.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/percent.test.ts
+++ b/src/plugins/data/common/field_formats/converters/percent.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/percent.ts
+++ b/src/plugins/data/common/field_formats/converters/percent.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/relative_date.test.ts
+++ b/src/plugins/data/common/field_formats/converters/relative_date.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/relative_date.ts
+++ b/src/plugins/data/common/field_formats/converters/relative_date.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/source.test.ts
+++ b/src/plugins/data/common/field_formats/converters/source.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/source.ts
+++ b/src/plugins/data/common/field_formats/converters/source.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/static_lookup.ts
+++ b/src/plugins/data/common/field_formats/converters/static_lookup.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/string.test.ts
+++ b/src/plugins/data/common/field_formats/converters/string.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/string.ts
+++ b/src/plugins/data/common/field_formats/converters/string.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/truncate.test.ts
+++ b/src/plugins/data/common/field_formats/converters/truncate.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/truncate.ts
+++ b/src/plugins/data/common/field_formats/converters/truncate.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/url.test.ts
+++ b/src/plugins/data/common/field_formats/converters/url.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/converters/url.ts
+++ b/src/plugins/data/common/field_formats/converters/url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/errors.ts
+++ b/src/plugins/data/common/field_formats/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/field_format.test.ts
+++ b/src/plugins/data/common/field_formats/field_format.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/field_format.ts
+++ b/src/plugins/data/common/field_formats/field_format.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/field_formats_registry.test.ts
+++ b/src/plugins/data/common/field_formats/field_formats_registry.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/field_formats_registry.ts
+++ b/src/plugins/data/common/field_formats/field_formats_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/index.ts
+++ b/src/plugins/data/common/field_formats/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/mocks.ts
+++ b/src/plugins/data/common/field_formats/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/types.ts
+++ b/src/plugins/data/common/field_formats/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/utils/as_pretty_string.test.ts
+++ b/src/plugins/data/common/field_formats/utils/as_pretty_string.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/utils/as_pretty_string.ts
+++ b/src/plugins/data/common/field_formats/utils/as_pretty_string.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/utils/highlight/highlight_html.test.ts
+++ b/src/plugins/data/common/field_formats/utils/highlight/highlight_html.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/utils/highlight/highlight_html.ts
+++ b/src/plugins/data/common/field_formats/utils/highlight/highlight_html.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/utils/highlight/highlight_request.test.ts
+++ b/src/plugins/data/common/field_formats/utils/highlight/highlight_request.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/utils/highlight/highlight_request.ts
+++ b/src/plugins/data/common/field_formats/utils/highlight/highlight_request.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/utils/highlight/highlight_tags.ts
+++ b/src/plugins/data/common/field_formats/utils/highlight/highlight_tags.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/utils/highlight/html_tags.ts
+++ b/src/plugins/data/common/field_formats/utils/highlight/html_tags.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/utils/highlight/index.ts
+++ b/src/plugins/data/common/field_formats/utils/highlight/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_formats/utils/index.ts
+++ b/src/plugins/data/common/field_formats/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_mapping/index.ts
+++ b/src/plugins/data/common/field_mapping/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_mapping/mapping_setup.test.ts
+++ b/src/plugins/data/common/field_mapping/mapping_setup.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_mapping/mapping_setup.ts
+++ b/src/plugins/data/common/field_mapping/mapping_setup.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/field_mapping/types.ts
+++ b/src/plugins/data/common/field_mapping/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index.ts
+++ b/src/plugins/data/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/errors/duplicate_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/errors/duplicate_index_pattern.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/errors/index.ts
+++ b/src/plugins/data/common/index_patterns/errors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/field.stub.ts
+++ b/src/plugins/data/common/index_patterns/field.stub.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/fields/field_list.ts
+++ b/src/plugins/data/common/index_patterns/fields/field_list.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/fields/fields.mocks.ts
+++ b/src/plugins/data/common/index_patterns/fields/fields.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/fields/index.ts
+++ b/src/plugins/data/common/index_patterns/fields/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/fields/index_pattern_field.test.ts
+++ b/src/plugins/data/common/index_patterns/fields/index_pattern_field.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/fields/index_pattern_field.ts
+++ b/src/plugins/data/common/index_patterns/fields/index_pattern_field.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/fields/types.ts
+++ b/src/plugins/data/common/index_patterns/fields/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/fields/utils.ts
+++ b/src/plugins/data/common/index_patterns/fields/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/index.ts
+++ b/src/plugins/data/common/index_patterns/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/index_pattern.stub.ts
+++ b/src/plugins/data/common/index_patterns/index_pattern.stub.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/index_patterns/_pattern_cache.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/_pattern_cache.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/index_patterns/flatten_hit.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/flatten_hit.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/index_patterns/format_hit.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/format_hit.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/index_patterns/index.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/index_patterns/index_pattern.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_pattern.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/lib/errors.ts
+++ b/src/plugins/data/common/index_patterns/lib/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/lib/get_from_saved_object.ts
+++ b/src/plugins/data/common/index_patterns/lib/get_from_saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/lib/get_title.ts
+++ b/src/plugins/data/common/index_patterns/lib/get_title.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/lib/index.ts
+++ b/src/plugins/data/common/index_patterns/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/lib/is_default.ts
+++ b/src/plugins/data/common/index_patterns/lib/is_default.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/lib/types.ts
+++ b/src/plugins/data/common/index_patterns/lib/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/lib/validate_index_pattern.test.ts
+++ b/src/plugins/data/common/index_patterns/lib/validate_index_pattern.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/lib/validate_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/lib/validate_index_pattern.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/mocks.ts
+++ b/src/plugins/data/common/index_patterns/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/types.ts
+++ b/src/plugins/data/common/index_patterns/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/utils.test.ts
+++ b/src/plugins/data/common/index_patterns/utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/index_patterns/utils.ts
+++ b/src/plugins/data/common/index_patterns/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/__fixtures__/index_pattern_response.ts
+++ b/src/plugins/data/common/opensearch_query/__fixtures__/index_pattern_response.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/build_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/build_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/build_filters.ts
+++ b/src/plugins/data/common/opensearch_query/filters/build_filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/custom_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/custom_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/exists_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/exists_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/exists_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/exists_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/geo_bounding_box_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/geo_bounding_box_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/geo_bounding_box_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/geo_bounding_box_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/geo_polygon_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/geo_polygon_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/geo_polygon_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/geo_polygon_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/get_display_value.ts
+++ b/src/plugins/data/common/opensearch_query/filters/get_display_value.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/get_filter_field.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/get_filter_field.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/get_filter_field.ts
+++ b/src/plugins/data/common/opensearch_query/filters/get_filter_field.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/get_filter_params.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/get_filter_params.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/get_filter_params.ts
+++ b/src/plugins/data/common/opensearch_query/filters/get_filter_params.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/get_index_pattern_from_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/get_index_pattern_from_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/get_index_pattern_from_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/get_index_pattern_from_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/index.ts
+++ b/src/plugins/data/common/opensearch_query/filters/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/match_all_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/match_all_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/meta_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/meta_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/missing_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/missing_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/missing_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/missing_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/phrase_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/phrase_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/phrase_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/phrase_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/phrases_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/phrases_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/phrases_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/phrases_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/query_string_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/query_string_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/query_string_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/query_string_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/range_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/range_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/range_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/range_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/stubs/exists_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/stubs/exists_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/stubs/index.ts
+++ b/src/plugins/data/common/opensearch_query/filters/stubs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/stubs/phrase_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/stubs/phrase_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/stubs/phrases_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/stubs/phrases_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/stubs/range_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/stubs/range_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/filters/types.ts
+++ b/src/plugins/data/common/opensearch_query/filters/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/index.ts
+++ b/src/plugins/data/common/opensearch_query/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/ast/ast.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/ast/ast.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/ast/ast.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/ast/ast.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/ast/index.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/ast/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/and.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/and.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/and.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/and.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/exists.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/exists.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/exists.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/exists.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/geo_bounding_box.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/geo_bounding_box.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/geo_bounding_box.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/geo_bounding_box.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/geo_polygon.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/geo_polygon.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/geo_polygon.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/geo_polygon.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/index.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/is.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/is.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/is.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/is.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/nested.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/nested.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/nested.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/nested.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/not.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/not.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/not.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/not.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/or.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/or.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/or.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/or.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/range.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/range.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/range.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/utils/get_fields.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/utils/get_fields.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/utils/get_fields.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/utils/get_fields.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/utils/get_full_field_name_node.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/utils/get_full_field_name_node.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/functions/utils/get_full_field_name_node.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/functions/utils/get_full_field_name_node.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/index.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/kuery_syntax_error.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/kuery_syntax_error.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/kuery_syntax_error.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/kuery_syntax_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/node_types/function.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/node_types/function.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/node_types/function.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/node_types/function.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/node_types/index.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/node_types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/node_types/literal.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/node_types/literal.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/node_types/literal.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/node_types/literal.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/node_types/named_arg.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/node_types/named_arg.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/node_types/named_arg.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/node_types/named_arg.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/node_types/types.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/node_types/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/node_types/wildcard.test.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/node_types/wildcard.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/node_types/wildcard.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/node_types/wildcard.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/kuery/types.ts
+++ b/src/plugins/data/common/opensearch_query/kuery/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/build_opensearch_query.test.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/build_opensearch_query.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/build_opensearch_query.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/build_opensearch_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/decorate_query.test.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/decorate_query.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/decorate_query.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/decorate_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/filter_matches_index.test.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/filter_matches_index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/filter_matches_index.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/filter_matches_index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/from_filters.test.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/from_filters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/from_filters.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/from_filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/from_kuery.test.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/from_kuery.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/from_kuery.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/from_kuery.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/from_lucene.test.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/from_lucene.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/from_lucene.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/from_lucene.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/get_opensearch_query_config.test.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/get_opensearch_query_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/get_opensearch_query_config.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/get_opensearch_query_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/handle_nested_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/handle_nested_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/handle_nested_filter.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/handle_nested_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/index.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/lucene_string_to_dsl.test.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/lucene_string_to_dsl.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/lucene_string_to_dsl.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/lucene_string_to_dsl.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/migrate_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/migrate_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/migrate_filter.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/migrate_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/opensearch_query/opensearch_query_dsl.ts
+++ b/src/plugins/data/common/opensearch_query/opensearch_query/opensearch_query_dsl.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/opensearch_query/utils.ts
+++ b/src/plugins/data/common/opensearch_query/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/osd_field_types/index.ts
+++ b/src/plugins/data/common/osd_field_types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/osd_field_types/osd_field_type.ts
+++ b/src/plugins/data/common/osd_field_types/osd_field_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/osd_field_types/osd_field_types.test.ts
+++ b/src/plugins/data/common/osd_field_types/osd_field_types.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/osd_field_types/osd_field_types.ts
+++ b/src/plugins/data/common/osd_field_types/osd_field_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/osd_field_types/osd_field_types_factory.ts
+++ b/src/plugins/data/common/osd_field_types/osd_field_types_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/osd_field_types/types.ts
+++ b/src/plugins/data/common/osd_field_types/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/filter_manager/compare_filters.test.ts
+++ b/src/plugins/data/common/query/filter_manager/compare_filters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/filter_manager/compare_filters.ts
+++ b/src/plugins/data/common/query/filter_manager/compare_filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/filter_manager/dedup_filters.test.ts
+++ b/src/plugins/data/common/query/filter_manager/dedup_filters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/filter_manager/dedup_filters.ts
+++ b/src/plugins/data/common/query/filter_manager/dedup_filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/filter_manager/index.ts
+++ b/src/plugins/data/common/query/filter_manager/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/filter_manager/uniq_filters.test.ts
+++ b/src/plugins/data/common/query/filter_manager/uniq_filters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/filter_manager/uniq_filters.ts
+++ b/src/plugins/data/common/query/filter_manager/uniq_filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/index.ts
+++ b/src/plugins/data/common/query/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/is_query.ts
+++ b/src/plugins/data/common/query/is_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/timefilter/get_time.test.ts
+++ b/src/plugins/data/common/query/timefilter/get_time.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/timefilter/get_time.ts
+++ b/src/plugins/data/common/query/timefilter/get_time.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/timefilter/index.ts
+++ b/src/plugins/data/common/query/timefilter/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/timefilter/is_time_range.ts
+++ b/src/plugins/data/common/query/timefilter/is_time_range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/timefilter/types.ts
+++ b/src/plugins/data/common/query/timefilter/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/query/types.ts
+++ b/src/plugins/data/common/query/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_config.test.ts
+++ b/src/plugins/data/common/search/aggs/agg_config.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_config.ts
+++ b/src/plugins/data/common/search/aggs/agg_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_configs.test.ts
+++ b/src/plugins/data/common/search/aggs/agg_configs.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_configs.ts
+++ b/src/plugins/data/common/search/aggs/agg_configs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_groups.ts
+++ b/src/plugins/data/common/search/aggs/agg_groups.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_params.test.ts
+++ b/src/plugins/data/common/search/aggs/agg_params.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_params.ts
+++ b/src/plugins/data/common/search/aggs/agg_params.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_type.test.ts
+++ b/src/plugins/data/common/search/aggs/agg_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_type.ts
+++ b/src/plugins/data/common/search/aggs/agg_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_types.ts
+++ b/src/plugins/data/common/search/aggs/agg_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_types_registry.test.ts
+++ b/src/plugins/data/common/search/aggs/agg_types_registry.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/agg_types_registry.ts
+++ b/src/plugins/data/common/search/aggs/agg_types_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/aggs_service.test.ts
+++ b/src/plugins/data/common/search/aggs/aggs_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/aggs_service.ts
+++ b/src/plugins/data/common/search/aggs/aggs_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/_interval_options.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_interval_options.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/bucket_agg_type.ts
+++ b/src/plugins/data/common/search/aggs/buckets/bucket_agg_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/bucket_agg_types.ts
+++ b/src/plugins/data/common/search/aggs/buckets/bucket_agg_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/date_histogram.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/date_histogram.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/date_histogram.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/date_histogram.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/date_range.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/date_range.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/date_range.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/date_range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/filters.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/filters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/filters.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/histogram.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/histogram.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/histogram.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/histogram.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/ip_range.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/ip_range.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/ip_range.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/ip_range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/range.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/range.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/range.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/terms.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/terms.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/create_filter/terms.ts
+++ b/src/plugins/data/common/search/aggs/buckets/create_filter/terms.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/date_histogram.ts
+++ b/src/plugins/data/common/search/aggs/buckets/date_histogram.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/date_histogram_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/date_histogram_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/date_histogram_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/date_histogram_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/date_range.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/date_range.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/date_range.ts
+++ b/src/plugins/data/common/search/aggs/buckets/date_range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/date_range_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/date_range_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/date_range_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/date_range_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/filter.ts
+++ b/src/plugins/data/common/search/aggs/buckets/filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/filter_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/filter_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/filter_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/filter_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/filters.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/filters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/filters.ts
+++ b/src/plugins/data/common/search/aggs/buckets/filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/filters_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/filters_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/filters_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/filters_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/geo_hash.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/geo_hash.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/geo_hash.ts
+++ b/src/plugins/data/common/search/aggs/buckets/geo_hash.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/geo_hash_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/geo_hash_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/geo_hash_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/geo_hash_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/geo_tile.ts
+++ b/src/plugins/data/common/search/aggs/buckets/geo_tile.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/geo_tile_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/geo_tile_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/geo_tile_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/geo_tile_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/histogram.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/histogram.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/histogram.ts
+++ b/src/plugins/data/common/search/aggs/buckets/histogram.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/histogram_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/histogram_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/histogram_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/histogram_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/index.ts
+++ b/src/plugins/data/common/search/aggs/buckets/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/ip_range.ts
+++ b/src/plugins/data/common/search/aggs/buckets/ip_range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/ip_range_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/ip_range_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/ip_range_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/ip_range_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/cidr_mask.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/cidr_mask.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/cidr_mask.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/cidr_mask.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/date_range.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/date_range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/extended_bounds.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/extended_bounds.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/geo_point.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/geo_point.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/histogram_calculate_interval.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/histogram_calculate_interval.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/histogram_calculate_interval.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/histogram_calculate_interval.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/ip_range.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/ip_range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/calc_auto_interval.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/calc_auto_interval.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/calc_auto_interval.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/calc_auto_interval.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/calc_opensearch_interval.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/calc_opensearch_interval.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/index.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/time_buckets.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/time_buckets.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/time_buckets.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/time_buckets.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/migrate_include_exclude_format.ts
+++ b/src/plugins/data/common/search/aggs/buckets/migrate_include_exclude_format.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/range.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/range.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/range.ts
+++ b/src/plugins/data/common/search/aggs/buckets/range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/range_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/range_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/range_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/range_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/range_key.ts
+++ b/src/plugins/data/common/search/aggs/buckets/range_key.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/shard_delay.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/shard_delay.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/shard_delay.ts
+++ b/src/plugins/data/common/search/aggs/buckets/shard_delay.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/shard_delay_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/shard_delay_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/shard_delay_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/shard_delay_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/significant_terms.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/significant_terms.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/significant_terms.ts
+++ b/src/plugins/data/common/search/aggs/buckets/significant_terms.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/significant_terms_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/significant_terms_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/significant_terms_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/significant_terms_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/terms.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/terms.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/terms.ts
+++ b/src/plugins/data/common/search/aggs/buckets/terms.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/terms_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/terms_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/buckets/terms_fn.ts
+++ b/src/plugins/data/common/search/aggs/buckets/terms_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/index.test.ts
+++ b/src/plugins/data/common/search/aggs/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/index.ts
+++ b/src/plugins/data/common/search/aggs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/avg.ts
+++ b/src/plugins/data/common/search/aggs/metrics/avg.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/avg_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/avg_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/avg_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/avg_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_avg.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_avg.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_avg_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_avg_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_avg_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_avg_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_max.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_max.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_max_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_max_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_max_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_max_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_min.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_min.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_min_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_min_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_min_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_min_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_sum.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_sum.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_sum_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_sum_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/bucket_sum_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/bucket_sum_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/cardinality.ts
+++ b/src/plugins/data/common/search/aggs/metrics/cardinality.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/cardinality_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/cardinality_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/cardinality_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/cardinality_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/count.ts
+++ b/src/plugins/data/common/search/aggs/metrics/count.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/count_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/count_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/count_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/count_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/cumulative_sum.ts
+++ b/src/plugins/data/common/search/aggs/metrics/cumulative_sum.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/cumulative_sum_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/cumulative_sum_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/cumulative_sum_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/cumulative_sum_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/derivative.ts
+++ b/src/plugins/data/common/search/aggs/metrics/derivative.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/derivative_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/derivative_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/derivative_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/derivative_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/geo_bounds.ts
+++ b/src/plugins/data/common/search/aggs/metrics/geo_bounds.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/geo_bounds_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/geo_bounds_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/geo_bounds_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/geo_bounds_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/geo_centroid.ts
+++ b/src/plugins/data/common/search/aggs/metrics/geo_centroid.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/geo_centroid_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/geo_centroid_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/geo_centroid_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/geo_centroid_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/index.ts
+++ b/src/plugins/data/common/search/aggs/metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/lib/get_response_agg_config_class.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/get_response_agg_config_class.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/lib/make_nested_label.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/make_nested_label.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/lib/make_nested_label.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/make_nested_label.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/lib/nested_agg_helpers.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/nested_agg_helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/lib/ordinal_suffix.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/ordinal_suffix.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/lib/ordinal_suffix.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/ordinal_suffix.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/lib/parent_pipeline_agg_helper.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/parent_pipeline_agg_helper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/lib/parent_pipeline_agg_writer.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/parent_pipeline_agg_writer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_helper.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_helper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_writer.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/sibling_pipeline_agg_writer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/max.ts
+++ b/src/plugins/data/common/search/aggs/metrics/max.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/max_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/max_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/max_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/max_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/median.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/median.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/median.ts
+++ b/src/plugins/data/common/search/aggs/metrics/median.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/median_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/median_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/median_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/median_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/metric_agg_type.ts
+++ b/src/plugins/data/common/search/aggs/metrics/metric_agg_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/metric_agg_types.ts
+++ b/src/plugins/data/common/search/aggs/metrics/metric_agg_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/min.ts
+++ b/src/plugins/data/common/search/aggs/metrics/min.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/min_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/min_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/min_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/min_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/moving_avg.ts
+++ b/src/plugins/data/common/search/aggs/metrics/moving_avg.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/moving_avg_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/moving_avg_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/moving_avg_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/moving_avg_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/parent_pipeline.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/parent_pipeline.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/percentile_ranks.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/percentile_ranks.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/percentile_ranks.ts
+++ b/src/plugins/data/common/search/aggs/metrics/percentile_ranks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/percentile_ranks_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/percentile_ranks_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/percentile_ranks_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/percentile_ranks_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/percentiles.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/percentiles.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/percentiles.ts
+++ b/src/plugins/data/common/search/aggs/metrics/percentiles.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/percentiles_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/percentiles_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/percentiles_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/percentiles_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/percentiles_get_value.ts
+++ b/src/plugins/data/common/search/aggs/metrics/percentiles_get_value.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/serial_diff.ts
+++ b/src/plugins/data/common/search/aggs/metrics/serial_diff.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/serial_diff_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/serial_diff_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/serial_diff_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/serial_diff_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/sibling_pipeline.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/sibling_pipeline.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/std_deviation.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/std_deviation.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/std_deviation.ts
+++ b/src/plugins/data/common/search/aggs/metrics/std_deviation.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/std_deviation_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/std_deviation_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/std_deviation_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/std_deviation_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/sum.ts
+++ b/src/plugins/data/common/search/aggs/metrics/sum.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/sum_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/sum_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/sum_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/sum_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/top_hit.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_hit.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/top_hit.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_hit.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/top_hit_fn.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_hit_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/metrics/top_hit_fn.ts
+++ b/src/plugins/data/common/search/aggs/metrics/top_hit_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/param_types/agg.ts
+++ b/src/plugins/data/common/search/aggs/param_types/agg.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/param_types/base.ts
+++ b/src/plugins/data/common/search/aggs/param_types/base.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/param_types/field.test.ts
+++ b/src/plugins/data/common/search/aggs/param_types/field.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/param_types/field.ts
+++ b/src/plugins/data/common/search/aggs/param_types/field.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/param_types/index.ts
+++ b/src/plugins/data/common/search/aggs/param_types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/param_types/json.test.ts
+++ b/src/plugins/data/common/search/aggs/param_types/json.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/param_types/json.ts
+++ b/src/plugins/data/common/search/aggs/param_types/json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/param_types/optioned.test.ts
+++ b/src/plugins/data/common/search/aggs/param_types/optioned.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/param_types/optioned.ts
+++ b/src/plugins/data/common/search/aggs/param_types/optioned.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/param_types/string.test.ts
+++ b/src/plugins/data/common/search/aggs/param_types/string.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/param_types/string.ts
+++ b/src/plugins/data/common/search/aggs/param_types/string.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/test_helpers/function_wrapper.ts
+++ b/src/plugins/data/common/search/aggs/test_helpers/function_wrapper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/test_helpers/index.ts
+++ b/src/plugins/data/common/search/aggs/test_helpers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/test_helpers/mock_agg_types_registry.ts
+++ b/src/plugins/data/common/search/aggs/test_helpers/mock_agg_types_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/types.ts
+++ b/src/plugins/data/common/search/aggs/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/calculate_auto_time_expression.ts
+++ b/src/plugins/data/common/search/aggs/utils/calculate_auto_time_expression.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/date_histogram_interval.test.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/date_histogram_interval.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/date_histogram_interval.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/date_histogram_interval.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/index.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/invalid_opensearch_calendar_interval_error.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/invalid_opensearch_calendar_interval_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/invalid_opensearch_interval_format_error.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/invalid_opensearch_interval_format_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/is_valid_interval.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/is_valid_interval.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/is_valid_opensearch_interval.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/is_valid_opensearch_interval.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/least_common_interval.test.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/least_common_interval.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/least_common_interval.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/least_common_interval.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/least_common_multiple.test.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/least_common_multiple.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/least_common_multiple.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/least_common_multiple.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/parse_interval.test.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/parse_interval.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/parse_interval.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/parse_interval.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/parse_opensearch_interval.test.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/parse_opensearch_interval.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/parse_opensearch_interval.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/parse_opensearch_interval.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/date_interval_utils/to_absolute_dates.ts
+++ b/src/plugins/data/common/search/aggs/utils/date_interval_utils/to_absolute_dates.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/get_format_with_aggs.test.ts
+++ b/src/plugins/data/common/search/aggs/utils/get_format_with_aggs.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/get_format_with_aggs.ts
+++ b/src/plugins/data/common/search/aggs/utils/get_format_with_aggs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/get_parsed_value.ts
+++ b/src/plugins/data/common/search/aggs/utils/get_parsed_value.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/index.ts
+++ b/src/plugins/data/common/search/aggs/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/ipv4_address.test.ts
+++ b/src/plugins/data/common/search/aggs/utils/ipv4_address.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/ipv4_address.ts
+++ b/src/plugins/data/common/search/aggs/utils/ipv4_address.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/prop_filter.test.ts
+++ b/src/plugins/data/common/search/aggs/utils/prop_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/prop_filter.ts
+++ b/src/plugins/data/common/search/aggs/utils/prop_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/aggs/utils/to_angular_json.ts
+++ b/src/plugins/data/common/search/aggs/utils/to_angular_json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/expressions/index.ts
+++ b/src/plugins/data/common/search/expressions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/expressions/opensearchaggs.ts
+++ b/src/plugins/data/common/search/expressions/opensearchaggs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/expressions/utils/courier_inspector_stats.ts
+++ b/src/plugins/data/common/search/expressions/utils/courier_inspector_stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/expressions/utils/index.ts
+++ b/src/plugins/data/common/search/expressions/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/index.ts
+++ b/src/plugins/data/common/search/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/opensearch_search/index.ts
+++ b/src/plugins/data/common/search/opensearch_search/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/opensearch_search/types.ts
+++ b/src/plugins/data/common/search/opensearch_search/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/opensearch_search/utils.ts
+++ b/src/plugins/data/common/search/opensearch_search/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/create_search_source.test.ts
+++ b/src/plugins/data/common/search/search_source/create_search_source.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/create_search_source.ts
+++ b/src/plugins/data/common/search/search_source/create_search_source.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/extract_references.ts
+++ b/src/plugins/data/common/search/search_source/extract_references.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/fetch/get_search_params.test.ts
+++ b/src/plugins/data/common/search/search_source/fetch/get_search_params.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/fetch/get_search_params.ts
+++ b/src/plugins/data/common/search/search_source/fetch/get_search_params.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/fetch/index.ts
+++ b/src/plugins/data/common/search/search_source/fetch/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/fetch/request_error.ts
+++ b/src/plugins/data/common/search/search_source/fetch/request_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/fetch/types.ts
+++ b/src/plugins/data/common/search/search_source/fetch/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/filter_docvalue_fields.test.ts
+++ b/src/plugins/data/common/search/search_source/filter_docvalue_fields.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/filter_docvalue_fields.ts
+++ b/src/plugins/data/common/search/search_source/filter_docvalue_fields.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/index.ts
+++ b/src/plugins/data/common/search/search_source/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/inject_references.test.ts
+++ b/src/plugins/data/common/search/search_source/inject_references.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/inject_references.ts
+++ b/src/plugins/data/common/search/search_source/inject_references.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/legacy/call_client.test.ts
+++ b/src/plugins/data/common/search/search_source/legacy/call_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/legacy/call_client.ts
+++ b/src/plugins/data/common/search/search_source/legacy/call_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/legacy/default_search_strategy.test.ts
+++ b/src/plugins/data/common/search/search_source/legacy/default_search_strategy.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/legacy/default_search_strategy.ts
+++ b/src/plugins/data/common/search/search_source/legacy/default_search_strategy.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/legacy/fetch_soon.test.ts
+++ b/src/plugins/data/common/search/search_source/legacy/fetch_soon.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/legacy/fetch_soon.ts
+++ b/src/plugins/data/common/search/search_source/legacy/fetch_soon.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/legacy/index.ts
+++ b/src/plugins/data/common/search/search_source/legacy/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/legacy/types.ts
+++ b/src/plugins/data/common/search/search_source/legacy/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/migrate_legacy_query.ts
+++ b/src/plugins/data/common/search/search_source/migrate_legacy_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/mocks.ts
+++ b/src/plugins/data/common/search/search_source/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/normalize_sort_request.test.ts
+++ b/src/plugins/data/common/search/search_source/normalize_sort_request.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/normalize_sort_request.ts
+++ b/src/plugins/data/common/search/search_source/normalize_sort_request.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/parse_json.ts
+++ b/src/plugins/data/common/search/search_source/parse_json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/search_source.test.ts
+++ b/src/plugins/data/common/search/search_source/search_source.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/search_source_service.test.ts
+++ b/src/plugins/data/common/search/search_source/search_source_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/search_source_service.ts
+++ b/src/plugins/data/common/search/search_source/search_source_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/search_source/types.ts
+++ b/src/plugins/data/common/search/search_source/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/tabify/buckets.test.ts
+++ b/src/plugins/data/common/search/tabify/buckets.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/tabify/buckets.ts
+++ b/src/plugins/data/common/search/tabify/buckets.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/tabify/get_columns.test.ts
+++ b/src/plugins/data/common/search/tabify/get_columns.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/tabify/get_columns.ts
+++ b/src/plugins/data/common/search/tabify/get_columns.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/tabify/index.ts
+++ b/src/plugins/data/common/search/tabify/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/tabify/response_writer.test.ts
+++ b/src/plugins/data/common/search/tabify/response_writer.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/tabify/response_writer.ts
+++ b/src/plugins/data/common/search/tabify/response_writer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/tabify/tabify.test.ts
+++ b/src/plugins/data/common/search/tabify/tabify.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/tabify/tabify.ts
+++ b/src/plugins/data/common/search/tabify/tabify.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/tabify/types.ts
+++ b/src/plugins/data/common/search/tabify/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/search/types.ts
+++ b/src/plugins/data/common/search/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/stubs.ts
+++ b/src/plugins/data/common/stubs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/types.ts
+++ b/src/plugins/data/common/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/utils/abort_utils.test.ts
+++ b/src/plugins/data/common/utils/abort_utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/utils/abort_utils.ts
+++ b/src/plugins/data/common/utils/abort_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/utils/index.ts
+++ b/src/plugins/data/common/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/utils/shorten_dotted_string.test.ts
+++ b/src/plugins/data/common/utils/shorten_dotted_string.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/common/utils/shorten_dotted_string.ts
+++ b/src/plugins/data/common/utils/shorten_dotted_string.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/config.ts
+++ b/src/plugins/data/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/actions/apply_filter_action.ts
+++ b/src/plugins/data/public/actions/apply_filter_action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/actions/filters/create_filters_from_range_select.test.ts
+++ b/src/plugins/data/public/actions/filters/create_filters_from_range_select.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/actions/filters/create_filters_from_range_select.ts
+++ b/src/plugins/data/public/actions/filters/create_filters_from_range_select.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/actions/filters/create_filters_from_value_click.test.ts
+++ b/src/plugins/data/public/actions/filters/create_filters_from_value_click.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/actions/filters/create_filters_from_value_click.ts
+++ b/src/plugins/data/public/actions/filters/create_filters_from_value_click.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/actions/index.ts
+++ b/src/plugins/data/public/actions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/actions/select_range_action.ts
+++ b/src/plugins/data/public/actions/select_range_action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/actions/value_click_action.ts
+++ b/src/plugins/data/public/actions/value_click_action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/autocomplete/autocomplete_service.ts
+++ b/src/plugins/data/public/autocomplete/autocomplete_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/autocomplete/index.ts
+++ b/src/plugins/data/public/autocomplete/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/autocomplete/providers/query_suggestion_provider.ts
+++ b/src/plugins/data/public/autocomplete/providers/query_suggestion_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/autocomplete/providers/value_suggestion_provider.test.ts
+++ b/src/plugins/data/public/autocomplete/providers/value_suggestion_provider.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/autocomplete/providers/value_suggestion_provider.ts
+++ b/src/plugins/data/public/autocomplete/providers/value_suggestion_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/field_formats/constants.ts
+++ b/src/plugins/data/public/field_formats/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/field_formats/converters/date.test.ts
+++ b/src/plugins/data/public/field_formats/converters/date.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/field_formats/converters/date.ts
+++ b/src/plugins/data/public/field_formats/converters/date.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/field_formats/converters/date_nanos.ts
+++ b/src/plugins/data/public/field_formats/converters/date_nanos.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/field_formats/converters/index.ts
+++ b/src/plugins/data/public/field_formats/converters/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/field_formats/field_formats_registry.stub.ts
+++ b/src/plugins/data/public/field_formats/field_formats_registry.stub.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/field_formats/field_formats_service.test.ts
+++ b/src/plugins/data/public/field_formats/field_formats_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/field_formats/field_formats_service.ts
+++ b/src/plugins/data/public/field_formats/field_formats_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/field_formats/index.ts
+++ b/src/plugins/data/public/field_formats/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/field_formats/mocks.ts
+++ b/src/plugins/data/public/field_formats/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/field_formats/utils/deserialize.ts
+++ b/src/plugins/data/public/field_formats/utils/deserialize.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/expressions/index.ts
+++ b/src/plugins/data/public/index_patterns/expressions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/expressions/load_index_pattern.test.ts
+++ b/src/plugins/data/public/index_patterns/expressions/load_index_pattern.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/expressions/load_index_pattern.ts
+++ b/src/plugins/data/public/index_patterns/expressions/load_index_pattern.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/index.ts
+++ b/src/plugins/data/public/index_patterns/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/index_pattern.stub.ts
+++ b/src/plugins/data/public/index_patterns/index_pattern.stub.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/index_patterns/index.ts
+++ b/src/plugins/data/public/index_patterns/index_patterns/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/index_patterns/index_patterns_api_client.test.mock.ts
+++ b/src/plugins/data/public/index_patterns/index_patterns/index_patterns_api_client.test.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/index_patterns/index_patterns_api_client.test.ts
+++ b/src/plugins/data/public/index_patterns/index_patterns/index_patterns_api_client.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/index_patterns/index_patterns_api_client.ts
+++ b/src/plugins/data/public/index_patterns/index_patterns/index_patterns_api_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/index_patterns/on_unsupported_time_pattern.tsx
+++ b/src/plugins/data/public/index_patterns/index_patterns/on_unsupported_time_pattern.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/index_patterns/redirect_no_index_pattern.tsx
+++ b/src/plugins/data/public/index_patterns/index_patterns/redirect_no_index_pattern.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/saved_objects_client_wrapper.ts
+++ b/src/plugins/data/public/index_patterns/saved_objects_client_wrapper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/index_patterns/ui_settings_wrapper.ts
+++ b/src/plugins/data/public/index_patterns/ui_settings_wrapper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/mocks.ts
+++ b/src/plugins/data/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/plugin.ts
+++ b/src/plugins/data/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/filter_manager.mock.ts
+++ b/src/plugins/data/public/query/filter_manager/filter_manager.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/filter_manager.test.ts
+++ b/src/plugins/data/public/query/filter_manager/filter_manager.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/filter_manager.ts
+++ b/src/plugins/data/public/query/filter_manager/filter_manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/index.ts
+++ b/src/plugins/data/public/query/filter_manager/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/generate_filter.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/generate_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/generate_filters.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/generate_filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/generate_mapping_chain.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/generate_mapping_chain.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/generate_mapping_chain.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/generate_mapping_chain.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/map_and_flatten_filters.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/map_and_flatten_filters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/map_and_flatten_filters.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/map_and_flatten_filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/map_filter.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/map_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/map_filter.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/map_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_default.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_default.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_default.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_default.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_exists.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_exists.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_exists.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_exists.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_geo_bounding_box.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_geo_bounding_box.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_geo_bounding_box.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_geo_bounding_box.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_geo_polygon.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_geo_polygon.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_geo_polygon.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_geo_polygon.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_match_all.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_match_all.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_match_all.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_match_all.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_missing.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_missing.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_missing.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_missing.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrases.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrases.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_query_string.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_query_string.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_query_string.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_query_string.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_range.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_range.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_range.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_spatial_filter.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_spatial_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_spatial_filter.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_spatial_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/only_disabled.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/only_disabled.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/only_disabled.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/only_disabled.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/sort_filters.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/sort_filters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/lib/sort_filters.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/sort_filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/test_helpers/get_filters_array.ts
+++ b/src/plugins/data/public/query/filter_manager/test_helpers/get_filters_array.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/test_helpers/get_stub_filter.ts
+++ b/src/plugins/data/public/query/filter_manager/test_helpers/get_stub_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/filter_manager/types.ts
+++ b/src/plugins/data/public/query/filter_manager/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/index.tsx
+++ b/src/plugins/data/public/query/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/lib/add_to_query_log.ts
+++ b/src/plugins/data/public/query/lib/add_to_query_log.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/lib/from_user.test.ts
+++ b/src/plugins/data/public/query/lib/from_user.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/lib/from_user.ts
+++ b/src/plugins/data/public/query/lib/from_user.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/lib/get_default_query.ts
+++ b/src/plugins/data/public/query/lib/get_default_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/lib/get_query_log.ts
+++ b/src/plugins/data/public/query/lib/get_query_log.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/lib/index.ts
+++ b/src/plugins/data/public/query/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/lib/match_pairs.ts
+++ b/src/plugins/data/public/query/lib/match_pairs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/lib/to_user.test.ts
+++ b/src/plugins/data/public/query/lib/to_user.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/lib/to_user.ts
+++ b/src/plugins/data/public/query/lib/to_user.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/mocks.ts
+++ b/src/plugins/data/public/query/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/persisted_log/index.ts
+++ b/src/plugins/data/public/query/persisted_log/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/persisted_log/persisted_log.test.ts
+++ b/src/plugins/data/public/query/persisted_log/persisted_log.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/persisted_log/persisted_log.ts
+++ b/src/plugins/data/public/query/persisted_log/persisted_log.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/query_service.ts
+++ b/src/plugins/data/public/query/query_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/query_string/index.ts
+++ b/src/plugins/data/public/query/query_string/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/query_string/query_string_manager.mock.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/query_string/query_string_manager.test.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/saved_query/index.ts
+++ b/src/plugins/data/public/query/saved_query/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/saved_query/saved_query_service.test.ts
+++ b/src/plugins/data/public/query/saved_query/saved_query_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/saved_query/saved_query_service.ts
+++ b/src/plugins/data/public/query/saved_query/saved_query_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/saved_query/types.ts
+++ b/src/plugins/data/public/query/saved_query/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/state_sync/connect_to_query_state.test.ts
+++ b/src/plugins/data/public/query/state_sync/connect_to_query_state.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/state_sync/connect_to_query_state.ts
+++ b/src/plugins/data/public/query/state_sync/connect_to_query_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/state_sync/create_global_query_observable.ts
+++ b/src/plugins/data/public/query/state_sync/create_global_query_observable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/state_sync/index.ts
+++ b/src/plugins/data/public/query/state_sync/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/state_sync/sync_state_with_url.test.ts
+++ b/src/plugins/data/public/query/state_sync/sync_state_with_url.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/state_sync/sync_state_with_url.ts
+++ b/src/plugins/data/public/query/state_sync/sync_state_with_url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/state_sync/types.ts
+++ b/src/plugins/data/public/query/state_sync/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/index.ts
+++ b/src/plugins/data/public/query/timefilter/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/lib/change_time_filter.test.ts
+++ b/src/plugins/data/public/query/timefilter/lib/change_time_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/lib/change_time_filter.ts
+++ b/src/plugins/data/public/query/timefilter/lib/change_time_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/lib/diff_time_picker_vals.test.ts
+++ b/src/plugins/data/public/query/timefilter/lib/diff_time_picker_vals.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/lib/diff_time_picker_vals.ts
+++ b/src/plugins/data/public/query/timefilter/lib/diff_time_picker_vals.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/lib/extract_time_filter.test.ts
+++ b/src/plugins/data/public/query/timefilter/lib/extract_time_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/lib/extract_time_filter.ts
+++ b/src/plugins/data/public/query/timefilter/lib/extract_time_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/lib/get_force_now.ts
+++ b/src/plugins/data/public/query/timefilter/lib/get_force_now.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/lib/parse_querystring.ts
+++ b/src/plugins/data/public/query/timefilter/lib/parse_querystring.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/lib/validate_timerange.test.ts
+++ b/src/plugins/data/public/query/timefilter/lib/validate_timerange.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/lib/validate_timerange.ts
+++ b/src/plugins/data/public/query/timefilter/lib/validate_timerange.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/time_history.ts
+++ b/src/plugins/data/public/query/timefilter/time_history.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/timefilter.test.ts
+++ b/src/plugins/data/public/query/timefilter/timefilter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/timefilter.ts
+++ b/src/plugins/data/public/query/timefilter/timefilter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/timefilter_service.mock.ts
+++ b/src/plugins/data/public/query/timefilter/timefilter_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/timefilter_service.ts
+++ b/src/plugins/data/public/query/timefilter/timefilter_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/query/timefilter/types.ts
+++ b/src/plugins/data/public/query/timefilter/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/aggs/aggs_service.test.ts
+++ b/src/plugins/data/public/search/aggs/aggs_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/aggs/aggs_service.ts
+++ b/src/plugins/data/public/search/aggs/aggs_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/aggs/index.ts
+++ b/src/plugins/data/public/search/aggs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/aggs/mocks.ts
+++ b/src/plugins/data/public/search/aggs/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/aggs/types.ts
+++ b/src/plugins/data/public/search/aggs/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/collectors/create_usage_collector.test.ts
+++ b/src/plugins/data/public/search/collectors/create_usage_collector.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/collectors/create_usage_collector.ts
+++ b/src/plugins/data/public/search/collectors/create_usage_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/collectors/index.ts
+++ b/src/plugins/data/public/search/collectors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/collectors/types.ts
+++ b/src/plugins/data/public/search/collectors/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/errors/index.ts
+++ b/src/plugins/data/public/search/errors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/errors/painless_error.tsx
+++ b/src/plugins/data/public/search/errors/painless_error.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/errors/timeout_error.test.tsx
+++ b/src/plugins/data/public/search/errors/timeout_error.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/errors/timeout_error.tsx
+++ b/src/plugins/data/public/search/errors/timeout_error.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/errors/types.ts
+++ b/src/plugins/data/public/search/errors/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/expressions/build_tabular_inspector_data.ts
+++ b/src/plugins/data/public/search/expressions/build_tabular_inspector_data.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/expressions/create_filter.test.ts
+++ b/src/plugins/data/public/search/expressions/create_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/expressions/create_filter.ts
+++ b/src/plugins/data/public/search/expressions/create_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/expressions/index.ts
+++ b/src/plugins/data/public/search/expressions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/expressions/opensearch_raw_response.test.ts
+++ b/src/plugins/data/public/search/expressions/opensearch_raw_response.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/expressions/opensearch_raw_response.ts
+++ b/src/plugins/data/public/search/expressions/opensearch_raw_response.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/expressions/opensearchaggs.ts
+++ b/src/plugins/data/public/search/expressions/opensearchaggs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/expressions/opensearchdsl.test.ts
+++ b/src/plugins/data/public/search/expressions/opensearchdsl.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/expressions/opensearchdsl.ts
+++ b/src/plugins/data/public/search/expressions/opensearchdsl.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/expressions/utils/index.ts
+++ b/src/plugins/data/public/search/expressions/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/expressions/utils/serialize_agg_config.ts
+++ b/src/plugins/data/public/search/expressions/utils/serialize_agg_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/fetch/handle_response.test.ts
+++ b/src/plugins/data/public/search/fetch/handle_response.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/fetch/handle_response.tsx
+++ b/src/plugins/data/public/search/fetch/handle_response.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/fetch/index.ts
+++ b/src/plugins/data/public/search/fetch/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/index.ts
+++ b/src/plugins/data/public/search/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/legacy/call_msearch.test.ts
+++ b/src/plugins/data/public/search/legacy/call_msearch.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/legacy/call_msearch.ts
+++ b/src/plugins/data/public/search/legacy/call_msearch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/legacy/index.ts
+++ b/src/plugins/data/public/search/legacy/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/mocks.ts
+++ b/src/plugins/data/public/search/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/opensearch_search/get_opensearch_preference.test.ts
+++ b/src/plugins/data/public/search/opensearch_search/get_opensearch_preference.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/opensearch_search/get_opensearch_preference.ts
+++ b/src/plugins/data/public/search/opensearch_search/get_opensearch_preference.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/opensearch_search/index.ts
+++ b/src/plugins/data/public/search/opensearch_search/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/search_interceptor.test.ts
+++ b/src/plugins/data/public/search/search_interceptor.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/search_interceptor.ts
+++ b/src/plugins/data/public/search/search_interceptor.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/search_service.test.ts
+++ b/src/plugins/data/public/search/search_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/search_service.ts
+++ b/src/plugins/data/public/search/search_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/search_source/mocks.ts
+++ b/src/plugins/data/public/search/search_source/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/search/types.ts
+++ b/src/plugins/data/public/search/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/services.ts
+++ b/src/plugins/data/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/stubs.ts
+++ b/src/plugins/data/public/stubs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/test_utils.ts
+++ b/src/plugins/data/public/test_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/types.ts
+++ b/src/plugins/data/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/apply_filters/apply_filter_popover_content.tsx
+++ b/src/plugins/data/public/ui/apply_filters/apply_filter_popover_content.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/apply_filters/apply_filters_popover.tsx
+++ b/src/plugins/data/public/ui/apply_filters/apply_filters_popover.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/apply_filters/index.ts
+++ b/src/plugins/data/public/ui/apply_filters/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/generic_combo_box.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/generic_combo_box.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/index.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/lib/filter_editor_utils.test.ts
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/lib/filter_editor_utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/lib/filter_editor_utils.ts
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/lib/filter_editor_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/lib/filter_label.test.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/lib/filter_label.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/lib/filter_label.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/lib/filter_label.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/lib/filter_operators.ts
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/lib/filter_operators.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/phrase_suggestor.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/phrase_suggestor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/phrase_value_input.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/phrase_value_input.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/phrases_values_input.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/phrases_values_input.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/range_value_input.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/range_value_input.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/value_input_type.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/value_input_type.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_item.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_item.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_options.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/filter_view/index.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_view/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/filter_bar/index.tsx
+++ b/src/plugins/data/public/ui/filter_bar/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/index.ts
+++ b/src/plugins/data/public/ui/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/index_pattern_select/create_index_pattern_select.tsx
+++ b/src/plugins/data/public/ui/index_pattern_select/create_index_pattern_select.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/index_pattern_select/index.tsx
+++ b/src/plugins/data/public/ui/index_pattern_select/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/index_pattern_select/index_pattern_select.tsx
+++ b/src/plugins/data/public/ui/index_pattern_select/index_pattern_select.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/query_string_input/fetch_index_patterns.ts
+++ b/src/plugins/data/public/ui/query_string_input/fetch_index_patterns.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/query_string_input/index.tsx
+++ b/src/plugins/data/public/ui/query_string_input/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/query_string_input/language_switcher.test.tsx
+++ b/src/plugins/data/public/ui/query_string_input/language_switcher.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/query_string_input/language_switcher.tsx
+++ b/src/plugins/data/public/ui/query_string_input/language_switcher.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/query_string_input/no_data_popover.test.tsx
+++ b/src/plugins/data/public/ui/query_string_input/no_data_popover.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/query_string_input/no_data_popover.tsx
+++ b/src/plugins/data/public/ui/query_string_input/no_data_popover.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/query_string_input/query_bar_top_row.test.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_bar_top_row.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/query_string_input/query_string_input.test.mocks.ts
+++ b/src/plugins/data/public/ui/query_string_input/query_string_input.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/query_string_input/query_string_input.test.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_string_input.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/query_string_input/query_string_input.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_string_input.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/saved_query_form/index.ts
+++ b/src/plugins/data/public/ui/saved_query_form/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
+++ b/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/saved_query_management/index.ts
+++ b/src/plugins/data/public/ui/saved_query_management/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/saved_query_management/saved_query_list_item.tsx
+++ b/src/plugins/data/public/ui/saved_query_management/saved_query_list_item.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/saved_query_management/saved_query_management_component.tsx
+++ b/src/plugins/data/public/ui/saved_query_management/saved_query_management_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/index.tsx
+++ b/src/plugins/data/public/ui/search_bar/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/lib/clear_saved_query.test.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/clear_saved_query.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/lib/clear_saved_query.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/clear_saved_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.test.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/lib/use_filter_manager.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/use_filter_manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/lib/use_query_string_manager.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/use_query_string_manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/lib/use_saved_query.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/use_saved_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/lib/use_timefilter.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/use_timefilter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/search_bar.test.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/__mocks__/shard_failure_request.ts
+++ b/src/plugins/data/public/ui/shard_failure_modal/__mocks__/shard_failure_request.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/__mocks__/shard_failure_response.ts
+++ b/src/plugins/data/public/ui/shard_failure_modal/__mocks__/shard_failure_response.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/index.tsx
+++ b/src/plugins/data/public/ui/shard_failure_modal/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/shard_failure_description.test.tsx
+++ b/src/plugins/data/public/ui/shard_failure_modal/shard_failure_description.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/shard_failure_description.tsx
+++ b/src/plugins/data/public/ui/shard_failure_modal/shard_failure_description.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/shard_failure_description_header.tsx
+++ b/src/plugins/data/public/ui/shard_failure_modal/shard_failure_description_header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/shard_failure_modal.test.tsx
+++ b/src/plugins/data/public/ui/shard_failure_modal/shard_failure_modal.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/shard_failure_modal.tsx
+++ b/src/plugins/data/public/ui/shard_failure_modal/shard_failure_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/shard_failure_open_modal_button.test.mocks.tsx
+++ b/src/plugins/data/public/ui/shard_failure_modal/shard_failure_open_modal_button.test.mocks.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/shard_failure_open_modal_button.test.tsx
+++ b/src/plugins/data/public/ui/shard_failure_modal/shard_failure_open_modal_button.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/shard_failure_open_modal_button.tsx
+++ b/src/plugins/data/public/ui/shard_failure_modal/shard_failure_open_modal_button.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/shard_failure_table.test.tsx
+++ b/src/plugins/data/public/ui/shard_failure_modal/shard_failure_table.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/shard_failure_table.tsx
+++ b/src/plugins/data/public/ui/shard_failure_modal/shard_failure_table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/shard_failure_modal/shard_failure_types.ts
+++ b/src/plugins/data/public/ui/shard_failure_modal/shard_failure_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/typeahead/constants.ts
+++ b/src/plugins/data/public/ui/typeahead/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/typeahead/index.tsx
+++ b/src/plugins/data/public/ui/typeahead/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/typeahead/suggestion_component.test.tsx
+++ b/src/plugins/data/public/ui/typeahead/suggestion_component.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/typeahead/suggestion_component.tsx
+++ b/src/plugins/data/public/ui/typeahead/suggestion_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/typeahead/suggestions_component.test.tsx
+++ b/src/plugins/data/public/ui/typeahead/suggestions_component.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/public/ui/typeahead/suggestions_component.tsx
+++ b/src/plugins/data/public/ui/typeahead/suggestions_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/autocomplete/autocomplete_service.ts
+++ b/src/plugins/data/server/autocomplete/autocomplete_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/autocomplete/index.ts
+++ b/src/plugins/data/server/autocomplete/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/autocomplete/routes.ts
+++ b/src/plugins/data/server/autocomplete/routes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/autocomplete/value_suggestions_route.ts
+++ b/src/plugins/data/server/autocomplete/value_suggestions_route.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/dql_telemetry/dql_telemetry_service.ts
+++ b/src/plugins/data/server/dql_telemetry/dql_telemetry_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/dql_telemetry/index.ts
+++ b/src/plugins/data/server/dql_telemetry/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/dql_telemetry/route.ts
+++ b/src/plugins/data/server/dql_telemetry/route.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/dql_telemetry/usage_collector/fetch.test.ts
+++ b/src/plugins/data/server/dql_telemetry/usage_collector/fetch.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/dql_telemetry/usage_collector/fetch.ts
+++ b/src/plugins/data/server/dql_telemetry/usage_collector/fetch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/dql_telemetry/usage_collector/index.ts
+++ b/src/plugins/data/server/dql_telemetry/usage_collector/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/dql_telemetry/usage_collector/make_dql_usage_collector.test.ts
+++ b/src/plugins/data/server/dql_telemetry/usage_collector/make_dql_usage_collector.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/dql_telemetry/usage_collector/make_dql_usage_collector.ts
+++ b/src/plugins/data/server/dql_telemetry/usage_collector/make_dql_usage_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/field_formats/converters/date_nanos_server.test.ts
+++ b/src/plugins/data/server/field_formats/converters/date_nanos_server.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/field_formats/converters/date_nanos_server.ts
+++ b/src/plugins/data/server/field_formats/converters/date_nanos_server.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/field_formats/converters/date_server.ts
+++ b/src/plugins/data/server/field_formats/converters/date_server.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/field_formats/converters/index.ts
+++ b/src/plugins/data/server/field_formats/converters/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/field_formats/field_formats_service.test.ts
+++ b/src/plugins/data/server/field_formats/field_formats_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/field_formats/field_formats_service.ts
+++ b/src/plugins/data/server/field_formats/field_formats_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/field_formats/index.ts
+++ b/src/plugins/data/server/field_formats/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/field_formats/mocks.ts
+++ b/src/plugins/data/server/field_formats/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index.ts
+++ b/src/plugins/data/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/capabilities_provider.ts
+++ b/src/plugins/data/server/index_patterns/capabilities_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/index.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/index_patterns_fetcher.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/index_patterns_fetcher.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/errors.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/field_capabilities.test.js
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/field_capabilities.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/field_capabilities.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/field_capabilities.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/field_caps_response.test.js
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/field_caps_response.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/field_caps_response.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/field_caps_response.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/index.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/overrides.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/overrides.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/should_read_field_from_doc_values.test.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/should_read_field_from_doc_values.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/should_read_field_from_doc_values.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/should_read_field_from_doc_values.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/index.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/opensearch_api.test.js
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/opensearch_api.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/opensearch_api.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/opensearch_api.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/resolve_time_pattern.test.js
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/resolve_time_pattern.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/resolve_time_pattern.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/resolve_time_pattern.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/time_pattern_to_wildcard.test.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/time_pattern_to_wildcard.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/fetcher/lib/time_pattern_to_wildcard.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/time_pattern_to_wildcard.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/index.ts
+++ b/src/plugins/data/server/index_patterns/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/index_patterns_api_client.ts
+++ b/src/plugins/data/server/index_patterns/index_patterns_api_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/index_patterns_service.ts
+++ b/src/plugins/data/server/index_patterns/index_patterns_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/mocks.ts
+++ b/src/plugins/data/server/index_patterns/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/routes.ts
+++ b/src/plugins/data/server/index_patterns/routes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/saved_objects_client_wrapper.ts
+++ b/src/plugins/data/server/index_patterns/saved_objects_client_wrapper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/ui_settings_wrapper.ts
+++ b/src/plugins/data/server/index_patterns/ui_settings_wrapper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/index_patterns/utils.ts
+++ b/src/plugins/data/server/index_patterns/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/lib/get_request_aborted_signal.test.ts
+++ b/src/plugins/data/server/lib/get_request_aborted_signal.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/lib/get_request_aborted_signal.ts
+++ b/src/plugins/data/server/lib/get_request_aborted_signal.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/lib/index.ts
+++ b/src/plugins/data/server/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/mocks.ts
+++ b/src/plugins/data/server/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/plugin.ts
+++ b/src/plugins/data/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/query/index.ts
+++ b/src/plugins/data/server/query/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/query/query_service.ts
+++ b/src/plugins/data/server/query/query_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/saved_objects/dql_telemetry.ts
+++ b/src/plugins/data/server/saved_objects/dql_telemetry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/saved_objects/index.ts
+++ b/src/plugins/data/server/saved_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/saved_objects/index_pattern_migrations.test.ts
+++ b/src/plugins/data/server/saved_objects/index_pattern_migrations.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/saved_objects/index_pattern_migrations.ts
+++ b/src/plugins/data/server/saved_objects/index_pattern_migrations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/saved_objects/index_patterns.ts
+++ b/src/plugins/data/server/saved_objects/index_patterns.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/saved_objects/query.ts
+++ b/src/plugins/data/server/saved_objects/query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/saved_objects/search_telemetry.ts
+++ b/src/plugins/data/server/saved_objects/search_telemetry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/scripts/index.ts
+++ b/src/plugins/data/server/scripts/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/scripts/route.ts
+++ b/src/plugins/data/server/scripts/route.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/scripts/scripts_service.ts
+++ b/src/plugins/data/server/scripts/scripts_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/aggs/aggs_service.test.ts
+++ b/src/plugins/data/server/search/aggs/aggs_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/aggs/aggs_service.ts
+++ b/src/plugins/data/server/search/aggs/aggs_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/aggs/index.ts
+++ b/src/plugins/data/server/search/aggs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/aggs/mocks.ts
+++ b/src/plugins/data/server/search/aggs/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/aggs/types.ts
+++ b/src/plugins/data/server/search/aggs/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/collectors/fetch.ts
+++ b/src/plugins/data/server/search/collectors/fetch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/collectors/index.ts
+++ b/src/plugins/data/server/search/collectors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/collectors/register.ts
+++ b/src/plugins/data/server/search/collectors/register.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/collectors/usage.ts
+++ b/src/plugins/data/server/search/collectors/usage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/index.ts
+++ b/src/plugins/data/server/search/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/mocks.ts
+++ b/src/plugins/data/server/search/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/opensearch_search/get_default_search_params.ts
+++ b/src/plugins/data/server/search/opensearch_search/get_default_search_params.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/opensearch_search/get_total_loaded.test.ts
+++ b/src/plugins/data/server/search/opensearch_search/get_total_loaded.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/opensearch_search/get_total_loaded.ts
+++ b/src/plugins/data/server/search/opensearch_search/get_total_loaded.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/opensearch_search/index.ts
+++ b/src/plugins/data/server/search/opensearch_search/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/opensearch_search/opensearch.ts
+++ b/src/plugins/data/server/search/opensearch_search/opensearch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/opensearch_search/opensearch_search_strategy.test.ts
+++ b/src/plugins/data/server/search/opensearch_search/opensearch_search_strategy.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/opensearch_search/opensearch_search_strategy.ts
+++ b/src/plugins/data/server/search/opensearch_search/opensearch_search_strategy.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/opensearch_search/shim_abort_signal.test.ts
+++ b/src/plugins/data/server/search/opensearch_search/shim_abort_signal.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/opensearch_search/shim_abort_signal.ts
+++ b/src/plugins/data/server/search/opensearch_search/shim_abort_signal.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/opensearch_search/to_snake_case.ts
+++ b/src/plugins/data/server/search/opensearch_search/to_snake_case.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/routes/call_msearch.test.ts
+++ b/src/plugins/data/server/search/routes/call_msearch.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/routes/call_msearch.ts
+++ b/src/plugins/data/server/search/routes/call_msearch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/routes/index.ts
+++ b/src/plugins/data/server/search/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/routes/msearch.test.ts
+++ b/src/plugins/data/server/search/routes/msearch.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/routes/msearch.ts
+++ b/src/plugins/data/server/search/routes/msearch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/routes/search.test.ts
+++ b/src/plugins/data/server/search/routes/search.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/routes/search.ts
+++ b/src/plugins/data/server/search/routes/search.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/routes/shim_hits_total.test.ts
+++ b/src/plugins/data/server/search/routes/shim_hits_total.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/routes/shim_hits_total.ts
+++ b/src/plugins/data/server/search/routes/shim_hits_total.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/search_service.test.ts
+++ b/src/plugins/data/server/search/search_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/search_service.ts
+++ b/src/plugins/data/server/search/search_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/search_source/mocks.ts
+++ b/src/plugins/data/server/search/search_source/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/search/types.ts
+++ b/src/plugins/data/server/search/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dev_tools/public/application.tsx
+++ b/src/plugins/dev_tools/public/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dev_tools/public/dev_tool.ts
+++ b/src/plugins/dev_tools/public/dev_tool.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dev_tools/public/index.ts
+++ b/src/plugins/dev_tools/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/dev_tools/public/plugin.ts
+++ b/src/plugins/dev_tools/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/common/index.ts
+++ b/src/plugins/discover/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context.js
+++ b/src/plugins/discover/public/application/angular/context.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/_stubs.js
+++ b/src/plugins/discover/public/application/angular/context/api/_stubs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/anchor.js
+++ b/src/plugins/discover/public/application/angular/context/api/anchor.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/anchor.test.js
+++ b/src/plugins/discover/public/application/angular/context/api/anchor.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/context.predecessors.test.js
+++ b/src/plugins/discover/public/application/angular/context/api/context.predecessors.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/context.successors.test.js
+++ b/src/plugins/discover/public/application/angular/context/api/context.successors.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/context.ts
+++ b/src/plugins/discover/public/application/angular/context/api/context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/utils/date_conversion.test.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/date_conversion.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/utils/date_conversion.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/date_conversion.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/utils/fetch_hits_in_interval.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/fetch_hits_in_interval.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/utils/generate_intervals.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/generate_intervals.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/utils/get_opensearch_query_search_after.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/get_opensearch_query_search_after.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/utils/get_opensearch_query_sort.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/get_opensearch_query_sort.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/utils/sorting.test.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/sorting.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/api/utils/sorting.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/sorting.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/components/action_bar/action_bar.test.tsx
+++ b/src/plugins/discover/public/application/angular/context/components/action_bar/action_bar.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/components/action_bar/action_bar.tsx
+++ b/src/plugins/discover/public/application/angular/context/components/action_bar/action_bar.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/components/action_bar/action_bar_directive.ts
+++ b/src/plugins/discover/public/application/angular/context/components/action_bar/action_bar_directive.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/components/action_bar/action_bar_warning.tsx
+++ b/src/plugins/discover/public/application/angular/context/components/action_bar/action_bar_warning.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/components/action_bar/index.ts
+++ b/src/plugins/discover/public/application/angular/context/components/action_bar/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/helpers/call_after_bindings_workaround.js
+++ b/src/plugins/discover/public/application/angular/context/helpers/call_after_bindings_workaround.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/query/actions.js
+++ b/src/plugins/discover/public/application/angular/context/query/actions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/query/constants.js
+++ b/src/plugins/discover/public/application/angular/context/query/constants.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/query/index.js
+++ b/src/plugins/discover/public/application/angular/context/query/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/query/state.js
+++ b/src/plugins/discover/public/application/angular/context/query/state.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/query_parameters/actions.js
+++ b/src/plugins/discover/public/application/angular/context/query_parameters/actions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/query_parameters/actions.test.ts
+++ b/src/plugins/discover/public/application/angular/context/query_parameters/actions.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/query_parameters/constants.ts
+++ b/src/plugins/discover/public/application/angular/context/query_parameters/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/query_parameters/index.js
+++ b/src/plugins/discover/public/application/angular/context/query_parameters/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context/query_parameters/state.ts
+++ b/src/plugins/discover/public/application/angular/context/query_parameters/state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context_app.js
+++ b/src/plugins/discover/public/application/angular/context_app.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context_state.test.ts
+++ b/src/plugins/discover/public/application/angular/context_state.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/context_state.ts
+++ b/src/plugins/discover/public/application/angular/context_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/directives/debounce/debounce.js
+++ b/src/plugins/discover/public/application/angular/directives/debounce/debounce.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/directives/debounce/debounce.test.ts
+++ b/src/plugins/discover/public/application/angular/directives/debounce/debounce.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/directives/debounce/index.js
+++ b/src/plugins/discover/public/application/angular/directives/debounce/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/directives/fixed_scroll.js
+++ b/src/plugins/discover/public/application/angular/directives/fixed_scroll.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/directives/fixed_scroll.test.js
+++ b/src/plugins/discover/public/application/angular/directives/fixed_scroll.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/directives/histogram.tsx
+++ b/src/plugins/discover/public/application/angular/directives/histogram.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/directives/index.js
+++ b/src/plugins/discover/public/application/angular/directives/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/directives/no_results.js
+++ b/src/plugins/discover/public/application/angular/directives/no_results.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/directives/no_results.test.js
+++ b/src/plugins/discover/public/application/angular/directives/no_results.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/directives/render_complete.ts
+++ b/src/plugins/discover/public/application/angular/directives/render_complete.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/directives/uninitialized.tsx
+++ b/src/plugins/discover/public/application/angular/directives/uninitialized.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/discover.js
+++ b/src/plugins/discover/public/application/angular/discover.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/discover_state.test.ts
+++ b/src/plugins/discover/public/application/angular/discover_state.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/discover_state.ts
+++ b/src/plugins/discover/public/application/angular/discover_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc.ts
+++ b/src/plugins/discover/public/application/angular/doc.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/actions/columns.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/actions/columns.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/pager/index.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/components/pager/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/pager/tool_bar_pager_buttons.test.tsx
+++ b/src/plugins/discover/public/application/angular/doc_table/components/pager/tool_bar_pager_buttons.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/pager/tool_bar_pager_buttons.tsx
+++ b/src/plugins/discover/public/application/angular/doc_table/components/pager/tool_bar_pager_buttons.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/pager/tool_bar_pager_text.test.tsx
+++ b/src/plugins/discover/public/application/angular/doc_table/components/pager/tool_bar_pager_text.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/pager/tool_bar_pager_text.tsx
+++ b/src/plugins/discover/public/application/angular/doc_table/components/pager/tool_bar_pager_text.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/row_headers.test.js
+++ b/src/plugins/discover/public/application/angular/doc_table/components/row_headers.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/table_header.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/components/table_header.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/table_header/helpers.tsx
+++ b/src/plugins/discover/public/application/angular/doc_table/components/table_header/helpers.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/table_header/table_header.test.tsx
+++ b/src/plugins/discover/public/application/angular/doc_table/components/table_header/table_header.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/table_header/table_header.tsx
+++ b/src/plugins/discover/public/application/angular/doc_table/components/table_header/table_header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/table_header/table_header_column.tsx
+++ b/src/plugins/discover/public/application/angular/doc_table/components/table_header/table_header_column.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/components/table_row.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/components/table_row.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/create_doc_table_react.tsx
+++ b/src/plugins/discover/public/application/angular/doc_table/create_doc_table_react.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/doc_table.test.js
+++ b/src/plugins/discover/public/application/angular/doc_table/doc_table.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/doc_table.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/doc_table.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/doc_table_strings.js
+++ b/src/plugins/discover/public/application/angular/doc_table/doc_table_strings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/index.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/infinite_scroll.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/infinite_scroll.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/lib/get_default_sort.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/lib/get_default_sort.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/lib/get_sort.test.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/lib/get_sort.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/lib/get_sort.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/lib/get_sort.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/lib/get_sort_for_search_source.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/lib/get_sort_for_search_source.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/lib/pager/index.js
+++ b/src/plugins/discover/public/application/angular/doc_table/lib/pager/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/lib/pager/pager.js
+++ b/src/plugins/discover/public/application/angular/doc_table/lib/pager/pager.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_table/lib/pager/pager_factory.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/lib/pager/pager_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/doc_viewer.tsx
+++ b/src/plugins/discover/public/application/angular/doc_viewer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/helpers/index.ts
+++ b/src/plugins/discover/public/application/angular/helpers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/helpers/point_series.ts
+++ b/src/plugins/discover/public/application/angular/helpers/point_series.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/index.ts
+++ b/src/plugins/discover/public/application/angular/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/redirect.ts
+++ b/src/plugins/discover/public/application/angular/redirect.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/angular/response_handler.js
+++ b/src/plugins/discover/public/application/angular/response_handler.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/application.ts
+++ b/src/plugins/discover/public/application/application.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/context_error_message/context_error_message.test.tsx
+++ b/src/plugins/discover/public/application/components/context_error_message/context_error_message.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/context_error_message/context_error_message.tsx
+++ b/src/plugins/discover/public/application/components/context_error_message/context_error_message.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/context_error_message/context_error_message_directive.ts
+++ b/src/plugins/discover/public/application/components/context_error_message/context_error_message_directive.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/context_error_message/index.ts
+++ b/src/plugins/discover/public/application/components/context_error_message/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/create_discover_legacy_directive.ts
+++ b/src/plugins/discover/public/application/components/create_discover_legacy_directive.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/discover_legacy.tsx
+++ b/src/plugins/discover/public/application/components/discover_legacy.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/doc/doc.test.tsx
+++ b/src/plugins/discover/public/application/components/doc/doc.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/doc/doc.tsx
+++ b/src/plugins/discover/public/application/components/doc/doc.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/doc/use_opensearch_doc_search.test.tsx
+++ b/src/plugins/discover/public/application/components/doc/use_opensearch_doc_search.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/doc/use_opensearch_doc_search.ts
+++ b/src/plugins/discover/public/application/components/doc/use_opensearch_doc_search.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/doc_viewer/doc_viewer.test.tsx
+++ b/src/plugins/discover/public/application/components/doc_viewer/doc_viewer.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/doc_viewer/doc_viewer.tsx
+++ b/src/plugins/discover/public/application/components/doc_viewer/doc_viewer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_render_error.tsx
+++ b/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_render_error.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_render_tab.test.tsx
+++ b/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_render_tab.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_render_tab.tsx
+++ b/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_render_tab.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_tab.tsx
+++ b/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_tab.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/field_name/field_name.test.tsx
+++ b/src/plugins/discover/public/application/components/field_name/field_name.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/field_name/field_name.tsx
+++ b/src/plugins/discover/public/application/components/field_name/field_name.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/field_name/field_type_name.ts
+++ b/src/plugins/discover/public/application/components/field_name/field_type_name.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/help_menu/help_menu_util.js
+++ b/src/plugins/discover/public/application/components/help_menu/help_menu_util.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/hits_counter/hits_counter.test.tsx
+++ b/src/plugins/discover/public/application/components/hits_counter/hits_counter.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/hits_counter/hits_counter.tsx
+++ b/src/plugins/discover/public/application/components/hits_counter/hits_counter.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/hits_counter/index.ts
+++ b/src/plugins/discover/public/application/components/hits_counter/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/json_code_block/json_code_block.test.tsx
+++ b/src/plugins/discover/public/application/components/json_code_block/json_code_block.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/json_code_block/json_code_block.tsx
+++ b/src/plugins/discover/public/application/components/json_code_block/json_code_block.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/loading_spinner/loading_spinner.test.tsx
+++ b/src/plugins/discover/public/application/components/loading_spinner/loading_spinner.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/loading_spinner/loading_spinner.tsx
+++ b/src/plugins/discover/public/application/components/loading_spinner/loading_spinner.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/change_indexpattern.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/change_indexpattern.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_field.test.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_field_bucket.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field_bucket.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_field_details.test.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field_details.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_field_details.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field_details.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_field_search.test.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field_search.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_field_search.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field_search.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_index_pattern.test.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_index_pattern.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_index_pattern.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_index_pattern.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_index_pattern_title.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_index_pattern_title.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_sidebar.test.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_sidebar.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/discover_sidebar.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_sidebar.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/index.ts
+++ b/src/plugins/discover/public/application/components/sidebar/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/lib/field_calculator.js
+++ b/src/plugins/discover/public/application/components/sidebar/lib/field_calculator.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/lib/field_calculator.test.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/field_calculator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/lib/field_filter.test.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/field_filter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/lib/field_filter.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/field_filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/lib/get_details.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/get_details.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/lib/get_field_type_name.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/get_field_type_name.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/lib/get_index_pattern_field_list.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/get_index_pattern_field_list.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/lib/get_warnings.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/get_warnings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/lib/group_fields.test.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/group_fields.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/lib/group_fields.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/lib/group_fields.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/lib/visualize_trigger_utils.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/visualize_trigger_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/string_progress_bar.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/string_progress_bar.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/sidebar/types.ts
+++ b/src/plugins/discover/public/application/components/sidebar/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/skip_bottom_button/index.ts
+++ b/src/plugins/discover/public/application/components/skip_bottom_button/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/skip_bottom_button/skip_bottom_button.test.tsx
+++ b/src/plugins/discover/public/application/components/skip_bottom_button/skip_bottom_button.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/skip_bottom_button/skip_bottom_button.tsx
+++ b/src/plugins/discover/public/application/components/skip_bottom_button/skip_bottom_button.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table.test.tsx
+++ b/src/plugins/discover/public/application/components/table/table.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table.tsx
+++ b/src/plugins/discover/public/application/components/table/table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table_helper.test.ts
+++ b/src/plugins/discover/public/application/components/table/table_helper.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table_helper.tsx
+++ b/src/plugins/discover/public/application/components/table/table_helper.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table_row.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table_row_btn_collapse.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_collapse.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table_row_btn_filter_add.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_filter_add.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table_row_btn_filter_exists.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_filter_exists.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table_row_btn_filter_remove.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_filter_remove.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table_row_btn_toggle_column.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_toggle_column.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table_row_icon_no_mapping.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_icon_no_mapping.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/table/table_row_icon_underscore.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_icon_underscore.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/timechart_header/index.ts
+++ b/src/plugins/discover/public/application/components/timechart_header/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/timechart_header/timechart_header.test.tsx
+++ b/src/plugins/discover/public/application/components/timechart_header/timechart_header.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/timechart_header/timechart_header.tsx
+++ b/src/plugins/discover/public/application/components/timechart_header/timechart_header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/top_nav/open_search_panel.js
+++ b/src/plugins/discover/public/application/components/top_nav/open_search_panel.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/top_nav/open_search_panel.test.js
+++ b/src/plugins/discover/public/application/components/top_nav/open_search_panel.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/components/top_nav/show_open_search_panel.js
+++ b/src/plugins/discover/public/application/components/top_nav/show_open_search_panel.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/doc_views/doc_views_helpers.tsx
+++ b/src/plugins/discover/public/application/doc_views/doc_views_helpers.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/doc_views/doc_views_registry.ts
+++ b/src/plugins/discover/public/application/doc_views/doc_views_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/doc_views/doc_views_types.ts
+++ b/src/plugins/discover/public/application/doc_views/doc_views_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/embeddable/constants.ts
+++ b/src/plugins/discover/public/application/embeddable/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/embeddable/index.ts
+++ b/src/plugins/discover/public/application/embeddable/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/embeddable/search_embeddable.ts
+++ b/src/plugins/discover/public/application/embeddable/search_embeddable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/embeddable/search_embeddable_factory.ts
+++ b/src/plugins/discover/public/application/embeddable/search_embeddable_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/embeddable/types.ts
+++ b/src/plugins/discover/public/application/embeddable/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/breadcrumbs.ts
+++ b/src/plugins/discover/public/application/helpers/breadcrumbs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/format_number_with_commas.ts
+++ b/src/plugins/discover/public/application/helpers/format_number_with_commas.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/get_index_pattern_id.ts
+++ b/src/plugins/discover/public/application/helpers/get_index_pattern_id.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/get_switch_index_pattern_app_state.test.ts
+++ b/src/plugins/discover/public/application/helpers/get_switch_index_pattern_app_state.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/get_switch_index_pattern_app_state.ts
+++ b/src/plugins/discover/public/application/helpers/get_switch_index_pattern_app_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/index.ts
+++ b/src/plugins/discover/public/application/helpers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/migrate_legacy_query.ts
+++ b/src/plugins/discover/public/application/helpers/migrate_legacy_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/popularize_field.test.ts
+++ b/src/plugins/discover/public/application/helpers/popularize_field.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/popularize_field.ts
+++ b/src/plugins/discover/public/application/helpers/popularize_field.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/shorten_dotted_string.ts
+++ b/src/plugins/discover/public/application/helpers/shorten_dotted_string.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/validate_time_range.test.ts
+++ b/src/plugins/discover/public/application/helpers/validate_time_range.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/application/helpers/validate_time_range.ts
+++ b/src/plugins/discover/public/application/helpers/validate_time_range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/build_services.ts
+++ b/src/plugins/discover/public/build_services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/get_inner_angular.ts
+++ b/src/plugins/discover/public/get_inner_angular.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/index.ts
+++ b/src/plugins/discover/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/mocks.ts
+++ b/src/plugins/discover/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/opensearch_dashboards_services.ts
+++ b/src/plugins/discover/public/opensearch_dashboards_services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/plugin.ts
+++ b/src/plugins/discover/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/register_feature.ts
+++ b/src/plugins/discover/public/register_feature.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/saved_searches/_saved_search.ts
+++ b/src/plugins/discover/public/saved_searches/_saved_search.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/saved_searches/index.ts
+++ b/src/plugins/discover/public/saved_searches/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/saved_searches/saved_searches.ts
+++ b/src/plugins/discover/public/saved_searches/saved_searches.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/saved_searches/types.ts
+++ b/src/plugins/discover/public/saved_searches/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/url_generator.test.ts
+++ b/src/plugins/discover/public/url_generator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/public/url_generator.ts
+++ b/src/plugins/discover/public/url_generator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/server/capabilities_provider.ts
+++ b/src/plugins/discover/server/capabilities_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/server/index.ts
+++ b/src/plugins/discover/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/server/plugin.ts
+++ b/src/plugins/discover/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/server/saved_objects/index.ts
+++ b/src/plugins/discover/server/saved_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/server/saved_objects/search.ts
+++ b/src/plugins/discover/server/saved_objects/search.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/server/saved_objects/search_migrations.test.ts
+++ b/src/plugins/discover/server/saved_objects/search_migrations.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/server/saved_objects/search_migrations.ts
+++ b/src/plugins/discover/server/saved_objects/search_migrations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/discover/server/ui_settings.ts
+++ b/src/plugins/discover/server/ui_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/common/lib/migrate_base_input.ts
+++ b/src/plugins/embeddable/common/lib/migrate_base_input.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/common/types.ts
+++ b/src/plugins/embeddable/common/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/bootstrap.ts
+++ b/src/plugins/embeddable/public/bootstrap.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/components/panel_options_menu/__examples__/panel_options_menu.stories.tsx
+++ b/src/plugins/embeddable/public/components/panel_options_menu/__examples__/panel_options_menu.stories.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/components/panel_options_menu/index.tsx
+++ b/src/plugins/embeddable/public/components/panel_options_menu/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/index.ts
+++ b/src/plugins/embeddable/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/actions/edit_panel_action.test.tsx
+++ b/src/plugins/embeddable/public/lib/actions/edit_panel_action.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/actions/edit_panel_action.ts
+++ b/src/plugins/embeddable/public/lib/actions/edit_panel_action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/actions/index.ts
+++ b/src/plugins/embeddable/public/lib/actions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/containers/container.ts
+++ b/src/plugins/embeddable/public/lib/containers/container.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/containers/embeddable_child_panel.test.tsx
+++ b/src/plugins/embeddable/public/lib/containers/embeddable_child_panel.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/containers/embeddable_child_panel.tsx
+++ b/src/plugins/embeddable/public/lib/containers/embeddable_child_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/containers/i_container.ts
+++ b/src/plugins/embeddable/public/lib/containers/i_container.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/containers/index.ts
+++ b/src/plugins/embeddable/public/lib/containers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/default_embeddable_factory_provider.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/default_embeddable_factory_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable.test.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable_factory.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable_factory_definition.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable_factory_definition.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable_renderer.test.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable_renderer.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable_renderer.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable_renderer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable_root.test.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable_root.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/embeddable_root.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/embeddable_root.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/error_embeddable.test.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/error_embeddable.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/error_embeddable.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/error_embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/i_embeddable.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/i_embeddable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/index.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/saved_object_embeddable.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/saved_object_embeddable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/embeddables/with_subscription.tsx
+++ b/src/plugins/embeddable/public/lib/embeddables/with_subscription.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/errors.test.ts
+++ b/src/plugins/embeddable/public/lib/errors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/errors.ts
+++ b/src/plugins/embeddable/public/lib/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/index.ts
+++ b/src/plugins/embeddable/public/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/inspector.ts
+++ b/src/plugins/embeddable/public/lib/inspector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/embeddable_error_label.tsx
+++ b/src/plugins/embeddable/public/lib/panel/embeddable_error_label.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/embeddable_panel.test.tsx
+++ b/src/plugins/embeddable/public/lib/panel/embeddable_panel.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/embeddable_panel.tsx
+++ b/src/plugins/embeddable/public/lib/panel/embeddable_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/index.ts
+++ b/src/plugins/embeddable/public/lib/panel/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/index.ts
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_action.test.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_action.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_action.ts
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_flyout.test.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_flyout.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_flyout.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_flyout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/index.ts
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/open_add_panel_flyout.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/open_add_panel_flyout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/saved_object_finder_create_new.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/saved_object_finder_create_new.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/tests/saved_object_finder_create_new.test.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/tests/saved_object_finder_create_new.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/customize_title/customize_panel_action.test.ts
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/customize_title/customize_panel_action.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/customize_title/customize_panel_action.ts
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/customize_title/customize_panel_action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/customize_title/customize_panel_modal.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/customize_title/customize_panel_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/customize_title/customize_title_form.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/customize_title/customize_title_form.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/customize_title/index.ts
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/customize_title/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/index.ts
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/inspect_panel_action.test.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/inspect_panel_action.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/inspect_panel_action.ts
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/inspect_panel_action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/remove_panel_action.test.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/remove_panel_action.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/remove_panel_action.ts
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/remove_panel_action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_options_menu.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_options_menu.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/reference_or_value_embeddable/index.ts
+++ b/src/plugins/embeddable/public/lib/reference_or_value_embeddable/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/reference_or_value_embeddable/types.ts
+++ b/src/plugins/embeddable/public/lib/reference_or_value_embeddable/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/state_transfer/embeddable_state_transfer.test.ts
+++ b/src/plugins/embeddable/public/lib/state_transfer/embeddable_state_transfer.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/state_transfer/embeddable_state_transfer.ts
+++ b/src/plugins/embeddable/public/lib/state_transfer/embeddable_state_transfer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/state_transfer/index.ts
+++ b/src/plugins/embeddable/public/lib/state_transfer/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/state_transfer/types.ts
+++ b/src/plugins/embeddable/public/lib/state_transfer/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/actions/edit_mode_action.ts
+++ b/src/plugins/embeddable/public/lib/test_samples/actions/edit_mode_action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/actions/get_message_modal.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/actions/get_message_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/actions/index.ts
+++ b/src/plugins/embeddable/public/lib/test_samples/actions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/actions/say_hello_action.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/actions/say_hello_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/actions/send_message_action.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/actions/send_message_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/contact_card.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/contact_card.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/contact_card_embeddable.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/contact_card_embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/contact_card_embeddable_factory.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/contact_card_embeddable_factory.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/contact_card_initializer.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/contact_card_initializer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/index.ts
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/slow_contact_card_embeddable_factory.ts
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/contact_card/slow_contact_card_embeddable_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/empty_embeddable.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/empty_embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/filterable_container.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/filterable_container.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/filterable_container_factory.ts
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/filterable_container_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/filterable_embeddable.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/filterable_embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/filterable_embeddable_factory.ts
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/filterable_embeddable_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/hello_world_container.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/hello_world_container.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/hello_world_container_component.tsx
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/hello_world_container_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/embeddables/index.ts
+++ b/src/plugins/embeddable/public/lib/test_samples/embeddables/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/test_samples/index.ts
+++ b/src/plugins/embeddable/public/lib/test_samples/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/triggers/index.ts
+++ b/src/plugins/embeddable/public/lib/triggers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/triggers/triggers.ts
+++ b/src/plugins/embeddable/public/lib/triggers/triggers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/types.ts
+++ b/src/plugins/embeddable/public/lib/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/lib/ui_actions.ts
+++ b/src/plugins/embeddable/public/lib/ui_actions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/mocks.tsx
+++ b/src/plugins/embeddable/public/mocks.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/plugin.test.ts
+++ b/src/plugins/embeddable/public/plugin.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/plugin.tsx
+++ b/src/plugins/embeddable/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/tests/container.test.ts
+++ b/src/plugins/embeddable/public/tests/container.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/tests/customize_panel_modal.test.tsx
+++ b/src/plugins/embeddable/public/tests/customize_panel_modal.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/tests/explicit_input.test.ts
+++ b/src/plugins/embeddable/public/tests/explicit_input.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/tests/get_embeddable_factories.test.ts
+++ b/src/plugins/embeddable/public/tests/get_embeddable_factories.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/tests/helpers.ts
+++ b/src/plugins/embeddable/public/tests/helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/tests/test_plugin.ts
+++ b/src/plugins/embeddable/public/tests/test_plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/public/types.ts
+++ b/src/plugins/embeddable/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/server/index.ts
+++ b/src/plugins/embeddable/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/server/plugin.ts
+++ b/src/plugins/embeddable/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/embeddable/server/types.ts
+++ b/src/plugins/embeddable/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/build_expression.test.ts
+++ b/src/plugins/expressions/common/ast/build_expression.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/build_expression.ts
+++ b/src/plugins/expressions/common/ast/build_expression.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/build_function.test.ts
+++ b/src/plugins/expressions/common/ast/build_function.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/build_function.ts
+++ b/src/plugins/expressions/common/ast/build_function.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/format.test.ts
+++ b/src/plugins/expressions/common/ast/format.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/format.ts
+++ b/src/plugins/expressions/common/ast/format.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/format_expression.test.ts
+++ b/src/plugins/expressions/common/ast/format_expression.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/format_expression.ts
+++ b/src/plugins/expressions/common/ast/format_expression.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/index.ts
+++ b/src/plugins/expressions/common/ast/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/parse.test.ts
+++ b/src/plugins/expressions/common/ast/parse.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/parse.ts
+++ b/src/plugins/expressions/common/ast/parse.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/parse_expression.test.ts
+++ b/src/plugins/expressions/common/ast/parse_expression.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/parse_expression.ts
+++ b/src/plugins/expressions/common/ast/parse_expression.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/ast/types.ts
+++ b/src/plugins/expressions/common/ast/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/execution/container.ts
+++ b/src/plugins/expressions/common/execution/container.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/execution/execution.abortion.test.ts
+++ b/src/plugins/expressions/common/execution/execution.abortion.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/execution/execution.test.ts
+++ b/src/plugins/expressions/common/execution/execution.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/execution/execution.ts
+++ b/src/plugins/expressions/common/execution/execution.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/execution/execution_contract.test.ts
+++ b/src/plugins/expressions/common/execution/execution_contract.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/execution/execution_contract.ts
+++ b/src/plugins/expressions/common/execution/execution_contract.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/execution/index.ts
+++ b/src/plugins/expressions/common/execution/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/execution/types.ts
+++ b/src/plugins/expressions/common/execution/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/executor/container.ts
+++ b/src/plugins/expressions/common/executor/container.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/executor/executor.execution.test.ts
+++ b/src/plugins/expressions/common/executor/executor.execution.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/executor/executor.test.ts
+++ b/src/plugins/expressions/common/executor/executor.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/executor/executor.ts
+++ b/src/plugins/expressions/common/executor/executor.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/executor/index.ts
+++ b/src/plugins/expressions/common/executor/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/arguments.ts
+++ b/src/plugins/expressions/common/expression_functions/arguments.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/expression_function.ts
+++ b/src/plugins/expressions/common/expression_functions/expression_function.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/expression_function_parameter.ts
+++ b/src/plugins/expressions/common/expression_functions/expression_function_parameter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/expression_function_parameters.test.ts
+++ b/src/plugins/expressions/common/expression_functions/expression_function_parameters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/index.ts
+++ b/src/plugins/expressions/common/expression_functions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/clog.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/clog.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/font.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/font.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/index.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/opensearch_dashboards.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/opensearch_dashboards.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/opensearch_dashboards_context.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/opensearch_dashboards_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/tests/font.test.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/tests/font.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/tests/opensearch_dashboards.test.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/tests/opensearch_dashboards.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/tests/theme.test.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/tests/theme.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/tests/utils.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/tests/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/tests/var.test.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/tests/var.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/tests/var_set.test.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/tests/var_set.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/theme.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/theme.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/var.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/var.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/specs/var_set.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/var_set.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_functions/types.ts
+++ b/src/plugins/expressions/common/expression_functions/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_renderers/expression_renderer.ts
+++ b/src/plugins/expressions/common/expression_renderers/expression_renderer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_renderers/expression_renderer_registry.ts
+++ b/src/plugins/expressions/common/expression_renderers/expression_renderer_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_renderers/index.ts
+++ b/src/plugins/expressions/common/expression_renderers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_renderers/types.ts
+++ b/src/plugins/expressions/common/expression_renderers/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/expression_type.test.ts
+++ b/src/plugins/expressions/common/expression_types/expression_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/expression_type.ts
+++ b/src/plugins/expressions/common/expression_types/expression_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/get_type.test.ts
+++ b/src/plugins/expressions/common/expression_types/get_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/get_type.ts
+++ b/src/plugins/expressions/common/expression_types/get_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/index.ts
+++ b/src/plugins/expressions/common/expression_types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/serialize_provider.ts
+++ b/src/plugins/expressions/common/expression_types/serialize_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/boolean.ts
+++ b/src/plugins/expressions/common/expression_types/specs/boolean.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/datatable.ts
+++ b/src/plugins/expressions/common/expression_types/specs/datatable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/error.ts
+++ b/src/plugins/expressions/common/expression_types/specs/error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/filter.ts
+++ b/src/plugins/expressions/common/expression_types/specs/filter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/image.ts
+++ b/src/plugins/expressions/common/expression_types/specs/image.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/index.ts
+++ b/src/plugins/expressions/common/expression_types/specs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/null.ts
+++ b/src/plugins/expressions/common/expression_types/specs/null.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/num.ts
+++ b/src/plugins/expressions/common/expression_types/specs/num.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/number.ts
+++ b/src/plugins/expressions/common/expression_types/specs/number.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/opensearch_dashboards_context.ts
+++ b/src/plugins/expressions/common/expression_types/specs/opensearch_dashboards_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/opensearch_dashboards_datatable.ts
+++ b/src/plugins/expressions/common/expression_types/specs/opensearch_dashboards_datatable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/pointseries.ts
+++ b/src/plugins/expressions/common/expression_types/specs/pointseries.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/range.ts
+++ b/src/plugins/expressions/common/expression_types/specs/range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/render.ts
+++ b/src/plugins/expressions/common/expression_types/specs/render.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/shape.ts
+++ b/src/plugins/expressions/common/expression_types/specs/shape.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/string.ts
+++ b/src/plugins/expressions/common/expression_types/specs/string.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/style.ts
+++ b/src/plugins/expressions/common/expression_types/specs/style.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/specs/tests/number.test.ts
+++ b/src/plugins/expressions/common/expression_types/specs/tests/number.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/expression_types/types.ts
+++ b/src/plugins/expressions/common/expression_types/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/fonts.ts
+++ b/src/plugins/expressions/common/fonts.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/index.ts
+++ b/src/plugins/expressions/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/mocks.ts
+++ b/src/plugins/expressions/common/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/service/expressions_services.test.ts
+++ b/src/plugins/expressions/common/service/expressions_services.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/service/expressions_services.ts
+++ b/src/plugins/expressions/common/service/expressions_services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/service/index.ts
+++ b/src/plugins/expressions/common/service/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/test_helpers/create_unit_test_executor.ts
+++ b/src/plugins/expressions/common/test_helpers/create_unit_test_executor.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/test_helpers/expression_functions/access.ts
+++ b/src/plugins/expressions/common/test_helpers/expression_functions/access.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/test_helpers/expression_functions/add.ts
+++ b/src/plugins/expressions/common/test_helpers/expression_functions/add.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/test_helpers/expression_functions/error.ts
+++ b/src/plugins/expressions/common/test_helpers/expression_functions/error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/test_helpers/expression_functions/index.ts
+++ b/src/plugins/expressions/common/test_helpers/expression_functions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/test_helpers/expression_functions/introspect_context.ts
+++ b/src/plugins/expressions/common/test_helpers/expression_functions/introspect_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/test_helpers/expression_functions/mult.ts
+++ b/src/plugins/expressions/common/test_helpers/expression_functions/mult.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/test_helpers/expression_functions/sleep.ts
+++ b/src/plugins/expressions/common/test_helpers/expression_functions/sleep.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/test_helpers/index.ts
+++ b/src/plugins/expressions/common/test_helpers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/types/common.ts
+++ b/src/plugins/expressions/common/types/common.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/types/index.ts
+++ b/src/plugins/expressions/common/types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/types/registry.ts
+++ b/src/plugins/expressions/common/types/registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/types/style.ts
+++ b/src/plugins/expressions/common/types/style.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/util/create_error.ts
+++ b/src/plugins/expressions/common/util/create_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/util/get_by_alias.ts
+++ b/src/plugins/expressions/common/util/get_by_alias.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/common/util/index.ts
+++ b/src/plugins/expressions/common/util/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/index.ts
+++ b/src/plugins/expressions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/index.ts
+++ b/src/plugins/expressions/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/loader.test.ts
+++ b/src/plugins/expressions/public/loader.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/loader.ts
+++ b/src/plugins/expressions/public/loader.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/mocks.tsx
+++ b/src/plugins/expressions/public/mocks.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/plugin.test.ts
+++ b/src/plugins/expressions/public/plugin.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/plugin.ts
+++ b/src/plugins/expressions/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/react_expression_renderer.test.tsx
+++ b/src/plugins/expressions/public/react_expression_renderer.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/react_expression_renderer.tsx
+++ b/src/plugins/expressions/public/react_expression_renderer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/render.test.ts
+++ b/src/plugins/expressions/public/render.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/render.ts
+++ b/src/plugins/expressions/public/render.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/render_error_handler.ts
+++ b/src/plugins/expressions/public/render_error_handler.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/services.ts
+++ b/src/plugins/expressions/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/public/types/index.ts
+++ b/src/plugins/expressions/public/types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/server/index.ts
+++ b/src/plugins/expressions/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/server/mocks.ts
+++ b/src/plugins/expressions/server/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/server/plugin.test.ts
+++ b/src/plugins/expressions/server/plugin.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/expressions/server/plugin.ts
+++ b/src/plugins/expressions/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/common/constants.ts
+++ b/src/plugins/home/common/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/common/instruction_variant.ts
+++ b/src/plugins/home/common/instruction_variant.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/config.ts
+++ b/src/plugins/home/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/application.tsx
+++ b/src/plugins/home/public/application/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/add_data/add_data.test.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/add_data/index.ts
+++ b/src/plugins/home/public/application/components/add_data/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/app_navigation_handler.ts
+++ b/src/plugins/home/public/application/components/app_navigation_handler.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/feature_directory.js
+++ b/src/plugins/home/public/application/components/feature_directory.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/home.js
+++ b/src/plugins/home/public/application/components/home.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/home.test.js
+++ b/src/plugins/home/public/application/components/home.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/home_app.js
+++ b/src/plugins/home/public/application/components/home_app.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/manage_data/index.tsx
+++ b/src/plugins/home/public/application/components/manage_data/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/manage_data/manage_data.test.tsx
+++ b/src/plugins/home/public/application/components/manage_data/manage_data.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/manage_data/manage_data.tsx
+++ b/src/plugins/home/public/application/components/manage_data/manage_data.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/recently_accessed.js
+++ b/src/plugins/home/public/application/components/recently_accessed.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/recently_accessed.test.js
+++ b/src/plugins/home/public/application/components/recently_accessed.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/sample_data/index.tsx
+++ b/src/plugins/home/public/application/components/sample_data/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/sample_data_set_card.js
+++ b/src/plugins/home/public/application/components/sample_data_set_card.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/sample_data_set_cards.js
+++ b/src/plugins/home/public/application/components/sample_data_set_cards.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/sample_data_view_data_button.js
+++ b/src/plugins/home/public/application/components/sample_data_view_data_button.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/sample_data_view_data_button.test.js
+++ b/src/plugins/home/public/application/components/sample_data_view_data_button.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/solutions_section/index.ts
+++ b/src/plugins/home/public/application/components/solutions_section/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/solutions_section/solution_panel.test.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_panel.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/solutions_section/solution_panel.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/solutions_section/solution_title.test.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_title.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/solutions_section/solution_title.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_title.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/solutions_section/solutions_section.test.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solutions_section.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/solutions_section/solutions_section.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solutions_section.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/synopsis.js
+++ b/src/plugins/home/public/application/components/synopsis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/synopsis.test.js
+++ b/src/plugins/home/public/application/components/synopsis.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/content.js
+++ b/src/plugins/home/public/application/components/tutorial/content.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/content.test.js
+++ b/src/plugins/home/public/application/components/tutorial/content.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/footer.js
+++ b/src/plugins/home/public/application/components/tutorial/footer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/footer.test.js
+++ b/src/plugins/home/public/application/components/tutorial/footer.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/instruction.js
+++ b/src/plugins/home/public/application/components/tutorial/instruction.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/instruction_set.js
+++ b/src/plugins/home/public/application/components/tutorial/instruction_set.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/instruction_set.test.js
+++ b/src/plugins/home/public/application/components/tutorial/instruction_set.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/introduction.js
+++ b/src/plugins/home/public/application/components/tutorial/introduction.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/introduction.test.js
+++ b/src/plugins/home/public/application/components/tutorial/introduction.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/number_parameter.js
+++ b/src/plugins/home/public/application/components/tutorial/number_parameter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/parameter_form.js
+++ b/src/plugins/home/public/application/components/tutorial/parameter_form.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/replace_template_strings.js
+++ b/src/plugins/home/public/application/components/tutorial/replace_template_strings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/saved_objects_installer.js
+++ b/src/plugins/home/public/application/components/tutorial/saved_objects_installer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/saved_objects_installer.test.js
+++ b/src/plugins/home/public/application/components/tutorial/saved_objects_installer.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/status_check_states.js
+++ b/src/plugins/home/public/application/components/tutorial/status_check_states.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/string_parameter.js
+++ b/src/plugins/home/public/application/components/tutorial/string_parameter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/tutorial.js
+++ b/src/plugins/home/public/application/components/tutorial/tutorial.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial/tutorial.test.js
+++ b/src/plugins/home/public/application/components/tutorial/tutorial.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/tutorial_directory.js
+++ b/src/plugins/home/public/application/components/tutorial_directory.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/welcome.test.tsx
+++ b/src/plugins/home/public/application/components/welcome.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/components/welcome.tsx
+++ b/src/plugins/home/public/application/components/welcome.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/index.ts
+++ b/src/plugins/home/public/application/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/load_tutorials.js
+++ b/src/plugins/home/public/application/load_tutorials.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/opensearch_dashboards_services.ts
+++ b/src/plugins/home/public/application/opensearch_dashboards_services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/application/sample_data_client.js
+++ b/src/plugins/home/public/application/sample_data_client.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/index.ts
+++ b/src/plugins/home/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/mocks/index.ts
+++ b/src/plugins/home/public/mocks/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/plugin.test.mocks.ts
+++ b/src/plugins/home/public/plugin.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/plugin.test.ts
+++ b/src/plugins/home/public/plugin.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/environment/environment.mock.ts
+++ b/src/plugins/home/public/services/environment/environment.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/environment/environment.test.ts
+++ b/src/plugins/home/public/services/environment/environment.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/environment/environment.ts
+++ b/src/plugins/home/public/services/environment/environment.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/environment/index.ts
+++ b/src/plugins/home/public/services/environment/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/feature_catalogue/feature_catalogue_registry.mock.ts
+++ b/src/plugins/home/public/services/feature_catalogue/feature_catalogue_registry.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/feature_catalogue/feature_catalogue_registry.test.ts
+++ b/src/plugins/home/public/services/feature_catalogue/feature_catalogue_registry.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/feature_catalogue/feature_catalogue_registry.ts
+++ b/src/plugins/home/public/services/feature_catalogue/feature_catalogue_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/feature_catalogue/index.ts
+++ b/src/plugins/home/public/services/feature_catalogue/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/index.ts
+++ b/src/plugins/home/public/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/tutorials/index.ts
+++ b/src/plugins/home/public/services/tutorials/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/tutorials/tutorial_service.mock.ts
+++ b/src/plugins/home/public/services/tutorials/tutorial_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/tutorials/tutorial_service.test.tsx
+++ b/src/plugins/home/public/services/tutorials/tutorial_service.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/public/services/tutorials/tutorial_service.ts
+++ b/src/plugins/home/public/services/tutorials/tutorial_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/capabilities_provider.ts
+++ b/src/plugins/home/server/capabilities_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/index.ts
+++ b/src/plugins/home/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/plugin.test.mocks.ts
+++ b/src/plugins/home/server/plugin.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/plugin.test.ts
+++ b/src/plugins/home/server/plugin.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/plugin.ts
+++ b/src/plugins/home/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/routes/fetch_opensearch_hits_status.ts
+++ b/src/plugins/home/server/routes/fetch_opensearch_hits_status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/routes/index.ts
+++ b/src/plugins/home/server/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/saved_objects/index.ts
+++ b/src/plugins/home/server/saved_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/saved_objects/sample_data_telemetry.ts
+++ b/src/plugins/home/server/saved_objects/sample_data_telemetry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/index.ts
+++ b/src/plugins/home/server/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/data_sets/ecommerce/field_mappings.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/ecommerce/field_mappings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/data_sets/ecommerce/index.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/ecommerce/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/data_sets/ecommerce/saved_objects.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/ecommerce/saved_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/data_sets/flights/field_mappings.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/flights/field_mappings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/data_sets/flights/index.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/flights/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/data_sets/flights/saved_objects.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/flights/saved_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/data_sets/index.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/data_sets/logs/field_mappings.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/logs/field_mappings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/data_sets/logs/index.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/data_sets/logs/saved_objects.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/logs/saved_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/index.ts
+++ b/src/plugins/home/server/services/sample_data/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/lib/create_index_name.ts
+++ b/src/plugins/home/server/services/sample_data/lib/create_index_name.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/lib/load_data.ts
+++ b/src/plugins/home/server/services/sample_data/lib/load_data.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/lib/sample_dataset_registry_types.ts
+++ b/src/plugins/home/server/services/sample_data/lib/sample_dataset_registry_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/lib/sample_dataset_schema.ts
+++ b/src/plugins/home/server/services/sample_data/lib/sample_dataset_schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/lib/translate_timestamp.ts
+++ b/src/plugins/home/server/services/sample_data/lib/translate_timestamp.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/routes/index.ts
+++ b/src/plugins/home/server/services/sample_data/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/routes/install.ts
+++ b/src/plugins/home/server/services/sample_data/routes/install.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/routes/list.ts
+++ b/src/plugins/home/server/services/sample_data/routes/list.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/routes/uninstall.ts
+++ b/src/plugins/home/server/services/sample_data/routes/uninstall.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/sample_data_registry.mock.ts
+++ b/src/plugins/home/server/services/sample_data/sample_data_registry.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/sample_data_registry.ts
+++ b/src/plugins/home/server/services/sample_data/sample_data_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/usage/collector.ts
+++ b/src/plugins/home/server/services/sample_data/usage/collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/usage/collector_fetch.test.ts
+++ b/src/plugins/home/server/services/sample_data/usage/collector_fetch.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/usage/collector_fetch.ts
+++ b/src/plugins/home/server/services/sample_data/usage/collector_fetch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/usage/index.ts
+++ b/src/plugins/home/server/services/sample_data/usage/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/sample_data/usage/usage.ts
+++ b/src/plugins/home/server/services/sample_data/usage/usage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/tutorials/index.ts
+++ b/src/plugins/home/server/services/tutorials/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/tutorials/lib/tutorial_schema.ts
+++ b/src/plugins/home/server/services/tutorials/lib/tutorial_schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/tutorials/lib/tutorials_registry_types.ts
+++ b/src/plugins/home/server/services/tutorials/lib/tutorials_registry_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/tutorials/tutorials_registry.mock.ts
+++ b/src/plugins/home/server/services/tutorials/tutorials_registry.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/tutorials/tutorials_registry.test.ts
+++ b/src/plugins/home/server/services/tutorials/tutorials_registry.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/services/tutorials/tutorials_registry.ts
+++ b/src/plugins/home/server/services/tutorials/tutorials_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/activemq_logs/index.ts
+++ b/src/plugins/home/server/tutorials/activemq_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/activemq_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/activemq_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/aerospike_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/aerospike_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/apache_logs/index.ts
+++ b/src/plugins/home/server/tutorials/apache_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/apache_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/apache_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/auditbeat/index.ts
+++ b/src/plugins/home/server/tutorials/auditbeat/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/auditd_logs/index.ts
+++ b/src/plugins/home/server/tutorials/auditd_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/aws_logs/index.ts
+++ b/src/plugins/home/server/tutorials/aws_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/aws_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/aws_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/azure_logs/index.ts
+++ b/src/plugins/home/server/tutorials/azure_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/azure_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/azure_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/barracuda_logs/index.ts
+++ b/src/plugins/home/server/tutorials/barracuda_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/bluecoat_logs/index.ts
+++ b/src/plugins/home/server/tutorials/bluecoat_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/cef_logs/index.ts
+++ b/src/plugins/home/server/tutorials/cef_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/ceph_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/ceph_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/checkpoint_logs/index.ts
+++ b/src/plugins/home/server/tutorials/checkpoint_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/cisco_logs/index.ts
+++ b/src/plugins/home/server/tutorials/cisco_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/cloudwatch_logs/index.ts
+++ b/src/plugins/home/server/tutorials/cloudwatch_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/cockroachdb_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/cockroachdb_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/consul_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/consul_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/coredns_logs/index.ts
+++ b/src/plugins/home/server/tutorials/coredns_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/coredns_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/coredns_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/couchbase_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/couchbase_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/couchdb_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/couchdb_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/crowdstrike_logs/index.ts
+++ b/src/plugins/home/server/tutorials/crowdstrike_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/cylance_logs/index.ts
+++ b/src/plugins/home/server/tutorials/cylance_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/docker_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/docker_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/dropwizard_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/dropwizard_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/envoyproxy_logs/index.ts
+++ b/src/plugins/home/server/tutorials/envoyproxy_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/envoyproxy_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/envoyproxy_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/etcd_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/etcd_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/f5_logs/index.ts
+++ b/src/plugins/home/server/tutorials/f5_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/fortinet_logs/index.ts
+++ b/src/plugins/home/server/tutorials/fortinet_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/golang_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/golang_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/googlecloud_logs/index.ts
+++ b/src/plugins/home/server/tutorials/googlecloud_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/googlecloud_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/googlecloud_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/gsuite_logs/index.ts
+++ b/src/plugins/home/server/tutorials/gsuite_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/haproxy_logs/index.ts
+++ b/src/plugins/home/server/tutorials/haproxy_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/haproxy_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/haproxy_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/ibmmq_logs/index.ts
+++ b/src/plugins/home/server/tutorials/ibmmq_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/ibmmq_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/ibmmq_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/icinga_logs/index.ts
+++ b/src/plugins/home/server/tutorials/icinga_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/iis_logs/index.ts
+++ b/src/plugins/home/server/tutorials/iis_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/iis_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/iis_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/imperva_logs/index.ts
+++ b/src/plugins/home/server/tutorials/imperva_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/infoblox_logs/index.ts
+++ b/src/plugins/home/server/tutorials/infoblox_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/instructions/auditbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/auditbeat_instructions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/instructions/filebeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/filebeat_instructions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/instructions/functionbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/functionbeat_instructions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/instructions/get_space_id_for_beats_tutorial.ts
+++ b/src/plugins/home/server/tutorials/instructions/get_space_id_for_beats_tutorial.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/instructions/heartbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/heartbeat_instructions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/instructions/logstash_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/logstash_instructions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/instructions/metricbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/metricbeat_instructions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/instructions/param_types.ts
+++ b/src/plugins/home/server/tutorials/instructions/param_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/instructions/winlogbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/winlogbeat_instructions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/iptables_logs/index.ts
+++ b/src/plugins/home/server/tutorials/iptables_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/juniper_logs/index.ts
+++ b/src/plugins/home/server/tutorials/juniper_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/kafka_logs/index.ts
+++ b/src/plugins/home/server/tutorials/kafka_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/kafka_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/kafka_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/kubernetes_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/kubernetes_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/logstash_logs/index.ts
+++ b/src/plugins/home/server/tutorials/logstash_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/logstash_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/logstash_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/memcached_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/memcached_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/microsoft_logs/index.ts
+++ b/src/plugins/home/server/tutorials/microsoft_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/misp_logs/index.ts
+++ b/src/plugins/home/server/tutorials/misp_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/mongodb_logs/index.ts
+++ b/src/plugins/home/server/tutorials/mongodb_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/mongodb_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/mongodb_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/mssql_logs/index.ts
+++ b/src/plugins/home/server/tutorials/mssql_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/mssql_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/mssql_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/munin_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/munin_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/mysql_logs/index.ts
+++ b/src/plugins/home/server/tutorials/mysql_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/mysql_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/mysql_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/nats_logs/index.ts
+++ b/src/plugins/home/server/tutorials/nats_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/nats_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/nats_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/netflow_logs/index.ts
+++ b/src/plugins/home/server/tutorials/netflow_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/netscout_logs/index.ts
+++ b/src/plugins/home/server/tutorials/netscout_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/nginx_logs/index.ts
+++ b/src/plugins/home/server/tutorials/nginx_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/nginx_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/nginx_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/o365_logs/index.ts
+++ b/src/plugins/home/server/tutorials/o365_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/okta_logs/index.ts
+++ b/src/plugins/home/server/tutorials/okta_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/openmetrics_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/openmetrics_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/opensearch_dashboards_logs/index.ts
+++ b/src/plugins/home/server/tutorials/opensearch_dashboards_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/opensearch_dashboards_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/opensearch_dashboards_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/opensearch_logs/index.ts
+++ b/src/plugins/home/server/tutorials/opensearch_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/opensearch_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/opensearch_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/oracle_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/oracle_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/osquery_logs/index.ts
+++ b/src/plugins/home/server/tutorials/osquery_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/panw_logs/index.ts
+++ b/src/plugins/home/server/tutorials/panw_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/php_fpm_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/php_fpm_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/postgresql_logs/index.ts
+++ b/src/plugins/home/server/tutorials/postgresql_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/postgresql_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/postgresql_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/prometheus_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/prometheus_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/rabbitmq_logs/index.ts
+++ b/src/plugins/home/server/tutorials/rabbitmq_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/rabbitmq_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/rabbitmq_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/radware_logs/index.ts
+++ b/src/plugins/home/server/tutorials/radware_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/redis_logs/index.ts
+++ b/src/plugins/home/server/tutorials/redis_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/redis_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/redis_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/redisenterprise_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/redisenterprise_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/register.ts
+++ b/src/plugins/home/server/tutorials/register.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/santa_logs/index.ts
+++ b/src/plugins/home/server/tutorials/santa_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/sonicwall_logs/index.ts
+++ b/src/plugins/home/server/tutorials/sonicwall_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/sophos_logs/index.ts
+++ b/src/plugins/home/server/tutorials/sophos_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/squid_logs/index.ts
+++ b/src/plugins/home/server/tutorials/squid_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/stan_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/stan_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/statsd_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/statsd_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/suricata_logs/index.ts
+++ b/src/plugins/home/server/tutorials/suricata_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/system_logs/index.ts
+++ b/src/plugins/home/server/tutorials/system_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/system_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/system_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/tomcat_logs/index.ts
+++ b/src/plugins/home/server/tutorials/tomcat_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/traefik_logs/index.ts
+++ b/src/plugins/home/server/tutorials/traefik_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/traefik_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/traefik_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/uptime_monitors/index.ts
+++ b/src/plugins/home/server/tutorials/uptime_monitors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/uwsgi_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/uwsgi_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/vsphere_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/vsphere_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/windows_event_logs/index.ts
+++ b/src/plugins/home/server/tutorials/windows_event_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/windows_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/windows_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/zeek_logs/index.ts
+++ b/src/plugins/home/server/tutorials/zeek_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/zookeeper_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/zookeeper_metrics/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/home/server/tutorials/zscaler_logs/index.ts
+++ b/src/plugins/home/server/tutorials/zscaler_logs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/breadcrumbs.ts
+++ b/src/plugins/index_pattern_management/public/components/breadcrumbs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_button/create_button.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_button/create_button.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_button/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_button/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/loading_state/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/loading_state/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/loading_state/loading_state.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/loading_state/loading_state.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/loading_state/loading_state.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/loading_state/loading_state.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/header/header.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/header/header.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/header/header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/header/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/header/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/indices_list/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/indices_list/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/indices_list/indices_list.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/indices_list/indices_list.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/indices_list/indices_list.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/indices_list/indices_list.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/loading_indices/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/loading_indices/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/loading_indices/loading_indices.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/loading_indices/loading_indices.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/loading_indices/loading_indices.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/loading_indices/loading_indices.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/status_message/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/status_message/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/status_message/status_message.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/status_message/status_message.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/status_message/status_message.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/status_message/status_message.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/step_index_pattern.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/step_index_pattern.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/step_index_pattern.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/step_index_pattern.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/action_buttons/action_buttons.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/action_buttons/action_buttons.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/action_buttons/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/action_buttons/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/advanced_options/advanced_options.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/advanced_options/advanced_options.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/advanced_options/advanced_options.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/advanced_options/advanced_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/advanced_options/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/advanced_options/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/header/header.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/header/header.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/header/header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/header/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/header/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/time_field/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/time_field/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/time_field/time_field.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/time_field/time_field.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/time_field/time_field.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/time_field/time_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/step_time_field.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/step_time_field.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/step_time_field.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/step_time_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/constants/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/constants/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/can_append_wildcard.test.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/can_append_wildcard.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/can_append_wildcard.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/can_append_wildcard.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/contains_illegal_characters.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/contains_illegal_characters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/contains_invalid_characters.test.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/contains_invalid_characters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/ensure_minimum_time.test.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/ensure_minimum_time.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/ensure_minimum_time.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/ensure_minimum_time.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/extract_time_fields.test.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/extract_time_fields.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/extract_time_fields.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/extract_time_fields.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_indices.test.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_indices.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_indices.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_indices.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_matched_indices.test.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_matched_indices.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_matched_indices.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_matched_indices.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/index.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/types.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/constants.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/create_edit_field/create_edit_field.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/create_edit_field/create_edit_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/create_edit_field/create_edit_field_container.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/create_edit_field/create_edit_field_container.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/create_edit_field/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/create_edit_field/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern_container.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern_container.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern_state_container.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern_state_container.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/index.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/index_header/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/index_header/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/index_header/index_header.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/index_header/index_header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/components/table/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/components/table/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/components/table/table.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/components/table/table.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/components/table/table.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/components/table/table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/indexed_fields_table.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/indexed_fields_table.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/indexed_fields_table.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/indexed_fields_table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/lib/get_field_format.test.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/lib/get_field_format.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/lib/get_field_format.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/lib/get_field_format.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/lib/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/types.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/call_outs/call_outs.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/call_outs/call_outs.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/call_outs/call_outs.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/call_outs/call_outs.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/call_outs/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/call_outs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/confirmation_modal/confirmation_modal.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/confirmation_modal/confirmation_modal.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/confirmation_modal/confirmation_modal.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/confirmation_modal/confirmation_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/confirmation_modal/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/confirmation_modal/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/header.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/header.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/table/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/table/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/table/table.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/table/table.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/table/table.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/table/table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/scripted_field_table.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/scripted_field_table.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/scripted_fields_table.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/scripted_fields_table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/types.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/add_filter/add_filter.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/add_filter/add_filter.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/add_filter/add_filter.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/add_filter/add_filter.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/add_filter/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/add_filter/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/confirmation_modal/confirmation_modal.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/confirmation_modal/confirmation_modal.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/confirmation_modal/confirmation_modal.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/confirmation_modal/confirmation_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/confirmation_modal/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/confirmation_modal/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/header/header.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/header/header.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/header/header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/header/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/header/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/table/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/table/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/table/table.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/table/table.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/table/table.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/table/table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/source_filters_table.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/source_filters_table.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/source_filters_table.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/source_filters_table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/types.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/tabs/index.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/tabs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/tabs/tabs.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/tabs/tabs.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/tabs/utils.ts
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/tabs/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/bytes/bytes.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/bytes/bytes.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/bytes/bytes.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/bytes/bytes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/bytes/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/bytes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/color/color.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/color/color.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/color/color.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/color/color.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/color/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/color/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date/date.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date/date.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date/date.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date/date.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date_nanos/date_nanos.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date_nanos/date_nanos.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date_nanos/date_nanos.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date_nanos/date_nanos.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date_nanos/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/date_nanos/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/default/default.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/default/default.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/default/default.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/default/default.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/default/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/default/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/duration/duration.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/duration/duration.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/duration/duration.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/duration/duration.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/duration/index.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/duration/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/number/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/number/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/number/number.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/number/number.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/number/number.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/number/number.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/percent/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/percent/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/percent/percent.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/percent/percent.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/percent/percent.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/percent/percent.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/static_lookup/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/static_lookup/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/static_lookup/static_lookup.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/static_lookup/static_lookup.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/static_lookup/static_lookup.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/static_lookup/static_lookup.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/string/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/string/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/string/string.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/string/string.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/string/string.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/string/string.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/truncate/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/truncate/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/truncate/sample.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/truncate/sample.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/truncate/truncate.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/truncate/truncate.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/truncate/truncate.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/truncate/truncate.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/label_template_flyout.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/label_template_flyout.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/label_template_flyout.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/label_template_flyout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/url.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/url.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/url.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/url.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/url_template_flyout.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/url_template_flyout.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/url_template_flyout.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/editors/url/url_template_flyout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/field_format_editor.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/field_format_editor.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/field_format_editor.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/field_format_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/samples/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/samples/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/samples/samples.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/samples/samples.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/samples/samples.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/field_format_editor/samples/samples.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/disabled_call_out.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/disabled_call_out.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/disabled_call_out.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/disabled_call_out.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/help_flyout.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/help_flyout.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/help_flyout.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/help_flyout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/scripting_syntax.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/scripting_syntax.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/test_script.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/test_script.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/constants/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/constants/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/field_editor.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/field_editor.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/field_editor.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/field_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/lib/index.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/lib/validate_script.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/lib/validate_script.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/field_editor/types.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/index.ts
+++ b/src/plugins/index_pattern_management/public/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_index_pattern_prompt/assets/index_pattern_illustration.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_index_pattern_prompt/assets/index_pattern_illustration.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_index_pattern_prompt/empty_index_pattern_prompt.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_index_pattern_prompt/empty_index_pattern_prompt.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_index_pattern_prompt/empty_index_pattern_prompt.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_index_pattern_prompt/empty_index_pattern_prompt.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_index_pattern_prompt/index.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_index_pattern_prompt/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/empty_state.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/empty_state.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/empty_state.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/empty_state.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/index.ts
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/index.ts
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/test_utils.tsx
+++ b/src/plugins/index_pattern_management/public/components/test_utils.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/types.ts
+++ b/src/plugins/index_pattern_management/public/components/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/utils.test.ts
+++ b/src/plugins/index_pattern_management/public/components/utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/components/utils.ts
+++ b/src/plugins/index_pattern_management/public/components/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/index.ts
+++ b/src/plugins/index_pattern_management/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/management_app/index.tsx
+++ b/src/plugins/index_pattern_management/public/management_app/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/management_app/mount_management_section.tsx
+++ b/src/plugins/index_pattern_management/public/management_app/mount_management_section.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/mocks.ts
+++ b/src/plugins/index_pattern_management/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/plugin.ts
+++ b/src/plugins/index_pattern_management/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/scripting_languages/index.ts
+++ b/src/plugins/index_pattern_management/public/scripting_languages/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/creation/config.ts
+++ b/src/plugins/index_pattern_management/public/service/creation/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/creation/index.ts
+++ b/src/plugins/index_pattern_management/public/service/creation/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/creation/manager.ts
+++ b/src/plugins/index_pattern_management/public/service/creation/manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/environment/environment.mock.ts
+++ b/src/plugins/index_pattern_management/public/service/environment/environment.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/environment/environment.test.ts
+++ b/src/plugins/index_pattern_management/public/service/environment/environment.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/environment/environment.ts
+++ b/src/plugins/index_pattern_management/public/service/environment/environment.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/environment/index.ts
+++ b/src/plugins/index_pattern_management/public/service/environment/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/field_format_editors/field_format_editors.ts
+++ b/src/plugins/index_pattern_management/public/service/field_format_editors/field_format_editors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/field_format_editors/index.ts
+++ b/src/plugins/index_pattern_management/public/service/field_format_editors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/index.ts
+++ b/src/plugins/index_pattern_management/public/service/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/index_pattern_management_service.ts
+++ b/src/plugins/index_pattern_management/public/service/index_pattern_management_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/list/config.ts
+++ b/src/plugins/index_pattern_management/public/service/list/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/list/index.ts
+++ b/src/plugins/index_pattern_management/public/service/list/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/service/list/manager.ts
+++ b/src/plugins/index_pattern_management/public/service/list/manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/public/types.ts
+++ b/src/plugins/index_pattern_management/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/server/index.ts
+++ b/src/plugins/index_pattern_management/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/server/plugin.ts
+++ b/src/plugins/index_pattern_management/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/server/routes/index.ts
+++ b/src/plugins/index_pattern_management/server/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/server/routes/preview_scripted_field.test.ts
+++ b/src/plugins/index_pattern_management/server/routes/preview_scripted_field.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/server/routes/preview_scripted_field.ts
+++ b/src/plugins/index_pattern_management/server/routes/preview_scripted_field.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/index_pattern_management/server/routes/resolve_index.ts
+++ b/src/plugins/index_pattern_management/server/routes/resolve_index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/editor/control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/control_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/editor/controls_tab.test.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/controls_tab.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/editor/controls_tab.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/controls_tab.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/editor/field_select.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/field_select.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/editor/index_pattern_select_form_row.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/index_pattern_select_form_row.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/editor/list_control_editor.test.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/list_control_editor.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/editor/list_control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/list_control_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/editor/options_tab.test.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/options_tab.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/editor/options_tab.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/options_tab.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/editor/range_control_editor.test.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/range_control_editor.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/editor/range_control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/range_control_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/vis/form_row.test.tsx
+++ b/src/plugins/input_control_vis/public/components/vis/form_row.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/vis/form_row.tsx
+++ b/src/plugins/input_control_vis/public/components/vis/form_row.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/vis/input_control_vis.test.tsx
+++ b/src/plugins/input_control_vis/public/components/vis/input_control_vis.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/vis/input_control_vis.tsx
+++ b/src/plugins/input_control_vis/public/components/vis/input_control_vis.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/vis/list_control.test.tsx
+++ b/src/plugins/input_control_vis/public/components/vis/list_control.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/vis/list_control.tsx
+++ b/src/plugins/input_control_vis/public/components/vis/list_control.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/vis/range_control.test.tsx
+++ b/src/plugins/input_control_vis/public/components/vis/range_control.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/components/vis/range_control.tsx
+++ b/src/plugins/input_control_vis/public/components/vis/range_control.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/control.test.ts
+++ b/src/plugins/input_control_vis/public/control/control.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/control.ts
+++ b/src/plugins/input_control_vis/public/control/control.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/control_factory.ts
+++ b/src/plugins/input_control_vis/public/control/control_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/create_search_source.ts
+++ b/src/plugins/input_control_vis/public/control/create_search_source.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/filter_manager/filter_manager.test.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/filter_manager.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/filter_manager/filter_manager.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/filter_manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/filter_manager/phrase_filter_manager.test.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/phrase_filter_manager.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/filter_manager/phrase_filter_manager.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/phrase_filter_manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/filter_manager/range_filter_manager.test.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/range_filter_manager.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/filter_manager/range_filter_manager.ts
+++ b/src/plugins/input_control_vis/public/control/filter_manager/range_filter_manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/list_control_factory.test.ts
+++ b/src/plugins/input_control_vis/public/control/list_control_factory.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/list_control_factory.ts
+++ b/src/plugins/input_control_vis/public/control/list_control_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/range_control_factory.test.ts
+++ b/src/plugins/input_control_vis/public/control/range_control_factory.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/control/range_control_factory.ts
+++ b/src/plugins/input_control_vis/public/control/range_control_factory.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/editor_utils.ts
+++ b/src/plugins/input_control_vis/public/editor_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/index.ts
+++ b/src/plugins/input_control_vis/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/input_control_fn.test.ts
+++ b/src/plugins/input_control_vis/public/input_control_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/input_control_fn.ts
+++ b/src/plugins/input_control_vis/public/input_control_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/input_control_vis_type.ts
+++ b/src/plugins/input_control_vis/public/input_control_vis_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/lineage/index.ts
+++ b/src/plugins/input_control_vis/public/lineage/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/lineage/lineage_map.test.ts
+++ b/src/plugins/input_control_vis/public/lineage/lineage_map.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/lineage/lineage_map.ts
+++ b/src/plugins/input_control_vis/public/lineage/lineage_map.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/lineage/parent_candidates.test.ts
+++ b/src/plugins/input_control_vis/public/lineage/parent_candidates.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/lineage/parent_candidates.ts
+++ b/src/plugins/input_control_vis/public/lineage/parent_candidates.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/plugin.ts
+++ b/src/plugins/input_control_vis/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/test_utils/get_deps_mock.tsx
+++ b/src/plugins/input_control_vis/public/test_utils/get_deps_mock.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/test_utils/get_index_pattern_mock.ts
+++ b/src/plugins/input_control_vis/public/test_utils/get_index_pattern_mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/test_utils/get_index_patterns_mock.ts
+++ b/src/plugins/input_control_vis/public/test_utils/get_index_patterns_mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/test_utils/get_search_service_mock.ts
+++ b/src/plugins/input_control_vis/public/test_utils/get_search_service_mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/test_utils/index.ts
+++ b/src/plugins/input_control_vis/public/test_utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/test_utils/update_component.ts
+++ b/src/plugins/input_control_vis/public/test_utils/update_component.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/public/vis_controller.tsx
+++ b/src/plugins/input_control_vis/public/vis_controller.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/input_control_vis/server/index.ts
+++ b/src/plugins/input_control_vis/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/data/data_adapter.ts
+++ b/src/plugins/inspector/common/adapters/data/data_adapter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/data/data_adapters.test.ts
+++ b/src/plugins/inspector/common/adapters/data/data_adapters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/data/formatted_data.ts
+++ b/src/plugins/inspector/common/adapters/data/formatted_data.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/data/index.ts
+++ b/src/plugins/inspector/common/adapters/data/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/data/types.ts
+++ b/src/plugins/inspector/common/adapters/data/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/index.ts
+++ b/src/plugins/inspector/common/adapters/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/request/index.ts
+++ b/src/plugins/inspector/common/adapters/request/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/request/request_adapter.test.ts
+++ b/src/plugins/inspector/common/adapters/request/request_adapter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/request/request_adapter.ts
+++ b/src/plugins/inspector/common/adapters/request/request_adapter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/request/request_responder.ts
+++ b/src/plugins/inspector/common/adapters/request/request_responder.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/request/types.ts
+++ b/src/plugins/inspector/common/adapters/request/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/adapters/types.ts
+++ b/src/plugins/inspector/common/adapters/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/common/index.ts
+++ b/src/plugins/inspector/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/index.ts
+++ b/src/plugins/inspector/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/index.ts
+++ b/src/plugins/inspector/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/mocks.ts
+++ b/src/plugins/inspector/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/plugin.tsx
+++ b/src/plugins/inspector/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/test/is_available.test.ts
+++ b/src/plugins/inspector/public/test/is_available.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/test/open.test.ts
+++ b/src/plugins/inspector/public/test/open.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/types.ts
+++ b/src/plugins/inspector/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/ui/inspector_panel.test.tsx
+++ b/src/plugins/inspector/public/ui/inspector_panel.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/ui/inspector_panel.tsx
+++ b/src/plugins/inspector/public/ui/inspector_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/ui/inspector_view_chooser.tsx
+++ b/src/plugins/inspector/public/ui/inspector_view_chooser.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/view_registry.test.ts
+++ b/src/plugins/inspector/public/view_registry.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/view_registry.ts
+++ b/src/plugins/inspector/public/view_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/data/components/data_table.tsx
+++ b/src/plugins/inspector/public/views/data/components/data_table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/data/components/data_view.test.tsx
+++ b/src/plugins/inspector/public/views/data/components/data_view.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/data/components/data_view.tsx
+++ b/src/plugins/inspector/public/views/data/components/data_view.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/data/components/download_options.tsx
+++ b/src/plugins/inspector/public/views/data/components/download_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/data/index.tsx
+++ b/src/plugins/inspector/public/views/data/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/data/lib/export_csv.ts
+++ b/src/plugins/inspector/public/views/data/lib/export_csv.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/data/types.ts
+++ b/src/plugins/inspector/public/views/data/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/index.ts
+++ b/src/plugins/inspector/public/views/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/requests/components/details/index.ts
+++ b/src/plugins/inspector/public/views/requests/components/details/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/requests/components/details/req_details_request.tsx
+++ b/src/plugins/inspector/public/views/requests/components/details/req_details_request.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/requests/components/details/req_details_response.tsx
+++ b/src/plugins/inspector/public/views/requests/components/details/req_details_response.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/requests/components/details/req_details_stats.tsx
+++ b/src/plugins/inspector/public/views/requests/components/details/req_details_stats.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/requests/components/request_details.tsx
+++ b/src/plugins/inspector/public/views/requests/components/request_details.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/requests/components/request_selector.tsx
+++ b/src/plugins/inspector/public/views/requests/components/request_selector.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/requests/components/requests_view.tsx
+++ b/src/plugins/inspector/public/views/requests/components/requests_view.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/requests/components/types.ts
+++ b/src/plugins/inspector/public/views/requests/components/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/inspector/public/views/requests/index.ts
+++ b/src/plugins/inspector/public/views/requests/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/legacy_export/server/index.ts
+++ b/src/plugins/legacy_export/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/legacy_export/server/lib/export/collect_references_deep.test.ts
+++ b/src/plugins/legacy_export/server/lib/export/collect_references_deep.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/legacy_export/server/lib/export/collect_references_deep.ts
+++ b/src/plugins/legacy_export/server/lib/export/collect_references_deep.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/legacy_export/server/lib/export/export_dashboards.ts
+++ b/src/plugins/legacy_export/server/lib/export/export_dashboards.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/legacy_export/server/lib/import/import_dashboards.test.ts
+++ b/src/plugins/legacy_export/server/lib/import/import_dashboards.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/legacy_export/server/lib/import/import_dashboards.ts
+++ b/src/plugins/legacy_export/server/lib/import/import_dashboards.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/legacy_export/server/lib/index.ts
+++ b/src/plugins/legacy_export/server/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/legacy_export/server/plugin.ts
+++ b/src/plugins/legacy_export/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/legacy_export/server/routes/export.ts
+++ b/src/plugins/legacy_export/server/routes/export.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/legacy_export/server/routes/import.ts
+++ b/src/plugins/legacy_export/server/routes/import.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/legacy_export/server/routes/index.ts
+++ b/src/plugins/legacy_export/server/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/common/contants.ts
+++ b/src/plugins/management/common/contants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/application.tsx
+++ b/src/plugins/management/public/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/components/index.ts
+++ b/src/plugins/management/public/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/components/landing/index.ts
+++ b/src/plugins/management/public/components/landing/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/components/landing/landing.tsx
+++ b/src/plugins/management/public/components/landing/landing.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/components/management_app/index.ts
+++ b/src/plugins/management/public/components/management_app/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/components/management_app/management_app.tsx
+++ b/src/plugins/management/public/components/management_app/management_app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/components/management_app/management_router.tsx
+++ b/src/plugins/management/public/components/management_app/management_router.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/components/management_app_wrapper/index.tsx
+++ b/src/plugins/management/public/components/management_app_wrapper/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/components/management_app_wrapper/management_app_wrapper.tsx
+++ b/src/plugins/management/public/components/management_app_wrapper/management_app_wrapper.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/components/management_sections.tsx
+++ b/src/plugins/management/public/components/management_sections.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/components/management_sidebar_nav/index.ts
+++ b/src/plugins/management/public/components/management_sidebar_nav/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/components/management_sidebar_nav/management_sidebar_nav.tsx
+++ b/src/plugins/management/public/components/management_sidebar_nav/management_sidebar_nav.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/index.ts
+++ b/src/plugins/management/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/management_sections_service.test.ts
+++ b/src/plugins/management/public/management_sections_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/management_sections_service.ts
+++ b/src/plugins/management/public/management_sections_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/mocks/index.ts
+++ b/src/plugins/management/public/mocks/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/plugin.ts
+++ b/src/plugins/management/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/types.ts
+++ b/src/plugins/management/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/utils/breadcrumbs.ts
+++ b/src/plugins/management/public/utils/breadcrumbs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/utils/index.ts
+++ b/src/plugins/management/public/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/utils/management_app.ts
+++ b/src/plugins/management/public/utils/management_app.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/utils/management_item.ts
+++ b/src/plugins/management/public/utils/management_item.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/utils/management_section.test.ts
+++ b/src/plugins/management/public/utils/management_section.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/public/utils/management_section.ts
+++ b/src/plugins/management/public/utils/management_section.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/server/capabilities_provider.ts
+++ b/src/plugins/management/server/capabilities_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/server/index.ts
+++ b/src/plugins/management/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/management/server/plugin.ts
+++ b/src/plugins/management/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/config.ts
+++ b/src/plugins/maps_legacy/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/common/constants/origin.ts
+++ b/src/plugins/maps_legacy/public/common/constants/origin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/common/opensearch_maps_client.js
+++ b/src/plugins/maps_legacy/public/common/opensearch_maps_client.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/common/types/external_basemap_types.ts
+++ b/src/plugins/maps_legacy/public/common/types/external_basemap_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/common/types/index.ts
+++ b/src/plugins/maps_legacy/public/common/types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/common/types/map_types.ts
+++ b/src/plugins/maps_legacy/public/common/types/map_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/common/types/region_map_types.ts
+++ b/src/plugins/maps_legacy/public/common/types/region_map_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/components/wms_internal_options.tsx
+++ b/src/plugins/maps_legacy/public/components/wms_internal_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/components/wms_options.tsx
+++ b/src/plugins/maps_legacy/public/components/wms_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/get_service_settings.ts
+++ b/src/plugins/maps_legacy/public/get_service_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/index.ts
+++ b/src/plugins/maps_legacy/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/lazy_load_bundle/index.ts
+++ b/src/plugins/maps_legacy/public/lazy_load_bundle/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/lazy_load_bundle/lazy/index.ts
+++ b/src/plugins/maps_legacy/public/lazy_load_bundle/lazy/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/leaflet.js
+++ b/src/plugins/maps_legacy/public/leaflet.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/base_maps_visualization.js
+++ b/src/plugins/maps_legacy/public/map/base_maps_visualization.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/color_util.js
+++ b/src/plugins/maps_legacy/public/map/color_util.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/convert_to_geojson.js
+++ b/src/plugins/maps_legacy/public/map/convert_to_geojson.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/decode_geo_hash.test.ts
+++ b/src/plugins/maps_legacy/public/map/decode_geo_hash.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/decode_geo_hash.ts
+++ b/src/plugins/maps_legacy/public/map/decode_geo_hash.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/grid_dimensions.js
+++ b/src/plugins/maps_legacy/public/map/grid_dimensions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/map_messages.js
+++ b/src/plugins/maps_legacy/public/map/map_messages.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/opensearch_dashboards_map.js
+++ b/src/plugins/maps_legacy/public/map/opensearch_dashboards_map.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/opensearch_dashboards_map_layer.js
+++ b/src/plugins/maps_legacy/public/map/opensearch_dashboards_map_layer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/precision.ts
+++ b/src/plugins/maps_legacy/public/map/precision.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/service_settings.js
+++ b/src/plugins/maps_legacy/public/map/service_settings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/service_settings.test.js
+++ b/src/plugins/maps_legacy/public/map/service_settings.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/service_settings_types.ts
+++ b/src/plugins/maps_legacy/public/map/service_settings_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/map/zoom_to_precision.ts
+++ b/src/plugins/maps_legacy/public/map/zoom_to_precision.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/opensearch_dashboards_services.js
+++ b/src/plugins/maps_legacy/public/opensearch_dashboards_services.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/plugin.ts
+++ b/src/plugins/maps_legacy/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/public/tooltip_provider.js
+++ b/src/plugins/maps_legacy/public/tooltip_provider.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/server/index.ts
+++ b/src/plugins/maps_legacy/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/maps_legacy/server/ui_settings.ts
+++ b/src/plugins/maps_legacy/server/ui_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/index.ts
+++ b/src/plugins/navigation/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/mocks.ts
+++ b/src/plugins/navigation/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/plugin.ts
+++ b/src/plugins/navigation/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/top_nav_menu/create_top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/create_top_nav_menu.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/top_nav_menu/index.ts
+++ b/src/plugins/navigation/public/top_nav_menu/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.test.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_extensions_registry.ts
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_extensions_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.test.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/navigation/public/types.ts
+++ b/src/plugins/navigation/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/common/constants.ts
+++ b/src/plugins/newsfeed/common/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/public/components/empty_news.test.tsx
+++ b/src/plugins/newsfeed/public/components/empty_news.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/public/components/empty_news.tsx
+++ b/src/plugins/newsfeed/public/components/empty_news.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/public/components/flyout_list.tsx
+++ b/src/plugins/newsfeed/public/components/flyout_list.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/public/components/loading_news.test.tsx
+++ b/src/plugins/newsfeed/public/components/loading_news.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/public/components/loading_news.tsx
+++ b/src/plugins/newsfeed/public/components/loading_news.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/public/components/newsfeed_header_nav_button.tsx
+++ b/src/plugins/newsfeed/public/components/newsfeed_header_nav_button.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/public/index.ts
+++ b/src/plugins/newsfeed/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/public/lib/api.test.ts
+++ b/src/plugins/newsfeed/public/lib/api.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/public/lib/api.ts
+++ b/src/plugins/newsfeed/public/lib/api.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/public/plugin.tsx
+++ b/src/plugins/newsfeed/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/public/types.ts
+++ b/src/plugins/newsfeed/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/server/config.ts
+++ b/src/plugins/newsfeed/server/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/server/index.ts
+++ b/src/plugins/newsfeed/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/newsfeed/server/plugin.ts
+++ b/src/plugins/newsfeed/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/config.ts
+++ b/src/plugins/opensearch_dashboards_legacy/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/angular/angular_config.tsx
+++ b/src/plugins/opensearch_dashboards_legacy/public/angular/angular_config.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/angular/index.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/angular/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/angular/osd_top_nav.js
+++ b/src/plugins/opensearch_dashboards_legacy/public/angular/osd_top_nav.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/angular/promises.js
+++ b/src/plugins/opensearch_dashboards_legacy/public/angular/promises.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/angular/subscribe_with_scope.test.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/angular/subscribe_with_scope.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/angular/subscribe_with_scope.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/angular/subscribe_with_scope.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/angular/watch_multi.js
+++ b/src/plugins/opensearch_dashboards_legacy/public/angular/watch_multi.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/dashboard_config.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/dashboard_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/font_awesome/index.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/font_awesome/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/index.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/mocks.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/index.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/lib/add_fatal_error.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/lib/add_fatal_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_angular_http_error.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_angular_http_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_msg.test.js
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_msg.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_msg.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_msg.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_opensearch_msg.test.js
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_opensearch_msg.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_opensearch_msg.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_opensearch_msg.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_stack.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/lib/format_stack.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/lib/index.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/toasts/index.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/toasts/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/toasts/toast_notifications.test.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/toasts/toast_notifications.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/notify/toasts/toast_notifications.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/notify/toasts/toast_notifications.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/paginate/paginate.d.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/paginate/paginate.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/paginate/paginate.js
+++ b/src/plugins/opensearch_dashboards_legacy/public/paginate/paginate.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/plugin.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/utils/index.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/utils/inject_header_style.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/utils/inject_header_style.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/utils/osd_accessible_click.js
+++ b/src/plugins/opensearch_dashboards_legacy/public/utils/osd_accessible_click.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/utils/private.d.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/utils/private.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/utils/private.js
+++ b/src/plugins/opensearch_dashboards_legacy/public/utils/private.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/utils/register_listen_event_listener.js
+++ b/src/plugins/opensearch_dashboards_legacy/public/utils/register_listen_event_listener.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/public/utils/system_api.ts
+++ b/src/plugins/opensearch_dashboards_legacy/public/utils/system_api.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_legacy/server/index.ts
+++ b/src/plugins/opensearch_dashboards_legacy/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/common/index.ts
+++ b/src/plugins/opensearch_dashboards_overview/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/application.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.test.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/add_data/add_data.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/add_data/index.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/components/add_data/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/app.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/getting_started/getting_started.test.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/getting_started/getting_started.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/getting_started/getting_started.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/getting_started/getting_started.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/getting_started/index.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/components/getting_started/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/manage_data/index.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/manage_data/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/manage_data/manage_data.test.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/manage_data/manage_data.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/manage_data/manage_data.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/manage_data/manage_data.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/news_feed/index.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/components/news_feed/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/news_feed/news_feed.test.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/news_feed/news_feed.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/news_feed/news_feed.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/news_feed/news_feed.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/overview/index.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/components/overview/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.test.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/overview/overview.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/synopsis/index.js
+++ b/src/plugins/opensearch_dashboards_overview/public/components/synopsis/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/synopsis/synopsis.js
+++ b/src/plugins/opensearch_dashboards_overview/public/components/synopsis/synopsis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/components/synopsis/synopsis.test.js
+++ b/src/plugins/opensearch_dashboards_overview/public/components/synopsis/synopsis.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/index.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/plugin.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_overview/public/types.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/adapters/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/adapters/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/adapters/react_to_ui_component.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/adapters/react_to_ui_component.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/adapters/react_to_ui_component.ts
+++ b/src/plugins/opensearch_dashboards_react/public/adapters/react_to_ui_component.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/adapters/ui_to_react_component.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/adapters/ui_to_react_component.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/adapters/ui_to_react_component.ts
+++ b/src/plugins/opensearch_dashboards_react/public/adapters/ui_to_react_component.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/app_links/click_handler.test.ts
+++ b/src/plugins/opensearch_dashboards_react/public/app_links/click_handler.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/app_links/click_handler.ts
+++ b/src/plugins/opensearch_dashboards_react/public/app_links/click_handler.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/app_links/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/app_links/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/app_links/redirect_app_link.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/app_links/redirect_app_link.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/app_links/redirect_app_link.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/app_links/redirect_app_link.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/app_links/utils.test.ts
+++ b/src/plugins/opensearch_dashboards_react/public/app_links/utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/app_links/utils.ts
+++ b/src/plugins/opensearch_dashboards_react/public/app_links/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/code_editor/code_editor.stories.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/code_editor/code_editor.stories.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/code_editor/code_editor.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/code_editor/code_editor.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/code_editor/code_editor.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/code_editor/code_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/code_editor/editor_theme.ts
+++ b/src/plugins/opensearch_dashboards_react/public/code_editor/editor_theme.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/code_editor/index.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/code_editor/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/context/context.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/context/context.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/context/context.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/context/context.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/context/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/context/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/context/types.ts
+++ b/src/plugins/opensearch_dashboards_react/public/context/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/exit_full_screen_button/exit_full_screen_button.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/exit_full_screen_button/exit_full_screen_button.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/exit_full_screen_button/exit_full_screen_button.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/exit_full_screen_button/exit_full_screen_button.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/exit_full_screen_button/index.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/exit_full_screen_button/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/field_button/field_button.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/field_button/field_button.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/field_button/field_button.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/field_button/field_button.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/field_button/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/field_button/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/field_icon/field_icon.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/field_icon/field_icon.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/field_icon/field_icon.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/field_icon/field_icon.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/field_icon/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/field_icon/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/markdown/index.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/markdown/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/markdown/markdown.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/markdown/markdown.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/markdown/markdown.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/markdown/markdown.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/markdown/markdown_simple.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/markdown/markdown_simple.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/notifications/create_notifications.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/notifications/create_notifications.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/notifications/create_notifications.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/notifications/create_notifications.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/notifications/index.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/notifications/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/notifications/types.ts
+++ b/src/plugins/opensearch_dashboards_react/public/notifications/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/overlays/create_react_overlays.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overlays/create_react_overlays.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/overlays/create_react_overlays.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overlays/create_react_overlays.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/overlays/index.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overlays/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/overlays/types.ts
+++ b/src/plugins/opensearch_dashboards_react/public/overlays/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_footer/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_footer/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_footer/overview_page_footer.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_footer/overview_page_footer.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_footer/overview_page_footer.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_footer/overview_page_footer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/react_router_navigate/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/react_router_navigate/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/react_router_navigate/react_router_navigate.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/react_router_navigate/react_router_navigate.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/split_panel/components/resizer.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/split_panel/components/resizer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/split_panel/containers/panel.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/split_panel/containers/panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/split_panel/containers/panel_container.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/split_panel/containers/panel_container.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/split_panel/context.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/split_panel/context.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/split_panel/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/split_panel/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/split_panel/registry.ts
+++ b/src/plugins/opensearch_dashboards_react/public/split_panel/registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/split_panel/split_panel.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/split_panel/split_panel.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/ui_settings/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/ui_settings/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/ui_settings/use_ui_setting.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/ui_settings/use_ui_setting.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/ui_settings/use_ui_setting.ts
+++ b/src/plugins/opensearch_dashboards_react/public/ui_settings/use_ui_setting.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/use_url_tracker/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/use_url_tracker/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/use_url_tracker/use_url_tracker.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/use_url_tracker/use_url_tracker.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/use_url_tracker/use_url_tracker.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/use_url_tracker/use_url_tracker.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/util/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/util/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/util/mount_point_portal.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/util/mount_point_portal.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/util/mount_point_portal.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/util/mount_point_portal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/util/test_helpers/react_mount_serializer.ts
+++ b/src/plugins/opensearch_dashboards_react/public/util/test_helpers/react_mount_serializer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/util/to_mount_point.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/util/to_mount_point.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/util/utils.ts
+++ b/src/plugins/opensearch_dashboards_react/public/util/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/validated_range/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/validated_range/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/validated_range/is_range_valid.test.ts
+++ b/src/plugins/opensearch_dashboards_react/public/validated_range/is_range_valid.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/validated_range/is_range_valid.ts
+++ b/src/plugins/opensearch_dashboards_react/public/validated_range/is_range_valid.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_react/public/validated_range/validated_dual_range.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/validated_range/validated_dual_range.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/common/constants.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/common/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/index.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/rollups.test.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/rollups.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/rollups.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/rollups.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/saved_objects_types.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/saved_objects_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/schema.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/telemetry_application_usage_collector.test.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/telemetry_application_usage_collector.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/telemetry_application_usage_collector.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/application_usage/telemetry_application_usage_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/core/core_usage_collector.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/core/core_usage_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/core/index.test.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/core/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/core/index.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/core/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/csp/csp_collector.test.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/csp/csp_collector.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/csp/csp_collector.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/csp/csp_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/csp/index.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/csp/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/index.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/management/index.test.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/management/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/management/index.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/management/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/management/schema.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/management/schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/management/telemetry_management_collector.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/management/telemetry_management_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/opensearch_dashboards/get_saved_object_counts.test.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/opensearch_dashboards/get_saved_object_counts.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/opensearch_dashboards/get_saved_object_counts.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/opensearch_dashboards/get_saved_object_counts.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/opensearch_dashboards/index.test.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/opensearch_dashboards/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/opensearch_dashboards/index.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/opensearch_dashboards/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/opensearch_dashboards/opensearch_dashboards_usage_collector.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/opensearch_dashboards/opensearch_dashboards_usage_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ops_stats/index.test.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ops_stats/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ops_stats/index.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ops_stats/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ops_stats/ops_stats_collector.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ops_stats/ops_stats_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ui_metric/index.test.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ui_metric/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ui_metric/index.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ui_metric/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ui_metric/schema.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ui_metric/schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ui_metric/telemetry_ui_metric_collector.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/ui_metric/telemetry_ui_metric_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/index.test.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/index.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_usage_collection/server/plugin.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/calculate_object_hash.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/calculate_object_hash.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/create_getter_setter.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/create_getter_setter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/defer.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/defer.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/defer.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/defer.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/distinct_until_changed_with_initial_value.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/distinct_until_changed_with_initial_value.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/distinct_until_changed_with_initial_value.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/distinct_until_changed_with_initial_value.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/errors/errors.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/errors/errors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/errors/errors.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/errors/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/errors/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/errors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/field_wildcard.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/field_wildcard.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/field_wildcard.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/field_wildcard.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/now.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/now.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/of.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/of.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/of.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/of.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/persistable_state/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/persistable_state/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/state_containers/create_state_container.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/state_containers/create_state_container.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/state_containers/create_state_container.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/state_containers/create_state_container.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/state_containers/create_state_container_react_helpers.test.tsx
+++ b/src/plugins/opensearch_dashboards_utils/common/state_containers/create_state_container_react_helpers.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/state_containers/create_state_container_react_helpers.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/state_containers/create_state_container_react_helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/state_containers/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/state_containers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/state_containers/types.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/state_containers/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/typed_json.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/typed_json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/ui/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/ui/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/ui/ui_component.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/ui/ui_component.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/url/encode_uri_query.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/url/encode_uri_query.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/url/encode_uri_query.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/url/encode_uri_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/common/url/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/common/url/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/demos/demos.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/demos/demos.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/demos/state_containers/counter.ts
+++ b/src/plugins/opensearch_dashboards_utils/demos/state_containers/counter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/demos/state_containers/todomvc.ts
+++ b/src/plugins/opensearch_dashboards_utils/demos/state_containers/todomvc.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/demos/state_sync/url.ts
+++ b/src/plugins/opensearch_dashboards_utils/demos/state_sync/url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/core/create_start_service_getter.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/core/create_start_service_getter.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/core/create_start_service_getter.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/core/create_start_service_getter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/core/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/core/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/history/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/history/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/history/redirect_when_missing.tsx
+++ b/src/plugins/opensearch_dashboards_utils/public/history/redirect_when_missing.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/history/remove_query_param.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/history/remove_query_param.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/history/remove_query_param.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/history/remove_query_param.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/index.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/render_complete/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/render_complete/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/render_complete/render_complete_dispatcher.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/render_complete/render_complete_dispatcher.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/render_complete/render_complete_listener.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/render_complete/render_complete_listener.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/resize_checker/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/resize_checker/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/resize_checker/resize_checker.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/resize_checker/resize_checker.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/resize_checker/resize_checker.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/resize_checker/resize_checker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/state_encoder/encode_decode_state.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/state_encoder/encode_decode_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/state_encoder/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/state_encoder/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/state_hash/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/state_hash/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/state_hash/state_hash.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/state_hash/state_hash.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/state_hash/state_hash.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/state_hash/state_hash.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/errors.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/format.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/format.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/format.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/format.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/hash_unhash_url.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/hash_unhash_url.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/hash_unhash_url.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/hash_unhash_url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_storage.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_storage.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_storage.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_storage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_tracker.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_tracker.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_tracker.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_tracker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/parse.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/parse.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/parse.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/parse.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/url_tracker.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/url_tracker.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/url_tracker.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/url_tracker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/utils/diff_object.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/utils/diff_object.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/utils/diff_object.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/utils/diff_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_sync/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_sync/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/create_osd_url_state_storage.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/create_osd_url_state_storage.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/create_osd_url_state_storage.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/create_osd_url_state_storage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/create_session_storage_state_storage.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/create_session_storage_state_storage.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/create_session_storage_state_storage.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/create_session_storage_state_storage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/types.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_sync/state_sync_state_storage/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/state_sync/types.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_sync/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/storage/hashed_item_store/hashed_item_store.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/storage/hashed_item_store/hashed_item_store.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/storage/hashed_item_store/hashed_item_store.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/storage/hashed_item_store/hashed_item_store.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/storage/hashed_item_store/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/storage/hashed_item_store/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/storage/hashed_item_store/mock.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/storage/hashed_item_store/mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/storage/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/storage/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/storage/storage.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/storage/storage.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/storage/storage.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/storage/storage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/storage/types.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/storage/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/ui/configurable.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/ui/configurable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/public/ui/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/ui/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_dashboards_utils/server/index.ts
+++ b/src/plugins/opensearch_dashboards_utils/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/ace/index.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/ace/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/ace/use_ui_ace_keyboard_mode.tsx
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/ace/use_ui_ace_keyboard_mode.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/components/authorization_provider.tsx
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/components/authorization_provider.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/components/index.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/components/not_authorized_section.tsx
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/components/not_authorized_section.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/components/section_error.tsx
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/components/section_error.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/components/with_privileges.tsx
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/components/with_privileges.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/index.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/types.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/authorization/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/errors/index.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/errors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/errors/is_opensearch_error.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/errors/is_opensearch_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/global_flyout/global_flyout.tsx
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/global_flyout/global_flyout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/global_flyout/index.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/global_flyout/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/xjson/index.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/xjson/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/xjson/json_xjson_translation_tools/__tests__/json_xjson_translation_tools.test.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/xjson/json_xjson_translation_tools/__tests__/json_xjson_translation_tools.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/xjson/json_xjson_translation_tools/index.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/xjson/json_xjson_translation_tools/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/xjson/json_xjson_translation_tools/parser.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/xjson/json_xjson_translation_tools/parser.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/__packages_do_not_import__/xjson/use_xjson_mode.ts
+++ b/src/plugins/opensearch_ui_shared/__packages_do_not_import__/xjson/use_xjson_mode.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/common/index.ts
+++ b/src/plugins/opensearch_ui_shared/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/ace/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/ace/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/authorization/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/authorization/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_daily.js
+++ b/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_daily.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_editor.js
+++ b/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_editor.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_hourly.js
+++ b/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_hourly.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_monthly.js
+++ b/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_monthly.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_weekly.js
+++ b/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_weekly.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_yearly.js
+++ b/src/plugins/opensearch_ui_shared/public/components/cron_editor/cron_yearly.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/cron_editor/index.d.ts
+++ b/src/plugins/opensearch_ui_shared/public/components/cron_editor/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/cron_editor/index.js
+++ b/src/plugins/opensearch_ui_shared/public/components/cron_editor/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/cron_editor/services/cron.js
+++ b/src/plugins/opensearch_ui_shared/public/components/cron_editor/services/cron.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/cron_editor/services/humanized_numbers.js
+++ b/src/plugins/opensearch_ui_shared/public/components/cron_editor/services/humanized_numbers.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/cron_editor/services/index.js
+++ b/src/plugins/opensearch_ui_shared/public/components/cron_editor/services/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/json_editor/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/components/json_editor/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/json_editor/json_editor.tsx
+++ b/src/plugins/opensearch_ui_shared/public/components/json_editor/json_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/json_editor/use_json.ts
+++ b/src/plugins/opensearch_ui_shared/public/components/json_editor/use_json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/section_loading/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/components/section_loading/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/components/section_loading/section_loading.tsx
+++ b/src/plugins/opensearch_ui_shared/public/components/section_loading/section_loading.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/forms/form_wizard/form_wizard.tsx
+++ b/src/plugins/opensearch_ui_shared/public/forms/form_wizard/form_wizard.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/forms/form_wizard/form_wizard_context.tsx
+++ b/src/plugins/opensearch_ui_shared/public/forms/form_wizard/form_wizard_context.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/forms/form_wizard/form_wizard_nav.tsx
+++ b/src/plugins/opensearch_ui_shared/public/forms/form_wizard/form_wizard_nav.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/forms/form_wizard/form_wizard_step.tsx
+++ b/src/plugins/opensearch_ui_shared/public/forms/form_wizard/form_wizard_step.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/forms/form_wizard/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/forms/form_wizard/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/forms/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/forms/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/forms/multi_content/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/forms/multi_content/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/forms/multi_content/multi_content_context.tsx
+++ b/src/plugins/opensearch_ui_shared/public/forms/multi_content/multi_content_context.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/forms/multi_content/use_multi_content.ts
+++ b/src/plugins/opensearch_ui_shared/public/forms/multi_content/use_multi_content.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/forms/multi_content/with_multi_content.tsx
+++ b/src/plugins/opensearch_ui_shared/public/forms/multi_content/with_multi_content.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/global_flyout/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/global_flyout/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/indices/constants/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/indices/constants/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/indices/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/indices/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/indices/validate/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/indices/validate/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/indices/validate/validate_index.test.ts
+++ b/src/plugins/opensearch_ui_shared/public/indices/validate/validate_index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/indices/validate/validate_index.ts
+++ b/src/plugins/opensearch_ui_shared/public/indices/validate/validate_index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/request/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/request/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/request/send_request.test.helpers.ts
+++ b/src/plugins/opensearch_ui_shared/public/request/send_request.test.helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/request/send_request.test.ts
+++ b/src/plugins/opensearch_ui_shared/public/request/send_request.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/request/send_request.ts
+++ b/src/plugins/opensearch_ui_shared/public/request/send_request.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/request/use_request.test.helpers.tsx
+++ b/src/plugins/opensearch_ui_shared/public/request/use_request.test.helpers.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/request/use_request.test.ts
+++ b/src/plugins/opensearch_ui_shared/public/request/use_request.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/request/use_request.ts
+++ b/src/plugins/opensearch_ui_shared/public/request/use_request.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/url/extract_query_params.ts
+++ b/src/plugins/opensearch_ui_shared/public/url/extract_query_params.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/url/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/url/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/public/xjson/index.ts
+++ b/src/plugins/opensearch_ui_shared/public/xjson/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/server/errors/index.ts
+++ b/src/plugins/opensearch_ui_shared/server/errors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/server/index.ts
+++ b/src/plugins/opensearch_ui_shared/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/checkbox_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/checkbox_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/combobox_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/combobox_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/index.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/json_editor_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/json_editor_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/multi_select_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/multi_select_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/numeric_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/numeric_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/radio_group_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/radio_group_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/range_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/range_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/select_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/select_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/super_select_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/super_select_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/text_area_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/text_area_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/text_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/text_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/fields/toggle_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/fields/toggle_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/form_row.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/form_row.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/components/index.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/de_serializers.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/de_serializers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_formatters.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_formatters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/contains_char.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/contains_char.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/empty_field.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/empty_field.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/index.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/index_name.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/index_name.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/index_pattern_field.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/index_pattern_field.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/is_json.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/is_json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/lowercase_string.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/lowercase_string.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/min_length.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/min_length.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/min_selectable_selection.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/min_selectable_selection.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/number_greater_than.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/number_greater_than.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/number_smaller_than.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/number_smaller_than.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/starts_with.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/starts_with.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/types.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/url.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/field_validators/url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/index.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/serializers.test.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/serializers.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/helpers/serializers.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/helpers/serializers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/form.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/form.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/form_data_provider.test.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/form_data_provider.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/form_data_provider.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/form_data_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/index.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/use_array.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/use_array.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/use_field.test.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/use_field.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/use_field.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/use_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/use_multi_fields.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/components/use_multi_fields.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/constants.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/form_context.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/form_context.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/form_data_context.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/form_data_context.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/helpers.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/index.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/use_field.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/use_field.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/use_form.test.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/use_form.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/use_form_data.test.tsx
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/use_form_data.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/use_form_data.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/hooks/use_form_data.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/index.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/lib/index.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/lib/subject.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/lib/subject.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/lib/utils.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/lib/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/shared_imports.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/shared_imports.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/types.ts
+++ b/src/plugins/opensearch_ui_shared/static/forms/hook_form_lib/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/array/has_max_length.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/array/has_max_length.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/array/has_min_length.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/array/has_min_length.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/array/index.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/array/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/array/is_empty.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/array/is_empty.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/number/greater_than.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/number/greater_than.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/number/index.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/number/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/number/smaller_than.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/number/smaller_than.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/string/contains_chars.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/string/contains_chars.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/string/ends_with.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/string/ends_with.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/string/has_max_length.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/string/has_max_length.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/string/has_min_length.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/string/has_min_length.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/string/index.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/string/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/string/is_empty.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/string/is_empty.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/string/is_json.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/string/is_json.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/string/is_lowercase.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/string/is_lowercase.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/string/is_url.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/string/is_url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/opensearch_ui_shared/static/validators/string/starts_with.ts
+++ b/src/plugins/opensearch_ui_shared/static/validators/string/starts_with.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/config.ts
+++ b/src/plugins/region_map/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/public/choropleth_layer.js
+++ b/src/plugins/region_map/public/choropleth_layer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/public/components/region_map_options.tsx
+++ b/src/plugins/region_map/public/components/region_map_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/public/index.ts
+++ b/src/plugins/region_map/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/public/opensearch_dashboards_services.ts
+++ b/src/plugins/region_map/public/opensearch_dashboards_services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/public/plugin.ts
+++ b/src/plugins/region_map/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/public/region_map_fn.js
+++ b/src/plugins/region_map/public/region_map_fn.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/public/region_map_fn.test.js
+++ b/src/plugins/region_map/public/region_map_fn.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/public/region_map_type.js
+++ b/src/plugins/region_map/public/region_map_type.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/public/region_map_visualization.js
+++ b/src/plugins/region_map/public/region_map_visualization.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/public/tooltip_formatter.js
+++ b/src/plugins/region_map/public/tooltip_formatter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/public/util.ts
+++ b/src/plugins/region_map/public/util.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/server/index.ts
+++ b/src/plugins/region_map/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/region_map/server/ui_settings.ts
+++ b/src/plugins/region_map/server/ui_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/common/index.ts
+++ b/src/plugins/saved_objects/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/constants.ts
+++ b/src/plugins/saved_objects/public/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/finder/index.ts
+++ b/src/plugins/saved_objects/public/finder/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/finder/saved_object_finder.test.tsx
+++ b/src/plugins/saved_objects/public/finder/saved_object_finder.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/finder/saved_object_finder.tsx
+++ b/src/plugins/saved_objects/public/finder/saved_object_finder.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/index.ts
+++ b/src/plugins/saved_objects/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/plugin.ts
+++ b/src/plugins/saved_objects/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/save_modal/index.ts
+++ b/src/plugins/saved_objects/public/save_modal/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.test.tsx
+++ b/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
+++ b/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/save_modal/saved_object_save_modal_origin.tsx
+++ b/src/plugins/saved_objects/public/save_modal/saved_object_save_modal_origin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/save_modal/show_saved_object_save_modal.tsx
+++ b/src/plugins/saved_objects/public/save_modal/show_saved_object_save_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/apply_opensearch_resp.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/apply_opensearch_resp.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/build_saved_object.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/build_saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/check_for_duplicate_title.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/check_for_duplicate_title.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/confirm_modal_promise.tsx
+++ b/src/plugins/saved_objects/public/saved_object/helpers/confirm_modal_promise.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/create_source.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/create_source.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/display_duplicate_title_confirm_modal.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/display_duplicate_title_confirm_modal.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/find_object_by_title.test.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/find_object_by_title.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/find_object_by_title.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/find_object_by_title.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/hydrate_index_pattern.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/hydrate_index_pattern.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/initialize_saved_object.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/initialize_saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/save_saved_object.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/save_saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/save_with_confirmation.test.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/save_with_confirmation.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/save_with_confirmation.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/save_with_confirmation.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/serialize_saved_object.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/serialize_saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/string_utils.test.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/string_utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/helpers/string_utils.ts
+++ b/src/plugins/saved_objects/public/saved_object/helpers/string_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/index.ts
+++ b/src/plugins/saved_objects/public/saved_object/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/saved_object.test.ts
+++ b/src/plugins/saved_objects/public/saved_object/saved_object.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/saved_object.ts
+++ b/src/plugins/saved_objects/public/saved_object/saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/saved_object/saved_object_loader.ts
+++ b/src/plugins/saved_objects/public/saved_object/saved_object_loader.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/public/types.ts
+++ b/src/plugins/saved_objects/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/server/index.ts
+++ b/src/plugins/saved_objects/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/server/plugin.ts
+++ b/src/plugins/saved_objects/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects/server/ui_settings.ts
+++ b/src/plugins/saved_objects/server/ui_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/common/index.ts
+++ b/src/plugins/saved_objects_management/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/common/types.ts
+++ b/src/plugins/saved_objects_management/common/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/index.ts
+++ b/src/plugins/saved_objects_management/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/case_conversion.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/case_conversion.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/case_conversion.ts
+++ b/src/plugins/saved_objects_management/public/lib/case_conversion.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/create_field_list.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/create_field_list.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/create_field_list.ts
+++ b/src/plugins/saved_objects_management/public/lib/create_field_list.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/extract_export_details.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/extract_export_details.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/extract_export_details.ts
+++ b/src/plugins/saved_objects_management/public/lib/extract_export_details.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/fetch_export_by_type_and_search.ts
+++ b/src/plugins/saved_objects_management/public/lib/fetch_export_by_type_and_search.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/fetch_export_objects.ts
+++ b/src/plugins/saved_objects_management/public/lib/fetch_export_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/find_objects.ts
+++ b/src/plugins/saved_objects_management/public/lib/find_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/get_allowed_types.ts
+++ b/src/plugins/saved_objects_management/public/lib/get_allowed_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/get_default_title.ts
+++ b/src/plugins/saved_objects_management/public/lib/get_default_title.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/get_relationships.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/get_relationships.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/get_relationships.ts
+++ b/src/plugins/saved_objects_management/public/lib/get_relationships.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/get_saved_object_counts.ts
+++ b/src/plugins/saved_objects_management/public/lib/get_saved_object_counts.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/get_saved_object_label.ts
+++ b/src/plugins/saved_objects_management/public/lib/get_saved_object_label.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/import_file.ts
+++ b/src/plugins/saved_objects_management/public/lib/import_file.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/import_legacy_file.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/import_legacy_file.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/import_legacy_file.ts
+++ b/src/plugins/saved_objects_management/public/lib/import_legacy_file.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/in_app_url.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/in_app_url.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/in_app_url.ts
+++ b/src/plugins/saved_objects_management/public/lib/in_app_url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/index.ts
+++ b/src/plugins/saved_objects_management/public/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/log_legacy_import.ts
+++ b/src/plugins/saved_objects_management/public/lib/log_legacy_import.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/numeric.ts
+++ b/src/plugins/saved_objects_management/public/lib/numeric.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/parse_query.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/parse_query.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/parse_query.ts
+++ b/src/plugins/saved_objects_management/public/lib/parse_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/process_import_response.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/process_import_response.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/process_import_response.ts
+++ b/src/plugins/saved_objects_management/public/lib/process_import_response.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/resolve_import_errors.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/resolve_import_errors.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/resolve_import_errors.ts
+++ b/src/plugins/saved_objects_management/public/lib/resolve_import_errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/resolve_saved_objects.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/resolve_saved_objects.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/lib/resolve_saved_objects.ts
+++ b/src/plugins/saved_objects_management/public/lib/resolve_saved_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/index.ts
+++ b/src/plugins/saved_objects_management/public/management_section/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/mount_section.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/mount_section.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/field.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/field.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/field.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/form.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/form.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/header.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/header.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/header.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/index.ts
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/intro.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/intro.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/intro.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/intro.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/not_found_errors.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/not_found_errors.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/not_found_errors.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/not_found_errors.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/index.ts
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/object_view/saved_object_view.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/saved_object_view.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.mocks.ts
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_mode_control.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_mode_control.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_mode_control.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_mode_control.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_summary.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_summary.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_summary.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_summary.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/index.ts
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/overwrite_modal.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/overwrite_modal.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/overwrite_modal.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/overwrite_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/index.ts
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.mocks.ts
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/saved_objects_edition_page.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/saved_objects_edition_page.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/management_section/types.ts
+++ b/src/plugins/saved_objects_management/public/management_section/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/mocks.ts
+++ b/src/plugins/saved_objects_management/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/plugin.test.ts
+++ b/src/plugins/saved_objects_management/public/plugin.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/plugin.ts
+++ b/src/plugins/saved_objects_management/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/register_services.ts
+++ b/src/plugins/saved_objects_management/public/register_services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/action_service.mock.ts
+++ b/src/plugins/saved_objects_management/public/services/action_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/action_service.test.ts
+++ b/src/plugins/saved_objects_management/public/services/action_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/action_service.ts
+++ b/src/plugins/saved_objects_management/public/services/action_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/column_service.mock.ts
+++ b/src/plugins/saved_objects_management/public/services/column_service.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/column_service.test.ts
+++ b/src/plugins/saved_objects_management/public/services/column_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/column_service.ts
+++ b/src/plugins/saved_objects_management/public/services/column_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/index.ts
+++ b/src/plugins/saved_objects_management/public/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/service_registry.mock.ts
+++ b/src/plugins/saved_objects_management/public/services/service_registry.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/service_registry.ts
+++ b/src/plugins/saved_objects_management/public/services/service_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/types/action.ts
+++ b/src/plugins/saved_objects_management/public/services/types/action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/types/column.ts
+++ b/src/plugins/saved_objects_management/public/services/types/column.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/types/index.ts
+++ b/src/plugins/saved_objects_management/public/services/types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/services/types/record.ts
+++ b/src/plugins/saved_objects_management/public/services/types/record.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/public/types.ts
+++ b/src/plugins/saved_objects_management/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/capabilities_provider.ts
+++ b/src/plugins/saved_objects_management/server/capabilities_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/index.ts
+++ b/src/plugins/saved_objects_management/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/lib/find_all.test.ts
+++ b/src/plugins/saved_objects_management/server/lib/find_all.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/lib/find_all.ts
+++ b/src/plugins/saved_objects_management/server/lib/find_all.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/lib/find_relationships.test.ts
+++ b/src/plugins/saved_objects_management/server/lib/find_relationships.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/lib/find_relationships.ts
+++ b/src/plugins/saved_objects_management/server/lib/find_relationships.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/lib/index.ts
+++ b/src/plugins/saved_objects_management/server/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/lib/inject_meta_attributes.test.ts
+++ b/src/plugins/saved_objects_management/server/lib/inject_meta_attributes.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/lib/inject_meta_attributes.ts
+++ b/src/plugins/saved_objects_management/server/lib/inject_meta_attributes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/plugin.test.mocks.ts
+++ b/src/plugins/saved_objects_management/server/plugin.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/plugin.test.ts
+++ b/src/plugins/saved_objects_management/server/plugin.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/plugin.ts
+++ b/src/plugins/saved_objects_management/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/routes/find.ts
+++ b/src/plugins/saved_objects_management/server/routes/find.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/routes/get.ts
+++ b/src/plugins/saved_objects_management/server/routes/get.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/routes/get_allowed_types.ts
+++ b/src/plugins/saved_objects_management/server/routes/get_allowed_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/routes/index.test.ts
+++ b/src/plugins/saved_objects_management/server/routes/index.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/routes/index.ts
+++ b/src/plugins/saved_objects_management/server/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/routes/relationships.ts
+++ b/src/plugins/saved_objects_management/server/routes/relationships.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/routes/scroll_count.ts
+++ b/src/plugins/saved_objects_management/server/routes/scroll_count.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/routes/scroll_export.ts
+++ b/src/plugins/saved_objects_management/server/routes/scroll_export.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/services/index.ts
+++ b/src/plugins/saved_objects_management/server/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/services/management.mock.ts
+++ b/src/plugins/saved_objects_management/server/services/management.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/services/management.test.ts
+++ b/src/plugins/saved_objects_management/server/services/management.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/services/management.ts
+++ b/src/plugins/saved_objects_management/server/services/management.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/saved_objects_management/server/types.ts
+++ b/src/plugins/saved_objects_management/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/common/constants.ts
+++ b/src/plugins/share/common/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/common/short_url_routes.ts
+++ b/src/plugins/share/common/short_url_routes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/components/share_context_menu.test.tsx
+++ b/src/plugins/share/public/components/share_context_menu.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/components/share_context_menu.tsx
+++ b/src/plugins/share/public/components/share_context_menu.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/components/url_panel_content.test.tsx
+++ b/src/plugins/share/public/components/url_panel_content.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/components/url_panel_content.tsx
+++ b/src/plugins/share/public/components/url_panel_content.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/index.ts
+++ b/src/plugins/share/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/lib/url_shortener.test.ts
+++ b/src/plugins/share/public/lib/url_shortener.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/lib/url_shortener.ts
+++ b/src/plugins/share/public/lib/url_shortener.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/opensearch_dashboards_url.ts
+++ b/src/plugins/share/public/opensearch_dashboards_url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/plugin.test.mocks.ts
+++ b/src/plugins/share/public/plugin.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/plugin.test.ts
+++ b/src/plugins/share/public/plugin.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/plugin.ts
+++ b/src/plugins/share/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/services/index.ts
+++ b/src/plugins/share/public/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/services/share_menu_manager.mock.ts
+++ b/src/plugins/share/public/services/share_menu_manager.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/services/share_menu_manager.tsx
+++ b/src/plugins/share/public/services/share_menu_manager.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/services/share_menu_registry.mock.ts
+++ b/src/plugins/share/public/services/share_menu_registry.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/services/share_menu_registry.test.ts
+++ b/src/plugins/share/public/services/share_menu_registry.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/services/share_menu_registry.ts
+++ b/src/plugins/share/public/services/share_menu_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/services/short_url_redirect_app.test.ts
+++ b/src/plugins/share/public/services/short_url_redirect_app.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/services/short_url_redirect_app.ts
+++ b/src/plugins/share/public/services/short_url_redirect_app.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/types.ts
+++ b/src/plugins/share/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/url_generators/index.ts
+++ b/src/plugins/share/public/url_generators/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/url_generators/url_generator_contract.ts
+++ b/src/plugins/share/public/url_generators/url_generator_contract.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/url_generators/url_generator_definition.ts
+++ b/src/plugins/share/public/url_generators/url_generator_definition.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/url_generators/url_generator_internal.ts
+++ b/src/plugins/share/public/url_generators/url_generator_internal.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/url_generators/url_generator_service.test.ts
+++ b/src/plugins/share/public/url_generators/url_generator_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/public/url_generators/url_generator_service.ts
+++ b/src/plugins/share/public/url_generators/url_generator_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/index.ts
+++ b/src/plugins/share/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/plugin.ts
+++ b/src/plugins/share/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/routes/create_routes.ts
+++ b/src/plugins/share/server/routes/create_routes.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/routes/get.ts
+++ b/src/plugins/share/server/routes/get.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/routes/goto.ts
+++ b/src/plugins/share/server/routes/goto.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/routes/lib/short_url_assert_valid.test.ts
+++ b/src/plugins/share/server/routes/lib/short_url_assert_valid.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/routes/lib/short_url_assert_valid.ts
+++ b/src/plugins/share/server/routes/lib/short_url_assert_valid.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/routes/lib/short_url_lookup.test.ts
+++ b/src/plugins/share/server/routes/lib/short_url_lookup.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/routes/lib/short_url_lookup.ts
+++ b/src/plugins/share/server/routes/lib/short_url_lookup.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/routes/shorten_url.ts
+++ b/src/plugins/share/server/routes/shorten_url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/saved_objects/index.ts
+++ b/src/plugins/share/server/saved_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/share/server/saved_objects/url.ts
+++ b/src/plugins/share/server/saved_objects/url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/constants.ts
+++ b/src/plugins/telemetry/common/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_allow_changing_opt_in_status.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_allow_changing_opt_in_status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_failure_details.test.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_failure_details.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_failure_details.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_failure_details.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_notify_user_about_optin_default.test.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_notify_user_about_optin_default.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_notify_user_about_optin_default.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_notify_user_about_optin_default.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_opt_in.test.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_opt_in.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_opt_in.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_opt_in.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_send_usage_from.test.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_send_usage_from.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_send_usage_from.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_send_usage_from.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/telemetry_config/index.ts
+++ b/src/plugins/telemetry/common/telemetry_config/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/common/telemetry_config/types.ts
+++ b/src/plugins/telemetry/common/telemetry_config/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/components/index.ts
+++ b/src/plugins/telemetry/public/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/components/opt_in_banner.test.tsx
+++ b/src/plugins/telemetry/public/components/opt_in_banner.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/components/opt_in_banner.tsx
+++ b/src/plugins/telemetry/public/components/opt_in_banner.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/components/opt_in_message.test.tsx
+++ b/src/plugins/telemetry/public/components/opt_in_message.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/components/opt_in_message.tsx
+++ b/src/plugins/telemetry/public/components/opt_in_message.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/components/opted_in_notice_banner.test.tsx
+++ b/src/plugins/telemetry/public/components/opted_in_notice_banner.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/components/opted_in_notice_banner.tsx
+++ b/src/plugins/telemetry/public/components/opted_in_notice_banner.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/index.ts
+++ b/src/plugins/telemetry/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/mocks.ts
+++ b/src/plugins/telemetry/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/plugin.ts
+++ b/src/plugins/telemetry/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/index.ts
+++ b/src/plugins/telemetry/public/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/telemetry_notifications/index.ts
+++ b/src/plugins/telemetry/public/services/telemetry_notifications/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/telemetry_notifications/render_opt_in_banner.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_notifications/render_opt_in_banner.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/telemetry_notifications/render_opt_in_banner.tsx
+++ b/src/plugins/telemetry/public/services/telemetry_notifications/render_opt_in_banner.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/telemetry_notifications/render_opted_in_notice_banner.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_notifications/render_opted_in_notice_banner.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/telemetry_notifications/render_opted_in_notice_banner.tsx
+++ b/src/plugins/telemetry/public/services/telemetry_notifications/render_opted_in_notice_banner.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/telemetry_notifications/telemetry_notifications.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_notifications/telemetry_notifications.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/telemetry_notifications/telemetry_notifications.ts
+++ b/src/plugins/telemetry/public/services/telemetry_notifications/telemetry_notifications.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/telemetry_sender.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_sender.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/telemetry_sender.ts
+++ b/src/plugins/telemetry/public/services/telemetry_sender.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/telemetry_service.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/public/services/telemetry_service.ts
+++ b/src/plugins/telemetry/public/services/telemetry_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/collectors/index.ts
+++ b/src/plugins/telemetry/server/collectors/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/collectors/telemetry_plugin/index.ts
+++ b/src/plugins/telemetry/server/collectors/telemetry_plugin/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/collectors/telemetry_plugin/telemetry_plugin_collector.ts
+++ b/src/plugins/telemetry/server/collectors/telemetry_plugin/telemetry_plugin_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/collectors/usage/ensure_deep_object.test.ts
+++ b/src/plugins/telemetry/server/collectors/usage/ensure_deep_object.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/collectors/usage/ensure_deep_object.ts
+++ b/src/plugins/telemetry/server/collectors/usage/ensure_deep_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/collectors/usage/index.ts
+++ b/src/plugins/telemetry/server/collectors/usage/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/collectors/usage/schema.ts
+++ b/src/plugins/telemetry/server/collectors/usage/schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/collectors/usage/telemetry_usage_collector.test.ts
+++ b/src/plugins/telemetry/server/collectors/usage/telemetry_usage_collector.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/collectors/usage/telemetry_usage_collector.ts
+++ b/src/plugins/telemetry/server/collectors/usage/telemetry_usage_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/config.ts
+++ b/src/plugins/telemetry/server/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/fetcher.test.ts
+++ b/src/plugins/telemetry/server/fetcher.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/fetcher.ts
+++ b/src/plugins/telemetry/server/fetcher.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/handle_old_settings/handle_old_settings.ts
+++ b/src/plugins/telemetry/server/handle_old_settings/handle_old_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/handle_old_settings/index.ts
+++ b/src/plugins/telemetry/server/handle_old_settings/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/index.ts
+++ b/src/plugins/telemetry/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/mocks.ts
+++ b/src/plugins/telemetry/server/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/plugin.ts
+++ b/src/plugins/telemetry/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/routes/index.ts
+++ b/src/plugins/telemetry/server/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/routes/telemetry_opt_in.ts
+++ b/src/plugins/telemetry/server/routes/telemetry_opt_in.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/routes/telemetry_opt_in_stats.ts
+++ b/src/plugins/telemetry/server/routes/telemetry_opt_in_stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/routes/telemetry_usage_stats.ts
+++ b/src/plugins/telemetry/server/routes/telemetry_usage_stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/routes/telemetry_user_has_seen_notice.ts
+++ b/src/plugins/telemetry/server/routes/telemetry_user_has_seen_notice.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/constants.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_cluster_info.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_cluster_info.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_cluster_info.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_cluster_info.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_cluster_stats.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_cluster_stats.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_cluster_stats.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_cluster_stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/constants.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/index.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_local_license.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_local_license.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_local_stats.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_local_stats.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_local_stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_nodes_usage.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_nodes_usage.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_nodes_usage.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_nodes_usage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/get_opensearch_dashboards.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_opensearch_dashboards.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/index.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_collection/register_collection.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/register_collection.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
@@ -31,8 +34,11 @@
  */
 
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_repository/get_telemetry_saved_object.test.ts
+++ b/src/plugins/telemetry/server/telemetry_repository/get_telemetry_saved_object.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_repository/get_telemetry_saved_object.ts
+++ b/src/plugins/telemetry/server/telemetry_repository/get_telemetry_saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_repository/index.ts
+++ b/src/plugins/telemetry/server/telemetry_repository/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry/server/telemetry_repository/update_telemetry_saved_object.ts
+++ b/src/plugins/telemetry/server/telemetry_repository/update_telemetry_saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_collection_manager/common/index.ts
+++ b/src/plugins/telemetry_collection_manager/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_collection_manager/server/encryption/encrypt.test.mocks.ts
+++ b/src/plugins/telemetry_collection_manager/server/encryption/encrypt.test.mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_collection_manager/server/encryption/encrypt.test.ts
+++ b/src/plugins/telemetry_collection_manager/server/encryption/encrypt.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_collection_manager/server/encryption/encrypt.ts
+++ b/src/plugins/telemetry_collection_manager/server/encryption/encrypt.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_collection_manager/server/encryption/index.ts
+++ b/src/plugins/telemetry_collection_manager/server/encryption/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_collection_manager/server/encryption/telemetry_jwks.ts
+++ b/src/plugins/telemetry_collection_manager/server/encryption/telemetry_jwks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_collection_manager/server/index.ts
+++ b/src/plugins/telemetry_collection_manager/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_collection_manager/server/plugin.ts
+++ b/src/plugins/telemetry_collection_manager/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_collection_manager/server/types.ts
+++ b/src/plugins/telemetry_collection_manager/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_collection_manager/server/util.test.ts
+++ b/src/plugins/telemetry_collection_manager/server/util.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_collection_manager/server/util.ts
+++ b/src/plugins/telemetry_collection_manager/server/util.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_management_section/public/components/index.ts
+++ b/src/plugins/telemetry_management_section/public/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.test.tsx
+++ b/src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.tsx
+++ b/src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_management_section/public/components/opt_in_security_example_flyout.test.tsx
+++ b/src/plugins/telemetry_management_section/public/components/opt_in_security_example_flyout.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_management_section/public/components/opt_in_security_example_flyout.tsx
+++ b/src/plugins/telemetry_management_section/public/components/opt_in_security_example_flyout.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_management_section/public/components/telemetry_management_section.test.tsx
+++ b/src/plugins/telemetry_management_section/public/components/telemetry_management_section.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_management_section/public/components/telemetry_management_section.tsx
+++ b/src/plugins/telemetry_management_section/public/components/telemetry_management_section.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_management_section/public/components/telemetry_management_section_wrapper.tsx
+++ b/src/plugins/telemetry_management_section/public/components/telemetry_management_section_wrapper.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_management_section/public/index.ts
+++ b/src/plugins/telemetry_management_section/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/telemetry_management_section/public/plugin.tsx
+++ b/src/plugins/telemetry_management_section/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/config.ts
+++ b/src/plugins/tile_map/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/components/tile_map_options.tsx
+++ b/src/plugins/tile_map/public/components/tile_map_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/css_filters.js
+++ b/src/plugins/tile_map/public/css_filters.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/geohash_layer.js
+++ b/src/plugins/tile_map/public/geohash_layer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/index.ts
+++ b/src/plugins/tile_map/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/markers/geohash_grid.js
+++ b/src/plugins/tile_map/public/markers/geohash_grid.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/markers/heatmap.js
+++ b/src/plugins/tile_map/public/markers/heatmap.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/markers/scaled_circles.js
+++ b/src/plugins/tile_map/public/markers/scaled_circles.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/markers/shaded_circles.js
+++ b/src/plugins/tile_map/public/markers/shaded_circles.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/plugin.ts
+++ b/src/plugins/tile_map/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/services.ts
+++ b/src/plugins/tile_map/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/tile_map_fn.js
+++ b/src/plugins/tile_map/public/tile_map_fn.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/tile_map_type.js
+++ b/src/plugins/tile_map/public/tile_map_type.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/tile_map_visualization.js
+++ b/src/plugins/tile_map/public/tile_map_visualization.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/tilemap_fn.test.js
+++ b/src/plugins/tile_map/public/tilemap_fn.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/public/tooltip_formatter.js
+++ b/src/plugins/tile_map/public/tooltip_formatter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/tile_map/server/index.ts
+++ b/src/plugins/tile_map/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/app.js
+++ b/src/plugins/timeline/public/app.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/application.ts
+++ b/src/plugins/timeline/public/application.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/breadcrumbs.js
+++ b/src/plugins/timeline/public/breadcrumbs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/components/timeline_deprecation.tsx
+++ b/src/plugins/timeline/public/components/timeline_deprecation.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/components/timeline_deprecation_directive.js
+++ b/src/plugins/timeline/public/components/timeline_deprecation_directive.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/components/timelinehelp_tabs.js
+++ b/src/plugins/timeline/public/components/timelinehelp_tabs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/components/timelinehelp_tabs_directive.js
+++ b/src/plugins/timeline/public/components/timelinehelp_tabs_directive.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/cells/cells.js
+++ b/src/plugins/timeline/public/directives/cells/cells.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/cells/collection.ts
+++ b/src/plugins/timeline/public/directives/cells/collection.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/chart/chart.js
+++ b/src/plugins/timeline/public/directives/chart/chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/fixed_element.js
+++ b/src/plugins/timeline/public/directives/fixed_element.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/fullscreen/fullscreen.js
+++ b/src/plugins/timeline/public/directives/fullscreen/fullscreen.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/input_focus.js
+++ b/src/plugins/timeline/public/directives/input_focus.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/key_map.ts
+++ b/src/plugins/timeline/public/directives/key_map.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/saved_object_finder.js
+++ b/src/plugins/timeline/public/directives/saved_object_finder.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/saved_object_save_as_checkbox.js
+++ b/src/plugins/timeline/public/directives/saved_object_save_as_checkbox.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/timeline_expression_input.js
+++ b/src/plugins/timeline/public/directives/timeline_expression_input.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/timeline_expression_input_helpers.js
+++ b/src/plugins/timeline/public/directives/timeline_expression_input_helpers.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/timeline_expression_suggestions/timeline_expression_suggestions.js
+++ b/src/plugins/timeline/public/directives/timeline_expression_suggestions/timeline_expression_suggestions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/timeline_grid.js
+++ b/src/plugins/timeline/public/directives/timeline_grid.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/timeline_help/timeline_help.js
+++ b/src/plugins/timeline/public/directives/timeline_help/timeline_help.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/timeline_interval/timeline_interval.js
+++ b/src/plugins/timeline/public/directives/timeline_interval/timeline_interval.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/timeline_load_sheet.js
+++ b/src/plugins/timeline/public/directives/timeline_load_sheet.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/timeline_options_sheet.js
+++ b/src/plugins/timeline/public/directives/timeline_options_sheet.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/directives/timeline_save_sheet.js
+++ b/src/plugins/timeline/public/directives/timeline_save_sheet.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/index.ts
+++ b/src/plugins/timeline/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/lib/observe_resize.js
+++ b/src/plugins/timeline/public/lib/observe_resize.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/panels/panel.ts
+++ b/src/plugins/timeline/public/panels/panel.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/panels/timechart/schema.ts
+++ b/src/plugins/timeline/public/panels/timechart/schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/panels/timechart/timechart.ts
+++ b/src/plugins/timeline/public/panels/timechart/timechart.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/plugin.ts
+++ b/src/plugins/timeline/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/services/_saved_sheet.ts
+++ b/src/plugins/timeline/public/services/_saved_sheet.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/services/saved_sheets.ts
+++ b/src/plugins/timeline/public/services/saved_sheets.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/timeline_app_state.ts
+++ b/src/plugins/timeline/public/timeline_app_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/public/types.ts
+++ b/src/plugins/timeline/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/server/config.ts
+++ b/src/plugins/timeline/server/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/server/index.ts
+++ b/src/plugins/timeline/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/server/plugin.ts
+++ b/src/plugins/timeline/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/server/saved_objects/index.ts
+++ b/src/plugins/timeline/server/saved_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/timeline/server/saved_objects/timeline_sheet.ts
+++ b/src/plugins/timeline/server/saved_objects/timeline_sheet.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/actions/action.test.ts
+++ b/src/plugins/ui_actions/public/actions/action.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/actions/action.ts
+++ b/src/plugins/ui_actions/public/actions/action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/actions/action_internal.test.ts
+++ b/src/plugins/ui_actions/public/actions/action_internal.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/actions/action_internal.ts
+++ b/src/plugins/ui_actions/public/actions/action_internal.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/actions/create_action.ts
+++ b/src/plugins/ui_actions/public/actions/create_action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/actions/incompatible_action_error.ts
+++ b/src/plugins/ui_actions/public/actions/incompatible_action_error.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/actions/index.ts
+++ b/src/plugins/ui_actions/public/actions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/context_menu/build_eui_context_menu_panels.test.ts
+++ b/src/plugins/ui_actions/public/context_menu/build_eui_context_menu_panels.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/context_menu/build_eui_context_menu_panels.tsx
+++ b/src/plugins/ui_actions/public/context_menu/build_eui_context_menu_panels.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/context_menu/index.ts
+++ b/src/plugins/ui_actions/public/context_menu/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/context_menu/open_context_menu.test.ts
+++ b/src/plugins/ui_actions/public/context_menu/open_context_menu.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/context_menu/open_context_menu.tsx
+++ b/src/plugins/ui_actions/public/context_menu/open_context_menu.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/index.ts
+++ b/src/plugins/ui_actions/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/mocks.ts
+++ b/src/plugins/ui_actions/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/plugin.ts
+++ b/src/plugins/ui_actions/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/service/index.ts
+++ b/src/plugins/ui_actions/public/service/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/service/ui_actions_execution_service.ts
+++ b/src/plugins/ui_actions/public/service/ui_actions_execution_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/service/ui_actions_service.test.ts
+++ b/src/plugins/ui_actions/public/service/ui_actions_service.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/service/ui_actions_service.ts
+++ b/src/plugins/ui_actions/public/service/ui_actions_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/tests/execute_trigger_actions.test.ts
+++ b/src/plugins/ui_actions/public/tests/execute_trigger_actions.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/tests/get_trigger_actions.test.ts
+++ b/src/plugins/ui_actions/public/tests/get_trigger_actions.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/tests/get_trigger_compatible_actions.test.ts
+++ b/src/plugins/ui_actions/public/tests/get_trigger_compatible_actions.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/tests/index.ts
+++ b/src/plugins/ui_actions/public/tests/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/tests/test_samples/hello_world_action.tsx
+++ b/src/plugins/ui_actions/public/tests/test_samples/hello_world_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/tests/test_samples/index.ts
+++ b/src/plugins/ui_actions/public/tests/test_samples/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/triggers/apply_filter_trigger.ts
+++ b/src/plugins/ui_actions/public/triggers/apply_filter_trigger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/triggers/default_trigger.ts
+++ b/src/plugins/ui_actions/public/triggers/default_trigger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/triggers/index.ts
+++ b/src/plugins/ui_actions/public/triggers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/triggers/select_range_trigger.ts
+++ b/src/plugins/ui_actions/public/triggers/select_range_trigger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/triggers/trigger.ts
+++ b/src/plugins/ui_actions/public/triggers/trigger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/triggers/trigger_contract.ts
+++ b/src/plugins/ui_actions/public/triggers/trigger_contract.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/triggers/trigger_internal.ts
+++ b/src/plugins/ui_actions/public/triggers/trigger_internal.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/triggers/value_click_trigger.ts
+++ b/src/plugins/ui_actions/public/triggers/value_click_trigger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/triggers/visualize_field_trigger.ts
+++ b/src/plugins/ui_actions/public/triggers/visualize_field_trigger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/triggers/visualize_geo_field_trigger.ts
+++ b/src/plugins/ui_actions/public/triggers/visualize_geo_field_trigger.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/types.ts
+++ b/src/plugins/ui_actions/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/util/index.ts
+++ b/src/plugins/ui_actions/public/util/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/ui_actions/public/util/presentable.ts
+++ b/src/plugins/ui_actions/public/util/presentable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/url_forwarding/public/forward_app/forward_app.ts
+++ b/src/plugins/url_forwarding/public/forward_app/forward_app.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/url_forwarding/public/forward_app/index.ts
+++ b/src/plugins/url_forwarding/public/forward_app/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/url_forwarding/public/forward_app/navigate_to_legacy_opensearch_dashboards_url.test.ts
+++ b/src/plugins/url_forwarding/public/forward_app/navigate_to_legacy_opensearch_dashboards_url.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/url_forwarding/public/forward_app/navigate_to_legacy_opensearch_dashboards_url.ts
+++ b/src/plugins/url_forwarding/public/forward_app/navigate_to_legacy_opensearch_dashboards_url.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/url_forwarding/public/forward_app/normalize_path.ts
+++ b/src/plugins/url_forwarding/public/forward_app/normalize_path.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/url_forwarding/public/index.ts
+++ b/src/plugins/url_forwarding/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/url_forwarding/public/mocks.ts
+++ b/src/plugins/url_forwarding/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/url_forwarding/public/navigate_to_default_app.ts
+++ b/src/plugins/url_forwarding/public/navigate_to_default_app.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/url_forwarding/public/plugin.ts
+++ b/src/plugins/url_forwarding/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/common/constants.ts
+++ b/src/plugins/usage_collection/common/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/public/index.ts
+++ b/src/plugins/usage_collection/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/public/mocks.ts
+++ b/src/plugins/usage_collection/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/public/plugin.ts
+++ b/src/plugins/usage_collection/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/public/services/application_usage.test.ts
+++ b/src/plugins/usage_collection/public/services/application_usage.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/public/services/application_usage.ts
+++ b/src/plugins/usage_collection/public/services/application_usage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/public/services/create_reporter.ts
+++ b/src/plugins/usage_collection/public/services/create_reporter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/public/services/index.ts
+++ b/src/plugins/usage_collection/public/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/collector/collector.test.ts
+++ b/src/plugins/usage_collection/server/collector/collector.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/collector/collector.ts
+++ b/src/plugins/usage_collection/server/collector/collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/collector/collector_set.test.ts
+++ b/src/plugins/usage_collection/server/collector/collector_set.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/collector/collector_set.ts
+++ b/src/plugins/usage_collection/server/collector/collector_set.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/collector/index.ts
+++ b/src/plugins/usage_collection/server/collector/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/collector/usage_collector.ts
+++ b/src/plugins/usage_collection/server/collector/usage_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/config.ts
+++ b/src/plugins/usage_collection/server/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/index.ts
+++ b/src/plugins/usage_collection/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/mocks.ts
+++ b/src/plugins/usage_collection/server/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/plugin.ts
+++ b/src/plugins/usage_collection/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/report/index.ts
+++ b/src/plugins/usage_collection/server/report/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/report/schema.ts
+++ b/src/plugins/usage_collection/server/report/schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/report/store_report.test.ts
+++ b/src/plugins/usage_collection/server/report/store_report.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/report/store_report.ts
+++ b/src/plugins/usage_collection/server/report/store_report.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/routes/index.ts
+++ b/src/plugins/usage_collection/server/routes/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/routes/integration_tests/stats.test.ts
+++ b/src/plugins/usage_collection/server/routes/integration_tests/stats.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/routes/report_metrics.ts
+++ b/src/plugins/usage_collection/server/routes/report_metrics.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/routes/stats/index.ts
+++ b/src/plugins/usage_collection/server/routes/stats/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/routes/stats/stats.ts
+++ b/src/plugins/usage_collection/server/routes/stats/stats.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/usage_collection/server/usage_collection.mock.ts
+++ b/src/plugins/usage_collection/server/usage_collection.mock.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/agg_filters/agg_type_field_filters.ts
+++ b/src/plugins/vis_default_editor/public/agg_filters/agg_type_field_filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/agg_filters/agg_type_filters.ts
+++ b/src/plugins/vis_default_editor/public/agg_filters/agg_type_filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/agg_filters/index.ts
+++ b/src/plugins/vis_default_editor/public/agg_filters/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_add.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_add.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_common_props.ts
+++ b/src/plugins/vis_default_editor/public/components/agg_common_props.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_group.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_group.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_group.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_group.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_group_helper.test.ts
+++ b/src/plugins/vis_default_editor/public/components/agg_group_helper.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_group_helper.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_group_helper.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_group_state.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_group_state.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_param.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_param.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_param_props.ts
+++ b/src/plugins/vis_default_editor/public/components/agg_param_props.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_params.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_params.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_params.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_params.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_params_helper.test.ts
+++ b/src/plugins/vis_default_editor/public/components/agg_params_helper.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_params_helper.ts
+++ b/src/plugins/vis_default_editor/public/components/agg_params_helper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_params_map.ts
+++ b/src/plugins/vis_default_editor/public/components/agg_params_map.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_params_state.ts
+++ b/src/plugins/vis_default_editor/public/components/agg_params_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/agg_select.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_select.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/agg_control_props.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/agg_control_props.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/agg_utils.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/agg_utils.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/auto_precision.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/auto_precision.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/from_to_list.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/components/from_to_list.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/input_list.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/components/input_list.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/mask_list.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/components/mask_list.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/number_list/index.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/components/number_list/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/number_list/number_list.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/components/number_list/number_list.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/number_list/number_list.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/components/number_list/number_list.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/number_list/number_row.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/components/number_list/number_row.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/number_list/number_row.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/components/number_list/number_row.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/number_list/range.test.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/components/number_list/range.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/number_list/range.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/components/number_list/range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/number_list/utils.test.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/components/number_list/utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/number_list/utils.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/components/number_list/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/components/simple_number_list.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/components/simple_number_list.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/date_ranges.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/date_ranges.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/date_ranges.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/date_ranges.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/drop_partials.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/drop_partials.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/extended_bounds.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/extended_bounds.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/extended_bounds.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/extended_bounds.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/field.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/field.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/field.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/filter.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/filter.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/filters.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/filters.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/has_extended_bounds.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/has_extended_bounds.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/include_exclude.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/include_exclude.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/index.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/ip_range_type.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/ip_range_type.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/ip_ranges.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/ip_ranges.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/is_filtered_by_collar.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/is_filtered_by_collar.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/max_bars.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/max_bars.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/metric_agg.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/metric_agg.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/metric_agg.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/metric_agg.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/min_doc_count.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/min_doc_count.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/missing_bucket.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/missing_bucket.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/number_interval.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/number_interval.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/order.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/order.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/order_agg.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/order_agg.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/order_agg.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/order_agg.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/order_by.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/order_by.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/other_bucket.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/other_bucket.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/percentile_ranks.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/percentile_ranks.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/percentiles.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/percentiles.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/percentiles.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/percentiles.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/precision.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/precision.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/radius_ratio_option.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/radius_ratio_option.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/range_control.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/range_control.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/ranges.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/ranges.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/raw_json.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/raw_json.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/rows_or_columns.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/rows_or_columns.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/scale_metrics.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/scale_metrics.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/size.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/size.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/size.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/size.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/string.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/string.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/sub_agg.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/sub_agg.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/sub_metric.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/sub_metric.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/switch.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/switch.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/test_utils.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/test_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/time_interval.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/time_interval.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/top_aggregate.test.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/top_aggregate.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/top_aggregate.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/top_aggregate.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/top_field.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/top_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/top_size.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/top_size.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/top_sort_field.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/top_sort_field.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/use_geocentroid.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/use_geocentroid.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/utils/agg_utils.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/utils/agg_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/utils/index.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/utils/inline_comp_wrapper.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/utils/inline_comp_wrapper.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/utils/strings/comma_separated_list.test.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/utils/strings/comma_separated_list.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/utils/strings/comma_separated_list.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/utils/strings/comma_separated_list.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/utils/strings/index.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/utils/strings/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/utils/strings/prose.test.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/utils/strings/prose.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/utils/strings/prose.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/utils/strings/prose.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/controls/utils/use_handlers.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/utils/use_handlers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/controls.tsx
+++ b/src/plugins/vis_default_editor/public/components/sidebar/controls.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/data_tab.tsx
+++ b/src/plugins/vis_default_editor/public/components/sidebar/data_tab.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/index.ts
+++ b/src/plugins/vis_default_editor/public/components/sidebar/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/navbar.tsx
+++ b/src/plugins/vis_default_editor/public/components/sidebar/navbar.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/sidebar.tsx
+++ b/src/plugins/vis_default_editor/public/components/sidebar/sidebar.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/sidebar_title.tsx
+++ b/src/plugins/vis_default_editor/public/components/sidebar/sidebar_title.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/state/actions.ts
+++ b/src/plugins/vis_default_editor/public/components/sidebar/state/actions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/state/constants.ts
+++ b/src/plugins/vis_default_editor/public/components/sidebar/state/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/state/editor_form_state.ts
+++ b/src/plugins/vis_default_editor/public/components/sidebar/state/editor_form_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/state/index.ts
+++ b/src/plugins/vis_default_editor/public/components/sidebar/state/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/state/reducers.ts
+++ b/src/plugins/vis_default_editor/public/components/sidebar/state/reducers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/sidebar/use_option_tabs.ts
+++ b/src/plugins/vis_default_editor/public/components/sidebar/use_option_tabs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/utils/editor_config.ts
+++ b/src/plugins/vis_default_editor/public/components/utils/editor_config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/components/utils/index.ts
+++ b/src/plugins/vis_default_editor/public/components/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/default_editor.tsx
+++ b/src/plugins/vis_default_editor/public/default_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/default_editor_controller.tsx
+++ b/src/plugins/vis_default_editor/public/default_editor_controller.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/editor_size.ts
+++ b/src/plugins/vis_default_editor/public/editor_size.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/index.ts
+++ b/src/plugins/vis_default_editor/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/schemas.ts
+++ b/src/plugins/vis_default_editor/public/schemas.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/types.ts
+++ b/src/plugins/vis_default_editor/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/utils.test.ts
+++ b/src/plugins/vis_default_editor/public/utils.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/utils.ts
+++ b/src/plugins/vis_default_editor/public/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_default_editor/public/vis_options_props.tsx
+++ b/src/plugins/vis_default_editor/public/vis_options_props.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/config.ts
+++ b/src/plugins/vis_type_markdown/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/index.ts
+++ b/src/plugins/vis_type_markdown/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/markdown_fn.test.ts
+++ b/src/plugins/vis_type_markdown/public/markdown_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/markdown_fn.ts
+++ b/src/plugins/vis_type_markdown/public/markdown_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/markdown_options.tsx
+++ b/src/plugins/vis_type_markdown/public/markdown_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/markdown_renderer.tsx
+++ b/src/plugins/vis_type_markdown/public/markdown_renderer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/markdown_vis.ts
+++ b/src/plugins/vis_type_markdown/public/markdown_vis.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/markdown_vis_controller.test.tsx
+++ b/src/plugins/vis_type_markdown/public/markdown_vis_controller.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/markdown_vis_controller.tsx
+++ b/src/plugins/vis_type_markdown/public/markdown_vis_controller.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/plugin.ts
+++ b/src/plugins/vis_type_markdown/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/settings_options.tsx
+++ b/src/plugins/vis_type_markdown/public/settings_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/settings_options_lazy.tsx
+++ b/src/plugins/vis_type_markdown/public/settings_options_lazy.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/to_ast.test.ts
+++ b/src/plugins/vis_type_markdown/public/to_ast.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/to_ast.ts
+++ b/src/plugins/vis_type_markdown/public/to_ast.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/public/types.ts
+++ b/src/plugins/vis_type_markdown/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_markdown/server/index.ts
+++ b/src/plugins/vis_type_markdown/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/config.ts
+++ b/src/plugins/vis_type_metric/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/components/metric_vis_component.test.tsx
+++ b/src/plugins/vis_type_metric/public/components/metric_vis_component.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/components/metric_vis_component.tsx
+++ b/src/plugins/vis_type_metric/public/components/metric_vis_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/components/metric_vis_options.tsx
+++ b/src/plugins/vis_type_metric/public/components/metric_vis_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/components/metric_vis_value.test.tsx
+++ b/src/plugins/vis_type_metric/public/components/metric_vis_value.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/components/metric_vis_value.tsx
+++ b/src/plugins/vis_type_metric/public/components/metric_vis_value.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/index.ts
+++ b/src/plugins/vis_type_metric/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/metric_vis_fn.test.ts
+++ b/src/plugins/vis_type_metric/public/metric_vis_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/metric_vis_fn.ts
+++ b/src/plugins/vis_type_metric/public/metric_vis_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/metric_vis_renderer.tsx
+++ b/src/plugins/vis_type_metric/public/metric_vis_renderer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/metric_vis_type.ts
+++ b/src/plugins/vis_type_metric/public/metric_vis_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/plugin.ts
+++ b/src/plugins/vis_type_metric/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/services.ts
+++ b/src/plugins/vis_type_metric/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/to_ast.test.ts
+++ b/src/plugins/vis_type_metric/public/to_ast.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/to_ast.ts
+++ b/src/plugins/vis_type_metric/public/to_ast.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/public/types.ts
+++ b/src/plugins/vis_type_metric/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_metric/server/index.ts
+++ b/src/plugins/vis_type_metric/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/config.ts
+++ b/src/plugins/vis_type_table/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/agg_table/agg_table.js
+++ b/src/plugins/vis_type_table/public/agg_table/agg_table.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/agg_table/agg_table.test.js
+++ b/src/plugins/vis_type_table/public/agg_table/agg_table.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/agg_table/agg_table_group.js
+++ b/src/plugins/vis_type_table/public/agg_table/agg_table_group.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/agg_table/agg_table_group.test.js
+++ b/src/plugins/vis_type_table/public/agg_table/agg_table_group.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/agg_table/tabified_data.js
+++ b/src/plugins/vis_type_table/public/agg_table/tabified_data.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/components/table_vis_options.tsx
+++ b/src/plugins/vis_type_table/public/components/table_vis_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/components/table_vis_options_lazy.tsx
+++ b/src/plugins/vis_type_table/public/components/table_vis_options_lazy.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/components/utils.ts
+++ b/src/plugins/vis_type_table/public/components/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/get_inner_angular.ts
+++ b/src/plugins/vis_type_table/public/get_inner_angular.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/index.ts
+++ b/src/plugins/vis_type_table/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/paginated_table/paginated_table.js
+++ b/src/plugins/vis_type_table/public/paginated_table/paginated_table.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/paginated_table/paginated_table.test.ts
+++ b/src/plugins/vis_type_table/public/paginated_table/paginated_table.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/paginated_table/rows.js
+++ b/src/plugins/vis_type_table/public/paginated_table/rows.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/plugin.ts
+++ b/src/plugins/vis_type_table/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/services.ts
+++ b/src/plugins/vis_type_table/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/table_vis_controller.js
+++ b/src/plugins/vis_type_table/public/table_vis_controller.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/table_vis_controller.test.ts
+++ b/src/plugins/vis_type_table/public/table_vis_controller.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/table_vis_fn.test.ts
+++ b/src/plugins/vis_type_table/public/table_vis_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/table_vis_fn.ts
+++ b/src/plugins/vis_type_table/public/table_vis_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/table_vis_legacy_module.ts
+++ b/src/plugins/vis_type_table/public/table_vis_legacy_module.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/table_vis_response_handler.ts
+++ b/src/plugins/vis_type_table/public/table_vis_response_handler.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/table_vis_type.ts
+++ b/src/plugins/vis_type_table/public/table_vis_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/types.ts
+++ b/src/plugins/vis_type_table/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/public/vis_controller.ts
+++ b/src/plugins/vis_type_table/public/vis_controller.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_table/server/index.ts
+++ b/src/plugins/vis_type_table/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/config.ts
+++ b/src/plugins/vis_type_tagcloud/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/components/feedback_message.js
+++ b/src/plugins/vis_type_tagcloud/public/components/feedback_message.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/components/label.js
+++ b/src/plugins/vis_type_tagcloud/public/components/label.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/components/tag_cloud.js
+++ b/src/plugins/vis_type_tagcloud/public/components/tag_cloud.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/components/tag_cloud.test.js
+++ b/src/plugins/vis_type_tagcloud/public/components/tag_cloud.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/components/tag_cloud_chart.tsx
+++ b/src/plugins/vis_type_tagcloud/public/components/tag_cloud_chart.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/components/tag_cloud_options.tsx
+++ b/src/plugins/vis_type_tagcloud/public/components/tag_cloud_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/components/tag_cloud_visualization.js
+++ b/src/plugins/vis_type_tagcloud/public/components/tag_cloud_visualization.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/components/tag_cloud_visualization.test.js
+++ b/src/plugins/vis_type_tagcloud/public/components/tag_cloud_visualization.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/index.ts
+++ b/src/plugins/vis_type_tagcloud/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/plugin.ts
+++ b/src/plugins/vis_type_tagcloud/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/services.ts
+++ b/src/plugins/vis_type_tagcloud/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/tag_cloud_fn.test.ts
+++ b/src/plugins/vis_type_tagcloud/public/tag_cloud_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/tag_cloud_fn.ts
+++ b/src/plugins/vis_type_tagcloud/public/tag_cloud_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/tag_cloud_type.ts
+++ b/src/plugins/vis_type_tagcloud/public/tag_cloud_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/tag_cloud_vis_renderer.tsx
+++ b/src/plugins/vis_type_tagcloud/public/tag_cloud_vis_renderer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/to_ast.test.ts
+++ b/src/plugins/vis_type_tagcloud/public/to_ast.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/to_ast.ts
+++ b/src/plugins/vis_type_tagcloud/public/to_ast.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/public/types.ts
+++ b/src/plugins/vis_type_tagcloud/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_tagcloud/server/index.ts
+++ b/src/plugins/vis_type_tagcloud/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/common/lib/calculate_interval.test.ts
+++ b/src/plugins/vis_type_timeline/common/lib/calculate_interval.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/common/lib/calculate_interval.ts
+++ b/src/plugins/vis_type_timeline/common/lib/calculate_interval.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/common/lib/index.ts
+++ b/src/plugins/vis_type_timeline/common/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/common/lib/to_milliseconds.ts
+++ b/src/plugins/vis_type_timeline/common/lib/to_milliseconds.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/common/types.ts
+++ b/src/plugins/vis_type_timeline/common/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/config.ts
+++ b/src/plugins/vis_type_timeline/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/components/index.ts
+++ b/src/plugins/vis_type_timeline/public/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/components/timeline_expression_input.tsx
+++ b/src/plugins/vis_type_timeline/public/components/timeline_expression_input.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/components/timeline_expression_input_helpers.test.ts
+++ b/src/plugins/vis_type_timeline/public/components/timeline_expression_input_helpers.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/components/timeline_expression_input_helpers.ts
+++ b/src/plugins/vis_type_timeline/public/components/timeline_expression_input_helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/components/timeline_interval.tsx
+++ b/src/plugins/vis_type_timeline/public/components/timeline_interval.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/components/timeline_vis_component.tsx
+++ b/src/plugins/vis_type_timeline/public/components/timeline_vis_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/helpers/arg_value_suggestions.ts
+++ b/src/plugins/vis_type_timeline/public/helpers/arg_value_suggestions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/helpers/get_timezone.ts
+++ b/src/plugins/vis_type_timeline/public/helpers/get_timezone.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/helpers/panel_utils.ts
+++ b/src/plugins/vis_type_timeline/public/helpers/panel_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/helpers/plugin_services.ts
+++ b/src/plugins/vis_type_timeline/public/helpers/plugin_services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/helpers/tick_formatters.test.ts
+++ b/src/plugins/vis_type_timeline/public/helpers/tick_formatters.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/helpers/tick_formatters.ts
+++ b/src/plugins/vis_type_timeline/public/helpers/tick_formatters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/helpers/tick_generator.test.ts
+++ b/src/plugins/vis_type_timeline/public/helpers/tick_generator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/helpers/tick_generator.ts
+++ b/src/plugins/vis_type_timeline/public/helpers/tick_generator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/helpers/timeline_request_handler.ts
+++ b/src/plugins/vis_type_timeline/public/helpers/timeline_request_handler.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/helpers/xaxis_formatter.ts
+++ b/src/plugins/vis_type_timeline/public/helpers/xaxis_formatter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/index.ts
+++ b/src/plugins/vis_type_timeline/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/plugin.ts
+++ b/src/plugins/vis_type_timeline/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/timeline_options.tsx
+++ b/src/plugins/vis_type_timeline/public/timeline_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/timeline_vis_fn.ts
+++ b/src/plugins/vis_type_timeline/public/timeline_vis_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/timeline_vis_renderer.tsx
+++ b/src/plugins/vis_type_timeline/public/timeline_vis_renderer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/timeline_vis_type.tsx
+++ b/src/plugins/vis_type_timeline/public/timeline_vis_type.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/to_ast.test.ts
+++ b/src/plugins/vis_type_timeline/public/to_ast.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/public/to_ast.ts
+++ b/src/plugins/vis_type_timeline/public/to_ast.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/fit_functions/average.js
+++ b/src/plugins/vis_type_timeline/server/fit_functions/average.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/fit_functions/average.test.js
+++ b/src/plugins/vis_type_timeline/server/fit_functions/average.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/fit_functions/carry.js
+++ b/src/plugins/vis_type_timeline/server/fit_functions/carry.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/fit_functions/carry.test.js
+++ b/src/plugins/vis_type_timeline/server/fit_functions/carry.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/fit_functions/nearest.js
+++ b/src/plugins/vis_type_timeline/server/fit_functions/nearest.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/fit_functions/none.js
+++ b/src/plugins/vis_type_timeline/server/fit_functions/none.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/fit_functions/scale.js
+++ b/src/plugins/vis_type_timeline/server/fit_functions/scale.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/handlers/chain_runner.js
+++ b/src/plugins/vis_type_timeline/server/handlers/chain_runner.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/handlers/lib/arg_type.js
+++ b/src/plugins/vis_type_timeline/server/handlers/lib/arg_type.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/handlers/lib/index_arguments.js
+++ b/src/plugins/vis_type_timeline/server/handlers/lib/index_arguments.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/handlers/lib/parse_sheet.js
+++ b/src/plugins/vis_type_timeline/server/handlers/lib/parse_sheet.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/handlers/lib/parse_sheet.test.js
+++ b/src/plugins/vis_type_timeline/server/handlers/lib/parse_sheet.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/handlers/lib/preprocess_chain.js
+++ b/src/plugins/vis_type_timeline/server/handlers/lib/preprocess_chain.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/handlers/lib/reposition_arguments.js
+++ b/src/plugins/vis_type_timeline/server/handlers/lib/reposition_arguments.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/handlers/lib/tl_config.js
+++ b/src/plugins/vis_type_timeline/server/handlers/lib/tl_config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/handlers/lib/validate_arg.js
+++ b/src/plugins/vis_type_timeline/server/handlers/lib/validate_arg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/handlers/lib/validate_time.js
+++ b/src/plugins/vis_type_timeline/server/handlers/lib/validate_time.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/index.ts
+++ b/src/plugins/vis_type_timeline/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/alter.js
+++ b/src/plugins/vis_type_timeline/server/lib/alter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/as_sorted.js
+++ b/src/plugins/vis_type_timeline/server/lib/as_sorted.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/build_target.js
+++ b/src/plugins/vis_type_timeline/server/lib/build_target.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/classes/chainable.js
+++ b/src/plugins/vis_type_timeline/server/lib/classes/chainable.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/classes/datasource.js
+++ b/src/plugins/vis_type_timeline/server/lib/classes/datasource.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/classes/timeline_function.d.ts
+++ b/src/plugins/vis_type_timeline/server/lib/classes/timeline_function.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/classes/timeline_function.js
+++ b/src/plugins/vis_type_timeline/server/lib/classes/timeline_function.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/config_manager.ts
+++ b/src/plugins/vis_type_timeline/server/lib/config_manager.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/functions_md.js
+++ b/src/plugins/vis_type_timeline/server/lib/functions_md.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/get_namespaced_settings.js
+++ b/src/plugins/vis_type_timeline/server/lib/get_namespaced_settings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/load_functions.d.ts
+++ b/src/plugins/vis_type_timeline/server/lib/load_functions.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/load_functions.js
+++ b/src/plugins/vis_type_timeline/server/lib/load_functions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/load_functions.test.js
+++ b/src/plugins/vis_type_timeline/server/lib/load_functions.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/offset_time.js
+++ b/src/plugins/vis_type_timeline/server/lib/offset_time.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/offset_time.test.js
+++ b/src/plugins/vis_type_timeline/server/lib/offset_time.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/process_function_definition.js
+++ b/src/plugins/vis_type_timeline/server/lib/process_function_definition.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/reduce.js
+++ b/src/plugins/vis_type_timeline/server/lib/reduce.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/split_interval.js
+++ b/src/plugins/vis_type_timeline/server/lib/split_interval.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/lib/unzip_pairs.js
+++ b/src/plugins/vis_type_timeline/server/lib/unzip_pairs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/plugin.ts
+++ b/src/plugins/vis_type_timeline/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/routes/functions.ts
+++ b/src/plugins/vis_type_timeline/server/routes/functions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/routes/run.ts
+++ b/src/plugins/vis_type_timeline/server/routes/run.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/routes/validate_es.ts
+++ b/src/plugins/vis_type_timeline/server/routes/validate_es.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/abs.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/abs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/abs.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/abs.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/aggregate/aggregate.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/aggregate/aggregate.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/aggregate/avg.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/aggregate/avg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/aggregate/cardinality.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/aggregate/cardinality.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/aggregate/first.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/aggregate/first.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/aggregate/index.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/aggregate/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/aggregate/last.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/aggregate/last.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/aggregate/max.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/aggregate/max.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/aggregate/min.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/aggregate/min.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/aggregate/sum.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/aggregate/sum.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/bars.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/bars.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/bars.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/bars.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/color.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/color.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/color.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/color.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/condition.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/condition.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/condition.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/condition.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/cusum.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/cusum.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/cusum.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/cusum.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/derivative.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/derivative.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/derivative.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/derivative.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/divide.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/divide.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/divide.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/divide.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/first.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/first.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/first.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/first.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/fit.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/fit.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/fit.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/fit.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/fixtures/bucket_list.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/fixtures/bucket_list.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/fixtures/opensearch_response.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/fixtures/opensearch_response.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/fixtures/series_list.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/fixtures/series_list.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/fixtures/tl_config.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/fixtures/tl_config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/graphite.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/graphite.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/graphite.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/graphite.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/helpers/get_series.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/helpers/get_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/helpers/get_series_list.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/helpers/get_series_list.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/helpers/get_single_series_list.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/helpers/get_single_series_list.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/helpers/graphite_helper.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/helpers/graphite_helper.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/helpers/graphite_helper.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/helpers/graphite_helper.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/helpers/invoke_series_fn.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/helpers/invoke_series_fn.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/hide.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/hide.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/hide.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/hide.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/holt/index.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/holt/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/holt/lib/des.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/holt/lib/des.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/holt/lib/ses.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/holt/lib/ses.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/holt/lib/tes.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/holt/lib/tes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/label.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/label.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/label.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/label.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/legend.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/legend.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/legend.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/legend.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/lines.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/lines.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/lines.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/lines.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/log.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/log.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/log.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/log.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/max.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/max.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/max.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/max.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/min.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/min.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/min.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/min.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/movingaverage.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/movingaverage.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/movingaverage.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/movingaverage.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/movingstd.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/movingstd.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/movingstd.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/movingstd.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/multiply.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/multiply.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/multiply.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/multiply.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/opensearch/index.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/opensearch/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/opensearch/lib/agg_body.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/opensearch/lib/agg_body.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/opensearch/lib/agg_response_to_series_list.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/opensearch/lib/agg_response_to_series_list.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/opensearch/lib/build_request.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/opensearch/lib/build_request.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/opensearch/lib/create_date_agg.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/opensearch/lib/create_date_agg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/opensearch/opensearch.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/opensearch/opensearch.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/points.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/points.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/points.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/points.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/precision.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/precision.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/precision.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/precision.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/props.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/props.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/quandl.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/quandl.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/quandl.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/quandl.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/range.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/range.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/range.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/range.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/scale_interval.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/scale_interval.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/scale_interval.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/scale_interval.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/static.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/static.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/static.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/static.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/subtract.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/subtract.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/subtract.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/subtract.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/sum.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/sum.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/sum.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/sum.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/title.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/title.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/title.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/title.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/trend/index.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/trend/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/trend/lib/regress.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/trend/lib/regress.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/trim.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/trim.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/trim.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/trim.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/worldbank.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/worldbank.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/worldbank_indicators.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/worldbank_indicators.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/yaxis.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/yaxis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/series_functions/yaxis.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/yaxis.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeline/server/types.ts
+++ b/src/plugins/vis_type_timeline/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/agg_lookup.js
+++ b/src/plugins/vis_type_timeseries/common/agg_lookup.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/agg_lookup.test.js
+++ b/src/plugins/vis_type_timeseries/common/agg_lookup.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/basic_aggs.js
+++ b/src/plugins/vis_type_timeseries/common/basic_aggs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/calculate_label.js
+++ b/src/plugins/vis_type_timeseries/common/calculate_label.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/calculate_label.test.js
+++ b/src/plugins/vis_type_timeseries/common/calculate_label.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/constants.ts
+++ b/src/plugins/vis_type_timeseries/common/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/extract_index_patterns.js
+++ b/src/plugins/vis_type_timeseries/common/extract_index_patterns.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/extract_index_patterns.test.js
+++ b/src/plugins/vis_type_timeseries/common/extract_index_patterns.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/field_types.js
+++ b/src/plugins/vis_type_timeseries/common/field_types.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/get_last_value.js
+++ b/src/plugins/vis_type_timeseries/common/get_last_value.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/get_last_value.test.js
+++ b/src/plugins/vis_type_timeseries/common/get_last_value.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/interval_regexp.js
+++ b/src/plugins/vis_type_timeseries/common/interval_regexp.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/interval_regexp.test.js
+++ b/src/plugins/vis_type_timeseries/common/interval_regexp.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/metric_types.js
+++ b/src/plugins/vis_type_timeseries/common/metric_types.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/model_options.js
+++ b/src/plugins/vis_type_timeseries/common/model_options.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/model_options.test.js
+++ b/src/plugins/vis_type_timeseries/common/model_options.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/panel_types.ts
+++ b/src/plugins/vis_type_timeseries/common/panel_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/timerange_data_modes.js
+++ b/src/plugins/vis_type_timeseries/common/timerange_data_modes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/to_percentile_number.js
+++ b/src/plugins/vis_type_timeseries/common/to_percentile_number.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/types.ts
+++ b/src/plugins/vis_type_timeseries/common/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/ui_restrictions.ts
+++ b/src/plugins/vis_type_timeseries/common/ui_restrictions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/common/vis_schema.ts
+++ b/src/plugins/vis_type_timeseries/common/vis_schema.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/add_delete_buttons.test.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/add_delete_buttons.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/add_delete_buttons.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/add_delete_buttons.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/agg.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/agg.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/agg_row.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/agg_row.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/agg_select.test.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/agg_select.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/agg_select.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/agg_select.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/aggs.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/aggs.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/calculation.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/calculation.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/cumulative_sum.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/cumulative_sum.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/derivative.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/derivative.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/field_select.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/field_select.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/filter_ratio.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/filter_ratio.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/filter_ratio.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/filter_ratio.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/histogram_support.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/histogram_support.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/math.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/math.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/metric_select.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/metric_select.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/moving_average.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/moving_average.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile_rank/index.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile_rank/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile_rank/multi_value_row.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile_rank/multi_value_row.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile_rank/percentile_rank.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile_rank/percentile_rank.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile_rank/percentile_rank_values.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile_rank/percentile_rank_values.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile_ui.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile_ui.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/positive_only.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/positive_only.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/positive_rate.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/positive_rate.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/serial_diff.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/serial_diff.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/series_agg.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/series_agg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/static.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/static.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/std_agg.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/std_agg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/std_deviation.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/std_deviation.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/std_sibling.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/std_sibling.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/temporary_unsupported_agg.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/temporary_unsupported_agg.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/top_hit.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/top_hit.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/unsupported_agg.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/unsupported_agg.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/vars.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/vars.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/annotations_editor.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/annotations_editor.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/color_picker.test.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/color_picker.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/color_picker.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/color_picker.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/color_rules.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/color_rules.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/color_rules.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/color_rules.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/data_format_picker.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/data_format_picker.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/error.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/error.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/icon_select/icon_select.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/icon_select/icon_select.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/icon_select/icon_select.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/icon_select/icon_select.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/index_pattern.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/index_pattern.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/agg_to_component.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/agg_to_component.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/calculate_siblings.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/calculate_siblings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/calculate_siblings.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/calculate_siblings.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/collection_actions.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/collection_actions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/collection_actions.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/collection_actions.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/convert_series_to_vars.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/convert_series_to_vars.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/convert_series_to_vars.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/convert_series_to_vars.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/create_change_handler.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/create_change_handler.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/create_number_handler.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/create_number_handler.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/create_number_handler.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/create_number_handler.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/create_select_handler.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/create_select_handler.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/create_select_handler.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/create_select_handler.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/create_text_handler.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/create_text_handler.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/create_text_handler.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/create_text_handler.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/create_xaxis_formatter.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/create_xaxis_formatter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/detect_ie.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/detect_ie.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/durations.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/durations.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/durations.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/durations.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/get_axis_label_string.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/get_axis_label_string.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/get_axis_label_string.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/get_axis_label_string.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/get_default_query_language.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/get_default_query_language.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/get_display_name.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/get_display_name.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/get_interval.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/get_interval.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/get_supported_fields_by_metric_type.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/get_supported_fields_by_metric_type.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/get_supported_fields_by_metric_type.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/get_supported_fields_by_metric_type.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/new_metric_agg_fn.ts
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/new_metric_agg_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/new_series_fn.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/new_series_fn.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/re_id_series.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/re_id_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/re_id_series.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/re_id_series.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/reorder.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/reorder.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/replace_vars.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/replace_vars.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/replace_vars.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/replace_vars.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/series_change_handler.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/series_change_handler.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/stacked.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/stacked.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/tick_formatter.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/tick_formatter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/tick_formatter.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/tick_formatter.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/markdown_editor.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/markdown_editor.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/no_data.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/no_data.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config/gauge.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config/gauge.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config/gauge.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config/gauge.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config/markdown.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config/markdown.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config/metric.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config/metric.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config/table.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config/table.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config/timeseries.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config/timeseries.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config/top_n.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config/top_n.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/query_bar_wrapper.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/query_bar_wrapper.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/series.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/series_config.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/series_config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/series_drag_handler.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/series_drag_handler.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/series_editor.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/series_editor.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/split.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/split.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/splits/everything.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/everything.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/splits/filter.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/filter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/splits/filter_items.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/filter_items.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/splits/filters.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/filters.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/splits/group_by_select.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/group_by_select.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/splits/terms.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/terms.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/splits/terms.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/terms.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/splits/unsupported_split.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/unsupported_split.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/svg/bomb_icon.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/svg/bomb_icon.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/svg/fire_icon.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/svg/fire_icon.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_editor.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_editor.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_editor_lazy.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_editor_lazy.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_editor_visualization.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_editor_visualization.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_picker.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_picker.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/gauge/series.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/gauge/series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/gauge/series.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/gauge/series.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/gauge/vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/gauge/vis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/markdown/series.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/markdown/series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/markdown/vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/markdown/vis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/metric/series.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/metric/series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/metric/series.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/metric/series.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/metric/vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/metric/vis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/config.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/is_sortable.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/is_sortable.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/series.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/vis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/config.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/series.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/vis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/top_n/series.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/top_n/series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/top_n/vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/top_n/vis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_with_splits.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_with_splits.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/visualization.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/visualization.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/yes_no.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/yes_no.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/components/yes_no.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/yes_no.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/contexts/form_validation_context.js
+++ b/src/plugins/vis_type_timeseries/public/application/contexts/form_validation_context.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/contexts/query_input_bar_context.ts
+++ b/src/plugins/vis_type_timeseries/public/application/contexts/query_input_bar_context.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/contexts/vis_data_context.js
+++ b/src/plugins/vis_type_timeseries/public/application/contexts/vis_data_context.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/editor_controller.js
+++ b/src/plugins/vis_type_timeseries/public/application/editor_controller.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/index.ts
+++ b/src/plugins/vis_type_timeseries/public/application/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/lib/check_ui_restrictions.js
+++ b/src/plugins/vis_type_timeseries/public/application/lib/check_ui_restrictions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/lib/create_brush_handler.test.ts
+++ b/src/plugins/vis_type_timeseries/public/application/lib/create_brush_handler.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/lib/create_brush_handler.ts
+++ b/src/plugins/vis_type_timeseries/public/application/lib/create_brush_handler.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/lib/fetch_fields.js
+++ b/src/plugins/vis_type_timeseries/public/application/lib/fetch_fields.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/lib/get_timezone.ts
+++ b/src/plugins/vis_type_timeseries/public/application/lib/get_timezone.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/lib/index.ts
+++ b/src/plugins/vis_type_timeseries/public/application/lib/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/lib/set_is_reversed.js
+++ b/src/plugins/vis_type_timeseries/public/application/lib/set_is_reversed.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/lib/validate_interval.js
+++ b/src/plugins/vis_type_timeseries/public/application/lib/validate_interval.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/constants/chart.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/constants/chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/constants/icons.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/constants/icons.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/constants/index.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/constants/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/lib/active_cursor.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/lib/active_cursor.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/lib/calc_dimensions.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/lib/calc_dimensions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/lib/calculate_coordinates.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/lib/calculate_coordinates.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/lib/get_value_by.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/lib/get_value_by.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/annotation.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/annotation.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/gauge.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/gauge.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/gauge_vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/gauge_vis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/metric.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/metric.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/__mocks__/@elastic/charts.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/__mocks__/@elastic/charts.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/decorators/area_decorator.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/decorators/area_decorator.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/decorators/area_decorator.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/decorators/area_decorator.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/decorators/bar_decorator.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/decorators/bar_decorator.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/decorators/bar_decorator.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/decorators/bar_decorator.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/model/charts.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/model/charts.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/model/charts.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/model/charts.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/series_styles.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/series_styles.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/series_styles.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/series_styles.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/stack_format.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/stack_format.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/stack_format.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/stack_format.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/theme.test.ts
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/theme.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/theme.ts
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/utils/theme.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/top_n.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/top_n.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/index.ts
+++ b/src/plugins/vis_type_timeseries/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/metrics_fn.ts
+++ b/src/plugins/vis_type_timeseries/public/metrics_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/metrics_type.ts
+++ b/src/plugins/vis_type_timeseries/public/metrics_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/plugin.ts
+++ b/src/plugins/vis_type_timeseries/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/request_handler.js
+++ b/src/plugins/vis_type_timeseries/public/request_handler.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/services.ts
+++ b/src/plugins/vis_type_timeseries/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/test_utils/index.ts
+++ b/src/plugins/vis_type_timeseries/public/test_utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/public/types.ts
+++ b/src/plugins/vis_type_timeseries/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/config.ts
+++ b/src/plugins/vis_type_timeseries/server/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/index.ts
+++ b/src/plugins/vis_type_timeseries/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/get_fields.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/get_fields.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/get_vis_data.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/get_vis_data.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/default_search_capabilities.js
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/default_search_capabilities.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/default_search_capabilities.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/default_search_capabilities.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/index.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/search_strategies_registry.test.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/search_strategies_registry.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/search_strategy_registry.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/search_strategy_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/abstract_search_strategy.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/abstract_search_strategy.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/abstract_search_strategy.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/abstract_search_strategy.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/default_search_strategy.js
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/default_search_strategy.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/default_search_strategy.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/default_search_strategy.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/annotations/build_request_body.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/annotations/build_request_body.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/annotations/get_request_params.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/annotations/get_request_params.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/build_processor_function.test.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/build_processor_function.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/build_processor_function.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/build_processor_function.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_annotations.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_annotations.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_interval_and_timefield.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_interval_and_timefield.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_interval_and_timefield.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_interval_and_timefield.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_panel_data.d.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_panel_data.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_panel_data.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_panel_data.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_series_data.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_series_data.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_table_data.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_table_data.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/handle_error_response.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/handle_error_response.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/bucket_transform.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/bucket_transform.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/bucket_transform.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/bucket_transform.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/calculate_auto.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/calculate_auto.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/format_key.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/format_key.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_active_series.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_active_series.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_agg_value.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_agg_value.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_agg_value.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_agg_value.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_bucket_size.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_bucket_size.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_bucket_size.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_bucket_size.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_buckets_path.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_buckets_path.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_buckets_path.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_buckets_path.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_default_decoration.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_default_decoration.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_default_decoration.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_default_decoration.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_index_pattern.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_index_pattern.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_last_metric.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_last_metric.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_last_metric.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_last_metric.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_opensearch_query_uisettings.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_opensearch_query_uisettings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_opensearch_shard_timeout.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_opensearch_shard_timeout.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_opensearch_shard_timeout.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_opensearch_shard_timeout.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_sibling_agg_value.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_sibling_agg_value.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_sibling_agg_value.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_sibling_agg_value.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_split_colors.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_split_colors.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_splits.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_splits.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_splits.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_splits.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_timerange.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_timerange.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_timerange.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_timerange.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_timerange_mode.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_timerange_mode.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/index.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/map_bucket.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/map_bucket.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/map_bucket.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/map_bucket.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/moving_fn_scripts.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/moving_fn_scripts.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/moving_fn_scripts.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/moving_fn_scripts.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/overwrite.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/overwrite.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/parse_interval.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/parse_interval.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/parse_settings.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/parse_settings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/parse_settings.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/parse_settings.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/timestamp.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/timestamp.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/timestamp.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/timestamp.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/unit_to_seconds.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/unit_to_seconds.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/unit_to_seconds.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/unit_to_seconds.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/offset_time.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/offset_time.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/offset_time.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/offset_time.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/annotations/date_histogram.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/annotations/date_histogram.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/annotations/index.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/annotations/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/annotations/query.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/annotations/query.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/annotations/top_hits.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/annotations/top_hits.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/date_histogram.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/date_histogram.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/date_histogram.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/date_histogram.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/filter_ratios.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/filter_ratios.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/filter_ratios.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/filter_ratios.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/index.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/metric_buckets.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/metric_buckets.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/metric_buckets.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/metric_buckets.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/normalize_query.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/normalize_query.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/normalize_query.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/normalize_query.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/positive_rate.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/positive_rate.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/positive_rate.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/positive_rate.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/query.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/query.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/query.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/query.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/sibling_buckets.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/sibling_buckets.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/sibling_buckets.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/sibling_buckets.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_everything.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_everything.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_everything.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_everything.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_filter.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_filter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_filter.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_filter.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_filters.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_filters.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_filters.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_filters.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_terms.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_terms.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_terms.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/split_by_terms.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/calculate_agg_root.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/calculate_agg_root.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/date_histogram.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/date_histogram.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/filter_ratios.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/filter_ratios.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/index.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/metric_buckets.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/metric_buckets.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/normalize_query.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/normalize_query.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/normalize_query.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/normalize_query.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/pivot.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/pivot.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/positive_rate.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/positive_rate.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/query.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/query.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/sibling_buckets.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/sibling_buckets.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/split_by_everything.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/split_by_everything.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/split_by_terms.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/split_by_terms.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/annotations/buckets.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/annotations/buckets.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/annotations/filter.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/annotations/filter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/annotations/filter.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/annotations/filter.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/annotations/index.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/annotations/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/_series_agg.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/_series_agg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/_series_agg.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/_series_agg.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/drop_last_bucket.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/drop_last_bucket.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/index.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/math.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/math.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/math.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/math.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/percentile.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/percentile.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/percentile.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/percentile.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/percentile_rank.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/percentile_rank.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/series_agg.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/series_agg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/series_agg.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/series_agg.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_deviation_bands.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_deviation_bands.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_deviation_bands.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_deviation_bands.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_deviation_sibling.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_deviation_sibling.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_deviation_sibling.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_deviation_sibling.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_metric.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_metric.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_metric.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_metric.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_sibling.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_sibling.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_sibling.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_sibling.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/time_shift.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/time_shift.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/time_shift.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/time_shift.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/_series_agg.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/_series_agg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/drop_last_bucket.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/drop_last_bucket.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/index.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/math.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/math.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/percentile.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/percentile.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/percentile_rank.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/percentile_rank.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/series_agg.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/series_agg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/std_metric.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/std_metric.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/std_sibling.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/std_sibling.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/series/build_request_body.test.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/series/build_request_body.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/series/build_request_body.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/series/build_request_body.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/series/get_request_params.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/series/get_request_params.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/series/handle_response_body.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/series/handle_response_body.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/table/build_request_body.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/table/build_request_body.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/table/process_bucket.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/table/process_bucket.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/table/process_bucket.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/table/process_bucket.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/plugin.ts
+++ b/src/plugins/vis_type_timeseries/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/routes/fields.ts
+++ b/src/plugins/vis_type_timeseries/server/routes/fields.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/routes/vis.ts
+++ b/src/plugins/vis_type_timeseries/server/routes/vis.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/saved_objects/index.ts
+++ b/src/plugins/vis_type_timeseries/server/saved_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/saved_objects/tsvb_telemetry.ts
+++ b/src/plugins/vis_type_timeseries/server/saved_objects/tsvb_telemetry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/ui_settings.ts
+++ b/src/plugins/vis_type_timeseries/server/ui_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/validation_telemetry/index.ts
+++ b/src/plugins/vis_type_timeseries/server/validation_telemetry/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_timeseries/server/validation_telemetry/validation_telemetry_service.ts
+++ b/src/plugins/vis_type_timeseries/server/validation_telemetry/validation_telemetry_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/config.ts
+++ b/src/plugins/vis_type_vega/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/components/experimental_map_vis_info.tsx
+++ b/src/plugins/vis_type_vega/public/components/experimental_map_vis_info.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/components/index.ts
+++ b/src/plugins/vis_type_vega/public/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/components/vega_actions_menu.tsx
+++ b/src/plugins/vis_type_vega/public/components/vega_actions_menu.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/components/vega_help_menu.tsx
+++ b/src/plugins/vis_type_vega/public/components/vega_help_menu.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/components/vega_vis_editor.tsx
+++ b/src/plugins/vis_type_vega/public/components/vega_vis_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/data_model/ems_file_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/ems_file_parser.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/data_model/opensearch_query_parser.test.js
+++ b/src/plugins/vis_type_vega/public/data_model/opensearch_query_parser.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/data_model/opensearch_query_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/opensearch_query_parser.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/data_model/search_api.ts
+++ b/src/plugins/vis_type_vega/public/data_model/search_api.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/data_model/time_cache.test.js
+++ b/src/plugins/vis_type_vega/public/data_model/time_cache.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/data_model/time_cache.ts
+++ b/src/plugins/vis_type_vega/public/data_model/time_cache.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/data_model/types.ts
+++ b/src/plugins/vis_type_vega/public/data_model/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/data_model/url_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/url_parser.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/data_model/utils.ts
+++ b/src/plugins/vis_type_vega/public/data_model/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.test.js
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/default_spec.ts
+++ b/src/plugins/vis_type_vega/public/default_spec.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/index.ts
+++ b/src/plugins/vis_type_vega/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/lib/extract_index_pattern.test.ts
+++ b/src/plugins/vis_type_vega/public/lib/extract_index_pattern.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/lib/extract_index_pattern.ts
+++ b/src/plugins/vis_type_vega/public/lib/extract_index_pattern.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/lib/vega.js
+++ b/src/plugins/vis_type_vega/public/lib/vega.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/plugin.ts
+++ b/src/plugins/vis_type_vega/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/services.ts
+++ b/src/plugins/vis_type_vega/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_fn.ts
+++ b/src/plugins/vis_type_vega/public/vega_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_inspector/components/data_viewer.tsx
+++ b/src/plugins/vis_type_vega/public/vega_inspector/components/data_viewer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_inspector/components/index.ts
+++ b/src/plugins/vis_type_vega/public/vega_inspector/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_inspector/components/inspector_data_grid.tsx
+++ b/src/plugins/vis_type_vega/public/vega_inspector/components/inspector_data_grid.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_inspector/components/signal_viewer.tsx
+++ b/src/plugins/vis_type_vega/public/vega_inspector/components/signal_viewer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_inspector/components/spec_viewer.tsx
+++ b/src/plugins/vis_type_vega/public/vega_inspector/components/spec_viewer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_inspector/index.ts
+++ b/src/plugins/vis_type_vega/public/vega_inspector/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_inspector/vega_adapter.ts
+++ b/src/plugins/vis_type_vega/public/vega_inspector/vega_adapter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_inspector/vega_data_inspector.tsx
+++ b/src/plugins/vis_type_vega/public/vega_inspector/vega_data_inspector.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_inspector/vega_inspector.tsx
+++ b/src/plugins/vis_type_vega/public/vega_inspector/vega_inspector.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_request_handler.ts
+++ b/src/plugins/vis_type_vega/public/vega_request_handler.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_type.ts
+++ b/src/plugins/vis_type_vega/public/vega_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_view/vega_map_layer.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_map_layer.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_view/vega_map_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_map_view.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_view/vega_tooltip.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_tooltip.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_view/vega_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_view.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_visualization.js
+++ b/src/plugins/vis_type_vega/public/vega_visualization.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/public/vega_visualization.test.js
+++ b/src/plugins/vis_type_vega/public/vega_visualization.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/server/index.ts
+++ b/src/plugins/vis_type_vega/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/server/plugin.ts
+++ b/src/plugins/vis_type_vega/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/server/types.ts
+++ b/src/plugins/vis_type_vega/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/server/usage_collector/get_usage_collector.test.ts
+++ b/src/plugins/vis_type_vega/server/usage_collector/get_usage_collector.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/server/usage_collector/get_usage_collector.ts
+++ b/src/plugins/vis_type_vega/server/usage_collector/get_usage_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vega/server/usage_collector/index.ts
+++ b/src/plugins/vis_type_vega/server/usage_collector/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/common/index.ts
+++ b/src/plugins/vis_type_vislib/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/area.ts
+++ b/src/plugins/vis_type_vislib/public/area.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/common/index.ts
+++ b/src/plugins/vis_type_vislib/public/components/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/common/truncate_labels.tsx
+++ b/src/plugins/vis_type_vislib/public/components/common/truncate_labels.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/common/validation_wrapper.tsx
+++ b/src/plugins/vis_type_vislib/public/components/common/validation_wrapper.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/index.ts
+++ b/src/plugins/vis_type_vislib/public/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/gauge/index.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/gauge/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/gauge/labels_panel.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/gauge/labels_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/gauge/ranges_panel.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/gauge/ranges_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/gauge/style_panel.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/gauge/style_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/heatmap/index.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/heatmap/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/heatmap/labels_panel.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/heatmap/labels_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/index.ts
+++ b/src/plugins/vis_type_vislib/public/components/options/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/category_axis_panel.test.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/category_axis_panel.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/category_axis_panel.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/category_axis_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/chart_options.test.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/chart_options.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/chart_options.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/chart_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/custom_extents_options.test.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/custom_extents_options.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/custom_extents_options.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/custom_extents_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/index.test.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/index.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/index.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/label_options.test.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/label_options.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/label_options.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/label_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/line_options.test.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/line_options.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/line_options.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/line_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/mocks.ts
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/series_panel.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/series_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/utils.ts
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/value_axes_panel.test.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/value_axes_panel.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/value_axes_panel.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/value_axes_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/value_axis_options.test.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/value_axis_options.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/value_axis_options.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/value_axis_options.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/y_extents.test.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/y_extents.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/metrics_axes/y_extents.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/metrics_axes/y_extents.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/pie.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/pie.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/point_series/grid_panel.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/point_series/grid_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/point_series/index.ts
+++ b/src/plugins/vis_type_vislib/public/components/options/point_series/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/point_series/point_series.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/point_series/point_series.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/components/options/point_series/threshold_panel.tsx
+++ b/src/plugins/vis_type_vislib/public/components/options/point_series/threshold_panel.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_columns.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_columns.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_rows.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_rows.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_rows_series_with_holes.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_rows_series_with_holes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_series.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_series_monthly_interval.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_series_monthly_interval.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_series_neg.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_series_neg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_series_pos_neg.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_series_pos_neg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_stacked_series.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/date_histogram/_stacked_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/filters/_columns.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/filters/_columns.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/filters/_rows.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/filters/_rows.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/filters/_series.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/filters/_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/geohash/_columns.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/geohash/_columns.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/geohash/_geo_json.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/geohash/_geo_json.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/geohash/_rows.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/geohash/_rows.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/histogram/_columns.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/histogram/_columns.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/histogram/_rows.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/histogram/_rows.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/histogram/_series.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/histogram/_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/histogram/_slices.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/histogram/_slices.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/not_enough_data/_one_point.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/not_enough_data/_one_point.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/range/_columns.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/range/_columns.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/range/_rows.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/range/_rows.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/range/_series.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/range/_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/significant_terms/_columns.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/significant_terms/_columns.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/significant_terms/_rows.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/significant_terms/_rows.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/significant_terms/_series.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/significant_terms/_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/stacked/_stacked.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/stacked/_stacked.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/terms/_columns.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/terms/_columns.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/terms/_rows.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/terms/_rows.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/terms/_series.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/terms/_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mock_data/terms/_series_multiple.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mock_data/terms/_series_multiple.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/fixtures/mocks.js
+++ b/src/plugins/vis_type_vislib/public/fixtures/mocks.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/gauge.ts
+++ b/src/plugins/vis_type_vislib/public/gauge.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/goal.ts
+++ b/src/plugins/vis_type_vislib/public/goal.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/heatmap.ts
+++ b/src/plugins/vis_type_vislib/public/heatmap.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/histogram.ts
+++ b/src/plugins/vis_type_vislib/public/histogram.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/horizontal_bar.ts
+++ b/src/plugins/vis_type_vislib/public/horizontal_bar.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/index.ts
+++ b/src/plugins/vis_type_vislib/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/line.ts
+++ b/src/plugins/vis_type_vislib/public/line.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/pie.ts
+++ b/src/plugins/vis_type_vislib/public/pie.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/pie_fn.test.ts
+++ b/src/plugins/vis_type_vislib/public/pie_fn.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/pie_fn.ts
+++ b/src/plugins/vis_type_vislib/public/pie_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/plugin.ts
+++ b/src/plugins/vis_type_vislib/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/services.ts
+++ b/src/plugins/vis_type_vislib/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/types.ts
+++ b/src/plugins/vis_type_vislib/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/utils/collections.ts
+++ b/src/plugins/vis_type_vislib/public/utils/collections.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/utils/common_config.tsx
+++ b/src/plugins/vis_type_vislib/public/utils/common_config.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vis_controller.tsx
+++ b/src/plugins/vis_type_vislib/public/vis_controller.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vis_type_vislib_vis_fn.ts
+++ b/src/plugins/vis_type_vislib/public/vis_type_vislib_vis_fn.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vis_type_vislib_vis_types.ts
+++ b/src/plugins/vis_type_vislib/public/vis_type_vislib_vis_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/labels/data_array.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/labels/data_array.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/labels/flatten_series.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/labels/flatten_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/labels/index.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/labels/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/labels/labels.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/labels/labels.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/labels/labels.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/labels/labels.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/labels/truncate_labels.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/labels/truncate_labels.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/labels/uniq_labels.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/labels/uniq_labels.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/legend/index.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/components/legend/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/legend/legend.test.tsx
+++ b/src/plugins/vis_type_vislib/public/vislib/components/legend/legend.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/legend/legend.tsx
+++ b/src/plugins/vis_type_vislib/public/vislib/components/legend/legend.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/legend/legend_item.tsx
+++ b/src/plugins/vis_type_vislib/public/vislib/components/legend/legend_item.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/legend/models.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/components/legend/models.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/legend/pie_utils.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/components/legend/pie_utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_collect_branch.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_collect_branch.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_collect_branch.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_collect_branch.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_hierarchical_tooltip_formatter.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_hierarchical_tooltip_formatter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/index.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/position_tooltip.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/position_tooltip.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/position_tooltip.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/position_tooltip.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/tooltip.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/tooltip.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/flatten_data.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/flatten_data.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/inject_zeros.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/inject_zeros.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/ordered_x_keys.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/ordered_x_keys.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/uniq_keys.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/uniq_keys.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/zero_fill_data_array.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/zero_fill_data_array.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/zero_filled_array.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/zero_filled_array.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/zero_injection.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/zero_injection/zero_injection.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/errors.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/hierarchical/build_hierarchical_data.test.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/hierarchical/build_hierarchical_data.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/hierarchical/build_hierarchical_data.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/hierarchical/build_hierarchical_data.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/index.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_add_to_siri.test.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_add_to_siri.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_add_to_siri.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_add_to_siri.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_fake_x_aspect.test.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_fake_x_aspect.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_fake_x_aspect.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_fake_x_aspect.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_aspects.test.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_aspects.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_aspects.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_aspects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_point.test.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_point.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_point.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_point.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_series.test.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_series.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_series.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_get_series.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_init_x_axis.test.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_init_x_axis.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_init_x_axis.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_init_x_axis.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_init_y_axis.test.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_init_y_axis.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_init_y_axis.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_init_y_axis.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_ordered_date_axis.test.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_ordered_date_axis.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_ordered_date_axis.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/_ordered_date_axis.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/index.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/point_series.test.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/point_series.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/point_series.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/helpers/point_series/point_series.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/_data_label.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/_data_label.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/_error_handler.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/_error_handler.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/_error_handler.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/_error_handler.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/alerts.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/alerts.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_config.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_labels.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_labels.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_scale.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_scale.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_title.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_title.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_title.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_title.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/index.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/scale_modes.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/scale_modes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/time_ticks.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/time_ticks.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/time_ticks.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/time_ticks.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/x_axis.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/x_axis.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/y_axis.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/y_axis.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/binder.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/binder.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/chart_grid.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/chart_grid.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/chart_title.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/chart_title.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/chart_title.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/chart_title.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/data.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/data.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/data.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/data.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/dispatch.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/dispatch.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/dispatch.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/dispatch.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/dispatch_heatmap.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/dispatch_heatmap.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/dispatch_vertical_bar_chart.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/dispatch_vertical_bar_chart.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/handler.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/handler.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/handler.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/handler.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/index.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/layout.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/layout.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/layout.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/layout.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/layout_types.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/layout_types.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/layout_types.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/layout_types.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/column_chart/chart_split.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/column_chart/chart_split.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/column_chart/chart_title_split.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/column_chart/chart_title_split.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/column_chart/splits.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/column_chart/splits.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/column_chart/x_axis_split.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/column_chart/x_axis_split.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/column_chart/y_axis_split.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/column_chart/y_axis_split.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/gauge_chart/chart_split.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/gauge_chart/chart_split.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/gauge_chart/chart_title_split.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/gauge_chart/chart_title_split.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/gauge_chart/splits.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/gauge_chart/splits.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/pie_chart/chart_split.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/pie_chart/chart_split.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/pie_chart/chart_title_split.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/splits/pie_chart/chart_title_split.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/types/column_layout.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/types/column_layout.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/types/column_layout.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/types/column_layout.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/types/gauge_layout.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/types/gauge_layout.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/layout/types/pie_layout.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/layout/types/pie_layout.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/types/gauge.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/types/gauge.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/types/index.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/types/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/types/pie.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/types/pie.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/types/point_series.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/types/point_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/types/point_series.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/types/point_series.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/vis_config.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/vis_config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/lib/vis_config.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/vis_config.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/response_handler.js
+++ b/src/plugins/vis_type_vislib/public/vislib/response_handler.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/response_handler.test.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/response_handler.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/types.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/vis.js
+++ b/src/plugins/vis_type_vislib/public/vislib/vis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/vis.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/vis.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/_chart.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/_vis_fixture.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/_vis_fixture.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/chart.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/chart.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/gauge_chart.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/gauge_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/gauge_chart.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/gauge_chart.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/gauges/gauge_types.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/gauges/gauge_types.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/gauges/meter.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/gauges/meter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/pie_chart.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/pie_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/pie_chart.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/pie_chart.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/pie_chart_mock_data.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/pie_chart_mock_data.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/_point_series.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/_point_series.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/_point_series.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/_point_series.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/area_chart.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/area_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/area_chart.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/area_chart.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/column_chart.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/column_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/column_chart.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/column_chart.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/heatmap_chart.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/heatmap_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/heatmap_chart.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/heatmap_chart.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/line_chart.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/line_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/line_chart.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/line_chart.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/series_types.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/point_series/series_types.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/time_marker.d.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/time_marker.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/time_marker.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/time_marker.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/time_marker.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/time_marker.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/vis_types.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/vis_types.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/public/vislib/visualizations/vis_types.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/visualizations/vis_types.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/server/index.ts
+++ b/src/plugins/vis_type_vislib/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/server/plugin.ts
+++ b/src/plugins/vis_type_vislib/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_vislib/server/ui_settings.ts
+++ b/src/plugins/vis_type_vislib/server/ui_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_xy/public/index.ts
+++ b/src/plugins/vis_type_xy/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_xy/public/plugin.ts
+++ b/src/plugins/vis_type_xy/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/vis_type_xy/server/index.ts
+++ b/src/plugins/vis_type_xy/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/common/constants.ts
+++ b/src/plugins/visualizations/common/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/components/index.ts
+++ b/src/plugins/visualizations/public/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/components/visualization.test.js
+++ b/src/plugins/visualizations/public/components/visualization.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/components/visualization.tsx
+++ b/src/plugins/visualizations/public/components/visualization.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/components/visualization_chart.test.js
+++ b/src/plugins/visualizations/public/components/visualization_chart.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/components/visualization_chart.tsx
+++ b/src/plugins/visualizations/public/components/visualization_chart.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/components/visualization_container.tsx
+++ b/src/plugins/visualizations/public/components/visualization_container.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/components/visualization_noresults.test.js
+++ b/src/plugins/visualizations/public/components/visualization_noresults.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/components/visualization_noresults.tsx
+++ b/src/plugins/visualizations/public/components/visualization_noresults.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/components/visualization_requesterror.test.js
+++ b/src/plugins/visualizations/public/components/visualization_requesterror.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/components/visualization_requesterror.tsx
+++ b/src/plugins/visualizations/public/components/visualization_requesterror.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/embeddable/constants.ts
+++ b/src/plugins/visualizations/public/embeddable/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/embeddable/create_vis_embeddable_from_object.ts
+++ b/src/plugins/visualizations/public/embeddable/create_vis_embeddable_from_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/embeddable/disabled_lab_embeddable.tsx
+++ b/src/plugins/visualizations/public/embeddable/disabled_lab_embeddable.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/embeddable/disabled_lab_visualization.tsx
+++ b/src/plugins/visualizations/public/embeddable/disabled_lab_visualization.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/embeddable/events.ts
+++ b/src/plugins/visualizations/public/embeddable/events.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/embeddable/get_index_pattern.ts
+++ b/src/plugins/visualizations/public/embeddable/get_index_pattern.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/embeddable/index.ts
+++ b/src/plugins/visualizations/public/embeddable/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/expression_functions/range.ts
+++ b/src/plugins/visualizations/public/expression_functions/range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/expression_functions/vis_dimension.ts
+++ b/src/plugins/visualizations/public/expression_functions/vis_dimension.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/expressions/vis.ts
+++ b/src/plugins/visualizations/public/expressions/vis.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/expressions/visualization_function.ts
+++ b/src/plugins/visualizations/public/expressions/visualization_function.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/expressions/visualization_renderer.tsx
+++ b/src/plugins/visualizations/public/expressions/visualization_renderer.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/index.ts
+++ b/src/plugins/visualizations/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/legacy/build_pipeline.test.ts
+++ b/src/plugins/visualizations/public/legacy/build_pipeline.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/legacy/build_pipeline.ts
+++ b/src/plugins/visualizations/public/legacy/build_pipeline.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/legacy/memoize.test.ts
+++ b/src/plugins/visualizations/public/legacy/memoize.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/legacy/memoize.ts
+++ b/src/plugins/visualizations/public/legacy/memoize.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/legacy/vis_update_state.js
+++ b/src/plugins/visualizations/public/legacy/vis_update_state.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/legacy/vis_update_state.stub.js
+++ b/src/plugins/visualizations/public/legacy/vis_update_state.stub.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/legacy/vis_update_state.test.js
+++ b/src/plugins/visualizations/public/legacy/vis_update_state.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/mocks.ts
+++ b/src/plugins/visualizations/public/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/persisted_state/index.ts
+++ b/src/plugins/visualizations/public/persisted_state/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/persisted_state/persisted_state.ts
+++ b/src/plugins/visualizations/public/persisted_state/persisted_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/persisted_state/persisted_state_provider.test.ts
+++ b/src/plugins/visualizations/public/persisted_state/persisted_state_provider.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/plugin.ts
+++ b/src/plugins/visualizations/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/saved_visualizations/_saved_vis.ts
+++ b/src/plugins/visualizations/public/saved_visualizations/_saved_vis.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/saved_visualizations/find_list_items.test.ts
+++ b/src/plugins/visualizations/public/saved_visualizations/find_list_items.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/saved_visualizations/find_list_items.ts
+++ b/src/plugins/visualizations/public/saved_visualizations/find_list_items.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/saved_visualizations/index.ts
+++ b/src/plugins/visualizations/public/saved_visualizations/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/saved_visualizations/saved_visualization_references.test.ts
+++ b/src/plugins/visualizations/public/saved_visualizations/saved_visualization_references.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/saved_visualizations/saved_visualization_references.ts
+++ b/src/plugins/visualizations/public/saved_visualizations/saved_visualization_references.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/saved_visualizations/saved_visualizations.ts
+++ b/src/plugins/visualizations/public/saved_visualizations/saved_visualizations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/services.ts
+++ b/src/plugins/visualizations/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/types.ts
+++ b/src/plugins/visualizations/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/vis.test.ts
+++ b/src/plugins/visualizations/public/vis.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/vis.ts
+++ b/src/plugins/visualizations/public/vis.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/vis_types/base_vis_type.test.ts
+++ b/src/plugins/visualizations/public/vis_types/base_vis_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/vis_types/base_vis_type.ts
+++ b/src/plugins/visualizations/public/vis_types/base_vis_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/vis_types/index.ts
+++ b/src/plugins/visualizations/public/vis_types/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/vis_types/react_vis_controller.tsx
+++ b/src/plugins/visualizations/public/vis_types/react_vis_controller.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/vis_types/react_vis_type.test.ts
+++ b/src/plugins/visualizations/public/vis_types/react_vis_type.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/vis_types/react_vis_type.ts
+++ b/src/plugins/visualizations/public/vis_types/react_vis_type.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/vis_types/types.ts
+++ b/src/plugins/visualizations/public/vis_types/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/vis_types/types_service.ts
+++ b/src/plugins/visualizations/public/vis_types/types_service.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/vis_types/vis_type_alias_registry.ts
+++ b/src/plugins/visualizations/public/vis_types/vis_type_alias_registry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/index.ts
+++ b/src/plugins/visualizations/public/wizard/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/new_vis_modal.test.tsx
+++ b/src/plugins/visualizations/public/wizard/new_vis_modal.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
+++ b/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/search_selection/index.ts
+++ b/src/plugins/visualizations/public/wizard/search_selection/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/show_new_vis.tsx
+++ b/src/plugins/visualizations/public/wizard/show_new_vis.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/type_selection/index.ts
+++ b/src/plugins/visualizations/public/wizard/type_selection/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/type_selection/new_vis_help.test.tsx
+++ b/src/plugins/visualizations/public/wizard/type_selection/new_vis_help.test.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/type_selection/new_vis_help.tsx
+++ b/src/plugins/visualizations/public/wizard/type_selection/new_vis_help.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/type_selection/type_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/type_selection/type_selection.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/type_selection/vis_help_text.tsx
+++ b/src/plugins/visualizations/public/wizard/type_selection/vis_help_text.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/public/wizard/type_selection/vis_type_icon.tsx
+++ b/src/plugins/visualizations/public/wizard/type_selection/vis_type_icon.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/index.ts
+++ b/src/plugins/visualizations/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/plugin.ts
+++ b/src/plugins/visualizations/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/saved_objects/index.ts
+++ b/src/plugins/visualizations/server/saved_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/saved_objects/visualization.ts
+++ b/src/plugins/visualizations/server/saved_objects/visualization.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/saved_objects/visualization_migrations.test.ts
+++ b/src/plugins/visualizations/server/saved_objects/visualization_migrations.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/saved_objects/visualization_migrations.ts
+++ b/src/plugins/visualizations/server/saved_objects/visualization_migrations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/types.ts
+++ b/src/plugins/visualizations/server/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/usage_collector/get_past_days.test.ts
+++ b/src/plugins/visualizations/server/usage_collector/get_past_days.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/usage_collector/get_past_days.ts
+++ b/src/plugins/visualizations/server/usage_collector/get_past_days.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/usage_collector/get_usage_collector.test.ts
+++ b/src/plugins/visualizations/server/usage_collector/get_usage_collector.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/usage_collector/get_usage_collector.ts
+++ b/src/plugins/visualizations/server/usage_collector/get_usage_collector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualizations/server/usage_collector/index.ts
+++ b/src/plugins/visualizations/server/usage_collector/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/common/constants.ts
+++ b/src/plugins/visualize/common/constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/actions/visualize_field_action.ts
+++ b/src/plugins/visualize/public/actions/visualize_field_action.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/app.tsx
+++ b/src/plugins/visualize/public/application/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/components/experimental_vis_info.tsx
+++ b/src/plugins/visualize/public/application/components/experimental_vis_info.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/components/index.ts
+++ b/src/plugins/visualize/public/application/components/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/components/visualize_byvalue_editor.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_byvalue_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/components/visualize_editor.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/components/visualize_editor_common.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_editor_common.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/components/visualize_listing.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_listing.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/components/visualize_no_match.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_no_match.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/components/visualize_top_nav.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_top_nav.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/index.tsx
+++ b/src/plugins/visualize/public/application/index.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/types.ts
+++ b/src/plugins/visualize/public/application/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/breadcrumbs.ts
+++ b/src/plugins/visualize/public/application/utils/breadcrumbs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/create_visualize_app_state.test.ts
+++ b/src/plugins/visualize/public/application/utils/create_visualize_app_state.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/create_visualize_app_state.ts
+++ b/src/plugins/visualize/public/application/utils/create_visualize_app_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/get_table_columns.tsx
+++ b/src/plugins/visualize/public/application/utils/get_table_columns.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/get_visualization_instance.test.ts
+++ b/src/plugins/visualize/public/application/utils/get_visualization_instance.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/get_visualization_instance.ts
+++ b/src/plugins/visualize/public/application/utils/get_visualization_instance.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/index.ts
+++ b/src/plugins/visualize/public/application/utils/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/migrate_app_state.ts
+++ b/src/plugins/visualize/public/application/utils/migrate_app_state.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/migrate_legacy_query.ts
+++ b/src/plugins/visualize/public/application/utils/migrate_legacy_query.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/mocks.ts
+++ b/src/plugins/visualize/public/application/utils/mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/stubs.ts
+++ b/src/plugins/visualize/public/application/utils/stubs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/index.ts
+++ b/src/plugins/visualize/public/application/utils/use/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/use_chrome_visibility.test.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_chrome_visibility.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/use_chrome_visibility.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_chrome_visibility.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/use_editor_updates.test.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_editor_updates.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/use_editor_updates.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_editor_updates.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/use_linked_search_updates.test.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_linked_search_updates.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/use_linked_search_updates.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_linked_search_updates.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/use_saved_vis_instance.test.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_saved_vis_instance.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/use_saved_vis_instance.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_saved_vis_instance.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/use_vis_byvalue.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_vis_byvalue.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/use_visualize_app_state.test.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_visualize_app_state.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/use/use_visualize_app_state.tsx
+++ b/src/plugins/visualize/public/application/utils/use/use_visualize_app_state.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/utils/utils.ts
+++ b/src/plugins/visualize/public/application/utils/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/application/visualize_constants.ts
+++ b/src/plugins/visualize/public/application/visualize_constants.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/index.ts
+++ b/src/plugins/visualize/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/plugin.ts
+++ b/src/plugins/visualize/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/services.ts
+++ b/src/plugins/visualize/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/url_generator.test.ts
+++ b/src/plugins/visualize/public/url_generator.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/public/url_generator.ts
+++ b/src/plugins/visualize/public/url_generator.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/server/capabilities_provider.ts
+++ b/src/plugins/visualize/server/capabilities_provider.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/server/index.ts
+++ b/src/plugins/visualize/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/plugins/visualize/server/plugin.ts
+++ b/src/plugins/visualize/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/dist.js
+++ b/src/setup_node_env/dist.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/exit_on_warning.js
+++ b/src/setup_node_env/exit_on_warning.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/harden/child_process.js
+++ b/src/setup_node_env/harden/child_process.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/harden/index.js
+++ b/src/setup_node_env/harden/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/harden/lodash_template.js
+++ b/src/setup_node_env/harden/lodash_template.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/index.js
+++ b/src/setup_node_env/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/no_transpilation.js
+++ b/src/setup_node_env/no_transpilation.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/node_version_validator.js
+++ b/src/setup_node_env/node_version_validator.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/node_version_validator.test.js
+++ b/src/setup_node_env/node_version_validator.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/polyfill.js
+++ b/src/setup_node_env/polyfill.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/root/force.js
+++ b/src/setup_node_env/root/force.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/root/force.test.js
+++ b/src/setup_node_env/root/force.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/root/index.js
+++ b/src/setup_node_env/root/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/root/is_root.js
+++ b/src/setup_node_env/root/is_root.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/setup_node_env/root/is_root.test.js
+++ b/src/setup_node_env/root/is_root.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/__tests__/get_url.js
+++ b/src/test_utils/__tests__/get_url.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/get_url.js
+++ b/src/test_utils/get_url.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/enzyme_helpers.tsx
+++ b/src/test_utils/public/enzyme_helpers.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/helpers/find_test_subject.ts
+++ b/src/test_utils/public/helpers/find_test_subject.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/helpers/index.ts
+++ b/src/test_utils/public/helpers/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/helpers/jsdom_svg_mocks.ts
+++ b/src/test_utils/public/helpers/jsdom_svg_mocks.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/helpers/redux_helpers.tsx
+++ b/src/test_utils/public/helpers/redux_helpers.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/helpers/router_helpers.tsx
+++ b/src/test_utils/public/helpers/router_helpers.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/helpers/utils.ts
+++ b/src/test_utils/public/helpers/utils.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/index.ts
+++ b/src/test_utils/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/key_map.ts
+++ b/src/test_utils/public/key_map.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/stub_browser_storage.test.ts
+++ b/src/test_utils/public/stub_browser_storage.test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/stub_browser_storage.ts
+++ b/src/test_utils/public/stub_browser_storage.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/testbed/index.ts
+++ b/src/test_utils/public/testbed/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/testbed/mount_component.tsx
+++ b/src/test_utils/public/testbed/mount_component.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/testbed/testbed.ts
+++ b/src/test_utils/public/testbed/testbed.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/test_utils/public/testbed/types.ts
+++ b/src/test_utils/public/testbed/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/src/type_definitions/react_virtualized.d.ts
+++ b/src/type_definitions/react_virtualized.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/tasks/check_plugins.js
+++ b/tasks/check_plugins.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/tasks/config/availabletasks.js
+++ b/tasks/config/availabletasks.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/tasks/config/peg.js
+++ b/tasks/config/peg.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/tasks/config/run.js
+++ b/tasks/config/run.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/tasks/config/watch.js
+++ b/tasks/config/watch.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/tasks/docker_docs.js
+++ b/tasks/docker_docs.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/tasks/function_test_groups.js
+++ b/tasks/function_test_groups.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/tasks/jenkins.js
+++ b/tasks/jenkins.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/tasks/licenses_csv_report.js
+++ b/tasks/licenses_csv_report.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/tasks/test_jest.js
+++ b/tasks/test_jest.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/apps/console.ts
+++ b/test/accessibility/apps/console.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/apps/dashboard.ts
+++ b/test/accessibility/apps/dashboard.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/apps/dashboard_panel.ts
+++ b/test/accessibility/apps/dashboard_panel.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/apps/discover.ts
+++ b/test/accessibility/apps/discover.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/apps/filter_panel.ts
+++ b/test/accessibility/apps/filter_panel.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/apps/home.ts
+++ b/test/accessibility/apps/home.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/apps/management.ts
+++ b/test/accessibility/apps/management.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/apps/opensearch_dashboards_overview.ts
+++ b/test/accessibility/apps/opensearch_dashboards_overview.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/apps/visualize.ts
+++ b/test/accessibility/apps/visualize.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/config.ts
+++ b/test/accessibility/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/ftr_provider_context.d.ts
+++ b/test/accessibility/ftr_provider_context.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/page_objects.ts
+++ b/test/accessibility/page_objects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/services/a11y/a11y.ts
+++ b/test/accessibility/services/a11y/a11y.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/services/a11y/analyze_with_axe.js
+++ b/test/accessibility/services/a11y/analyze_with_axe.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/services/a11y/axe_report.ts
+++ b/test/accessibility/services/a11y/axe_report.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/services/a11y/index.ts
+++ b/test/accessibility/services/a11y/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/accessibility/services/index.ts
+++ b/test/accessibility/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/core/index.js
+++ b/test/api_integration/apis/core/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/dql_telemetry/dql_telemetry.js
+++ b/test/api_integration/apis/dql_telemetry/dql_telemetry.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/dql_telemetry/index.js
+++ b/test/api_integration/apis/dql_telemetry/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/general/cookies.js
+++ b/test/api_integration/apis/general/cookies.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/general/csp.js
+++ b/test/api_integration/apis/general/csp.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/general/index.js
+++ b/test/api_integration/apis/general/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/home/index.js
+++ b/test/api_integration/apis/home/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/home/sample_data.js
+++ b/test/api_integration/apis/home/sample_data.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index.js
+++ b/test/api_integration/apis/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/fields_for_time_pattern_route/errors.js
+++ b/test/api_integration/apis/index_patterns/fields_for_time_pattern_route/errors.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/fields_for_time_pattern_route/index.js
+++ b/test/api_integration/apis/index_patterns/fields_for_time_pattern_route/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/fields_for_time_pattern_route/pattern.js
+++ b/test/api_integration/apis/index_patterns/fields_for_time_pattern_route/pattern.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/fields_for_time_pattern_route/query_params.js
+++ b/test/api_integration/apis/index_patterns/fields_for_time_pattern_route/query_params.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/fields_for_wildcard_route/conflicts.js
+++ b/test/api_integration/apis/index_patterns/fields_for_wildcard_route/conflicts.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/fields_for_wildcard_route/index.js
+++ b/test/api_integration/apis/index_patterns/fields_for_wildcard_route/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/fields_for_wildcard_route/params.js
+++ b/test/api_integration/apis/index_patterns/fields_for_wildcard_route/params.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/fields_for_wildcard_route/response.js
+++ b/test/api_integration/apis/index_patterns/fields_for_wildcard_route/response.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/index.js
+++ b/test/api_integration/apis/index_patterns/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/opensearch_errors/errors.js
+++ b/test/api_integration/apis/index_patterns/opensearch_errors/errors.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/opensearch_errors/index.js
+++ b/test/api_integration/apis/index_patterns/opensearch_errors/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/opensearch_errors/lib/get_opensearch_errors.js
+++ b/test/api_integration/apis/index_patterns/opensearch_errors/lib/get_opensearch_errors.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/index_patterns/opensearch_errors/lib/index.js
+++ b/test/api_integration/apis/index_patterns/opensearch_errors/lib/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/bulk_create.js
+++ b/test/api_integration/apis/saved_objects/bulk_create.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/bulk_get.js
+++ b/test/api_integration/apis/saved_objects/bulk_get.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/bulk_update.js
+++ b/test/api_integration/apis/saved_objects/bulk_update.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/create.js
+++ b/test/api_integration/apis/saved_objects/create.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/delete.js
+++ b/test/api_integration/apis/saved_objects/delete.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/export.js
+++ b/test/api_integration/apis/saved_objects/export.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/find.js
+++ b/test/api_integration/apis/saved_objects/find.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/get.js
+++ b/test/api_integration/apis/saved_objects/get.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/import.js
+++ b/test/api_integration/apis/saved_objects/import.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/index.js
+++ b/test/api_integration/apis/saved_objects/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/migrations.ts
+++ b/test/api_integration/apis/saved_objects/migrations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/resolve_import_errors.js
+++ b/test/api_integration/apis/saved_objects/resolve_import_errors.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects/update.js
+++ b/test/api_integration/apis/saved_objects/update.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects_management/find.ts
+++ b/test/api_integration/apis/saved_objects_management/find.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects_management/get.ts
+++ b/test/api_integration/apis/saved_objects_management/get.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects_management/index.ts
+++ b/test/api_integration/apis/saved_objects_management/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects_management/relationships.ts
+++ b/test/api_integration/apis/saved_objects_management/relationships.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/saved_objects_management/scroll_count.ts
+++ b/test/api_integration/apis/saved_objects_management/scroll_count.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/scripts/index.js
+++ b/test/api_integration/apis/scripts/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/scripts/languages.js
+++ b/test/api_integration/apis/scripts/languages.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/search/index.ts
+++ b/test/api_integration/apis/search/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/search/search.ts
+++ b/test/api_integration/apis/search/search.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/shorten/index.js
+++ b/test/api_integration/apis/shorten/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/stats/index.js
+++ b/test/api_integration/apis/stats/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/stats/stats.js
+++ b/test/api_integration/apis/stats/stats.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/status/index.js
+++ b/test/api_integration/apis/status/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/status/status.js
+++ b/test/api_integration/apis/status/status.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/suggestions/index.js
+++ b/test/api_integration/apis/suggestions/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/suggestions/suggestions.js
+++ b/test/api_integration/apis/suggestions/suggestions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/telemetry/index.js
+++ b/test/api_integration/apis/telemetry/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/telemetry/opt_in.ts
+++ b/test/api_integration/apis/telemetry/opt_in.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/telemetry/telemetry_local.js
+++ b/test/api_integration/apis/telemetry/telemetry_local.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/telemetry/telemetry_optin_notice_seen.ts
+++ b/test/api_integration/apis/telemetry/telemetry_optin_notice_seen.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/ui_metric/index.js
+++ b/test/api_integration/apis/ui_metric/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/apis/ui_metric/ui_metric.js
+++ b/test/api_integration/apis/ui_metric/ui_metric.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/config.js
+++ b/test/api_integration/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/ftr_provider_context.d.ts
+++ b/test/api_integration/ftr_provider_context.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/services/index.ts
+++ b/test/api_integration/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/api_integration/services/supertest.ts
+++ b/test/api_integration/services/supertest.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/config.js
+++ b/test/common/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/fixtures/plugins/newsfeed/server/index.ts
+++ b/test/common/fixtures/plugins/newsfeed/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/fixtures/plugins/newsfeed/server/plugin.ts
+++ b/test/common/fixtures/plugins/newsfeed/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/ftr_provider_context.d.ts
+++ b/test/common/ftr_provider_context.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/deployment.ts
+++ b/test/common/services/deployment.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/index.ts
+++ b/test/common/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/legacy_opensearch.ts
+++ b/test/common/services/legacy_opensearch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/opensearch.ts
+++ b/test/common/services/opensearch.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/opensearch_archiver.ts
+++ b/test/common/services/opensearch_archiver.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/opensearch_dashboards_server/extend_opensearch_archiver.js
+++ b/test/common/services/opensearch_dashboards_server/extend_opensearch_archiver.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/opensearch_dashboards_server/index.ts
+++ b/test/common/services/opensearch_dashboards_server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/opensearch_dashboards_server/opensearch_dashboards_server.ts
+++ b/test/common/services/opensearch_dashboards_server/opensearch_dashboards_server.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/randomness.ts
+++ b/test/common/services/randomness.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/retry/index.ts
+++ b/test/common/services/retry/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/retry/retry.ts
+++ b/test/common/services/retry/retry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/retry/retry_for_success.ts
+++ b/test/common/services/retry/retry_for_success.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/retry/retry_for_truthy.ts
+++ b/test/common/services/retry/retry_for_truthy.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/security/index.ts
+++ b/test/common/services/security/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/security/role.ts
+++ b/test/common/services/security/role.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/security/role_mappings.ts
+++ b/test/common/services/security/role_mappings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/security/security.ts
+++ b/test/common/services/security/security.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/security/test_user.ts
+++ b/test/common/services/security/test_user.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/common/services/security/user.ts
+++ b/test/common/services/security/user.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/bfetch_explorer/batched_function.ts
+++ b/test/examples/bfetch_explorer/batched_function.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/bfetch_explorer/index.ts
+++ b/test/examples/bfetch_explorer/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/config.js
+++ b/test/examples/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/embeddables/adding_children.ts
+++ b/test/examples/embeddables/adding_children.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/embeddables/dashboard.ts
+++ b/test/examples/embeddables/dashboard.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/embeddables/hello_world_embeddable.ts
+++ b/test/examples/embeddables/hello_world_embeddable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/embeddables/index.ts
+++ b/test/examples/embeddables/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/embeddables/list_container.ts
+++ b/test/examples/embeddables/list_container.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/embeddables/todo_embeddable.ts
+++ b/test/examples/embeddables/todo_embeddable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/routing/index.ts
+++ b/test/examples/routing/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/state_sync/index.ts
+++ b/test/examples/state_sync/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/state_sync/todo_app.ts
+++ b/test/examples/state_sync/todo_app.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/ui_actions/index.ts
+++ b/test/examples/ui_actions/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/examples/ui_actions/ui_actions.ts
+++ b/test/examples/ui_actions/ui_actions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/bundles/index.js
+++ b/test/functional/apps/bundles/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/console/_console.ts
+++ b/test/functional/apps/console/_console.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/console/index.js
+++ b/test/functional/apps/console/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/context/_context_navigation.js
+++ b/test/functional/apps/context/_context_navigation.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/context/_date_nanos.js
+++ b/test/functional/apps/context/_date_nanos.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/context/_date_nanos_custom_timestamp.js
+++ b/test/functional/apps/context/_date_nanos_custom_timestamp.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/context/_discover_navigation.js
+++ b/test/functional/apps/context/_discover_navigation.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/context/_filters.js
+++ b/test/functional/apps/context/_filters.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/context/_size.js
+++ b/test/functional/apps/context/_size.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/context/index.js
+++ b/test/functional/apps/context/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/bwc_shared_urls.js
+++ b/test/functional/apps/dashboard/bwc_shared_urls.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/create_and_add_embeddables.js
+++ b/test/functional/apps/dashboard/create_and_add_embeddables.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_back_button.ts
+++ b/test/functional/apps/dashboard/dashboard_back_button.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_clone.js
+++ b/test/functional/apps/dashboard/dashboard_clone.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_error_handling.ts
+++ b/test/functional/apps/dashboard/dashboard_error_handling.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_filter_bar.js
+++ b/test/functional/apps/dashboard/dashboard_filter_bar.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_filtering.js
+++ b/test/functional/apps/dashboard/dashboard_filtering.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_grid.js
+++ b/test/functional/apps/dashboard/dashboard_grid.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_listing.js
+++ b/test/functional/apps/dashboard/dashboard_listing.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_options.js
+++ b/test/functional/apps/dashboard/dashboard_options.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_query_bar.js
+++ b/test/functional/apps/dashboard/dashboard_query_bar.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_save.js
+++ b/test/functional/apps/dashboard/dashboard_save.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_saved_query.js
+++ b/test/functional/apps/dashboard/dashboard_saved_query.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_snapshots.js
+++ b/test/functional/apps/dashboard/dashboard_snapshots.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_state.js
+++ b/test/functional/apps/dashboard/dashboard_state.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_time.js
+++ b/test/functional/apps/dashboard/dashboard_time.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/dashboard_time_picker.js
+++ b/test/functional/apps/dashboard/dashboard_time_picker.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/data_shared_attributes.js
+++ b/test/functional/apps/dashboard/data_shared_attributes.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/edit_embeddable_redirects.js
+++ b/test/functional/apps/dashboard/edit_embeddable_redirects.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/edit_visualizations.js
+++ b/test/functional/apps/dashboard/edit_visualizations.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/embed_mode.js
+++ b/test/functional/apps/dashboard/embed_mode.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/embeddable_rendering.js
+++ b/test/functional/apps/dashboard/embeddable_rendering.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/empty_dashboard.js
+++ b/test/functional/apps/dashboard/empty_dashboard.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/full_screen_mode.js
+++ b/test/functional/apps/dashboard/full_screen_mode.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/index.js
+++ b/test/functional/apps/dashboard/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/legacy_urls.ts
+++ b/test/functional/apps/dashboard/legacy_urls.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/panel_cloning.ts
+++ b/test/functional/apps/dashboard/panel_cloning.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/panel_context_menu.ts
+++ b/test/functional/apps/dashboard/panel_context_menu.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/panel_expand_toggle.js
+++ b/test/functional/apps/dashboard/panel_expand_toggle.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/panel_replacing.ts
+++ b/test/functional/apps/dashboard/panel_replacing.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/time_zones.js
+++ b/test/functional/apps/dashboard/time_zones.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/url_field_formatter.ts
+++ b/test/functional/apps/dashboard/url_field_formatter.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/dashboard/view_edit.js
+++ b/test/functional/apps/dashboard/view_edit.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_date_nanos.js
+++ b/test/functional/apps/discover/_date_nanos.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_date_nanos_mixed.js
+++ b/test/functional/apps/discover/_date_nanos_mixed.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_discover_histogram.ts
+++ b/test/functional/apps/discover/_discover_histogram.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_doc_navigation.js
+++ b/test/functional/apps/discover/_doc_navigation.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_doc_table.ts
+++ b/test/functional/apps/discover/_doc_table.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_errors.ts
+++ b/test/functional/apps/discover/_errors.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_field_data.js
+++ b/test/functional/apps/discover/_field_data.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_field_visualize.ts
+++ b/test/functional/apps/discover/_field_visualize.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_filter_editor.js
+++ b/test/functional/apps/discover/_filter_editor.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_indexpattern_without_timefield.ts
+++ b/test/functional/apps/discover/_indexpattern_without_timefield.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_inspector.js
+++ b/test/functional/apps/discover/_inspector.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_large_string.js
+++ b/test/functional/apps/discover/_large_string.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_saved_queries.js
+++ b/test/functional/apps/discover/_saved_queries.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_shared_links.js
+++ b/test/functional/apps/discover/_shared_links.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_sidebar.js
+++ b/test/functional/apps/discover/_sidebar.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/_source_filters.js
+++ b/test/functional/apps/discover/_source_filters.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/discover/index.js
+++ b/test/functional/apps/discover/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/getting_started/_shakespeare.js
+++ b/test/functional/apps/getting_started/_shakespeare.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/getting_started/index.js
+++ b/test/functional/apps/getting_started/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/home/_add_data.js
+++ b/test/functional/apps/home/_add_data.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/home/_home.js
+++ b/test/functional/apps/home/_home.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/home/_navigation.ts
+++ b/test/functional/apps/home/_navigation.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/home/_newsfeed.ts
+++ b/test/functional/apps/home/_newsfeed.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/home/_sample_data.ts
+++ b/test/functional/apps/home/_sample_data.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/home/index.js
+++ b/test/functional/apps/home/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_create_index_pattern_wizard.js
+++ b/test/functional/apps/management/_create_index_pattern_wizard.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_handle_alias.js
+++ b/test/functional/apps/management/_handle_alias.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_handle_version_conflict.js
+++ b/test/functional/apps/management/_handle_version_conflict.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_import_objects.js
+++ b/test/functional/apps/management/_import_objects.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_index_pattern_create_delete.js
+++ b/test/functional/apps/management/_index_pattern_create_delete.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_index_pattern_filter.js
+++ b/test/functional/apps/management/_index_pattern_filter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_index_pattern_popularity.js
+++ b/test/functional/apps/management/_index_pattern_popularity.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_index_pattern_results_sort.js
+++ b/test/functional/apps/management/_index_pattern_results_sort.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_index_patterns_empty.ts
+++ b/test/functional/apps/management/_index_patterns_empty.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_mgmt_import_saved_objects.js
+++ b/test/functional/apps/management/_mgmt_import_saved_objects.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_opensearch_dashboards_settings.js
+++ b/test/functional/apps/management/_opensearch_dashboards_settings.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_scripted_fields.js
+++ b/test/functional/apps/management/_scripted_fields.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_scripted_fields_filter.js
+++ b/test/functional/apps/management/_scripted_fields_filter.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_scripted_fields_preview.js
+++ b/test/functional/apps/management/_scripted_fields_preview.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/_test_huge_fields.js
+++ b/test/functional/apps/management/_test_huge_fields.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/management/index.js
+++ b/test/functional/apps/management/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/saved_objects_management/edit_saved_object.ts
+++ b/test/functional/apps/saved_objects_management/edit_saved_object.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/saved_objects_management/index.ts
+++ b/test/functional/apps/saved_objects_management/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/status_page/index.ts
+++ b/test/functional/apps/status_page/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/timeline/_expression_typeahead.js
+++ b/test/functional/apps/timeline/_expression_typeahead.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/timeline/index.js
+++ b/test/functional/apps/timeline/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_area_chart.js
+++ b/test/functional/apps/visualize/_area_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_chart_types.ts
+++ b/test/functional/apps/visualize/_chart_types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_custom_branding.js
+++ b/test/functional/apps/visualize/_custom_branding.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_data_table.js
+++ b/test/functional/apps/visualize/_data_table.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_data_table_nontimeindex.js
+++ b/test/functional/apps/visualize/_data_table_nontimeindex.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_data_table_notimeindex_filters.ts
+++ b/test/functional/apps/visualize/_data_table_notimeindex_filters.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_embedding_chart.js
+++ b/test/functional/apps/visualize/_embedding_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_experimental_vis.js
+++ b/test/functional/apps/visualize/_experimental_vis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_gauge_chart.js
+++ b/test/functional/apps/visualize/_gauge_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_heatmap_chart.js
+++ b/test/functional/apps/visualize/_heatmap_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_histogram_request_start.js
+++ b/test/functional/apps/visualize/_histogram_request_start.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_inspector.js
+++ b/test/functional/apps/visualize/_inspector.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_lab_mode.js
+++ b/test/functional/apps/visualize/_lab_mode.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_line_chart.js
+++ b/test/functional/apps/visualize/_line_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_linked_saved_searches.ts
+++ b/test/functional/apps/visualize/_linked_saved_searches.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_markdown_vis.js
+++ b/test/functional/apps/visualize/_markdown_vis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_metric_chart.js
+++ b/test/functional/apps/visualize/_metric_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_pie_chart.js
+++ b/test/functional/apps/visualize/_pie_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_point_series_options.js
+++ b/test/functional/apps/visualize/_point_series_options.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_region_map.js
+++ b/test/functional/apps/visualize/_region_map.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_shared_item.js
+++ b/test/functional/apps/visualize/_shared_item.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_tag_cloud.js
+++ b/test/functional/apps/visualize/_tag_cloud.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_tile_map.js
+++ b/test/functional/apps/visualize/_tile_map.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_tsvb_chart.ts
+++ b/test/functional/apps/visualize/_tsvb_chart.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_tsvb_markdown.ts
+++ b/test/functional/apps/visualize/_tsvb_markdown.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_tsvb_table.ts
+++ b/test/functional/apps/visualize/_tsvb_table.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_tsvb_time_series.ts
+++ b/test/functional/apps/visualize/_tsvb_time_series.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_vega_chart.ts
+++ b/test/functional/apps/visualize/_vega_chart.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_vertical_bar_chart.js
+++ b/test/functional/apps/visualize/_vertical_bar_chart.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_vertical_bar_chart_nontimeindex.js
+++ b/test/functional/apps/visualize/_vertical_bar_chart_nontimeindex.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/_visualize_listing.js
+++ b/test/functional/apps/visualize/_visualize_listing.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/index.ts
+++ b/test/functional/apps/visualize/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/input_control_vis/chained_controls.js
+++ b/test/functional/apps/visualize/input_control_vis/chained_controls.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/input_control_vis/dynamic_options.js
+++ b/test/functional/apps/visualize/input_control_vis/dynamic_options.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/input_control_vis/index.js
+++ b/test/functional/apps/visualize/input_control_vis/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/input_control_vis/input_control_options.js
+++ b/test/functional/apps/visualize/input_control_vis/input_control_options.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/apps/visualize/input_control_vis/input_control_range.ts
+++ b/test/functional/apps/visualize/input_control_vis/input_control_range.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/config.edge.js
+++ b/test/functional/config.edge.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/config.firefox.js
+++ b/test/functional/config.firefox.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/ftr_provider_context.d.ts
+++ b/test/functional/ftr_provider_context.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/console_page.ts
+++ b/test/functional/page_objects/console_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/context_page.ts
+++ b/test/functional/page_objects/context_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/discover_page.ts
+++ b/test/functional/page_objects/discover_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/error_page.ts
+++ b/test/functional/page_objects/error_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/header_page.ts
+++ b/test/functional/page_objects/header_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/home_page.ts
+++ b/test/functional/page_objects/home_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/index.ts
+++ b/test/functional/page_objects/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/login_page.ts
+++ b/test/functional/page_objects/login_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/management/saved_objects_page.ts
+++ b/test/functional/page_objects/management/saved_objects_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/newsfeed_page.ts
+++ b/test/functional/page_objects/newsfeed_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/settings_page.ts
+++ b/test/functional/page_objects/settings_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/share_page.ts
+++ b/test/functional/page_objects/share_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/tag_cloud_page.ts
+++ b/test/functional/page_objects/tag_cloud_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/tile_map_page.ts
+++ b/test/functional/page_objects/tile_map_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/time_picker.ts
+++ b/test/functional/page_objects/time_picker.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/timeline_page.ts
+++ b/test/functional/page_objects/timeline_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/vega_chart_page.ts
+++ b/test/functional/page_objects/vega_chart_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/visualize_chart_page.ts
+++ b/test/functional/page_objects/visualize_chart_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/visualize_editor_page.ts
+++ b/test/functional/page_objects/visualize_editor_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/page_objects/visualize_page.ts
+++ b/test/functional/page_objects/visualize_page.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/apps_menu.ts
+++ b/test/functional/services/apps_menu.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/combo_box.ts
+++ b/test/functional/services/combo_box.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/common/browser.ts
+++ b/test/functional/services/common/browser.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/common/failure_debugging.ts
+++ b/test/functional/services/common/failure_debugging.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/common/find.ts
+++ b/test/functional/services/common/find.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/common/index.ts
+++ b/test/functional/services/common/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/common/screenshots.ts
+++ b/test/functional/services/common/screenshots.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/common/snapshots.ts
+++ b/test/functional/services/common/snapshots.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/common/test_subjects.ts
+++ b/test/functional/services/common/test_subjects.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/dashboard/add_panel.ts
+++ b/test/functional/services/dashboard/add_panel.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/dashboard/expectations.ts
+++ b/test/functional/services/dashboard/expectations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/dashboard/index.ts
+++ b/test/functional/services/dashboard/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/dashboard/panel_actions.ts
+++ b/test/functional/services/dashboard/panel_actions.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/dashboard/replace_panel.ts
+++ b/test/functional/services/dashboard/replace_panel.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/dashboard/visualizations.ts
+++ b/test/functional/services/dashboard/visualizations.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/data_grid.ts
+++ b/test/functional/services/data_grid.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/doc_table.ts
+++ b/test/functional/services/doc_table.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/embedding.ts
+++ b/test/functional/services/embedding.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/filter_bar.ts
+++ b/test/functional/services/filter_bar.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/flyout.ts
+++ b/test/functional/services/flyout.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/global_nav.ts
+++ b/test/functional/services/global_nav.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/index.ts
+++ b/test/functional/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/inspector.ts
+++ b/test/functional/services/inspector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/lib/compare_pngs.ts
+++ b/test/functional/services/lib/compare_pngs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/lib/web_element_wrapper/index.ts
+++ b/test/functional/services/lib/web_element_wrapper/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/lib/web_element_wrapper/web_element_wrapper.ts
+++ b/test/functional/services/lib/web_element_wrapper/web_element_wrapper.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/listing_table.ts
+++ b/test/functional/services/listing_table.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/management/index.ts
+++ b/test/functional/services/management/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/management/management_menu.ts
+++ b/test/functional/services/management/management_menu.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/menu_toggle.ts
+++ b/test/functional/services/menu_toggle.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/query_bar.ts
+++ b/test/functional/services/query_bar.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/__tests__/fixtures/several_nested_window_size_changes/config.js
+++ b/test/functional/services/remote/__tests__/fixtures/several_nested_window_size_changes/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/__tests__/fixtures/several_nested_window_size_changes/test.js
+++ b/test/functional/services/remote/__tests__/fixtures/several_nested_window_size_changes/test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/__tests__/fixtures/several_nested_window_size_changes/test2.js
+++ b/test/functional/services/remote/__tests__/fixtures/several_nested_window_size_changes/test2.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/__tests__/fixtures/several_nested_window_size_changes/test3.1.js
+++ b/test/functional/services/remote/__tests__/fixtures/several_nested_window_size_changes/test3.1.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/__tests__/fixtures/several_nested_window_size_changes/test3.js
+++ b/test/functional/services/remote/__tests__/fixtures/several_nested_window_size_changes/test3.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/__tests__/remote_default_window_size.js
+++ b/test/functional/services/remote/__tests__/remote_default_window_size.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/browsers.ts
+++ b/test/functional/services/remote/browsers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/create_stdout_stream.ts
+++ b/test/functional/services/remote/create_stdout_stream.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/index.ts
+++ b/test/functional/services/remote/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/poll_for_log_entry.ts
+++ b/test/functional/services/remote/poll_for_log_entry.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/prevent_parallel_calls.test.js
+++ b/test/functional/services/remote/prevent_parallel_calls.test.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/prevent_parallel_calls.ts
+++ b/test/functional/services/remote/prevent_parallel_calls.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/remote.ts
+++ b/test/functional/services/remote/remote.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/remote/webdriver.ts
+++ b/test/functional/services/remote/webdriver.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/renderable.ts
+++ b/test/functional/services/renderable.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/saved_query_management_component.ts
+++ b/test/functional/services/saved_query_management_component.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/supertest.ts
+++ b/test/functional/services/supertest.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/table.ts
+++ b/test/functional/services/table.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/toasts.ts
+++ b/test/functional/services/toasts.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/visualizations/index.ts
+++ b/test/functional/services/visualizations/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/visualizations/opensearch_chart.ts
+++ b/test/functional/services/visualizations/opensearch_chart.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/visualizations/pie_chart.ts
+++ b/test/functional/services/visualizations/pie_chart.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/functional/services/visualizations/vega_debug_inspector.ts
+++ b/test/functional/services/visualizations/vega_debug_inspector.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/harden/_fork.js
+++ b/test/harden/_fork.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/harden/child_process.js
+++ b/test/harden/child_process.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/harden/lodash_template.js
+++ b/test/harden/lodash_template.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/config.ts
+++ b/test/interpreter_functional/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/app/app.tsx
+++ b/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/app/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/app/components/main.tsx
+++ b/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/app/components/main.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/index.ts
+++ b/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/plugin.ts
+++ b/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/services.ts
+++ b/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/services.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/types.ts
+++ b/test/interpreter_functional/plugins/osd_tp_run_pipeline/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/test_suites/run_pipeline/basic.ts
+++ b/test/interpreter_functional/test_suites/run_pipeline/basic.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/test_suites/run_pipeline/esaggs.ts
+++ b/test/interpreter_functional/test_suites/run_pipeline/esaggs.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/test_suites/run_pipeline/helpers.ts
+++ b/test/interpreter_functional/test_suites/run_pipeline/helpers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/test_suites/run_pipeline/index.ts
+++ b/test/interpreter_functional/test_suites/run_pipeline/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/test_suites/run_pipeline/metric.ts
+++ b/test/interpreter_functional/test_suites/run_pipeline/metric.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/interpreter_functional/test_suites/run_pipeline/tag_cloud.ts
+++ b/test/interpreter_functional/test_suites/run_pipeline/tag_cloud.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/mocha_decorations.d.ts
+++ b/test/mocha_decorations.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/new_visualize_flow/config.ts
+++ b/test/new_visualize_flow/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/new_visualize_flow/dashboard_embedding.ts
+++ b/test/new_visualize_flow/dashboard_embedding.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/new_visualize_flow/index.ts
+++ b/test/new_visualize_flow/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/config.ts
+++ b/test/plugin_functional/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/app_link_test/public/app.tsx
+++ b/test/plugin_functional/plugins/app_link_test/public/app.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/app_link_test/public/index.ts
+++ b/test/plugin_functional/plugins/app_link_test/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/app_link_test/public/plugin.ts
+++ b/test/plugin_functional/plugins/app_link_test/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_app_status/public/application.tsx
+++ b/test/plugin_functional/plugins/core_app_status/public/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_app_status/public/index.ts
+++ b/test/plugin_functional/plugins/core_app_status/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_app_status/public/plugin.tsx
+++ b/test/plugin_functional/plugins/core_app_status/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_app_status/public/types.ts
+++ b/test/plugin_functional/plugins/core_app_status/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_a/public/application.tsx
+++ b/test/plugin_functional/plugins/core_plugin_a/public/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_a/public/index.ts
+++ b/test/plugin_functional/plugins/core_plugin_a/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_a/public/plugin.tsx
+++ b/test/plugin_functional/plugins/core_plugin_a/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_a/server/index.ts
+++ b/test/plugin_functional/plugins/core_plugin_a/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_a/server/plugin.ts
+++ b/test/plugin_functional/plugins/core_plugin_a/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_appleave/public/application.tsx
+++ b/test/plugin_functional/plugins/core_plugin_appleave/public/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_appleave/public/index.ts
+++ b/test/plugin_functional/plugins/core_plugin_appleave/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_appleave/public/plugin.tsx
+++ b/test/plugin_functional/plugins/core_plugin_appleave/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_b/public/application.tsx
+++ b/test/plugin_functional/plugins/core_plugin_b/public/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_b/public/index.ts
+++ b/test/plugin_functional/plugins/core_plugin_b/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_b/public/plugin.tsx
+++ b/test/plugin_functional/plugins/core_plugin_b/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_b/server/index.ts
+++ b/test/plugin_functional/plugins/core_plugin_b/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_b/server/plugin.ts
+++ b/test/plugin_functional/plugins/core_plugin_b/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_chromeless/public/application.tsx
+++ b/test/plugin_functional/plugins/core_plugin_chromeless/public/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_chromeless/public/index.ts
+++ b/test/plugin_functional/plugins/core_plugin_chromeless/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_chromeless/public/plugin.tsx
+++ b/test/plugin_functional/plugins/core_plugin_chromeless/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_route_timeouts/server/index.ts
+++ b/test/plugin_functional/plugins/core_plugin_route_timeouts/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_route_timeouts/server/plugin.ts
+++ b/test/plugin_functional/plugins/core_plugin_route_timeouts/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_static_assets/public/index.ts
+++ b/test/plugin_functional/plugins/core_plugin_static_assets/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_plugin_static_assets/public/plugin.tsx
+++ b/test/plugin_functional/plugins/core_plugin_static_assets/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_provider_plugin/public/index.ts
+++ b/test/plugin_functional/plugins/core_provider_plugin/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/core_provider_plugin/types.ts
+++ b/test/plugin_functional/plugins/core_provider_plugin/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/data_search/server/index.ts
+++ b/test/plugin_functional/plugins/data_search/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/data_search/server/plugin.ts
+++ b/test/plugin_functional/plugins/data_search/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/doc_views_plugin/public/index.ts
+++ b/test/plugin_functional/plugins/doc_views_plugin/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/doc_views_plugin/public/plugin.tsx
+++ b/test/plugin_functional/plugins/doc_views_plugin/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/index_patterns/server/index.ts
+++ b/test/plugin_functional/plugins/index_patterns/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/index_patterns/server/plugin.ts
+++ b/test/plugin_functional/plugins/index_patterns/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/management_test_plugin/public/index.ts
+++ b/test/plugin_functional/plugins/management_test_plugin/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/management_test_plugin/public/plugin.tsx
+++ b/test/plugin_functional/plugins/management_test_plugin/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/opensearch_client_plugin/server/index.ts
+++ b/test/plugin_functional/plugins/opensearch_client_plugin/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/opensearch_client_plugin/server/plugin.ts
+++ b/test/plugin_functional/plugins/opensearch_client_plugin/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_sample_panel_action/public/index.ts
+++ b/test/plugin_functional/plugins/osd_sample_panel_action/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_sample_panel_action/public/plugin.ts
+++ b/test/plugin_functional/plugins/osd_sample_panel_action/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_sample_panel_action/public/sample_panel_action.tsx
+++ b/test/plugin_functional/plugins/osd_sample_panel_action/public/sample_panel_action.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_sample_panel_action/public/sample_panel_link.ts
+++ b/test/plugin_functional/plugins/osd_sample_panel_action/public/sample_panel_link.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_top_nav/public/application.tsx
+++ b/test/plugin_functional/plugins/osd_top_nav/public/application.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_top_nav/public/index.ts
+++ b/test/plugin_functional/plugins/osd_top_nav/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_top_nav/public/plugin.tsx
+++ b/test/plugin_functional/plugins/osd_top_nav/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_top_nav/public/types.ts
+++ b/test/plugin_functional/plugins/osd_top_nav/public/types.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_tp_custom_visualizations/public/index.ts
+++ b/test/plugin_functional/plugins/osd_tp_custom_visualizations/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_tp_custom_visualizations/public/plugin.ts
+++ b/test/plugin_functional/plugins/osd_tp_custom_visualizations/public/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_tp_custom_visualizations/public/self_changing_vis/self_changing_components.tsx
+++ b/test/plugin_functional/plugins/osd_tp_custom_visualizations/public/self_changing_vis/self_changing_components.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/osd_tp_custom_visualizations/public/self_changing_vis/self_changing_editor.tsx
+++ b/test/plugin_functional/plugins/osd_tp_custom_visualizations/public/self_changing_vis/self_changing_editor.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/rendering_plugin/public/index.ts
+++ b/test/plugin_functional/plugins/rendering_plugin/public/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/rendering_plugin/public/plugin.tsx
+++ b/test/plugin_functional/plugins/rendering_plugin/public/plugin.tsx
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/rendering_plugin/server/index.ts
+++ b/test/plugin_functional/plugins/rendering_plugin/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/rendering_plugin/server/plugin.ts
+++ b/test/plugin_functional/plugins/rendering_plugin/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/ui_settings_plugin/server/index.ts
+++ b/test/plugin_functional/plugins/ui_settings_plugin/server/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/plugins/ui_settings_plugin/server/plugin.ts
+++ b/test/plugin_functional/plugins/ui_settings_plugin/server/plugin.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/services/index.ts
+++ b/test/plugin_functional/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/application_links/index.ts
+++ b/test/plugin_functional/test_suites/application_links/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/application_links/redirect_app_links.ts
+++ b/test/plugin_functional/test_suites/application_links/redirect_app_links.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core/index.ts
+++ b/test/plugin_functional/test_suites/core/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core/route.ts
+++ b/test/plugin_functional/test_suites/core/route.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core_plugins/application_leave_confirm.ts
+++ b/test/plugin_functional/test_suites/core_plugins/application_leave_confirm.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core_plugins/application_status.ts
+++ b/test/plugin_functional/test_suites/core_plugins/application_status.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core_plugins/applications.ts
+++ b/test/plugin_functional/test_suites/core_plugins/applications.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core_plugins/index.ts
+++ b/test/plugin_functional/test_suites/core_plugins/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core_plugins/opensearch_client.ts
+++ b/test/plugin_functional/test_suites/core_plugins/opensearch_client.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core_plugins/server_plugins.ts
+++ b/test/plugin_functional/test_suites/core_plugins/server_plugins.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core_plugins/top_nav.ts
+++ b/test/plugin_functional/test_suites/core_plugins/top_nav.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core_plugins/ui_plugins.ts
+++ b/test/plugin_functional/test_suites/core_plugins/ui_plugins.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/core_plugins/ui_settings.ts
+++ b/test/plugin_functional/test_suites/core_plugins/ui_settings.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/custom_visualizations/index.js
+++ b/test/plugin_functional/test_suites/custom_visualizations/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/custom_visualizations/self_changing_vis.js
+++ b/test/plugin_functional/test_suites/custom_visualizations/self_changing_vis.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/data_plugin/index.ts
+++ b/test/plugin_functional/test_suites/data_plugin/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/data_plugin/index_patterns.ts
+++ b/test/plugin_functional/test_suites/data_plugin/index_patterns.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/data_plugin/search.ts
+++ b/test/plugin_functional/test_suites/data_plugin/search.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/doc_views/doc_views.ts
+++ b/test/plugin_functional/test_suites/doc_views/doc_views.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/doc_views/index.ts
+++ b/test/plugin_functional/test_suites/doc_views/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/management/index.js
+++ b/test/plugin_functional/test_suites/management/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/management/management_plugin.js
+++ b/test/plugin_functional/test_suites/management/management_plugin.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/panel_actions/index.js
+++ b/test/plugin_functional/test_suites/panel_actions/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/plugin_functional/test_suites/panel_actions/panel_actions.js
+++ b/test/plugin_functional/test_suites/panel_actions/panel_actions.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/security_functional/config.ts
+++ b/test/security_functional/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/security_functional/index.ts
+++ b/test/security_functional/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/security_functional/insecure_cluster_warning.ts
+++ b/test/security_functional/insecure_cluster_warning.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/__fixtures__/index.ts
+++ b/test/server_integration/__fixtures__/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/config.js
+++ b/test/server_integration/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/http/platform/cache.ts
+++ b/test/server_integration/http/platform/cache.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/http/platform/config.ts
+++ b/test/server_integration/http/platform/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/http/platform/headers.ts
+++ b/test/server_integration/http/platform/headers.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/http/ssl/config.js
+++ b/test/server_integration/http/ssl/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/http/ssl/index.js
+++ b/test/server_integration/http/ssl/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/http/ssl_redirect/config.js
+++ b/test/server_integration/http/ssl_redirect/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/http/ssl_redirect/index.js
+++ b/test/server_integration/http/ssl_redirect/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/http/ssl_with_p12/config.js
+++ b/test/server_integration/http/ssl_with_p12/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/http/ssl_with_p12/index.js
+++ b/test/server_integration/http/ssl_with_p12/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/http/ssl_with_p12_intermediate/config.js
+++ b/test/server_integration/http/ssl_with_p12_intermediate/config.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/http/ssl_with_p12_intermediate/index.js
+++ b/test/server_integration/http/ssl_with_p12_intermediate/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/services/index.js
+++ b/test/server_integration/services/index.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/services/supertest.js
+++ b/test/server_integration/services/supertest.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/server_integration/services/types.d.ts
+++ b/test/server_integration/services/types.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/typings/index.d.ts
+++ b/test/typings/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/typings/rison_node.d.ts
+++ b/test/typings/rison_node.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/ui_capabilities/newsfeed_err/config.ts
+++ b/test/ui_capabilities/newsfeed_err/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/ui_capabilities/newsfeed_err/test.ts
+++ b/test/ui_capabilities/newsfeed_err/test.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/visual_regression/config.ts
+++ b/test/visual_regression/config.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/visual_regression/ftr_provider_context.d.ts
+++ b/test/visual_regression/ftr_provider_context.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/visual_regression/services/index.ts
+++ b/test/visual_regression/services/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/visual_regression/services/visual_testing/index.ts
+++ b/test/visual_regression/services/visual_testing/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/visual_regression/services/visual_testing/take_percy_snapshot.js
+++ b/test/visual_regression/services/visual_testing/take_percy_snapshot.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/visual_regression/services/visual_testing/visual_testing.ts
+++ b/test/visual_regression/services/visual_testing/visual_testing.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/visual_regression/tests/console_app.ts
+++ b/test/visual_regression/tests/console_app.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/visual_regression/tests/discover/chart_visualization.ts
+++ b/test/visual_regression/tests/discover/chart_visualization.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/test/visual_regression/tests/discover/index.ts
+++ b/test/visual_regression/tests/discover/index.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/typings/@elastic/eui/index.d.ts
+++ b/typings/@elastic/eui/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/typings/@elastic/eui/lib/format.d.ts
+++ b/typings/@elastic/eui/lib/format.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/typings/@elastic/eui/lib/services.d.ts
+++ b/typings/@elastic/eui/lib/services.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/typings/accept.d.ts
+++ b/typings/accept.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/typings/rison_node.d.ts
+++ b/typings/rison_node.d.ts
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.

--- a/utilities/visual_regression.js
+++ b/utilities/visual_regression.js
@@ -1,6 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
+ */
+
+/*
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.


### PR DESCRIPTION
Signed-off-by: Ashwin Pc <ashwinpc@amazon.com>

### Description
Updates the license header across the project to reflect the simpler and more accurate license header (Issue: https://github.com/opensearch-project/.github/issues/21)

The 4 changes here are:
1. ESLint rule to enforce only the smaller header
2. Split and update existing headers across the project so that the new header and the existing ones are maintained
3. Adds `src/legacy/core_plugins/opensearch-dashboards/public/context/query_parameters` to pre-commit hook's file glob ignore pattern and removes the unused `src/legacy/ui/public/flot-charts` pattern. ([link](https://github.com/opensearch-project/OpenSearch-Dashboards/blame/ec5a9613424d9bf0b39699980a395d9c3e78d7dc/src/dev/precommit_hook/casing_check_config.js#L111)
4. Updates [schema_error.test.ts.snap](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/packages/osd-config-schema/src/errors/__snapshots__/schema_error.test.ts.snap) due to the header change (line number for the error changes due to the location of the error)

Aside from changes 1,3 and 4, every other file should only have a header change. 
 
### Issues Resolved
- https://github.com/opensearch-project/.github/issues/21
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 