### PR TITLE
[BUG] Dependencies don't specify python version (Issue 988)

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "mustache": "^2.3.2",
     "node-fetch": "^2.6.1",
     "node-forge": "^0.10.0",
+    "node-gyp": "8.2.0",
     "p-map": "^4.0.0",
     "pegjs": "0.10.0",
     "proxy-from-env": "1.0.0",


### PR DESCRIPTION
### Description
Runs pathfix.py before creating the tar file, to fix the references that point to `python` instead of `python3`. 
See https://github.com/opensearch-project/OpenSearch-Dashboards/issues/988

Please, note that this requires `/usr/bin/pathfix.py`. This comes with `platform-python-devel`.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/988

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 