### PR TITLE
[Branding] prevent logging when config not set

### DIFF
--- a/src/core/server/rendering/rendering_service.test.ts
+++ b/src/core/server/rendering/rendering_service.test.ts
@@ -163,6 +163,11 @@ describe('RenderingService', () => {
       const result = await service.isUrlValid('http://notfound.svg', 'config');
       expect(result).toEqual(false);
     });
+
+    it('checks default URL returns false', async () => {
+      const result = await service.isUrlValid('/', 'config');
+      expect(result).toEqual(false);
+    });
   });
 
   describe('isTitleValid()', () => {

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -315,8 +315,11 @@ export class RenderingService {
    * @returns {boolean} indicate if the URL is valid/invalid
    */
   public isUrlValid = async (url: string, configName?: string): Promise<boolean> => {
+    if (url === '/') {
+      return false;
+    }
     if (url.match(/\.(png|svg|gif|PNG|SVG|GIF)$/) === null) {
-      this.logger.get('branding').info(configName + ' config is not found or invalid.');
+      this.logger.get('branding').error(`${configName} config is invalid. Using default branding.`);
       return false;
     }
     return await Axios.get(url, { adapter: AxiosHttpAdapter, maxRedirects: 0 })
@@ -324,7 +327,9 @@ export class RenderingService {
         return true;
       })
       .catch(() => {
-        this.logger.get('branding').info(configName + ' config is not found or invalid');
+        this.logger
+          .get('branding')
+          .error(`${configName} URL was not found or invalid. Using default branding.`);
         return false;
       });
   };
@@ -338,12 +343,14 @@ export class RenderingService {
    * @returns {boolean} indicate if user input title is valid/invalid
    */
   public isTitleValid = (title: string, configName?: string): boolean => {
-    if (!title || title.length > 36) {
+    if (!title) {
+      return false;
+    }
+    if (title.length > 36) {
       this.logger
         .get('branding')
-        .info(
-          configName +
-            ' config is not found or invalid. Title length should be between 1 to 36 characters.'
+        .error(
+          `${configName} config is not found or invalid. Title length should be between 1 to 36 characters. Using default title.`
         );
       return false;
     }


### PR DESCRIPTION
### Description
Out of the box, the rendering service will check the config
and see the default value and log an info message saying that
the branding config is invalid or not set. Everytime
you refresh the browser you will get those log messages.

This sets it to only log error messages if the user sets
the branding config and it is invalid.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/725
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 