### PR TITLE
Don't terminate the server on NodeDeprecationWarning

### DIFF
--- a/src/setup_node_env/exit_on_warning.js
+++ b/src/setup_node_env/exit_on_warning.js
@@ -31,7 +31,7 @@
  */
 
 if (process.noProcessWarnings !== true) {
-  var ignore = ['MaxListenersExceededWarning'];
+  var ignore = ['MaxListenersExceededWarning', 'NodeDeprecationWarning'];
 
   process.on('warning', function (warn) {
     if (ignore.includes(warn.name)) return;


### PR DESCRIPTION
The last AWS SDK for Javascript that supports Node 10 (v3.45.0) emits a NodeDeprecationWarning to indicate that Node 10
is no longer supported. Without this workaround, this crashes the OSD server, so it becomes impossible to interact with
other AWS services from within OSD (e.g., in a custom plugin) until the Node 14 upgrade is done.

Signed-off-by: Thilo-Alexander Ginkel <tg@tgbyte.de>

### Description
See above. Without this fix the OSD server crashes with the following warning as soon as any AWS SDK functionality is used:

```
(node:74504) NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
no longer support Node.js v10.24.1 as of January 1, 2022.
To continue receiving updates to AWS services, bug fixes, and security
updates please upgrade to Node.js 12.x or later.

More information can be found at: https://a.co/1l6FLnu
Node.js process-warning detected:

NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
no longer support Node.js v10.24.1 as of January 1, 2022.
To continue receiving updates to AWS services, bug fixes, and security
updates please upgrade to Node.js 12.x or later.

More information can be found at: https://a.co/1l6FLnu
    at Object.emitWarningIfUnsupportedVersion (/home/tg/workspace/OpenSearch-Dashboards/plugins/.../node_modules/@aws-sdk/smithy-client/dist-cjs/emitWarningIfUnsupportedVersion.js:8:17)
    at Object.getRuntimeConfig (/home/tg/workspace/OpenSearch-Dashboards/plugins/.../node_modules/@aws-sdk/client-s3/dist-cjs/runtimeConfig.js:24:21)
    at new S3Client (/home/tg/workspace/OpenSearch-Dashboards/plugins/.../node_modules/@aws-sdk/client-s3/dist-cjs/S3Client.js:19:43)
    at <redcated>
    at <redcated>
    at /home/tg/workspace/OpenSearch-Dashboards/src/core/utils/context.ts:261:14
    at process._tickCallback (internal/process/next_tick.js:68:7)

Terminating process...
 server crashed  with status code 1
```
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 