### PR TITLE
Add .whitesource file to activate integration scan

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,15 @@
+{
+  "scanSettings": {
+    "configMode": "LOCAL",
+    "configExternalURL": "",
+    "projectToken": "",
+    "baseBranches": []
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure",
+    "displayMode": "diff"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW"
+  }
+}

--- a/whitesource.config
+++ b/whitesource.config
@@ -1,0 +1,372 @@
+###############################################################
+# WhiteSource Unified-Agent configuration file
+###############################################################
+# GENERAL SCAN MODE: Files and Package Managers
+###############################################################
+# Organization vitals
+######################
+
+#apiKey='${wss_apikey}'
+apiKey=
+#userKey is required if WhiteSource administrator has enabled "Enforce user level access" option
+#userKey=
+#requesterEmail=user@provider.com
+
+projectName=
+projectVersion=
+projectToken=
+#projectTag= key:value
+
+productName=
+productVersion=
+productToken=
+
+#projectPerFolder=true
+#projectPerFolderIncludes=
+#projectPerFolderExcludes=
+
+#wss.connectionTimeoutMinutes=60
+
+# Change the below URL to your WhiteSource server.
+# Use the 'WhiteSource Server URL' which can be retrieved
+# from your 'Profile' page on the 'Server URLs' panel.
+# Then, add the '/agent' path to it.
+wss.url=https://saas.whitesourcesoftware.com/agent
+#wss.url=https://app.whitesourcesoftware.com/agent
+#wss.url=https://app-eu.whitesourcesoftware.com/agent
+
+############
+# Policies #
+############
+checkPolicies=false
+forceCheckAllDependencies=false
+forceUpdate=false
+forceUpdate.failBuildOnPolicyViolation=false
+#updateInventory=false
+
+###########
+# General #
+###########
+#offline=false
+#updateType=APPEND
+#ignoreSourceFiles=true
+#scanComment=
+#failErrorLevel=ALL
+#requireKnownSha1=false
+
+#generateProjectDetailsJson=true
+#generateScanReport=true
+#scanReportTimeoutMinutes=10
+#scanReportFilenameFormat=
+
+#analyzeFrameworks=true
+#analyzeFrameworksReference=
+
+#updateEmptyProject=false
+
+#log.files.level=
+#log.files.maxFileSize=
+#log.files.maxFilesCount=
+#log.files.path=
+
+########################################
+# Package Manager Dependency resolvers #
+########################################
+resolveAllDependencies=false
+#excludeDependenciesFromNodes=.*commons-io.*,.*maven-model
+
+#npm.resolveDependencies=false
+#npm.ignoreSourceFiles=false
+#npm.includeDevDependencies=true
+#npm.runPreStep=true
+#npm.ignoreNpmLsErrors=true
+#npm.ignoreScripts=true
+#npm.yarnProject=true
+#npm.accessToken=
+#npm.identifyByNameAndVersion=true
+#npm.yarn.frozenLockfile=true
+#npm.resolveMainPackageJsonOnly=true
+#npm.removeDuplicateDependencies=false
+#npm.resolveAdditionalDependencies=true
+#npm.failOnNpmLsErrors = 
+#npm.projectNameFromDependencyFile = true
+#npm.resolveGlobalPackages=true							   
+#npm.resolveLockFile=true
+
+#bower.resolveDependencies=false
+#bower.ignoreSourceFiles=true
+#bower.runPreStep=true
+
+#nuget.resolvePackagesConfigFiles=false
+#nuget.resolveCsProjFiles=false
+#nuget.resolveDependencies=false
+#nuget.restoreDependencies=true
+#nuget.preferredEnvironment=
+#nuget.packagesDirectory=
+#nuget.ignoreSourceFiles=false
+#nuget.runPreStep=true
+#nuget.resolveNuspecFiles=false
+#nuget.resolveAssetsFiles=true
+
+#python.resolveDependencies=false
+#python.ignoreSourceFiles=false
+#python.ignorePipInstallErrors=true
+#python.installVirtualenv=true
+#python.resolveHierarchyTree=false
+#python.requirementsFileIncludes=requirements.txt
+#python.resolveSetupPyFiles=true
+#python.runPipenvPreStep=true
+#python.pipenvDevDependencies=true
+#python.IgnorePipenvInstallErrors=true
+#python.resolveGlobalPackages=true	
+#python.localPackagePathsToInstall=/path/to/local/dependency.egg, /path/to/local/dependency.zip	
+#python.resolvePipEditablePackages
+#python.path=/path/to/python
+#python.pipPath=/path/to/pip
+#python.runPoetryPreStep=true
+#python.includePoetryDevDependencies=true					  
+
+#maven.ignoredScopes=test provided
+#maven.resolveDependencies=false
+#maven.ignoreSourceFiles=true
+#maven.aggregateModules=true
+#maven.ignorePomModules=false
+#maven.runPreStep=true
+#maven.ignoreMvnTreeErrors=true
+#maven.environmentPath=
+#maven.m2RepositoryPath=
+#maven.downloadMissingDependencies=false
+#maven.additionalArguments=
+#maven.projectNameFromDependencyFile=true										 
+
+resolveAllDependencies=false
+archiveExtractionDepth=7
+followSymbolicLinks=true
+gradle.resolveDependencies=true
+gradle.aggregateModules=true
+gradle.preferredEnvironment=wrapper
+maven.resolveDependencies=true
+maven.runPreStep=true
+maven.aggregateModules=true
+maven.ignoredScopes=None
+html.resolveDependencies=true
+npm.resolveDependencies=true
+npm.runPreStep=true
+npm.yarnProject=true
+go.resolveDependencies=true
+go.collectDependenciesAtRuntime=true
+go.dependencyManager= 
+python.resolveDependencies=true
+python.ignoreSourceFiles=true
+python.runPipenvPreStep=true
+python.pipenvDevDependencies=true
+python.requirementsFileIncludes=dev-requirements.txt
+python.installVirtualenv=true
+ruby.resolveDependencies=true
+ruby.ignoreSourceFiles=false
+
+#gradle.ignoredScopes=
+#gradle.resolveDependencies=true
+#gradle.runAssembleCommand=true
+#gradle.runPreStep=true
+#gradle.ignoreSourceFiles=true
+#gradle.aggregateModules=true
+#gradle.preferredEnvironment=wrapper
+#gradle.localRepositoryPath=
+#gradle.wrapperPath=
+#gradle.downloadMissingDependencies=false
+#gradle.additionalArguments=
+#gradle.includedScopes=
+#gradle.excludeModules=
+#gradle.includeModules=
+#gradle.includedConfigurations=
+#gradle.ignoredConfigurations=
+
+#paket.resolveDependencies=false
+#paket.ignoredGroups=
+#paket.ignoreSourceFiles=false
+#paket.runPreStep=true
+#paket.exePath=
+
+#go.resolveDependencies=false
+#go.collectDependenciesAtRuntime=true
+#go.dependencyManager=
+#go.ignoreSourceFiles=true
+#go.glide.ignoreTestPackages=false
+#go.gogradle.enableTaskAlias=true
+
+#ruby.resolveDependencies=false
+#ruby.ignoreSourceFiles=false
+#ruby.installMissingGems=true
+#ruby.runBundleInstall=true
+#ruby.overwriteGemFile=true
+
+#sbt.resolveDependencies=false
+#sbt.ignoreSourceFiles=true
+#sbt.aggregateModules=true
+#sbt.runPreStep=true
+#sbt.includedScopes=
+
+#php.resolveDependencies=false
+#php.runPreStep=true
+#php.includeDevDependencies=true
+
+#html.resolveDependencies=false
+
+#cocoapods.resolveDependencies=false
+#cocoapods.runPreStep=true
+#cocoapods.ignoreSourceFiles=false
+
+#hex.resolveDependencies=false
+#hex.runPreStep=true
+#hex.ignoreSourceFiles=false
+#hex.aggregateModules=true
+
+#ant.resolveDependencies=false
+#ant.pathIdIncludes=.*
+#ant.external.parameters=
+
+#r.resolveDependencies=false
+#r.runPreStep=true
+#r.ignoreSourceFiles=false
+#r.cranMirrorUrl=
+#r.packageManager=None
+
+#cargo.resolveDependencies=false
+#cargo.runPreStep=true
+#cargo.ignoreSourceFiles=false
+
+#haskell.resolveDependencies=false
+#haskell.runPreStep=true
+#haskell.ignoreSourceFiles=false
+#haskell.ignorePreStepErrors=true
+
+#ocaml.resolveDependencies=false
+#ocaml.runPrepStep=true
+#ocaml.ignoreSourceFiles=false
+#ocaml.switchName=
+#ocaml.ignoredScopes=none
+#ocaml.aggregateModules=true
+
+#bazel.resolveDependencies=false
+#bazel.runPrepStep=true
+
+###########################################################################################
+# Includes/Excludes Glob patterns - Please use only one exclude line and one include line #
+###########################################################################################
+includes=**/*.cc **/*.zip **/*.cpp **/*.c **/*.swf **/*.tgz **/*.h **/*.js **/*.hpp **/*.py **/*.gzip **/*.cs **/*.rb **/*.exe **/*.gz **/*.pl **/*.cxx **/*.c++ **/*.hxx **/*.jar **/*.java **/*.go **/*.mod **/*.sum **/*.rb 
+#includes=**/*.m **/*.mm  **/*.js **/*.php
+#includes=**/*.jar
+#includes=**/*.gem **/*.rb
+#includes=**/*.dll **/*.cs **/*.nupkg
+#includes=**/*.tgz **/*.deb **/*.gzip **/*.rpm **/*.tar.bz2
+#includes=**/*.zip **/*.tar.gz **/*.egg **/*.whl **/*.py
+
+#Exclude file extensions or specific directories by adding **/*.<extension> or **/<excluded_dir>/**
+excludes=**/*sources.jar **/*javadoc.jar
+
+case.sensitive.glob=false
+followSymbolicLinks=true
+
+######################
+# Archive properties #
+######################
+#archiveExtractionDepth=2
+#archiveIncludes=**/*.war **/*.ear
+#archiveExcludes=**/*sources.jar
+
+##############
+# SCAN MODES #
+##############
+
+# Docker images
+################
+#docker.scanImages=true
+#docker.includes=.*.*
+#docker.excludes=
+#docker.pull.enable=true
+#docker.pull.images=.*.*
+#docker.pull.maxImages=10
+#docker.pull.tags=.*.*
+#docker.pull.digest=
+#docker.delete.force=true
+#docker.login.sudo=false
+#docker.projectNameFormat={repositoryNameAndTag|repositoryName|default}
+#docker.scanTarFiles=true
+
+#docker.aws.enable=true
+#docker.aws.registryIds=
+
+#docker.azure.enable=true
+#docker.azure.userName=
+#docker.azure.userPassword=
+#docker.azure.registryNames=
+#docker.azure.authenticationType=containerRegistry
+#docker.azure.registryAuthenticationParameters=<registry1UserName>:<registry1Password> <registry2UserName>:<registry2Password>
+
+#docker.gcr.enable=true
+#docker.gcr.account=
+#docker.gcr.repositories=
+
+#docker.artifactory.enable=true
+#docker.artifactory.url=
+#docker.artifactory.pullUrl=
+#docker.artifactory.userName=
+#docker.artifactory.userPassword=
+#docker.artifactory.repositoriesNames=
+#docker.artifactory.dockerAccessMethod=
+
+#docker.hub.enabled=true
+#docker.hub.userName=
+#docker.hub.userPassword=
+#docker.hub.organizationsNames=
+
+# Docker containers
+####################
+#docker.scanContainers=true
+#docker.containerIncludes=.*.*
+#docker.containerExcludes=
+
+# Linux package manager settings
+################################
+#scanPackageManager=true
+
+# Serverless settings
+######################
+#serverless.provider=
+#serverless.scanFunctions=true
+#serverless.includes=
+#serverless.excludes=
+#serverless.region=
+#serverless.maxFunctions=10
+
+# Artifactory settings
+########################
+#artifactory.enableScan=true
+#artifactory.url=
+#artifactory.accessToken=
+#artifactory.repoKeys=
+#artifactory.userName=
+#artifactory.userPassword=
+
+##################
+# Proxy settings #
+##################
+#proxy.host=
+#proxy.port=
+#proxy.user=
+#proxy.pass=
+
+################
+# SCM settings #
+################
+#scm.type=
+#scm.user=
+#scm.pass=
+#scm.ppk=
+#scm.url=
+#scm.branch=
+#scm.tag=
+#scm.npmInstall=
+#scm.npmInstallTimeoutMinutes=
+#scm.repositoriesFile=

