### PR TITLE
[LIC] Allows the simplified header for new files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,13 @@
  * GitHub history for details.
  */
 
+const SIMPLIFIED_OOS_HEADER = `
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+`;
+
 const NEW_OSS_HEADER = `
 /*
  * SPDX-License-Identifier: Apache-2.0
@@ -151,7 +158,7 @@ module.exports = {
         '@osd/eslint/require-license-header': [
           'error',
           {
-            license: NEW_OSS_HEADER,
+            licenses: [SIMPLIFIED_OOS_HEADER, NEW_OSS_HEADER],
           },
         ],
         '@osd/eslint/disallow-license-headers': [
@@ -187,7 +194,7 @@ module.exports = {
         '@osd/eslint/require-license-header': [
           'error',
           {
-            license: SAFER_LODASH_SET_LODASH_HEADER,
+            licenses: [SAFER_LODASH_SET_LODASH_HEADER],
           },
         ],
         '@osd/eslint/disallow-license-headers': [
@@ -209,7 +216,7 @@ module.exports = {
         '@osd/eslint/require-license-header': [
           'error',
           {
-            license: SAFER_LODASH_SET_HEADER,
+            licenses: [SAFER_LODASH_SET_HEADER],
           },
         ],
         '@osd/eslint/disallow-license-headers': [
@@ -233,7 +240,7 @@ module.exports = {
         '@osd/eslint/require-license-header': [
           'error',
           {
-            license: SAFER_LODASH_SET_DEFINITELYTYPED_HEADER,
+            licenses: [SAFER_LODASH_SET_DEFINITELYTYPED_HEADER],
           },
         ],
         '@osd/eslint/disallow-license-headers': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,14 +30,20 @@
  * GitHub history for details.
  */
 
-const SIMPLIFIED_OOS_HEADER = `
+/**
+ * For new files created by OpenSearch Contributers
+ */
+const OSD_HEADER = `
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 `;
 
