### PR TITLE
[Backwards Compatibility] restore URL forwarding from legacy app

### DIFF
--- a/src/plugins/data/common/field_formats/converters/url.test.ts
+++ b/src/plugins/data/common/field_formats/converters/url.test.ts
@@ -306,5 +306,34 @@ describe('UrlFormat', () => {
         '<span ng-non-bindable><a href="http://opensearch-dashboards.host.com/app/opensearch-dashboards#/dashboard/" target="_blank" rel="noopener noreferrer">#/dashboard/</a></span>'
       );
     });
+
+    test('should support multiple types of urls w/o basePath from legacy app', () => {
+      const parsedUrl = {
+        origin: 'http://opensearch-dashboards.host.com',
+        pathname: '/app/kibana',
+      };
+      const url = new UrlFormat({ parsedUrl });
+      const converter = url.getConverterFor(HTML_CONTEXT_TYPE) as Function;
+
+      expect(converter('10.22.55.66')).toBe(
+        '<span ng-non-bindable><a href="http://opensearch-dashboards.host.com/app/10.22.55.66" target="_blank" rel="noopener noreferrer">10.22.55.66</a></span>'
+      );
+
+      expect(converter('http://www.domain.name/app/kibana#/dashboard/')).toBe(
+        '<span ng-non-bindable><a href="http://www.domain.name/app/kibana#/dashboard/" target="_blank" rel="noopener noreferrer">http://www.domain.name/app/kibana#/dashboard/</a></span>'
+      );
+
+      expect(converter('/app/kibana')).toBe(
+        '<span ng-non-bindable><a href="http://opensearch-dashboards.host.com/app/kibana" target="_blank" rel="noopener noreferrer">/app/kibana</a></span>'
+      );
+
+      expect(converter('kibana#/dashboard/')).toBe(
+        '<span ng-non-bindable><a href="http://opensearch-dashboards.host.com/app/kibana#/dashboard/" target="_blank" rel="noopener noreferrer">kibana#/dashboard/</a></span>'
+      );
+
+      expect(converter('#/dashboard/')).toBe(
+        '<span ng-non-bindable><a href="http://opensearch-dashboards.host.com/app/kibana#/dashboard/" target="_blank" rel="noopener noreferrer">#/dashboard/</a></span>'
+      );
+    });
   });
 });

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/format.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/format.test.ts
@@ -52,5 +52,22 @@ describe('format', () => {
         `"http://localhost:5601/oxf/app/opensearch-dashboards#?test=test&test1=test1"`
       );
     });
+
+    it('should add hash query to url without hash with legacy app', () => {
+      const url = 'http://localhost:5601/oxf/app/kibana';
+      expect(replaceUrlHashQuery(url, () => ({ test: 'test' }))).toMatchInlineSnapshot(
+        `"http://localhost:5601/oxf/app/kibana#?test=test"`
+      );
+    });
+
+    it('should replace hash query with legacy app', () => {
+      const url = 'http://localhost:5601/oxf/app/kibana#?test=test';
+      expect(
+        replaceUrlHashQuery(url, (query) => ({
+          ...query,
+          test1: 'test1',
+        }))
+      ).toMatchInlineSnapshot(`"http://localhost:5601/oxf/app/kibana#?test=test&test1=test1"`);
+    });
   });
 });

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/hash_unhash_url.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/hash_unhash_url.test.ts
@@ -82,6 +82,36 @@ describe('hash unhash url', () => {
         expect(hashUrl(url)).toBe(url);
       });
 