--- a/whitesource.config
+++ b/whitesource.config
@@ -1,5 +1,8 @@
 ###############################################################
 # WhiteSource Unified-Agent configuration file
+# WhiteSource User Guide: https://whitesource.atlassian.net/wiki/spaces/WD/pages/34111720/WhiteSource+User+Guide
+# WhiteSource Integration with Github.com: https://whitesource.atlassian.net/wiki/spaces/WD/pages/697696422/WhiteSource+for+GitHub.com
+# WhiteSource Unified Agent Configurations: https://whitesource.atlassian.net/wiki/spaces/WD/pages/1544880156/Unified+Agent+Configuration+Parameters
 ###############################################################
 # GENERAL SCAN MODE: Files and Package Managers
 ###############################################################
@@ -88,9 +91,9 @@ resolveAllDependencies=false
 #npm.resolveMainPackageJsonOnly=true
 #npm.removeDuplicateDependencies=false
 #npm.resolveAdditionalDependencies=true
-#npm.failOnNpmLsErrors = 
+#npm.failOnNpmLsErrors =
 #npm.projectNameFromDependencyFile = true
-#npm.resolveGlobalPackages=true							   
+#npm.resolveGlobalPackages=true
 #npm.resolveLockFile=true
 
 #bower.resolveDependencies=false
