### PR TITLE
Fix Lychee Link Checker Error

### DIFF
--- a/.github/workflows/links_checker.yml
+++ b/.github/workflows/links_checker.yml
@@ -22,7 +22,7 @@ jobs:
         echo "LYCHEE_EXCLUDE=$LYCHEE_EXCLUDE" >> $GITHUB_ENV
     - name: Lychee Link Checker
       id: lychee
-      uses: lycheeverse/lychee-action@master
+      uses: lycheeverse/lychee-action@v1.0.9
       with:
         args: --accept=200,403,429 --exclude ${{ env.LYCHEE_EXCLUDE }} --exclude-mail "**/*.html" "**/*.md" "**/*.txt" "**/*.json" "**/*.js" "**/*.ts" "**/*.tsx"
       env:


### PR DESCRIPTION
Signed-off-by: Zuocheng Ding <zding817@gmail.com>

### Description
There is a bug introduced recently into latest Lychee linker checker. Previously, our link check workflow will pull the latest binary from `@master`. Change the Lychee dependency version to a stable v1.0.9. 
 
### Issues Resolved
Errors in Lychee Link checker.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff 