### PR TITLE
[Node 14 upgrade] Fix unit test failures

### DIFF
--- a/src/dev/jest/config.js
+++ b/src/dev/jest/config.js
@@ -107,7 +107,7 @@ export default {
   transformIgnorePatterns: [
     // ignore all node_modules except monaco-editor which requires babel transforms to handle dynamic import()
     // since ESM modules are not natively supported in Jest yet (https://github.com/facebook/jest/issues/4842)
-    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|lmdb-store|weak-lru-cache|ordered-binary))[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|weak-lru-cache|ordered-binary))[/\\\\].+\\.js$',
     'packages/osd-pm/dist/index.js',
   ],
   snapshotSerializers: [


### PR DESCRIPTION
Fixes jest unit test failures by removing lmdb-store from transformIgnorePatterns

Signed-off-by: Bishoy Boktor <boktorbb@amazon.com>

### Description
Fixes jest unit test failures by removing lmdb-store from transformIgnorePatterns
 
### Issues Resolved
Closes #990 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [X] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 