@@ -118,13 +121,13 @@ resolveAllDependencies=false
 #python.runPipenvPreStep=true
 #python.pipenvDevDependencies=true
 #python.IgnorePipenvInstallErrors=true
-#python.resolveGlobalPackages=true	
-#python.localPackagePathsToInstall=/path/to/local/dependency.egg, /path/to/local/dependency.zip	
+#python.resolveGlobalPackages=true
+#python.localPackagePathsToInstall=/path/to/local/dependency.egg, /path/to/local/dependency.zip
 #python.resolvePipEditablePackages
 #python.path=/path/to/python
 #python.pipPath=/path/to/pip
 #python.runPoetryPreStep=true
-#python.includePoetryDevDependencies=true					  
+#python.includePoetryDevDependencies=true
 
 #maven.ignoredScopes=test provided
 #maven.resolveDependencies=false
@@ -137,7 +140,7 @@ resolveAllDependencies=false
 #maven.m2RepositoryPath=
 #maven.downloadMissingDependencies=false
 #maven.additionalArguments=
-#maven.projectNameFromDependencyFile=true										 
+#maven.projectNameFromDependencyFile=true
 
 resolveAllDependencies=false
 archiveExtractionDepth=7
@@ -155,7 +158,7 @@ npm.runPreStep=true
 npm.yarnProject=true
 go.resolveDependencies=true
 go.collectDependenciesAtRuntime=true
-go.dependencyManager= 
+go.dependencyManager=
 python.resolveDependencies=true
 python.ignoreSourceFiles=true
 python.runPipenvPreStep=true
@@ -254,7 +257,7 @@ ruby.ignoreSourceFiles=false
 ###########################################################################################
 # Includes/Excludes Glob patterns - Please use only one exclude line and one include line #
 ###########################################################################################
-includes=**/*.cc **/*.zip **/*.cpp **/*.c **/*.swf **/*.tgz **/*.h **/*.js **/*.hpp **/*.py **/*.gzip **/*.cs **/*.rb **/*.exe **/*.gz **/*.pl **/*.cxx **/*.c++ **/*.hxx **/*.jar **/*.java **/*.go **/*.mod **/*.sum **/*.rb 
+includes=**/*.cc **/*.zip **/*.cpp **/*.c **/*.swf **/*.tgz **/*.h **/*.js **/*.hpp **/*.py **/*.gzip **/*.cs **/*.rb **/*.exe **/*.gz **/*.pl **/*.cxx **/*.c++ **/*.hxx **/*.jar **/*.java **/*.go **/*.mod **/*.sum **/*.rb
 #includes=**/*.m **/*.mm  **/*.js **/*.php
 #includes=**/*.jar
 #includes=**/*.gem **/*.rb


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
We @bbarani already enable the access of [WhiteSource integration](https://whitesource.atlassian.net/wiki/spaces/WD/pages/697696422/WhiteSource+for+GitHub.com) with Github.com for this repo.  However, the automatic PR of `.whitesource` is not created. We asked for the support from WhiteSource side and they suggested we could raise one by ourselves. This PR will also set the WhiteSource integration config mode to `Local` to be using the `whitesource.config`. Dashboards team can modify this configuration on their own to customize it. We are providing the one we had for all repos at this time. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/721
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 