### PR TITLE
[Build] remove legacy version check for plugin builds

### DIFF
--- a/packages/osd-plugin-helpers/src/integration_tests/build.test.ts
+++ b/packages/osd-plugin-helpers/src/integration_tests/build.test.ts
@@ -42,11 +42,16 @@ import globby from 'globby';
 import loadJsonFile from 'load-json-file';
 
 const OPENSEARCH_DASHBOARDS_VERSION = '1.0.0';
+const OPENSEARCH_DASHBOARDS_VERSION_X = '1.0.0.x';
 const PLUGIN_DIR = Path.resolve(REPO_ROOT, 'plugins/foo_test_plugin');
 const PLUGIN_BUILD_DIR = Path.resolve(PLUGIN_DIR, 'build');
 const PLUGIN_ARCHIVE = Path.resolve(
   PLUGIN_BUILD_DIR,
   `fooTestPlugin-${OPENSEARCH_DASHBOARDS_VERSION}.zip`
+);
+const PLUGIN_ARCHIVE_X = Path.resolve(
+  PLUGIN_BUILD_DIR,
+  `fooTestPlugin-${OPENSEARCH_DASHBOARDS_VERSION_X}.zip`
 );
 const TMP_DIR = Path.resolve(__dirname, '__tmp__');
 
@@ -140,6 +145,95 @@ it('builds a generated plugin into a viable archive', async () => {
     Object {
       "id": "fooTestPlugin",
       "opensearchDashboardsVersion": "1.0.0",
+      "optionalPlugins": Array [],
+      "requiredPlugins": Array [
+        "navigation",
+      ],
+      "server": true,
+      "ui": true,
+      "version": "1.0.0",
+    }
+  `);
+});
+
+it('builds a non-semver generated plugin into a viable archive', async () => {
+  const generateProc = await execa(
+    process.execPath,
+    ['scripts/generate_plugin', '-y', '--name', 'fooTestPlugin'],
+    {
+      cwd: REPO_ROOT,
+      all: true,
+    }
+  );
+
+  expect(generateProc.all).toMatchInlineSnapshot(`
+    " succ 🎉
+
+          Your plugin has been created in plugins/foo_test_plugin
+    "
+  `);
+
+  const buildProc = await execa(
+    process.execPath,
+    [
+      '../../scripts/plugin_helpers',
+      'build',
+      '--opensearch-dashboards-version',
+      OPENSEARCH_DASHBOARDS_VERSION_X,
+    ],
+    {
+      cwd: PLUGIN_DIR,
+      all: true,
+    }
+  );
+
+  expect(buildProc.all).toMatchInlineSnapshot(`
+    " info deleting the build and target directories
+     info running @osd/optimizer
+     │ info initialized, 0 bundles cached
+     │ info starting worker [1 bundle]
+     │ warn worker stderr Browserslist: caniuse-lite is outdated. Please run:
+     │ warn worker stderr npx browserslist@latest --update-db
+     │ succ 1 bundles compiled successfully after <time>
+     info copying assets from \`public/assets\` to build
+     info copying server source into the build and converting with babel
+     info running yarn to install dependencies
+     info compressing plugin into [fooTestPlugin-1.0.0.x.zip]"
+  `);
+
+  await extract(PLUGIN_ARCHIVE_X, { dir: TMP_DIR }, () => {});
+
+  const files = await globby(['**/*'], { cwd: TMP_DIR });
+  files.sort((a, b) => a.localeCompare(b));
+
+  expect(files).toMatchInlineSnapshot(`
+    Array [
+      "opensearch-dashboards/fooTestPlugin/common/index.js",
+      "opensearch-dashboards/fooTestPlugin/opensearch_dashboards.json",
+      "opensearch-dashboards/fooTestPlugin/package.json",
+      "opensearch-dashboards/fooTestPlugin/server/index.js",
+      "opensearch-dashboards/fooTestPlugin/server/plugin.js",
+      "opensearch-dashboards/fooTestPlugin/server/routes/index.js",
+      "opensearch-dashboards/fooTestPlugin/server/types.js",
+      "opensearch-dashboards/fooTestPlugin/target/public/fooTestPlugin.chunk.1.js",
+      "opensearch-dashboards/fooTestPlugin/target/public/fooTestPlugin.chunk.1.js.br",
+      "opensearch-dashboards/fooTestPlugin/target/public/fooTestPlugin.chunk.1.js.gz",
+      "opensearch-dashboards/fooTestPlugin/target/public/fooTestPlugin.plugin.js",
+      "opensearch-dashboards/fooTestPlugin/target/public/fooTestPlugin.plugin.js.br",
+      "opensearch-dashboards/fooTestPlugin/target/public/fooTestPlugin.plugin.js.gz",
+      "opensearch-dashboards/fooTestPlugin/translations/ja-JP.json",
+      "opensearch-dashboards/fooTestPlugin/tsconfig.json",
+    ]
+  `);
+
+  expect(
+    loadJsonFile.sync(
+      Path.resolve(TMP_DIR, 'opensearch-dashboards', 'fooTestPlugin', 'opensearch_dashboards.json')
+    )
+  ).toMatchInlineSnapshot(`
+    Object {
+      "id": "fooTestPlugin",
+      "opensearchDashboardsVersion": "1.0.0.x",
       "optionalPlugins": Array [],
       "requiredPlugins": Array [
         "navigation",

--- a/packages/osd-plugin-helpers/src/tasks/write_server_files.ts
+++ b/packages/osd-plugin-helpers/src/tasks/write_server_files.ts
@@ -33,7 +33,6 @@
 import { pipeline } from 'stream';
 import { promisify } from 'util';
 
-import semver from 'semver';
 import vfs from 'vinyl-fs';
 import { transformFileWithBabel, transformFileStream } from '@osd/dev-utils';
 
@@ -51,17 +50,12 @@ export async function writeServerFiles({
 }: BuildContext) {
   log.info('copying server source into the build and converting with babel');
 
-  const OPENSEARCH_DASHBOARDS_VERSION_79 = semver.satisfies(opensearchDashboardsVersion, '~7.9.0');
-
   // copy source files and apply some babel transformations in the process
   await asyncPipeline(
     vfs.src(
       [
         'opensearch_dashboards.json',
-        // always copy over the package.json file if we're building for 7.9
-        ...(OPENSEARCH_DASHBOARDS_VERSION_79 ? ['package.json'] : []),
-        // always copy over server files if we're building for 7.9, otherwise rely on `server: true` in opensearch_dashboards.json manifest
-        ...(OPENSEARCH_DASHBOARDS_VERSION_79 || plugin.manifest.server
+        ...(plugin.manifest.server
           ? config.serverSourcePatterns || [
               'yarn.lock',
               'tsconfig.json',
@@ -86,7 +80,7 @@ export async function writeServerFiles({
     ),
 
     // add opensearchDashboardsVersion to opensearch_dashboards.json files and opensearchDashboards.version to package.json files
-    // we don't check for `opensearchDashboards.version` in 7.10+ but the plugin helpers can still be used
+    // we don't check for `opensearchDashboards.version` in 1.0+ but the plugin helpers can still be used
     // to build plugins for older OpenSearch Dashboards versions so we do our best to support those needs by
     // setting the property if the package.json file is encountered
     transformFileStream((file) => {


### PR DESCRIPTION
### Description
Removes the SEMVAR check for external plugins. 7.9 is not relevant
to the application.

The semvar library was also preventing major.minor.patch.x which is the
format from OpenSearch plugins.

Related issue:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/992

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 