### PR TITLE
Disable WhiteSource check fails on commits/PRs

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -6,7 +6,7 @@
     "baseBranches": []
   },
   "checkRunSettings": {
-    "vulnerableCheckRunConclusionLevel": "failure",
+    "vulnerableCheckRunConclusionLevel": "success",
     "displayMode": "diff"
   },
   "issueSettings": {

--- a/whitesource.config
+++ b/whitesource.config
@@ -52,7 +52,7 @@ forceUpdate.failBuildOnPolicyViolation=false
 ###########
 #offline=false
 #updateType=APPEND
-#ignoreSourceFiles=true
+fileSystemScan=true
 #scanComment=
 #failErrorLevel=ALL
 #requireKnownSha1=false
@@ -78,18 +78,18 @@ forceUpdate.failBuildOnPolicyViolation=false
 resolveAllDependencies=false
 #excludeDependenciesFromNodes=.*commons-io.*,.*maven-model
 
-#npm.resolveDependencies=false
-#npm.ignoreSourceFiles=false
-#npm.includeDevDependencies=true
-#npm.runPreStep=true
-#npm.ignoreNpmLsErrors=true
+npm.resolveDependencies=true
+npm.ignoreSourceFiles=false
+npm.includeDevDependencies=true
+npm.runPreStep=true
+npm.ignoreNpmLsErrors=true
 #npm.ignoreScripts=true
-#npm.yarnProject=true
+npm.yarnProject=true
 #npm.accessToken=
 #npm.identifyByNameAndVersion=true
-#npm.yarn.frozenLockfile=true
-#npm.resolveMainPackageJsonOnly=true
-#npm.removeDuplicateDependencies=false
+npm.yarn.frozenLockfile=true
+npm.resolveMainPackageJsonOnly=false
+npm.removeDuplicateDependencies=true
 #npm.resolveAdditionalDependencies=true
 #npm.failOnNpmLsErrors =
 #npm.projectNameFromDependencyFile = true
@@ -142,32 +142,6 @@ resolveAllDependencies=false
 #maven.additionalArguments=
 #maven.projectNameFromDependencyFile=true
 
-resolveAllDependencies=false
-archiveExtractionDepth=7
-followSymbolicLinks=true
-gradle.resolveDependencies=true
-gradle.aggregateModules=true
-gradle.preferredEnvironment=wrapper
-maven.resolveDependencies=true
-maven.runPreStep=true
-maven.aggregateModules=true
-maven.ignoredScopes=None
-html.resolveDependencies=true
-npm.resolveDependencies=true
-npm.runPreStep=true
-npm.yarnProject=true
-go.resolveDependencies=true
-go.collectDependenciesAtRuntime=true
-go.dependencyManager=
-python.resolveDependencies=true
-python.ignoreSourceFiles=true
-python.runPipenvPreStep=true
-python.pipenvDevDependencies=true
-python.requirementsFileIncludes=dev-requirements.txt
-python.installVirtualenv=true
-ruby.resolveDependencies=true
-ruby.ignoreSourceFiles=false
-
 #gradle.ignoredScopes=
 #gradle.resolveDependencies=true
 #gradle.runAssembleCommand=true
@@ -214,7 +188,7 @@ ruby.ignoreSourceFiles=false
 #php.runPreStep=true
 #php.includeDevDependencies=true
 
-#html.resolveDependencies=false
+html.resolveDependencies=true
 
 #cocoapods.resolveDependencies=false
 #cocoapods.runPreStep=true
@@ -274,7 +248,7 @@ followSymbolicLinks=true
 ######################
 # Archive properties #
 ######################
-#archiveExtractionDepth=2
+archiveExtractionDepth=7
 #archiveIncludes=**/*.war **/*.ear
 #archiveExcludes=**/*sources.jar
 


### PR DESCRIPTION
### Description
* WhiteSource is not properly comparing scans against the latest changes in `main`. This prevents the need to override checks to merge PRs for those who don't have access (like the Dashboards Core members).
* Cleans up the WhiteSource config file. We don't need gradle, maven, go, python, or ruby scans enabled.
* Replaces the deprecated `ignoreSourceFiles` config with `fileSystemScan`.
 
### Issues Resolved

Resolves #1150 
 
### Check List
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 