+      it('if just a path with legacy app', () => {
+        const url = 'https://localhost:5601/app/kibana';
+        expect(hashUrl(url)).toBe(url);
+      });
+
+      it('if just a path and query with legacy app', () => {
+        const url = 'https://localhost:5601/app/kibana?foo=bar';
+        expect(hashUrl(url)).toBe(url);
+      });
+
+      it('if empty hash with query with legacy app', () => {
+        const url = 'https://localhost:5601/app/kibana?foo=bar#';
+        expect(hashUrl(url)).toBe(url);
+      });
+
+      it('if query parameter matches and there is no hash with legacy app', () => {
+        const url = 'https://localhost:5601/app/kibana?testParam=(yes:!t)';
+        expect(hashUrl(url)).toBe(url);
+      });
+
+      it(`if query parameter matches and it's before the hash with legacy app`, () => {
+        const url = 'https://localhost:5601/app/kibana?testParam=(yes:!t)';
+        expect(hashUrl(url)).toBe(url);
+      });
+
+      it('if empty hash without query with legacy app', () => {
+        const url = 'https://localhost:5601/app/kibana#';
+        expect(hashUrl(url)).toBe(url);
+      });
+
       it('if hash is just a path', () => {
         const url = 'https://localhost:5601/app/discover#/';
         expect(hashUrl(url)).toBe(url);
@@ -186,6 +216,26 @@ describe('hash unhash url', () => {
 
       it('if empty hash without query', () => {
         const url = 'https://localhost:5601/app/opensearch-dashboards#';
+        expect(unhashUrl(url)).toBe(url);
+      });
+
+      it('if just a path with legacy app', () => {
+        const url = 'https://localhost:5601/app/kibana';
+        expect(unhashUrl(url)).toBe(url);
+      });
+
+      it('if just a path and query with legacy app', () => {
+        const url = 'https://localhost:5601/app/kibana?foo=bar';
+        expect(unhashUrl(url)).toBe(url);
+      });
+
+      it('if empty hash with query with legacy app', () => {
+        const url = 'https://localhost:5601/app/kibana?foo=bar#';
+        expect(unhashUrl(url)).toBe(url);
+      });
+
+      it('if empty hash without query with legacy app', () => {
+        const url = 'https://localhost:5601/app/kibana#';
         expect(unhashUrl(url)).toBe(url);
       });
 

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_storage.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_storage.test.ts
@@ -49,6 +49,7 @@ import { ScopedHistory } from '../../../../../core/public';
 describe('osd_url_storage', () => {
   describe('getStateFromUrl & setStateToUrl', () => {
     const url = 'http://localhost:5601/oxf/app/opensearch-dashboards#/yourApp';
+    const legacyUrl = 'http://localhost:5601/oxf/app/kibana#/yourApp';
     const state1 = {
       testStr: '123',
       testNumber: 0,
@@ -110,6 +111,59 @@ describe('osd_url_storage', () => {
       );
       expect(newUrl).toMatchInlineSnapshot(
         `"http://localhost:5601/oxf/app/opensearch-dashboards/yourApp?_a=(tab:other)&_b=(f:test,i:'',l:'')"`
+      );
+    });
+
+    it('should set expanded state to url for legacy app', () => {
+      let newUrl = setStateToOsdUrl('_s', state1, { useHash: false }, legacyUrl);
+      expect(newUrl).toMatchInlineSnapshot(
+        `"http://localhost:5601/oxf/app/kibana#/yourApp?_s=(testArray:!(1,2,()),testNull:!n,testNumber:0,testObj:(test:'123'),testStr:'123')"`
+      );
+      const retrievedState1 = getStateFromOsdUrl('_s', newUrl);
+      expect(retrievedState1).toEqual(state1);
+
+      newUrl = setStateToOsdUrl('_s', state2, { useHash: false }, newUrl);
+      expect(newUrl).toMatchInlineSnapshot(
+        `"http://localhost:5601/oxf/app/kibana#/yourApp?_s=(test:'123')"`
+      );
+      const retrievedState2 = getStateFromOsdUrl('_s', newUrl);
+      expect(retrievedState2).toEqual(state2);
+    });
+
+    it('should set hashed state to url for legacy app', () => {
+      let newUrl = setStateToOsdUrl('_s', state1, { useHash: true }, legacyUrl);
+      expect(newUrl).toMatchInlineSnapshot(
+        `"http://localhost:5601/oxf/app/kibana#/yourApp?_s=h@a897fac"`
+      );
+      const retrievedState1 = getStateFromOsdUrl('_s', newUrl);
+      expect(retrievedState1).toEqual(state1);
+
+      newUrl = setStateToOsdUrl('_s', state2, { useHash: true }, newUrl);
+      expect(newUrl).toMatchInlineSnapshot(
+        `"http://localhost:5601/oxf/app/kibana#/yourApp?_s=h@40f94d5"`
+      );
+      const retrievedState2 = getStateFromOsdUrl('_s', newUrl);
+      expect(retrievedState2).toEqual(state2);
+    });
+
+    it('should set query to url for legacy app with storeInHashQuery: false', () => {
+      let newUrl = setStateToOsdUrl(
+        '_a',
+        { tab: 'other' },
+        { useHash: false, storeInHashQuery: false },
+        'http://localhost:5601/oxf/app/kibana/yourApp'
+      );
+      expect(newUrl).toMatchInlineSnapshot(
+        `"http://localhost:5601/oxf/app/kibana/yourApp?_a=(tab:other)"`
+      );
+      newUrl = setStateToOsdUrl(
+        '_b',
+        { f: 'test', i: '', l: '' },
+        { useHash: false, storeInHashQuery: false },
+        newUrl
+      );
+      expect(newUrl).toMatchInlineSnapshot(
+        `"http://localhost:5601/oxf/app/kibana/yourApp?_a=(tab:other)&_b=(f:test,i:'',l:'')"`
       );
     });
   });
@@ -329,6 +383,93 @@ describe('osd_url_storage', () => {
       const history = createHashHistory({ basename: 'management' });
       const url =
         "/oxf/app/opensearch-dashboards#/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')";
+      const relativePath = getRelativeToHistoryPath(url, history);
+      expect(relativePath).toEqual("/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')");
+    });
+  });
+
+  describe('urlControls - scoped history integration - legacy app', () => {
+    let history: History;
+    let urlControls: IOsdUrlControls;
+    beforeEach(() => {
+      const parentHistory = createBrowserHistory();
+      parentHistory.replace('/app/kibana/');
+      history = new ScopedHistory(parentHistory, '/app/kibana/');
+      urlControls = createOsdUrlControls(history);
+    });
+
+    const getCurrentUrl = () => history.createHref(history.location);
+
+    it('should flush async url updates', async () => {
+      const pr1 = urlControls.updateAsync(() => '/app/kibana/1', false);
+      const pr2 = urlControls.updateAsync(() => '/app/kibana/2', false);
+      const pr3 = urlControls.updateAsync(() => '/app/kibana/3', false);
+      expect(getCurrentUrl()).toBe('/app/kibana/');
+      expect(urlControls.flush()).toBe('/app/kibana/3');
+      expect(getCurrentUrl()).toBe('/app/kibana/3');
+      await Promise.all([pr1, pr2, pr3]);
+      expect(getCurrentUrl()).toBe('/app/kibana/3');
+    });
+
+    it('flush() should return undefined, if no url updates happened', () => {
+      expect(urlControls.flush()).toBeUndefined();
+      urlControls.updateAsync(() => '/app/kibana/1', false);
+      urlControls.updateAsync(() => '/app/kibana/', false);
+      expect(urlControls.flush()).toBeUndefined();
+    });
+  });
+
+  describe('getRelativeToHistoryPath - legacy app', () => {
+    it('should extract path relative to browser history without basename', () => {
+      const history = createBrowserHistory();
+      const url =
+        "http://localhost:5601/oxf/app/kibana#/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')";
+      const relativePath = getRelativeToHistoryPath(url, history);
+      expect(relativePath).toEqual(
+        "/oxf/app/kibana#/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')"
+      );
+    });
+
+    it('should extract path relative to browser history with basename', () => {
+      const url =
+        "http://localhost:5601/oxf/app/kibana#/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')";
+      const history1 = createBrowserHistory({ basename: '/oxf/app/' });
+      const relativePath1 = getRelativeToHistoryPath(url, history1);
+      expect(relativePath1).toEqual(
+        "/kibana#/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')"
+      );
+
+      const history2 = createBrowserHistory({ basename: '/oxf/app/kibana/' });
+      const relativePath2 = getRelativeToHistoryPath(url, history2);
+      expect(relativePath2).toEqual("#/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')");
+    });
+
+    it('should extract path relative to browser history with basename from relative url', () => {
+      const history = createBrowserHistory({ basename: '/oxf/app/' });
+      const url = "/oxf/app/kibana#/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')";
+      const relativePath = getRelativeToHistoryPath(url, history);
+      expect(relativePath).toEqual("/kibana#/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')");
+    });
+
+    it('should extract path relative to hash history without basename', () => {
+      const history = createHashHistory();
+      const url =
+        "http://localhost:5601/oxf/app/kibana#/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')";
+      const relativePath = getRelativeToHistoryPath(url, history);
+      expect(relativePath).toEqual("/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')");
+    });
+
+    it('should extract path relative to hash history with basename', () => {
+      const history = createHashHistory({ basename: 'management' });
+      const url =
+        "http://localhost:5601/oxf/app/kibana#/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')";
+      const relativePath = getRelativeToHistoryPath(url, history);
+      expect(relativePath).toEqual("/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')");
+    });
+
+    it('should extract path relative to hash history with basename from relative url', () => {
+      const history = createHashHistory({ basename: 'management' });
+      const url = "/oxf/app/kibana#/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')";
       const relativePath = getRelativeToHistoryPath(url, history);
       expect(relativePath).toEqual("/yourApp?_a=(tab:indexedFields)&_b=(f:test,i:'',l:'')");
     });

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/relationships.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/relationships.test.tsx.snap
@@ -1,5 +1,695 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Relationships from legacy app should render dashboards normally 1`] = `
+<EuiFlyout
+  onClose={[MockFunction]}
+>
+  <EuiFlyoutHeader
+    hasBorder={true}
+  >
+    <EuiTitle
+      size="m"
+    >
+      <h2>
+        <EuiToolTip
+          content="dashboard"
+          delay="regular"
+          position="top"
+        >
+          <EuiIcon
+            aria-label="dashboard"
+            size="m"
+            type="dashboardApp"
+          />
+        </EuiToolTip>
+          
+        MyDashboard
+      </h2>
+    </EuiTitle>
+  </EuiFlyoutHeader>
+  <EuiFlyoutBody>
+    <div>
+      <EuiCallOut>
+        <p>
+          Here are the saved objects related to MyDashboard. Deleting this dashboard affects its parent objects, but not its children.
+        </p>
+      </EuiCallOut>
+      <EuiSpacer />
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "center",
+              "description": "Type of the saved object",
+              "field": "type",
+              "name": "Type",
+              "render": [Function],
+              "sortable": false,
+              "width": "50px",
+            },
+            Object {
+              "data-test-subj": "directRelationship",
+              "dataType": "string",
+              "field": "relationship",
+              "name": "Direct relationship",
+              "render": [Function],
+              "sortable": false,
+              "width": "125px",
+            },
+            Object {
+              "dataType": "string",
+              "description": "Title of the saved object",
+              "field": "meta.title",
+              "name": "Title",
+              "render": [Function],
+              "sortable": false,
+            },
+            Object {
+              "actions": Array [
+                Object {
+                  "available": [Function],
+                  "data-test-subj": "relationshipsTableAction-inspect",
+                  "description": "Inspect this saved object",
+                  "icon": "inspect",
+                  "name": "Inspect",
+                  "onClick": [Function],
+                  "type": "icon",
+                },
+              ],
+              "name": "Actions",
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "id": "1",
+              "meta": Object {
+                "editUrl": "/management/kibana/objects/savedVisualizations/1",
+                "icon": "visualizeApp",
+                "inAppUrl": Object {
+                  "path": "/app/visualize#/edit/1",
+                  "uiCapabilitiesPath": "visualize.show",
+                },
+                "title": "My Visualization Title 1",
+              },
+              "relationship": "child",
+              "type": "visualization",
+            },
+            Object {
+              "id": "2",
+              "meta": Object {
+                "editUrl": "/management/kibana/objects/savedVisualizations/2",
+                "icon": "visualizeApp",
+                "inAppUrl": Object {
+                  "path": "/app/visualize#/edit/2",
+                  "uiCapabilitiesPath": "visualize.show",
+                },
+                "title": "My Visualization Title 2",
+              },
+              "relationship": "child",
+              "type": "visualization",
+            },
+          ]
+        }
+        pagination={true}
+        responsive={true}
+        rowProps={[Function]}
+        search={
+          Object {
+            "filters": Array [
+              Object {
+                "field": "relationship",
+                "multiSelect": "or",
+                "name": "Direct relationship",
+                "options": Array [
+                  Object {
+                    "name": "parent",
+                    "value": "parent",
+                    "view": "Parent",
+                  },
+                  Object {
+                    "name": "child",
+                    "value": "child",
+                    "view": "Child",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+              Object {
+                "field": "type",
+                "multiSelect": "or",
+                "name": "Type",
+                "options": Array [
+                  Object {
+                    "name": "visualization",
+                    "value": "visualization",
+                    "view": "visualization",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+            ],
+          }
+        }
+        tableLayout="fixed"
+      />
+    </div>
+  </EuiFlyoutBody>
+</EuiFlyout>
+`;
+
+exports[`Relationships from legacy app should render errors 1`] = `
+<EuiFlyout
+  onClose={[MockFunction]}
+>
+  <EuiFlyoutHeader
+    hasBorder={true}
+  >
+    <EuiTitle
+      size="m"
+    >
+      <h2>
+        <EuiToolTip
+          content="dashboard"
+          delay="regular"
+          position="top"
+        >
+          <EuiIcon
+            aria-label="dashboard"
+            size="m"
+            type="dashboardApp"
+          />
+        </EuiToolTip>
+          
+        MyDashboard
+      </h2>
+    </EuiTitle>
+  </EuiFlyoutHeader>
+  <EuiFlyoutBody>
+    <EuiCallOut
+      color="danger"
+      title={
+        <FormattedMessage
+          defaultMessage="Error"
+          id="savedObjectsManagement.objectsTable.relationships.renderErrorMessage"
+          values={Object {}}
+        />
+      }
+    >
+      foo
+    </EuiCallOut>
+  </EuiFlyoutBody>
+</EuiFlyout>
+`;
+
+exports[`Relationships from legacy app should render index patterns normally 1`] = `
+<EuiFlyout
+  onClose={[MockFunction]}
+>
+  <EuiFlyoutHeader
+    hasBorder={true}
+  >
+    <EuiTitle
+      size="m"
+    >
+      <h2>
+        <EuiToolTip
+          content="index patterns"
+          delay="regular"
+          position="top"
+        >
+          <EuiIcon
+            aria-label="index patterns"
+            size="m"
+            type="indexPatternApp"
+          />
+        </EuiToolTip>
+          
+        MyIndexPattern*
+      </h2>
+    </EuiTitle>
+  </EuiFlyoutHeader>
+  <EuiFlyoutBody>
+    <div>
+      <EuiCallOut>
+        <p>
+          Here are the saved objects related to MyIndexPattern*. Deleting this index-pattern affects its parent objects, but not its children.
+        </p>
+      </EuiCallOut>
+      <EuiSpacer />
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "center",
+              "description": "Type of the saved object",
+              "field": "type",
+              "name": "Type",
+              "render": [Function],
+              "sortable": false,
+              "width": "50px",
+            },
+            Object {
+              "data-test-subj": "directRelationship",
+              "dataType": "string",
+              "field": "relationship",
+              "name": "Direct relationship",
+              "render": [Function],
+              "sortable": false,
+              "width": "125px",
+            },
+            Object {
+              "dataType": "string",
+              "description": "Title of the saved object",
+              "field": "meta.title",
+              "name": "Title",
+              "render": [Function],
+              "sortable": false,
+            },
+            Object {
+              "actions": Array [
+                Object {
+                  "available": [Function],
+                  "data-test-subj": "relationshipsTableAction-inspect",
+                  "description": "Inspect this saved object",
+                  "icon": "inspect",
+                  "name": "Inspect",
+                  "onClick": [Function],
+                  "type": "icon",
+                },
+              ],
+              "name": "Actions",
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "id": "1",
+              "meta": Object {
+                "editUrl": "/management/kibana/objects/savedSearches/1",
+                "icon": "search",
+                "inAppUrl": Object {
+                  "path": "/app/discover#//1",
+                  "uiCapabilitiesPath": "discover.show",
+                },
+                "title": "My Search Title",
+              },
+              "relationship": "parent",
+              "type": "search",
+            },
+            Object {
+              "id": "2",
+              "meta": Object {
+                "editUrl": "/management/kibana/objects/savedVisualizations/2",
+                "icon": "visualizeApp",
+                "inAppUrl": Object {
+                  "path": "/app/visualize#/edit/2",
+                  "uiCapabilitiesPath": "visualize.show",
+                },
+                "title": "My Visualization Title",
+              },
+              "relationship": "parent",
+              "type": "visualization",
+            },
+          ]
+        }
+        pagination={true}
+        responsive={true}
+        rowProps={[Function]}
+        search={
+          Object {
+            "filters": Array [
+              Object {
+                "field": "relationship",
+                "multiSelect": "or",
+                "name": "Direct relationship",
+                "options": Array [
+                  Object {
+                    "name": "parent",
+                    "value": "parent",
+                    "view": "Parent",
+                  },
+                  Object {
+                    "name": "child",
+                    "value": "child",
+                    "view": "Child",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+              Object {
+                "field": "type",
+                "multiSelect": "or",
+                "name": "Type",
+                "options": Array [
+                  Object {
+                    "name": "search",
+                    "value": "search",
+                    "view": "search",
+                  },
+                  Object {
+                    "name": "visualization",
+                    "value": "visualization",
+                    "view": "visualization",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+            ],
+          }
+        }
+        tableLayout="fixed"
+      />
+    </div>
+  </EuiFlyoutBody>
+</EuiFlyout>
+`;
+
+exports[`Relationships from legacy app should render searches normally 1`] = `
+<EuiFlyout
+  onClose={[MockFunction]}
+>
+  <EuiFlyoutHeader
+    hasBorder={true}
+  >
+    <EuiTitle
+      size="m"
+    >
+      <h2>
+        <EuiToolTip
+          content="search"
+          delay="regular"
+          position="top"
+        >
+          <EuiIcon
+            aria-label="search"
+            size="m"
+            type="search"
+          />
+        </EuiToolTip>
+          
+        MySearch
+      </h2>
+    </EuiTitle>
+  </EuiFlyoutHeader>
+  <EuiFlyoutBody>
+    <div>
+      <EuiCallOut>
+        <p>
+          Here are the saved objects related to MySearch. Deleting this search affects its parent objects, but not its children.
+        </p>
+      </EuiCallOut>
+      <EuiSpacer />
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "center",
+              "description": "Type of the saved object",
+              "field": "type",
+              "name": "Type",
+              "render": [Function],
+              "sortable": false,
+              "width": "50px",
+            },
+            Object {
+              "data-test-subj": "directRelationship",
+              "dataType": "string",
+              "field": "relationship",
+              "name": "Direct relationship",
+              "render": [Function],
+              "sortable": false,
+              "width": "125px",
+            },
+            Object {
+              "dataType": "string",
+              "description": "Title of the saved object",
+              "field": "meta.title",
+              "name": "Title",
+              "render": [Function],
+              "sortable": false,
+            },
+            Object {
+              "actions": Array [
+                Object {
+                  "available": [Function],
+                  "data-test-subj": "relationshipsTableAction-inspect",
+                  "description": "Inspect this saved object",
+                  "icon": "inspect",
+                  "name": "Inspect",
+                  "onClick": [Function],
+                  "type": "icon",
+                },
+              ],
+              "name": "Actions",
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "id": "1",
+              "meta": Object {
+                "editUrl": "/management/kibana/indexPatterns/patterns/1",
+                "icon": "indexPatternApp",
+                "inAppUrl": Object {
+                  "path": "/app/management/kibana/indexPatterns/patterns/1",
+                  "uiCapabilitiesPath": "management.opensearchDashboards.indexPatterns",
+                },
+                "title": "My Index Pattern",
+              },
+              "relationship": "child",
+              "type": "index-pattern",
+            },
+            Object {
+              "id": "2",
+              "meta": Object {
+                "editUrl": "/management/kibana/objects/savedVisualizations/2",
+                "icon": "visualizeApp",
+                "inAppUrl": Object {
+                  "path": "/app/visualize#/edit/2",
+                  "uiCapabilitiesPath": "visualize.show",
+                },
+                "title": "My Visualization Title",
+              },
+              "relationship": "parent",
+              "type": "visualization",
+            },
+          ]
+        }
+        pagination={true}
+        responsive={true}
+        rowProps={[Function]}
+        search={
+          Object {
+            "filters": Array [
+              Object {
+                "field": "relationship",
+                "multiSelect": "or",
+                "name": "Direct relationship",
+                "options": Array [
+                  Object {
+                    "name": "parent",
+                    "value": "parent",
+                    "view": "Parent",
+                  },
+                  Object {
+                    "name": "child",
+                    "value": "child",
+                    "view": "Child",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+              Object {
+                "field": "type",
+                "multiSelect": "or",
+                "name": "Type",
+                "options": Array [
+                  Object {
+                    "name": "index-pattern",
+                    "value": "index-pattern",
+                    "view": "index-pattern",
+                  },
+                  Object {
+                    "name": "visualization",
+                    "value": "visualization",
+                    "view": "visualization",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+            ],
+          }
+        }
+        tableLayout="fixed"
+      />
+    </div>
+  </EuiFlyoutBody>
+</EuiFlyout>
+`;
+
+exports[`Relationships from legacy app should render visualizations normally 1`] = `
+<EuiFlyout
+  onClose={[MockFunction]}
+>
+  <EuiFlyoutHeader
+    hasBorder={true}
+  >
+    <EuiTitle
+      size="m"
+    >
+      <h2>
+        <EuiToolTip
+          content="visualization"
+          delay="regular"
+          position="top"
+        >
+          <EuiIcon
+            aria-label="visualization"
+            size="m"
+            type="visualizeApp"
+          />
+        </EuiToolTip>
+          
+        MyViz
+      </h2>
+    </EuiTitle>
+  </EuiFlyoutHeader>
+  <EuiFlyoutBody>
+    <div>
+      <EuiCallOut>
+        <p>
+          Here are the saved objects related to MyViz. Deleting this visualization affects its parent objects, but not its children.
+        </p>
+      </EuiCallOut>
+      <EuiSpacer />
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "center",
+              "description": "Type of the saved object",
+              "field": "type",
+              "name": "Type",
+              "render": [Function],
+              "sortable": false,
+              "width": "50px",
+            },
+            Object {
+              "data-test-subj": "directRelationship",
+              "dataType": "string",
+              "field": "relationship",
+              "name": "Direct relationship",
+              "render": [Function],
+              "sortable": false,
+              "width": "125px",
+            },
+            Object {
+              "dataType": "string",
+              "description": "Title of the saved object",
+              "field": "meta.title",
+              "name": "Title",
+              "render": [Function],
+              "sortable": false,
+            },
+            Object {
+              "actions": Array [
+                Object {
+                  "available": [Function],
+                  "data-test-subj": "relationshipsTableAction-inspect",
+                  "description": "Inspect this saved object",
+                  "icon": "inspect",
+                  "name": "Inspect",
+                  "onClick": [Function],
+                  "type": "icon",
+                },
+              ],
+              "name": "Actions",
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "id": "1",
+              "meta": Object {
+                "editUrl": "/management/kibana/objects/savedDashboards/1",
+                "icon": "dashboardApp",
+                "inAppUrl": Object {
+                  "path": "/app/kibana#/dashboard/1",
+                  "uiCapabilitiesPath": "dashboard.show",
+                },
+                "title": "My Dashboard 1",
+              },
+              "relationship": "parent",
+              "type": "dashboard",
+            },
+            Object {
+              "id": "2",
+              "meta": Object {
+                "editUrl": "/management/kibana/objects/savedDashboards/2",
+                "icon": "dashboardApp",
+                "inAppUrl": Object {
+                  "path": "/app/kibana#/dashboard/2",
+                  "uiCapabilitiesPath": "dashboard.show",
+                },
+                "title": "My Dashboard 2",
+              },
+              "relationship": "parent",
+              "type": "dashboard",
+            },
+          ]
+        }
+        pagination={true}
+        responsive={true}
+        rowProps={[Function]}
+        search={
+          Object {
+            "filters": Array [
+              Object {
+                "field": "relationship",
+                "multiSelect": "or",
+                "name": "Direct relationship",
+                "options": Array [
+                  Object {
+                    "name": "parent",
+                    "value": "parent",
+                    "view": "Parent",
+                  },
+                  Object {
+                    "name": "child",
+                    "value": "child",
+                    "view": "Child",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+              Object {
+                "field": "type",
+                "multiSelect": "or",
+                "name": "Type",
+                "options": Array [
+                  Object {
+                    "name": "dashboard",
+                    "value": "dashboard",
+                    "view": "dashboard",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+            ],
+          }
+        }
+        tableLayout="fixed"
+      />
+    </div>
+  </EuiFlyoutBody>
+</EuiFlyout>
+`;
+
 exports[`Relationships should render dashboards normally 1`] = `
 <EuiFlyout
   onClose={[MockFunction]}

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
@@ -349,3 +349,310 @@ describe('Relationships', () => {
     expect(component).toMatchSnapshot();
   });
 });
+
+describe('Relationships from legacy app', () => {
+  it('should render index patterns normally', async () => {
+    const props: RelationshipsProps = {
+      goInspectObject: () => {},
+      canGoInApp: () => true,
+      basePath: httpServiceMock.createSetupContract().basePath,
+      getRelationships: jest.fn().mockImplementation(() => [
+        {
+          type: 'search',
+          id: '1',
+          relationship: 'parent',
+          meta: {
+            editUrl: '/management/kibana/objects/savedSearches/1',
+            icon: 'search',
+            inAppUrl: {
+              path: '/app/discover#//1',
+              uiCapabilitiesPath: 'discover.show',
+            },
+            title: 'My Search Title',
+          },
+        },
+        {
+          type: 'visualization',
+          id: '2',
+          relationship: 'parent',
+          meta: {
+            editUrl: '/management/kibana/objects/savedVisualizations/2',
+            icon: 'visualizeApp',
+            inAppUrl: {
+              path: '/app/visualize#/edit/2',
+              uiCapabilitiesPath: 'visualize.show',
+            },
+            title: 'My Visualization Title',
+          },
+        },
+      ]),
+      savedObject: {
+        id: '1',
+        type: 'index-pattern',
+        attributes: {},
+        references: [],
+        meta: {
+          title: 'MyIndexPattern*',
+          icon: 'indexPatternApp',
+          editUrl: '#/management/kibana/indexPatterns/patterns/1',
+          inAppUrl: {
+            path: '/management/kibana/indexPatterns/patterns/1',
+            uiCapabilitiesPath: 'management.opensearchDashboards.indexPatterns',
+          },
+        },
+      },
+      close: jest.fn(),
+    };
+
+    const component = shallowWithI18nProvider(<Relationships {...props} />);
+
+    // Make sure we are showing loading
+    expect(component.find('EuiLoadingSpinner').length).toBe(1);
+
+    // Ensure all promises resolve
+    await new Promise((resolve) => process.nextTick(resolve));
+    // Ensure the state changes are reflected
+    component.update();
+
+    expect(props.getRelationships).toHaveBeenCalled();
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render searches normally', async () => {
+    const props: RelationshipsProps = {
+      goInspectObject: () => {},
+      canGoInApp: () => true,
+      basePath: httpServiceMock.createSetupContract().basePath,
+      getRelationships: jest.fn().mockImplementation(() => [
+        {
+          type: 'index-pattern',
+          id: '1',
+          relationship: 'child',
+          meta: {
+            editUrl: '/management/kibana/indexPatterns/patterns/1',
+            icon: 'indexPatternApp',
+            inAppUrl: {
+              path: '/app/management/kibana/indexPatterns/patterns/1',
+              uiCapabilitiesPath: 'management.opensearchDashboards.indexPatterns',
+            },
+            title: 'My Index Pattern',
+          },
+        },
+        {
+          type: 'visualization',
+          id: '2',
+          relationship: 'parent',
+          meta: {
+            editUrl: '/management/kibana/objects/savedVisualizations/2',
+            icon: 'visualizeApp',
+            inAppUrl: {
+              path: '/app/visualize#/edit/2',
+              uiCapabilitiesPath: 'visualize.show',
+            },
+            title: 'My Visualization Title',
+          },
+        },
+      ]),
+      savedObject: {
+        id: '1',
+        type: 'search',
+        attributes: {},
+        references: [],
+        meta: {
+          title: 'MySearch',
+          icon: 'search',
+          editUrl: '/management/kibana/objects/savedSearches/1',
+          inAppUrl: {
+            path: '/discover/1',
+            uiCapabilitiesPath: 'discover.show',
+          },
+        },
+      },
+      close: jest.fn(),
+    };
+
+    const component = shallowWithI18nProvider(<Relationships {...props} />);
+
+    // Make sure we are showing loading
+    expect(component.find('EuiLoadingSpinner').length).toBe(1);
+
+    // Ensure all promises resolve
+    await new Promise((resolve) => process.nextTick(resolve));
+    // Ensure the state changes are reflected
+    component.update();
+
+    expect(props.getRelationships).toHaveBeenCalled();
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render visualizations normally', async () => {
+    const props: RelationshipsProps = {
+      goInspectObject: () => {},
+      canGoInApp: () => true,
+      basePath: httpServiceMock.createSetupContract().basePath,
+      getRelationships: jest.fn().mockImplementation(() => [
+        {
+          type: 'dashboard',
+          id: '1',
+          relationship: 'parent',
+          meta: {
+            editUrl: '/management/kibana/objects/savedDashboards/1',
+            icon: 'dashboardApp',
+            inAppUrl: {
+              path: '/app/kibana#/dashboard/1',
+              uiCapabilitiesPath: 'dashboard.show',
+            },
+            title: 'My Dashboard 1',
+          },
+        },
+        {
+          type: 'dashboard',
+          id: '2',
+          relationship: 'parent',
+          meta: {
+            editUrl: '/management/kibana/objects/savedDashboards/2',
+            icon: 'dashboardApp',
+            inAppUrl: {
+              path: '/app/kibana#/dashboard/2',
+              uiCapabilitiesPath: 'dashboard.show',
+            },
+            title: 'My Dashboard 2',
+          },
+        },
+      ]),
+      savedObject: {
+        id: '1',
+        type: 'visualization',
+        attributes: {},
+        references: [],
+        meta: {
+          title: 'MyViz',
+          icon: 'visualizeApp',
+          editUrl: '/management/kibana/objects/savedVisualizations/1',
+          inAppUrl: {
+            path: '/edit/1',
+            uiCapabilitiesPath: 'visualize.show',
+          },
+        },
+      },
+      close: jest.fn(),
+    };
+
+    const component = shallowWithI18nProvider(<Relationships {...props} />);
+
+    // Make sure we are showing loading
+    expect(component.find('EuiLoadingSpinner').length).toBe(1);
+
+    // Ensure all promises resolve
+    await new Promise((resolve) => process.nextTick(resolve));
+    // Ensure the state changes are reflected
+    component.update();
+
+    expect(props.getRelationships).toHaveBeenCalled();
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render dashboards normally', async () => {
+    const props: RelationshipsProps = {
+      goInspectObject: () => {},
+      canGoInApp: () => true,
+      basePath: httpServiceMock.createSetupContract().basePath,
+      getRelationships: jest.fn().mockImplementation(() => [
+        {
+          type: 'visualization',
+          id: '1',
+          relationship: 'child',
+          meta: {
+            editUrl: '/management/kibana/objects/savedVisualizations/1',
+            icon: 'visualizeApp',
+            inAppUrl: {
+              path: '/app/visualize#/edit/1',
+              uiCapabilitiesPath: 'visualize.show',
+            },
+            title: 'My Visualization Title 1',
+          },
+        },
+        {
+          type: 'visualization',
+          id: '2',
+          relationship: 'child',
+          meta: {
+            editUrl: '/management/kibana/objects/savedVisualizations/2',
+            icon: 'visualizeApp',
+            inAppUrl: {
+              path: '/app/visualize#/edit/2',
+              uiCapabilitiesPath: 'visualize.show',
+            },
+            title: 'My Visualization Title 2',
+          },
+        },
+      ]),
+      savedObject: {
+        id: '1',
+        type: 'dashboard',
+        attributes: {},
+        references: [],
+        meta: {
+          title: 'MyDashboard',
+          icon: 'dashboardApp',
+          editUrl: '/management/kibana/objects/savedDashboards/1',
+          inAppUrl: {
+            path: '/dashboard/1',
+            uiCapabilitiesPath: 'dashboard.show',
+          },
+        },
+      },
+      close: jest.fn(),
+    };
+
+    const component = shallowWithI18nProvider(<Relationships {...props} />);
+
+    // Make sure we are showing loading
+    expect(component.find('EuiLoadingSpinner').length).toBe(1);
+
+    // Ensure all promises resolve
+    await new Promise((resolve) => process.nextTick(resolve));
+    // Ensure the state changes are reflected
+    component.update();
+
+    expect(props.getRelationships).toHaveBeenCalled();
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render errors', async () => {
+    const props: RelationshipsProps = {
+      goInspectObject: () => {},
+      canGoInApp: () => true,
+      basePath: httpServiceMock.createSetupContract().basePath,
+      getRelationships: jest.fn().mockImplementation(() => {
+        throw new Error('foo');
+      }),
+      savedObject: {
+        id: '1',
+        type: 'dashboard',
+        attributes: {},
+        references: [],
+        meta: {
+          title: 'MyDashboard',
+          icon: 'dashboardApp',
+          editUrl: '/management/kibana/objects/savedDashboards/1',
+          inAppUrl: {
+            path: '/dashboard/1',
+            uiCapabilitiesPath: 'dashboard.show',
+          },
+        },
+      },
+      close: jest.fn(),
+    };
+
+    const component = shallowWithI18nProvider(<Relationships {...props} />);
+
+    // Ensure all promises resolve
+    await new Promise((resolve) => process.nextTick(resolve));
+    // Ensure the state changes are reflected
+    component.update();
+
+    expect(props.getRelationships).toHaveBeenCalled();
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/plugins/share/public/lib/url_shortener.test.ts
+++ b/src/plugins/share/public/lib/url_shortener.test.ts
@@ -62,6 +62,28 @@ describe('Url shortener', () => {
         body: '{"url":"/app/opensearch-dashboards#123"}',
       });
     });
+
+    it('should shorten urls with a port for legacy app', async () => {
+      const shortUrl = await shortenUrl('http://localhost:5601/app/kibana#123', {
+        basePath: '',
+        post: postStub,
+      });
+      expect(shortUrl).toBe(`http://localhost:5601/goto/${shareId}`);
+      expect(postStub).toHaveBeenCalledWith(`/api/shorten_url`, {
+        body: '{"url":"/app/kibana#123"}',
+      });
+    });
+
+    it('should shorten urls without a port for legacy app', async () => {
+      const shortUrl = await shortenUrl('http://localhost/app/kibana#123', {
+        basePath: '',
+        post: postStub,
+      });
+      expect(shortUrl).toBe(`http://localhost/goto/${shareId}`);
+      expect(postStub).toHaveBeenCalledWith(`/api/shorten_url`, {
+        body: '{"url":"/app/kibana#123"}',
+      });
+    });
   });
 
   describe('Shorten with base path', () => {
@@ -117,6 +139,50 @@ describe('Url shortener', () => {
       expect(shortUrl).toBe(`http://localhost${basePath}/goto/${shareId}`);
       expect(postStub).toHaveBeenCalledWith(`/api/shorten_url`, {
         body: '{"url":"/app/opensearch-dashboards"}',
+      });
+    });
+
+    it('should shorten urls with a port for legacy app', async () => {
+      const shortUrl = await shortenUrl(`http://localhost:5601${basePath}/app/kibana#123`, {
+        basePath,
+        post: postStub,
+      });
+      expect(shortUrl).toBe(`http://localhost:5601${basePath}/goto/${shareId}`);
+      expect(postStub).toHaveBeenCalledWith(`/api/shorten_url`, {
+        body: '{"url":"/app/kibana#123"}',
+      });
+    });
+
+    it('should shorten urls without a port for legacy app', async () => {
+      const shortUrl = await shortenUrl(`http://localhost${basePath}/app/kibana#123`, {
+        basePath,
+        post: postStub,
+      });
+      expect(shortUrl).toBe(`http://localhost${basePath}/goto/${shareId}`);
+      expect(postStub).toHaveBeenCalledWith(`/api/shorten_url`, {
+        body: '{"url":"/app/kibana#123"}',
+      });
+    });
+
+    it('should shorten urls with a query string for legacy app', async () => {
+      const shortUrl = await shortenUrl(`http://localhost${basePath}/app/kibana?foo#123`, {
+        basePath,
+        post: postStub,
+      });
+      expect(shortUrl).toBe(`http://localhost${basePath}/goto/${shareId}`);
+      expect(postStub).toHaveBeenCalledWith(`/api/shorten_url`, {
+        body: '{"url":"/app/kibana?foo#123"}',
+      });
+    });
+
+    it('should shorten urls without a hash for legacy app', async () => {
+      const shortUrl = await shortenUrl(`http://localhost${basePath}/app/kibana`, {
+        basePath,
+        post: postStub,
+      });
+      expect(shortUrl).toBe(`http://localhost${basePath}/goto/${shareId}`);
+      expect(postStub).toHaveBeenCalledWith(`/api/shorten_url`, {
+        body: '{"url":"/app/kibana"}',
       });
     });
 

--- a/src/plugins/url_forwarding/public/forward_app/forward_app.ts
+++ b/src/plugins/url_forwarding/public/forward_app/forward_app.ts
@@ -39,6 +39,46 @@ export const createLegacyUrlForwardApp = (
   core: CoreSetup<{}, UrlForwardingStart>,
   forwards: ForwardDefinition[]
 ): App => ({
+  id: 'kibana',
+  chromeless: true,
+  title: 'Legacy URL migration',
+  appRoute: '/app/kibana#/',
+  navLinkStatus: AppNavLinkStatus.hidden,
+  async mount(params: AppMountParameters) {
+    const hash = params.history.location.hash.substr(1);
+
+    if (!hash) {
+      const [, , opensearchDashboardsLegacyStart] = await core.getStartServices();
+      opensearchDashboardsLegacyStart.navigateToDefaultApp();
+    }
+
+    const [
+      {
+        application,
+        http: { basePath },
+      },
+    ] = await core.getStartServices();
+
+    const result = await navigateToLegacyOpenSearchDashboardsUrl(
+      hash,
+      forwards,
+      basePath,
+      application
+    );
+
+    if (!result.navigated) {
+      const [, , opensearchDashboardsLegacyStart] = await core.getStartServices();
+      opensearchDashboardsLegacyStart.navigateToDefaultApp();
+    }
+
+    return () => {};
+  },
+});
+
+export const createLegacyUrlForwardCurrentApp = (
+  core: CoreSetup<{}, UrlForwardingStart>,
+  forwards: ForwardDefinition[]
+): App => ({
   id: 'opensearch-dashboards',
   chromeless: true,
   title: 'Legacy URL migration',

--- a/src/plugins/url_forwarding/public/plugin.ts
+++ b/src/plugins/url_forwarding/public/plugin.ts
@@ -34,7 +34,7 @@ import { CoreStart, CoreSetup } from 'opensearch-dashboards/public';
 import { OpenSearchDashboardsLegacyStart } from 'src/plugins/opensearch_dashboards_legacy/public';
 import { Subscription } from 'rxjs';
 import { navigateToDefaultApp } from './navigate_to_default_app';
-import { createLegacyUrlForwardApp } from './forward_app';
+import { createLegacyUrlForwardApp, createLegacyUrlForwardCurrentApp } from './forward_app';
 import { navigateToLegacyOpenSearchDashboardsUrl } from './forward_app/navigate_to_legacy_opensearch_dashboards_url';
 
 export interface ForwardDefinition {
@@ -50,6 +50,7 @@ export class UrlForwardingPlugin {
 
   public setup(core: CoreSetup<{}, UrlForwardingStart>) {
     core.application.register(createLegacyUrlForwardApp(core, this.forwardDefinitions));
+    core.application.register(createLegacyUrlForwardCurrentApp(core, this.forwardDefinitions));
     return {
       /**
        * Forwards URLs within the legacy `opensearchDashboards` app to a new platform application.


### PR DESCRIPTION
### Description
Forwarding legacy app to the current format of the application.
This enables the usage of stored URLs and other links that referenced
the format of the application URL that mentioned the application name.

Since we changed the URL forwarding we changed this value and released.
So incase forks were made and depended on this legacy formatted reference
of the application. It will still work. There are also references of the
application.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1013
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 