-const NEW_OSS_HEADER = `
+/**
+ * For files that modify or use code with an exsting OSS header
+ */
+const OSS_HEADER = `
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -158,7 +164,7 @@ module.exports = {
         '@osd/eslint/require-license-header': [
           'error',
           {
-            licenses: [SIMPLIFIED_OOS_HEADER, NEW_OSS_HEADER],
+            licenses: [OSD_HEADER, OSS_HEADER],
           },
         ],
         '@osd/eslint/disallow-license-headers': [
@@ -223,7 +229,7 @@ module.exports = {
           'error',
           {
             licenses: [
-              NEW_OSS_HEADER,
+              OSS_HEADER,
               ELASTIC_LICENSE_HEADER,
               APACHE_2_0_LICENSE_HEADER,
               SAFER_LODASH_SET_LODASH_HEADER,
@@ -247,7 +253,7 @@ module.exports = {
           'error',
           {
             licenses: [
-              NEW_OSS_HEADER,
+              OSS_HEADER,
               ELASTIC_LICENSE_HEADER,
               APACHE_2_0_LICENSE_HEADER,
               SAFER_LODASH_SET_HEADER,

--- a/packages/osd-eslint-plugin-eslint/rules/__tests__/require_license_header.js
+++ b/packages/osd-eslint-plugin-eslint/rules/__tests__/require_license_header.js
@@ -50,7 +50,7 @@ ruleTester.run('@osd/eslint/require-license-header', rule, {
         console.log('foo')
       `,
 
-      options: [{ license: '/* license */' }],
+      options: [{ licenses: ['/* license */'] }],
     },
     {
       code: dedent`
@@ -59,7 +59,17 @@ ruleTester.run('@osd/eslint/require-license-header', rule, {
         console.log('foo')
       `,
 
-      options: [{ license: '// license' }],
+      options: [{ licenses: ['// license'] }],
+    },
+    // multiple valid licenses
+    {
+      code: dedent`
+        /* license 2 */
+
+        console.log('foo')
+      `,
+
+      options: [{ licenses: ['/* license 1 */', '/* license 2 */'] }],
     },
   ],
 
@@ -73,7 +83,7 @@ ruleTester.run('@osd/eslint/require-license-header', rule, {
       options: [],
       errors: [
         {
-          message: '"license" option is required',
+          message: '"licenses" option is required',
         },
       ],
     },
@@ -84,10 +94,10 @@ ruleTester.run('@osd/eslint/require-license-header', rule, {
         console.log('foo')
       `,
 
-      options: [{ license: '/* one *//* two */' }],
+      options: [{ licenses: ['/* one *//* two */'] }],
       errors: [
         {
-          message: '"license" option must only include a single comment',
+          message: '"licenses[0]" option must only include a single comment',
         },
       ],
     },
@@ -98,10 +108,10 @@ ruleTester.run('@osd/eslint/require-license-header', rule, {
         console.log('foo')
       `,
 
-      options: [{ license: `// one\n// two` }],
+      options: [{ licenses: [`// one\n// two`] }],
       errors: [
         {
-          message: '"license" option must only include a single comment',
+          message: '"licenses[0]" option must only include a single comment',
         },
       ],
     },
@@ -114,15 +124,17 @@ ruleTester.run('@osd/eslint/require-license-header', rule, {
 
       options: [
         {
-          license: dedent`
+          licenses: [
+            dedent`
             /* license */
             console.log('hello world');
           `,
+          ],
         },
       ],
       errors: [
         {
-          message: '"license" option must only include a single comment',
+          message: '"licenses[0]" option must only include a single comment',
         },
       ],
     },
@@ -133,10 +145,10 @@ ruleTester.run('@osd/eslint/require-license-header', rule, {
         console.log('foo')
       `,
 
-      options: [{ license: `console.log('hello world');` }],
+      options: [{ licenses: [`console.log('hello world');`] }],
       errors: [
         {
-          message: '"license" option must only include a single comment',
+          message: '"licenses[0]" option must only include a single comment',
         },
       ],
     },
@@ -147,7 +159,7 @@ ruleTester.run('@osd/eslint/require-license-header', rule, {
         console.log('foo')
       `,
 
-      options: [{ license: '/* license */' }],
+      options: [{ licenses: ['/* license */'] }],
       errors: [
         {
           message: 'File must start with a license header',
@@ -171,7 +183,7 @@ ruleTester.run('@osd/eslint/require-license-header', rule, {
         console.log('foo')
       `,
 
-      options: [{ license: '/* license */' }],
+      options: [{ licenses: ['/* license */'] }],
       errors: [
         {
           message: 'License header must be at the very beginning of the file',
@@ -193,7 +205,7 @@ ruleTester.run('@osd/eslint/require-license-header', rule, {
         console.log('foo')
       `,
 
-      options: [{ license: '/* license */' }],
+      options: [{ licenses: ['/* license */'] }],
       errors: [
         {
           message: 'License header must be at the very beginning of the file',
@@ -207,6 +219,54 @@ ruleTester.run('@osd/eslint/require-license-header', rule, {
 
         console.log('foo')
       `,
+    },
+
+    // atleast one of multiple licenses must be present
+    {
+      code: dedent`
+        /* not license */
+        /* also not license */
+        console.log('foo')
+      `,
+
+      options: [{ licenses: ['/* license 1 */', '/* license 2 */'] }],
+      errors: [
+        {
+          message: 'File must start with a license header',
+        },
+      ],
+
+      output: dedent`
+        /* license 1 */
+
+        /* not license */
+        /* also not license */
+        console.log('foo')
+      `,
+    },
+
+    // atleast one of multiple licenses must be present at the top of the file
+    {
+      code: dedent`
+            /* not license */
+            /* license 2 */
+            console.log('foo')
+          `,
+
+      options: [{ licenses: ['/* license 1 */', '/* license 2 */'] }],
+      errors: [
+        {
+          message: 'License header must be at the very beginning of the file',
+        },
+      ],
+
+      output: dedent`
+            /* license 2 */
+
+            /* not license */
+
+            console.log('foo')
+          `,
     },
   ],
 });


### PR DESCRIPTION
Signed-off-by: Ashwin Pc <ashwinpc@amazon.com>

### Description
Allows for the simplified license header to exist alongside the modified license header. (Issue: https://github.com/opensearch-project/.github/issues/21). If neither license header is present, the simplified license is used.
 
### Issues Resolved
https://github.com/opensearch-project/.github/issues/21
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 