### PR TITLE
Allow node patch versions to be higher on runtime

### DIFF
--- a/src/setup_node_env/node_version_validator.js
+++ b/src/setup_node_env/node_version_validator.js
@@ -41,13 +41,8 @@ var isVersionValid = requiredVersionMajorMinor === currentVersion.match(/^v(\d+\
 // Validates current the NodeJS version compatibility when OpenSearch Dashboards starts.
 if (!isVersionValid) {
   var errorMessage =
-    'OpenSearch Dashboards was built with ' +
-    requiredVersion +
-    ' and does not support the current Node.js version ' +
-    currentVersion +
-    '. Please use Node.js ~v' +
-    requiredVersionMajorMinor +
-    '.';
+    `OpenSearch Dashboards was built with ${requiredVersion} and does not support the current Node.js version ${currentVersion}. ` +
+    `Please use Node.js ~v'${requiredVersionMajorMinor}' or higher.`;
 
   // Actions to apply when validation fails: error report + exit.
   console.error(errorMessage);

--- a/src/setup_node_env/node_version_validator.js
+++ b/src/setup_node_env/node_version_validator.js
@@ -42,7 +42,7 @@ var isVersionValid = requiredVersionMajorMinor === currentVersion.match(/^v(\d+\
 if (!isVersionValid) {
   var errorMessage =
     `OpenSearch Dashboards was built with ${requiredVersion} and does not support the current Node.js version ${currentVersion}. ` +
-    `Please use Node.js ~v'${requiredVersionMajorMinor}' or higher.`;
+    `Please use Node.js ~v${requiredVersionMajorMinor} or higher.`;
 
   // Actions to apply when validation fails: error report + exit.
   console.error(errorMessage);

--- a/src/setup_node_env/node_version_validator.js
+++ b/src/setup_node_env/node_version_validator.js
@@ -35,15 +35,16 @@ var pkg = require('../../package.json');
 var currentVersion = (process && process.version) || null;
 var rawRequiredVersion = (pkg && pkg.engines && pkg.engines.node) || null;
 var requiredVersion = rawRequiredVersion ? 'v' + rawRequiredVersion : rawRequiredVersion;
-var isVersionValid = !!currentVersion && !!requiredVersion && currentVersion === requiredVersion;
+var requiredVersionMajorMinor = requiredVersion.match(/^v(\d+\.\d+)/)[1];
+var isVersionValid = requiredVersionMajorMinor === currentVersion.match(/^v(\d+\.\d+)/)[1];
 
 // Validates current the NodeJS version compatibility when OpenSearch Dashboards starts.
 if (!isVersionValid) {
   var errorMessage =
     'OpenSearch Dashboards does not support the current Node.js version ' +
     currentVersion +
-    '. Please use Node.js ' +
-    requiredVersion +
+    '. Please use Node.js ~v' +
+    requiredVersionMajorMinor +
     '.';
 
   // Actions to apply when validation fails: error report + exit.

--- a/src/setup_node_env/node_version_validator.js
+++ b/src/setup_node_env/node_version_validator.js
@@ -35,14 +35,18 @@ var pkg = require('../../package.json');
 var currentVersion = (process && process.version) || null;
 var rawRequiredVersion = (pkg && pkg.engines && pkg.engines.node) || null;
 var requiredVersion = rawRequiredVersion ? 'v' + rawRequiredVersion : rawRequiredVersion;
-var requiredVersionMajorMinor = requiredVersion.match(/^v(\d+\.\d+)/)[1];
-var isVersionValid = requiredVersionMajorMinor === currentVersion.match(/^v(\d+\.\d+)/)[1];
+var currentVersionMajorMinorPatch = currentVersion.match(/^v(\d+)\.(\d+)\.(\d+)/);
+var requiredVersionMajorMinorPatch = requiredVersion.match(/^v(\d+)\.(\d+)\.(\d+)/);
+var isVersionValid =
+  currentVersionMajorMinorPatch[1] === requiredVersionMajorMinorPatch[1] &&
+  currentVersionMajorMinorPatch[2] === requiredVersionMajorMinorPatch[2] &&
+  parseInt(currentVersionMajorMinorPatch[3], 10) >= parseInt(requiredVersionMajorMinorPatch[3], 10);
 
 // Validates current the NodeJS version compatibility when OpenSearch Dashboards starts.
 if (!isVersionValid) {
   var errorMessage =
     `OpenSearch Dashboards was built with ${requiredVersion} and does not support the current Node.js version ${currentVersion}. ` +
-    `Please use Node.js ~v${requiredVersionMajorMinor} or higher.`;
+    `Please use Node.js ${requiredVersion} or a higher patch version.`;
 
   // Actions to apply when validation fails: error report + exit.
   console.error(errorMessage);

--- a/src/setup_node_env/node_version_validator.js
+++ b/src/setup_node_env/node_version_validator.js
@@ -41,7 +41,9 @@ var isVersionValid = requiredVersionMajorMinor === currentVersion.match(/^v(\d+\
 // Validates current the NodeJS version compatibility when OpenSearch Dashboards starts.
 if (!isVersionValid) {
   var errorMessage =
-    'OpenSearch Dashboards does not support the current Node.js version ' +
+    'OpenSearch Dashboards was built with ' +
+    requiredVersion +
+    ' and does not support the current Node.js version ' +
     currentVersion +
     '. Please use Node.js ~v' +
     requiredVersionMajorMinor +

--- a/src/setup_node_env/node_version_validator.test.js
+++ b/src/setup_node_env/node_version_validator.test.js
@@ -66,4 +66,30 @@ describe('NodeVersionValidator', function () {
       done();
     });
   });
+
+  it('should run the script WITHOUT error when only the patch version is different', function (done) {
+    var matches = REQUIRED_NODE_JS_VERSION.match(/^v(\d+)\.(\d+)\.(\d+)/);
+    var major = matches[1];
+    var minor = matches[2];
+    var patch = parseInt(matches[3]) + 1; // change patch version to be higher than required
+
+    var processVersionOverwrite =
+      "Object.defineProperty(process, 'version', { value: '" +
+      'v' +
+      major +
+      '.' +
+      minor +
+      '.' +
+      patch +
+      "', writable: true });";
+    var command =
+      'node -e "' + processVersionOverwrite + "require('./node_version_validator.js')\"";
+
+    exec(command, { cwd: __dirname }, function (error, stdout, stderr) {
+      expect(error).toBeNull();
+      expect(stderr).toBeDefined();
+      expect(stderr).toHaveLength(0);
+      done();
+    });
+  });
 });

--- a/src/setup_node_env/node_version_validator.test.js
+++ b/src/setup_node_env/node_version_validator.test.js
@@ -42,8 +42,8 @@ describe('NodeVersionValidator', function () {
     testValidateNodeVersion(done, requiredNodeVersionWithDiff(0, 0, +1));
   });
 
-  it('should run the script WITHOUT error when only the patch version is lower', function (done) {
-    testValidateNodeVersion(done, requiredNodeVersionWithDiff(0, 0, -1));
+  it('should run the script WITH error if the patch version is lower', function (done) {
+    testValidateNodeVersion(done, requiredNodeVersionWithDiff(0, 0, -1), true);
   });
 
   it('should run the script WITH error if the major version is higher', function (done) {
@@ -81,10 +81,9 @@ function testValidateNodeVersion(done, versionToTest, expectError = false) {
     if (expectError) {
       expect(error.code).toBe(1);
 
-      var majorMinorVersion = REQUIRED_NODE_JS_VERSION.substring(0, REQUIRED_NODE_JS_VERSION.lastIndexOf('.'));
       var speficicErrorMessage =
         `OpenSearch Dashboards was built with ${REQUIRED_NODE_JS_VERSION} and does not support the current Node.js version ${versionToTest}. ` +
-        `Please use Node.js ~${majorMinorVersion} or higher.\n`;
+        `Please use Node.js ${REQUIRED_NODE_JS_VERSION} or a higher patch version.\n`;
 
       expect(stderr).toStrictEqual(speficicErrorMessage);
     } else {

--- a/src/setup_node_env/node_version_validator.test.js
+++ b/src/setup_node_env/node_version_validator.test.js
@@ -36,14 +36,10 @@ var INVALID_NODE_JS_VERSION = 'v0.10.0';
 
 describe('NodeVersionValidator', function () {
   it('should run the script WITH error', function (done) {
-    var processVersionOverwrite =
-      "Object.defineProperty(process, 'version', { value: '" +
-      INVALID_NODE_JS_VERSION +
-      "', writable: true });";
-    var command =
-      'node -e "' + processVersionOverwrite + "require('./node_version_validator.js')\"";
+    var processVersionOverwrite = `Object.defineProperty(process, 'version', { value: '${INVALID_NODE_JS_VERSION}', writable: true });`;
+    var command = `node -e "${processVersionOverwrite}require('./node_version_validator.js')"`;
 
-    exec(command, { cwd: __dirname }, function (error, stdout, stderr) {
+    exec(command, { cwd: __dirname }, function (error, _stdout, stderr) {
       expect(error.code).toBe(1);
       expect(stderr).toBeDefined();
       expect(stderr).not.toHaveLength(0);
@@ -52,14 +48,10 @@ describe('NodeVersionValidator', function () {
   });
 
   it('should run the script WITHOUT error', function (done) {
-    var processVersionOverwrite =
-      "Object.defineProperty(process, 'version', { value: '" +
-      REQUIRED_NODE_JS_VERSION +
-      "', writable: true });";
-    var command =
-      'node -e "' + processVersionOverwrite + "require('./node_version_validator.js')\"";
+    var processVersionOverwrite = `Object.defineProperty(process, 'version', { value: '${REQUIRED_NODE_JS_VERSION}', writable: true });`;
+    var command = `node -e "${processVersionOverwrite}require('./node_version_validator.js')"`;
 
-    exec(command, { cwd: __dirname }, function (error, stdout, stderr) {
+    exec(command, { cwd: __dirname }, function (error, _stdout, stderr) {
       expect(error).toBeNull();
       expect(stderr).toBeDefined();
       expect(stderr).toHaveLength(0);
@@ -73,19 +65,10 @@ describe('NodeVersionValidator', function () {
     var minor = matches[2];
     var patch = parseInt(matches[3]) + 1; // change patch version to be higher than required
 
-    var processVersionOverwrite =
-      "Object.defineProperty(process, 'version', { value: '" +
-      'v' +
-      major +
-      '.' +
-      minor +
-      '.' +
-      patch +
-      "', writable: true });";
-    var command =
-      'node -e "' + processVersionOverwrite + "require('./node_version_validator.js')\"";
+    var processVersionOverwrite = `Object.defineProperty(process, 'version', { value: 'v${major}.${minor}.${patch}', writable: true });`;
+    var command = `node -e "${processVersionOverwrite}require('./node_version_validator.js')"`;
 
-    exec(command, { cwd: __dirname }, function (error, stdout, stderr) {
+    exec(command, { cwd: __dirname }, function (error, _stdout, stderr) {
       expect(error).toBeNull();
       expect(stderr).toBeDefined();
       expect(stderr).toHaveLength(0);


### PR DESCRIPTION
This adjusts the runtime node version check to only compare major and minor version requirements. Systems that don't use the bundled NodeJS might update their node due to security patches, [which would currently break OpenSearch Dashboards unnecessarily](https://github.com/opensearch-project/project-website/pull/642#issuecomment-1024136539).

```bash
% grep 14.18 ../../package.json
    "node": "14.18.2",
% nvm use 12
Now using node v12.22.8 (npm v6.14.15)
% node node_version_validator.js
OpenSearch Dashboards does not support the current Node.js version v12.22.8. Please use Node.js ~v14.18.
% nvm use 14
Now using node v14.18.3 (npm v6.14.15)
% node node_version_validator.js
%
```