### PR TITLE
[Link] Fix yarnpkg link error

### DIFF
--- a/.lycheeexclude
+++ b/.lycheeexclude
@@ -112,3 +112,4 @@ https://developer.mozilla.org/
 https://a.tile.openstreetmap.org/
 http://www.creedthoughts.gov
 https://media-for-the-masses.theacademyofperformingartsandscience.org/
+https://yarnpkg.com/latest.msi


### PR DESCRIPTION
Issue: https://yarnpkg.com/latest.msi is unavailable now and will be rerouted to a 404 page.

Signed-off-by: Zuocheng Ding <zding817@gmail.com>

### Description
https://yarnpkg.com/latest.msi is unavailable now and will be rerouted to a 404 page.
Add it to link checker allow list to unblock the PR process.
 
### Issues Resolved
Link checker error
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 