### PR TITLE
Add limit import file size using ui settings

### DIFF
--- a/src/plugins/saved_objects/common/index.ts
+++ b/src/plugins/saved_objects/common/index.ts
@@ -32,3 +32,4 @@
 
 export const PER_PAGE_SETTING = 'savedObjects:perPage';
 export const LISTING_LIMIT_SETTING = 'savedObjects:listingLimit';
+export const MAX_IMPORT_FILE_SIZE = 'savedObjects:maxImportFileSize';

--- a/src/plugins/saved_objects/server/ui_settings.ts
+++ b/src/plugins/saved_objects/server/ui_settings.ts
@@ -34,9 +34,17 @@ import { i18n } from '@osd/i18n';
 import { schema } from '@osd/config-schema';
 
 import { UiSettingsParams } from 'opensearch-dashboards/server';
-import { PER_PAGE_SETTING, LISTING_LIMIT_SETTING } from '../common';
+import { PER_PAGE_SETTING, LISTING_LIMIT_SETTING, MAX_IMPORT_FILE_SIZE } from '../common';
 
 export const uiSettings: Record<string, UiSettingsParams> = {
+  [MAX_IMPORT_FILE_SIZE]: {
+    name: i18n.translate('savedObjects.advancedSettings.maxImportFileSize', {
+      defaultMessage: 'set max import file size',
+    }),
+    value: 10 * 1024 * 1024,
+    type: 'number',
+    schema: schema.number(),
+  },
   [PER_PAGE_SETTING]: {
     name: i18n.translate('savedObjects.advancedSettings.perPageTitle', {
       defaultMessage: 'Objects per page',

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/flyout.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/flyout.test.tsx.snap
@@ -214,6 +214,7 @@ exports[`Flyout conflicts should allow conflict resolution 2`] = `
             "name": "foo.ndjson",
             "path": "/home/foo.ndjson",
           },
+          "fileSizeExceeded": false,
           "importCount": 0,
           "importMode": Object {
             "createNewCopies": false,
@@ -629,6 +630,7 @@ exports[`Flyout should render import step 1`] = `
       >
         <EuiButton
           data-test-subj="importSavedObjectsImportBtn"
+          disabled={false}
           fill={true}
           isLoading={false}
           onClick={[Function]}

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
@@ -87,6 +87,7 @@ describe('Flyout', () => {
       allowedTypes: ['search', 'index-pattern', 'visualization'],
       serviceRegistry: serviceRegistryMock.create(),
       search,
+      maxImportFileSize: 10 * 1024 * 1024,
     };
   });
 
@@ -127,6 +128,33 @@ describe('Flyout', () => {
     expect(component.state('file')).toBe(mockFile);
     component.find('EuiFilePicker').simulate('change', []);
     expect(component.state('file')).toBe(undefined);
+  });
+
+  it('should handle exceed max import file size', async () => {
+    const component = shallowRender(defaultProps);
+
+    // Ensure all promises resolve
+    await new Promise((resolve) => process.nextTick(resolve));
+    // Ensure the state changes are reflected
+    component.update();
+
+    expect(component.state('file')).toBe(undefined);
+    component.find('EuiFilePicker').simulate('change', [
+      {
+        ...mockFile,
+        size: defaultProps.maxImportFileSize + 1 * 1024 * 1024,
+      },
+    ]);
+    component.update();
+    expect(component.state('fileSizeExceeded')).toBe(true);
+    component.find('EuiFilePicker').simulate('change', [
+      {
+        ...mockFile,
+        size: defaultProps.maxImportFileSize,
+      },
+    ]);
+    component.update();
+    expect(component.state('fileSizeExceeded')).toBe(false);
   });
 
   it('should handle invalid files', async () => {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
@@ -63,6 +63,7 @@ import {
 import { Flyout, Relationships } from './components';
 import { SavedObjectWithMetadata } from '../../types';
 
+const maxImportFileSize = 10 * 1024 * 1024;
 const allowedTypes = ['index-pattern', 'visualization', 'dashboard', 'search'];
 
 const allSavedObjects = [
@@ -145,6 +146,7 @@ describe('SavedObjectsTable', () => {
     });
 
     defaultProps = {
+      maxImportFileSize,
       allowedTypes,
       serviceRegistry: serviceRegistryMock.create(),
       actionRegistry: actionServiceMock.createStart(),

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -98,6 +98,7 @@ interface ExportAllOption {
 
 export interface SavedObjectsTableProps {
   allowedTypes: string[];
+  maxImportFileSize: number;
   serviceRegistry: ISavedObjectsManagementServiceRegistry;
   actionRegistry: SavedObjectsManagementActionServiceStart;
   columnRegistry: SavedObjectsManagementColumnServiceStart;
@@ -524,6 +525,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
         indexPatterns={this.props.indexPatterns}
         newIndexPatternUrl={newIndexPatternUrl}
         allowedTypes={this.props.allowedTypes}
+        maxImportFileSize={this.props.maxImportFileSize}
         overlays={this.props.overlays}
         search={this.props.search}
       />

--- a/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
@@ -61,6 +61,7 @@ const SavedObjectsTablePage = ({
 }) => {
   const capabilities = coreStart.application.capabilities;
   const itemsPerPage = coreStart.uiSettings.get<number>('savedObjects:perPage', 50);
+  const maxImportFileSize = coreStart.uiSettings.get<number>('savedObjects:maxImportFileSize');
 
   useEffect(() => {
     setBreadcrumbs([
@@ -76,6 +77,7 @@ const SavedObjectsTablePage = ({
   return (
     <SavedObjectsTable
       allowedTypes={allowedTypes}
+      maxImportFileSize={maxImportFileSize}
       serviceRegistry={serviceRegistry}
       actionRegistry={actionRegistry}
       columnRegistry={columnRegistry}


### PR DESCRIPTION
Signed-off-by: sitbubu <royi.sitbon@logz.io>

### Description

Go to Stack management → Saved Objects
Try to import large-sized files, e.g above 10MB.
a request will be sent and we will get stuck in loading mode.
Once our request will be timed-out we will see the next err msg that doesn't specify our actual problem.

### Issues Resolved
Resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1183