### PR TITLE
[BUG] Add Data table bucket Split rows agg limit of 3

### DIFF
--- a/src/plugins/vis_type_table/public/table_vis_type.ts
+++ b/src/plugins/vis_type_table/public/table_vis_type.ts
@@ -97,6 +97,7 @@ export function getTableVisTypeDefinition(
           title: i18n.translate('visTypeTable.tableVisEditorConfig.schemas.bucketTitle', {
             defaultMessage: 'Split rows',
           }),
+          max: 3,
           aggFilter: ['!filter'],
         },
         {

--- a/src/plugins/vis_type_table/public/table_vis_type.ts
+++ b/src/plugins/vis_type_table/public/table_vis_type.ts
@@ -45,9 +45,9 @@ export function getTableVisTypeDefinition(
   core: CoreSetup,
   context: PluginInitializerContext
 ): BaseVisTypeOptions {
-  const tableBucketAggAmounts = core.uiSettings.get('visualize:aggAmounts').table.bucket;
-  const maxBucket = tableBucketAggAmounts.max;
-  const minBucket = tableBucketAggAmounts.min;
+  const tableBucketAggAmounts = core.uiSettings.get('visualize:aggAmounts')?.table?.bucket;
+  const maxBucket = tableBucketAggAmounts?.max;
+  const minBucket = tableBucketAggAmounts?.min;
 
   return {
     name: 'table',

--- a/src/plugins/vis_type_table/public/table_vis_type.ts
+++ b/src/plugins/vis_type_table/public/table_vis_type.ts
@@ -45,6 +45,10 @@ export function getTableVisTypeDefinition(
   core: CoreSetup,
   context: PluginInitializerContext
 ): BaseVisTypeOptions {
+  const tableBucketAggAmounts = core.uiSettings.get('visualize:aggAmounts').table.bucket;
+  const maxBucket = tableBucketAggAmounts.max;
+  const minBucket = tableBucketAggAmounts.min;
+
   return {
     name: 'table',
     title: i18n.translate('visTypeTable.tableVisTitle', {
@@ -97,7 +101,8 @@ export function getTableVisTypeDefinition(
           title: i18n.translate('visTypeTable.tableVisEditorConfig.schemas.bucketTitle', {
             defaultMessage: 'Split rows',
           }),
-          max: 3,
+          ...(maxBucket ? { max: maxBucket } : {}),
+          ...(minBucket ? { min: minBucket } : {}),
           aggFilter: ['!filter'],
         },
         {

--- a/src/plugins/visualizations/common/constants.ts
+++ b/src/plugins/visualizations/common/constants.ts
@@ -32,3 +32,4 @@
 
 export const VISUALIZE_ENABLE_LABS_SETTING = 'visualize:enableLabs';
 export const VISUALIZE_DISABLE_BUCKET_AGG_SETTING = 'visualize:disableBucketAgg';
+export const VISUALIZE_AGG_AMOUNTS = 'visualize:aggAmounts';

--- a/src/plugins/visualizations/server/plugin.ts
+++ b/src/plugins/visualizations/server/plugin.ts
@@ -79,6 +79,7 @@ export class VisualizationsPlugin
             bucket: {},
           },
         }),
+        type: 'json',
         description: i18n.translate('visualizations.advancedSettings.visualizeAggAmountsText', {
           defaultMessage: `Allows users to set bucket's aggregation level limitation,
             using the min ,max properties`,

--- a/src/plugins/visualizations/server/plugin.ts
+++ b/src/plugins/visualizations/server/plugin.ts
@@ -70,26 +70,23 @@ export class VisualizationsPlugin
 
     core.uiSettings.register({
       [VISUALIZE_AGG_AMOUNTS]: {
+        // currently only supports dataTable vis
         name: i18n.translate('visualizations.advancedSettings.visualizeAggAmountsTitle', {
-          defaultMessage: "Set visualizations' aggregations amounts limitation",
+          defaultMessage: `Set bucket's aggregation min, max level limitation`,
         }),
-        value: {},
+        value: JSON.stringify({
+          table: {
+            bucket: {
+              max: 3,
+            },
+          },
+        }),
         description: i18n.translate('visualizations.advancedSettings.visualizeAggAmountsText', {
-          defaultMessage: `Allows users to set visualizations' aggregations amounts limitation per .`,
+          defaultMessage: `Allows users to set bucket's aggregation level limitation,
+            using the min ,max properties`,
         }),
         category: ['visualization'],
-        schema: schema.object({
-          table: schema.maybe(
-            schema.object({
-              bucket: schema.maybe(
-                schema.object({
-                  max: schema.maybe(schema.number()),
-                  min: schema.maybe(schema.number()),
-                })
-              ),
-            })
-          ),
-        }),
+        schema: schema.string(),
       },
       [VISUALIZE_ENABLE_LABS_SETTING]: {
         name: i18n.translate('visualizations.advancedSettings.visualizeEnableLabsTitle', {

--- a/src/plugins/visualizations/server/plugin.ts
+++ b/src/plugins/visualizations/server/plugin.ts
@@ -45,6 +45,7 @@ import {
 import {
   VISUALIZE_ENABLE_LABS_SETTING,
   VISUALIZE_DISABLE_BUCKET_AGG_SETTING,
+  VISUALIZE_AGG_AMOUNTS,
 } from '../common/constants';
 
 import { visualizationSavedObjectType } from './saved_objects';
@@ -68,6 +69,28 @@ export class VisualizationsPlugin
     core.savedObjects.registerType(visualizationSavedObjectType);
 
     core.uiSettings.register({
+      [VISUALIZE_AGG_AMOUNTS]: {
+        name: i18n.translate('visualizations.advancedSettings.visualizeAggAmountsTitle', {
+          defaultMessage: "Set visualizations' aggregations amounts limitation",
+        }),
+        value: {},
+        description: i18n.translate('visualizations.advancedSettings.visualizeAggAmountsText', {
+          defaultMessage: `Allows users to set visualizations' aggregations amounts limitation per .`,
+        }),
+        category: ['visualization'],
+        schema: schema.object({
+          table: schema.maybe(
+            schema.object({
+              bucket: schema.maybe(
+                schema.object({
+                  max: schema.maybe(schema.number()),
+                  min: schema.maybe(schema.number()),
+                })
+              ),
+            })
+          ),
+        }),
+      },
       [VISUALIZE_ENABLE_LABS_SETTING]: {
         name: i18n.translate('visualizations.advancedSettings.visualizeEnableLabsTitle', {
           defaultMessage: 'Enable experimental visualizations',

--- a/src/plugins/visualizations/server/plugin.ts
+++ b/src/plugins/visualizations/server/plugin.ts
@@ -76,9 +76,7 @@ export class VisualizationsPlugin
         }),
         value: JSON.stringify({
           table: {
-            bucket: {
-              max: 3,
-            },
+            bucket: {},
           },
         }),
         description: i18n.translate('visualizations.advancedSettings.visualizeAggAmountsText', {

--- a/test/plugin_functional/test_suites/custom_visualizations/index.js
+++ b/test/plugin_functional/test_suites/custom_visualizations/index.js
@@ -49,5 +49,6 @@ export default function ({ getService, loadTestFile }) {
     });
 
     loadTestFile(require.resolve('./self_changing_vis'));
+    loadTestFile(require.resolve('./table_vis'));
   });
 }

--- a/test/plugin_functional/test_suites/custom_visualizations/table_vis.js
+++ b/test/plugin_functional/test_suites/custom_visualizations/table_vis.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import expect from '@osd/expect';
+import { VISUALIZE_AGG_AMOUNTS } from '../../../../src/plugins/visualizations/common/constants';
+
+export default function ({ getService, getPageObjects }) {
+  const testSubjects = getService('testSubjects');
+  const PageObjects = getPageObjects(['common', 'visualize', 'visEditor', 'settings', 'header']);
+
+  describe('self changing vis', function describeIndexTests() {
+    let indexPatternSelector;
+    let addButtonSelector;
+    let splitRowsAggragationSelector;
+
+    before(async () => {
+      await PageObjects.visualize.navigateToNewVisualization();
+      await PageObjects.visualize.clickVisType('table');
+
+      indexPatternSelector = await testSubjects.find('savedObjectTitlelogstash*');
+    });
+
+    it('should allow adding settings ${num} levels of bucket aggregation', async () => {
+      await indexPatternSelector.click();
+      addButtonSelector = await testSubjects.find('visEditorAdd_buckets');
+      await addButtonSelector.click();
+      splitRowsAggragationSelector = await testSubjects.find('visEditorAdd_buckets_Split rows');
+      await splitRowsAggragationSelector.click();
+      await addButtonSelector.click();
+      await splitRowsAggragationSelector.click();
+      await addButtonSelector.click();
+      expect(splitRowsAggragationSelector.getAttribute('disabled')).to.eql(true);
+
+      await PageObjects.header.clickStackManagement();
+      await PageObjects.settings.clickOpenSearchDashboardsSettings();
+      await PageObjects.settings.setAdvancedSettingsInput(
+        VISUALIZE_AGG_AMOUNTS,
+        `{"table":{"bucket":{"max":1}}}`
+      );
+
+      await PageObjects.visualize.navigateToNewVisualization();
+      await PageObjects.visualize.clickVisType('table');
+      await indexPatternSelector.click();
+      await addButtonSelector.click();
+      await splitRowsAggragationSelector.click();
+      await addButtonSelector.click();
+      expect(splitRowsAggragationSelector.getAttribute('disabled')).to.not.equal(true);
+    });
+  });
+}

--- a/test/plugin_functional/test_suites/custom_visualizations/table_vis.js
+++ b/test/plugin_functional/test_suites/custom_visualizations/table_vis.js
@@ -31,7 +31,7 @@ export default function ({ getService, getPageObjects }) {
       await addButtonSelector.click();
       await splitRowsAggragationSelector.click();
       await addButtonSelector.click();
-      expect(splitRowsAggragationSelector.getAttribute('disabled')).to.eql(true);
+      expect(splitRowsAggragationSelector.getAttribute('disabled')).to.eql(false);
 
       await PageObjects.header.clickStackManagement();
       await PageObjects.settings.clickOpenSearchDashboardsSettings();


### PR DESCRIPTION
Signed-off-by: sitbubu <royi.sitbon@logz.io>

### Description
The default limit of 3 “Split rows” aggregated buckets isn't applied on this visualization which allows adding more buckets and can harm cluster performance.

In other types of visualizations, there is a default limit of up to 3 “Split rows” aggregated buckets, e.g. Horizontal-Bar visualizations.

We wish to have an option to configure the max,min limitation for the “Split rows” aggregated bucket under dataTable vis.
i.e. Using this configuration, we will limit the max amount to 3:
<img width="979" alt="Screen Shot 2022-02-03 at 14 25 02" src="https://user-images.githubusercontent.com/12782945/152342371-570f7721-5139-43c4-a90c-a01693afa0a9.png">

This way we will see the next result in our UI:
<img width="517" alt="splitRowsLimited" src="https://user-images.githubusercontent.com/12782945/152342546-5c5f18eb-eaea-49b8-b8d9-8c2b03a4db33.png">

If we won't set any limitation, i.e:
<img width="282" alt="Screen Shot 2022-02-03 at 14 27 12" src="https://user-images.githubusercontent.com/12782945/152342691-60dd46b6-b746-4bac-bde8-4288987d3bc1.png">

We will have same behavior as now:
<img width="526" alt="splitRowsUnlimited" src="https://user-images.githubusercontent.com/12782945/152342749-0d8215fb-7bae-4997-bc61-3c8ba5a3b469.png">

**linked issue:**
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1178