### PR TITLE
Moves Drag and Drop to create visualization menu

### DIFF
--- a/src/plugins/visualizations/public/wizard/__snapshots__/new_vis_modal.test.tsx.snap
+++ b/src/plugins/visualizations/public/wizard/__snapshots__/new_vis_modal.test.tsx.snap
@@ -258,10 +258,9 @@ exports[`NewVisModal filter for visualization types should render as expected 1`
                                   <div
                                     class="euiKeyPadMenuItem__icon"
                                   >
-                                    <img
-                                      alt=""
-                                      class="visNewVisDialog__typeImage"
-                                      src="visTimelion"
+                                    <div
+                                      color="secondary"
+                                      data-euiicon-type="empty"
                                     />
                                   </div>
                                   <p
@@ -290,10 +289,9 @@ exports[`NewVisModal filter for visualization types should render as expected 1`
                                   <div
                                     class="euiKeyPadMenuItem__icon"
                                   >
-                                    <img
-                                      alt=""
-                                      class="visNewVisDialog__typeImage"
-                                      src="visTimelion"
+                                    <div
+                                      color="secondary"
+                                      data-euiicon-type="empty"
                                     />
                                   </div>
                                   <p
@@ -322,10 +320,9 @@ exports[`NewVisModal filter for visualization types should render as expected 1`
                                   <div
                                     class="euiKeyPadMenuItem__icon"
                                   >
-                                    <img
-                                      alt=""
-                                      class="visNewVisDialog__typeImage"
-                                      src="visTimelion"
+                                    <div
+                                      color="secondary"
+                                      data-euiicon-type="empty"
                                     />
                                   </div>
                                   <p
@@ -355,10 +352,9 @@ exports[`NewVisModal filter for visualization types should render as expected 1`
                                   <div
                                     class="euiKeyPadMenuItem__icon"
                                   >
-                                    <img
-                                      alt=""
-                                      class="visNewVisDialog__typeImage"
-                                      src="visTimelion"
+                                    <div
+                                      color="secondary"
+                                      data-euiicon-type="empty"
                                     />
                                   </div>
                                   <p
@@ -722,14 +718,18 @@ exports[`NewVisModal filter for visualization types should render as expected 1`
                                                 <div
                                                   className="euiKeyPadMenuItem__icon"
                                                 >
-                                                  <VisTypeIcon
-                                                    image="visTimelion"
-                                                  >
-                                                    <img
-                                                      alt=""
-                                                      className="visNewVisDialog__typeImage"
-                                                      src="visTimelion"
-                                                    />
+                                                  <VisTypeIcon>
+                                                    <EuiIcon
+                                                      color="secondary"
+                                                      size="l"
+                                                      type="empty"
+                                                    >
+                                                      <div
+                                                        color="secondary"
+                                                        data-euiicon-type="empty"
+                                                        size="l"
+                                                      />
+                                                    </EuiIcon>
                                                   </VisTypeIcon>
                                                 </div>
                                                 <p
@@ -787,14 +787,18 @@ exports[`NewVisModal filter for visualization types should render as expected 1`
                                                 <div
                                                   className="euiKeyPadMenuItem__icon"
                                                 >
-                                                  <VisTypeIcon
-                                                    image="visTimelion"
-                                                  >
-                                                    <img
-                                                      alt=""
-                                                      className="visNewVisDialog__typeImage"
-                                                      src="visTimelion"
-                                                    />
+                                                  <VisTypeIcon>
+                                                    <EuiIcon
+                                                      color="secondary"
+                                                      size="l"
+                                                      type="empty"
+                                                    >
+                                                      <div
+                                                        color="secondary"
+                                                        data-euiicon-type="empty"
+                                                        size="l"
+                                                      />
+                                                    </EuiIcon>
                                                   </VisTypeIcon>
                                                 </div>
                                                 <p
@@ -852,14 +856,18 @@ exports[`NewVisModal filter for visualization types should render as expected 1`
                                                 <div
                                                   className="euiKeyPadMenuItem__icon"
                                                 >
-                                                  <VisTypeIcon
-                                                    image="visTimelion"
-                                                  >
-                                                    <img
-                                                      alt=""
-                                                      className="visNewVisDialog__typeImage"
-                                                      src="visTimelion"
-                                                    />
+                                                  <VisTypeIcon>
+                                                    <EuiIcon
+                                                      color="secondary"
+                                                      size="l"
+                                                      type="empty"
+                                                    >
+                                                      <div
+                                                        color="secondary"
+                                                        data-euiicon-type="empty"
+                                                        size="l"
+                                                      />
+                                                    </EuiIcon>
                                                   </VisTypeIcon>
                                                 </div>
                                                 <p
@@ -917,14 +925,18 @@ exports[`NewVisModal filter for visualization types should render as expected 1`
                                                 <div
                                                   className="euiKeyPadMenuItem__icon"
                                                 >
-                                                  <VisTypeIcon
-                                                    image="visTimelion"
-                                                  >
-                                                    <img
-                                                      alt=""
-                                                      className="visNewVisDialog__typeImage"
-                                                      src="visTimelion"
-                                                    />
+                                                  <VisTypeIcon>
+                                                    <EuiIcon
+                                                      color="secondary"
+                                                      size="l"
+                                                      type="empty"
+                                                    >
+                                                      <div
+                                                        color="secondary"
+                                                        data-euiicon-type="empty"
+                                                        size="l"
+                                                      />
+                                                    </EuiIcon>
                                                   </VisTypeIcon>
                                                 </div>
                                                 <p
@@ -1332,10 +1344,9 @@ exports[`NewVisModal should render as expected 1`] = `
                                   <div
                                     class="euiKeyPadMenuItem__icon"
                                   >
-                                    <img
-                                      alt=""
-                                      class="visNewVisDialog__typeImage"
-                                      src="visTimelion"
+                                    <div
+                                      color="secondary"
+                                      data-euiicon-type="empty"
                                     />
                                   </div>
                                   <p
@@ -1364,10 +1375,9 @@ exports[`NewVisModal should render as expected 1`] = `
                                   <div
                                     class="euiKeyPadMenuItem__icon"
                                   >
-                                    <img
-                                      alt=""
-                                      class="visNewVisDialog__typeImage"
-                                      src="visTimelion"
+                                    <div
+                                      color="secondary"
+                                      data-euiicon-type="empty"
                                     />
                                   </div>
                                   <p
@@ -1396,10 +1406,9 @@ exports[`NewVisModal should render as expected 1`] = `
                                   <div
                                     class="euiKeyPadMenuItem__icon"
                                   >
-                                    <img
-                                      alt=""
-                                      class="visNewVisDialog__typeImage"
-                                      src="visTimelion"
+                                    <div
+                                      color="secondary"
+                                      data-euiicon-type="empty"
                                     />
                                   </div>
                                   <p
@@ -1428,10 +1437,9 @@ exports[`NewVisModal should render as expected 1`] = `
                                   <div
                                     class="euiKeyPadMenuItem__icon"
                                   >
-                                    <img
-                                      alt=""
-                                      class="visNewVisDialog__typeImage"
-                                      src="visTimelion"
+                                    <div
+                                      color="secondary"
+                                      data-euiicon-type="empty"
                                     />
                                   </div>
                                   <p
@@ -1744,14 +1752,18 @@ exports[`NewVisModal should render as expected 1`] = `
                                                 <div
                                                   className="euiKeyPadMenuItem__icon"
                                                 >
-                                                  <VisTypeIcon
-                                                    image="visTimelion"
-                                                  >
-                                                    <img
-                                                      alt=""
-                                                      className="visNewVisDialog__typeImage"
-                                                      src="visTimelion"
-                                                    />
+                                                  <VisTypeIcon>
+                                                    <EuiIcon
+                                                      color="secondary"
+                                                      size="l"
+                                                      type="empty"
+                                                    >
+                                                      <div
+                                                        color="secondary"
+                                                        data-euiicon-type="empty"
+                                                        size="l"
+                                                      />
+                                                    </EuiIcon>
                                                   </VisTypeIcon>
                                                 </div>
                                                 <p
@@ -1809,14 +1821,18 @@ exports[`NewVisModal should render as expected 1`] = `
                                                 <div
                                                   className="euiKeyPadMenuItem__icon"
                                                 >
-                                                  <VisTypeIcon
-                                                    image="visTimelion"
-                                                  >
-                                                    <img
-                                                      alt=""
-                                                      className="visNewVisDialog__typeImage"
-                                                      src="visTimelion"
-                                                    />
+                                                  <VisTypeIcon>
+                                                    <EuiIcon
+                                                      color="secondary"
+                                                      size="l"
+                                                      type="empty"
+                                                    >
+                                                      <div
+                                                        color="secondary"
+                                                        data-euiicon-type="empty"
+                                                        size="l"
+                                                      />
+                                                    </EuiIcon>
                                                   </VisTypeIcon>
                                                 </div>
                                                 <p
@@ -1874,14 +1890,18 @@ exports[`NewVisModal should render as expected 1`] = `
                                                 <div
                                                   className="euiKeyPadMenuItem__icon"
                                                 >
-                                                  <VisTypeIcon
-                                                    image="visTimelion"
-                                                  >
-                                                    <img
-                                                      alt=""
-                                                      className="visNewVisDialog__typeImage"
-                                                      src="visTimelion"
-                                                    />
+                                                  <VisTypeIcon>
+                                                    <EuiIcon
+                                                      color="secondary"
+                                                      size="l"
+                                                      type="empty"
+                                                    >
+                                                      <div
+                                                        color="secondary"
+                                                        data-euiicon-type="empty"
+                                                        size="l"
+                                                      />
+                                                    </EuiIcon>
                                                   </VisTypeIcon>
                                                 </div>
                                                 <p
@@ -1939,14 +1959,18 @@ exports[`NewVisModal should render as expected 1`] = `
                                                 <div
                                                   className="euiKeyPadMenuItem__icon"
                                                 >
-                                                  <VisTypeIcon
-                                                    image="visTimelion"
-                                                  >
-                                                    <img
-                                                      alt=""
-                                                      className="visNewVisDialog__typeImage"
-                                                      src="visTimelion"
-                                                    />
+                                                  <VisTypeIcon>
+                                                    <EuiIcon
+                                                      color="secondary"
+                                                      size="l"
+                                                      type="empty"
+                                                    >
+                                                      <div
+                                                        color="secondary"
+                                                        data-euiicon-type="empty"
+                                                        size="l"
+                                                      />
+                                                    </EuiIcon>
                                                   </VisTypeIcon>
                                                 </div>
                                                 <p

--- a/src/plugins/visualizations/public/wizard/type_selection/type_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/type_selection/type_selection.tsx
@@ -280,7 +280,7 @@ class TypeSelection extends React.Component<TypeSelectionProps, TypeSelectionSta
       >
         <VisTypeIcon
           icon={visType.type.icon === 'visTimeline' ? 'visTimelion' : visType.type.icon}
-          image={'image' in visType.type ? visType.type.image : 'visTimelion'}
+          image={'image' in visType.type ? visType.type.image : undefined}
         />
       </EuiKeyPadMenuItem>
     );

--- a/src/plugins/wizard/opensearch_dashboards.json
+++ b/src/plugins/wizard/opensearch_dashboards.json
@@ -10,7 +10,8 @@
     "opensearchDashboardsReact",
     "savedObjects",
     "embeddable",
-    "dashboard"
+    "dashboard",
+    "visualizations"
   ],
   "optionalPlugins": []
 }

--- a/src/plugins/wizard/public/index.ts
+++ b/src/plugins/wizard/public/index.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { PluginInitializerContext } from '../../../core/public';
 import { WizardPlugin } from './plugin';
 
 // This exports static code and TypeScript types,
 // as well as, OpenSearch Dashboards Platform `plugin()` initializer.
-export function plugin() {
-  return new WizardPlugin();
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new WizardPlugin(initializerContext);
 }
 export { WizardServices, WizardPluginStartDependencies } from './types';

--- a/src/plugins/wizard/public/plugin.ts
+++ b/src/plugins/wizard/public/plugin.ts
@@ -3,42 +3,53 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { i18n } from '@osd/i18n';
 import {
   AppMountParameters,
+  AppNavLinkStatus,
   CoreSetup,
   CoreStart,
-  DEFAULT_APP_CATEGORIES,
   Plugin,
+  PluginInitializerContext,
 } from '../../../core/public';
-import { WizardPluginStartDependencies, WizardServices } from './types';
+import {
+  WizardPluginSetupDependencies,
+  WizardPluginStartDependencies,
+  WizardServices,
+} from './types';
 import { PLUGIN_NAME } from '../common';
 
-export class WizardPlugin implements Plugin<void, void, object, WizardPluginStartDependencies> {
-  public setup(core: CoreSetup<WizardPluginStartDependencies>) {
-    // Register an application into the side navigation menu
+export class WizardPlugin
+  implements Plugin<void, void, WizardPluginSetupDependencies, WizardPluginStartDependencies> {
+  constructor(public initializerContext: PluginInitializerContext) {}
+
+  public setup(
+    core: CoreSetup<WizardPluginStartDependencies>,
+    { visualizations }: WizardPluginSetupDependencies
+  ) {
+    // Register the plugin to core
     core.application.register({
       id: 'wizard',
       title: PLUGIN_NAME,
-      euiIconType: 'inputOutput',
-      defaultPath: '#/',
-      category: DEFAULT_APP_CATEGORIES.opensearchDashboards,
+      navLinkStatus: AppNavLinkStatus.hidden,
       async mount(params: AppMountParameters) {
         // Load application bundle
         const { renderApp } = await import('./application');
         // Get start services as specified in opensearch_dashboards.json
         const [coreStart, pluginsStart] = await core.getStartServices();
+        const { data, savedObjects, navigation } = pluginsStart;
 
         const services: WizardServices = {
           ...coreStart,
           toastNotifications: coreStart.notifications.toasts,
-          data: pluginsStart.data,
-          savedObjectsPublic: pluginsStart.savedObjects,
-          navigation: pluginsStart.navigation,
+          data,
+          savedObjectsPublic: savedObjects,
+          navigation,
           setHeaderActionMenu: params.setHeaderActionMenu,
         };
 
         // make sure the index pattern list is up to date
-        pluginsStart.data.indexPatterns.clearCache();
+        data.indexPatterns.clearCache();
         // make sure a default index pattern exists
         // if not, the page will be redirected to management and visualize won't be rendered
         await pluginsStart.data.indexPatterns.ensureDefaultIndexPattern();
@@ -46,6 +57,20 @@ export class WizardPlugin implements Plugin<void, void, object, WizardPluginStar
         // Render the application
         return renderApp(params, services);
       },
+    });
+
+    // Register the plugin as an alias to create visualization
+    visualizations.registerAlias({
+      name: 'wizard',
+      title: 'Wizard',
+      description: i18n.translate('wizard.vizPicker.description', {
+        defaultMessage: 'TODO...',
+      }),
+      // TODO: Replace with actual icon once available
+      icon: 'vector',
+      stage: 'beta',
+      aliasApp: 'wizard',
+      aliasPath: '#/',
     });
   }
 

--- a/src/plugins/wizard/public/types.ts
+++ b/src/plugins/wizard/public/types.ts
@@ -7,11 +7,13 @@ import { SavedObjectsStart } from 'src/plugins/saved_objects/public';
 import { AppMountParameters, CoreStart, ToastsStart } from 'opensearch-dashboards/public';
 import { EmbeddableSetup } from 'src/plugins/embeddable/public';
 import { DashboardStart } from 'src/plugins/dashboard/public';
+import { VisualizationsSetup } from 'src/plugins/visualizations/public';
 import { NavigationPublicPluginStart } from '../../navigation/public';
 import { DataPublicPluginStart } from '../../data/public';
 
 export interface WizardPluginSetupDependencies {
   embeddable: EmbeddableSetup;
+  visualizations: VisualizationsSetup;
 }
 export interface WizardPluginStartDependencies {
   navigation: NavigationPublicPluginStart;


### PR DESCRIPTION
Signed-off-by: Ashwin Pc <ashwinpc@amazon.com>

### Description
Moves the entry point for the drag and drop plugin to the "create visualization" menu.

![Screen Shot 2021-12-10 at 5 50 40 PM](https://user-images.githubusercontent.com/20453492/145659846-cac17254-5643-4a35-ab81-3c306c5db6b6.png)


### Issues Resolved
#959 
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 