### PR TITLE
Add option to configure available bucket agg types + jest tests

### DIFF
--- a/src/plugins/data/common/search/aggs/agg_types_registry.test.ts
+++ b/src/plugins/data/common/search/aggs/agg_types_registry.test.ts
@@ -44,9 +44,7 @@ describe('AggTypesRegistry', () => {
   const uiSettings: any = {
     get: jest
       .fn()
-      .mockImplementation(
-        (key) => key === 'visualize:disableBucketAggSettings' && ['significant_terms']
-      ),
+      .mockImplementation((key) => key === 'visualize:disableBucketAgg' && ['significant_terms']),
   };
 
   beforeEach(() => {

--- a/src/plugins/data/common/search/aggs/agg_types_registry.test.ts
+++ b/src/plugins/data/common/search/aggs/agg_types_registry.test.ts
@@ -41,15 +41,22 @@ describe('AggTypesRegistry', () => {
   let registry: AggTypesRegistry;
   let setup: AggTypesRegistrySetup;
   let start: ReturnType<AggTypesRegistry['start']>;
+  const uiSettings: any = {
+    get: jest
+      .fn()
+      .mockImplementation(
+        (key) => key === 'visualize:disableBucketAggSettings' && ['significant_terms']
+      ),
+  };
 
   beforeEach(() => {
     registry = new AggTypesRegistry();
     setup = registry.setup();
-    start = registry.start();
   });
 
   it('registerBucket adds new buckets', () => {
     setup.registerBucket('terms', bucketType);
+    start = registry.start({ uiSettings });
     expect(start.getAll().buckets).toEqual([bucketType]);
   });
 
@@ -69,6 +76,7 @@ describe('AggTypesRegistry', () => {
 
   it('registerMetric adds new metrics', () => {
     setup.registerMetric('count', metricType);
+    start = registry.start({ uiSettings });
     expect(start.getAll().metrics).toEqual([metricType]);
   });
 
@@ -89,6 +97,7 @@ describe('AggTypesRegistry', () => {
   it('gets either buckets or metrics by id', () => {
     setup.registerBucket('terms', bucketType);
     setup.registerMetric('count', metricType);
+    start = registry.start({ uiSettings });
     expect(start.get('terms')).toEqual(bucketType);
     expect(start.get('count')).toEqual(metricType);
   });
@@ -96,9 +105,27 @@ describe('AggTypesRegistry', () => {
   it('getAll returns all buckets and metrics', () => {
     setup.registerBucket('terms', bucketType);
     setup.registerMetric('count', metricType);
+    start = registry.start({ uiSettings });
     expect(start.getAll()).toEqual({
       buckets: [bucketType],
       metrics: [metricType],
     });
+  });
+
+  it('getAll returns all buckets besides disabled bucket type', () => {
+    const termsBucket = () => ({ name: 'terms', type: 'buckets' } as BucketAggType<any>);
+    const histogramBucket = () => ({ name: 'histogram', type: 'buckets' } as BucketAggType<any>);
+    const significantTermsBucket = () =>
+      ({ name: 'significant_terms', type: 'buckets' } as BucketAggType<any>);
+    setup.registerBucket('terms', termsBucket);
+    setup.registerBucket('histogram', histogramBucket);
+    setup.registerBucket('significant_terms', significantTermsBucket);
+    start = registry.start({ uiSettings });
+
+    expect(start.getAll()).toEqual({
+      buckets: [termsBucket, histogramBucket],
+      metrics: [],
+    });
+    expect(start.get('significant_terms')).toEqual(undefined);
   });
 });

--- a/src/plugins/data/common/search/aggs/agg_types_registry.ts
+++ b/src/plugins/data/common/search/aggs/agg_types_registry.ts
@@ -89,7 +89,7 @@ export class AggTypesRegistry {
   };
 
   start = ({ uiSettings }: AggTypesRegistryStartDependencies) => {
-    const disabledBucketAgg = uiSettings.get('visualize:disableBucketAggSettings');
+    const disabledBucketAgg = uiSettings.get('visualize:disableBucketAgg');
 
     for (const k of this.bucketAggs.keys()) {
       if (disabledBucketAgg.includes(k)) this.bucketAggs.delete(k);

--- a/src/plugins/data/common/search/aggs/aggs_service.test.ts
+++ b/src/plugins/data/common/search/aggs/aggs_service.test.ts
@@ -57,6 +57,7 @@ describe('Aggs service', () => {
     };
     startDeps = {
       getConfig: jest.fn(),
+      uiSettings: { get: jest.fn().mockImplementation(() => []) } as any,
     };
   });
 

--- a/src/plugins/data/common/search/aggs/aggs_service.ts
+++ b/src/plugins/data/common/search/aggs/aggs_service.ts
@@ -31,6 +31,9 @@
  */
 
 import { ExpressionsServiceSetup } from 'src/plugins/expressions/common';
+import { IUiSettingsClient as IUiSettingsClientPublic } from 'src/core/public';
+// eslint-disable-next-line @osd/eslint/no-restricted-paths
+import { IUiSettingsClient as IUiSettingsClientServer } from 'src/core/server';
 import { UI_SETTINGS } from '../../../common';
 import { GetConfigFn } from '../../types';
 import {
@@ -63,6 +66,7 @@ export interface AggsCommonSetupDependencies {
 /** @internal */
 export interface AggsCommonStartDependencies {
   getConfig: GetConfigFn;
+  uiSettings: IUiSettingsClientPublic | IUiSettingsClientServer;
 }
 
 /**
@@ -90,8 +94,8 @@ export class AggsCommonService {
     };
   }
 
-  public start({ getConfig }: AggsCommonStartDependencies): AggsCommonStart {
-    const aggTypesStart = this.aggTypesRegistry.start();
+  public start({ getConfig, uiSettings }: AggsCommonStartDependencies): AggsCommonStart {
+    const aggTypesStart = this.aggTypesRegistry.start({ uiSettings });
 
     return {
       calculateAutoTimeExpression: getCalculateAutoTimeExpression(getConfig),

--- a/src/plugins/data/common/search/aggs/test_helpers/mock_agg_types_registry.ts
+++ b/src/plugins/data/common/search/aggs/test_helpers/mock_agg_types_registry.ts
@@ -93,7 +93,9 @@ export function mockAggTypesRegistry(deps?: AggTypesDependencies): AggTypesRegis
   aggTypes.buckets.forEach(({ name, fn }) => registrySetup.registerBucket(name, fn));
   aggTypes.metrics.forEach(({ name, fn }) => registrySetup.registerMetric(name, fn));
 
-  const registryStart = registry.start();
+  const registryStart = registry.start({
+    uiSettings: { get: jest.fn().mockImplementation(() => []) } as any,
+  });
 
   // initialize each agg type and store in memory
   registryStart.getAll().buckets.forEach((type) => {

--- a/src/plugins/data/public/search/aggs/aggs_service.ts
+++ b/src/plugins/data/public/search/aggs/aggs_service.ts
@@ -109,6 +109,7 @@ export class AggsService {
 
   public start({ fieldFormats, uiSettings }: AggsStartDependencies): AggsStart {
     const { calculateAutoTimeExpression, types } = this.aggsCommonService.start({
+      uiSettings,
       getConfig: this.getConfig!,
     });
 

--- a/src/plugins/data/server/search/aggs/aggs_service.ts
+++ b/src/plugins/data/server/search/aggs/aggs_service.ts
@@ -32,7 +32,11 @@
 
 import { pick } from 'lodash';
 
-import { UiSettingsServiceStart, SavedObjectsClientContract } from 'src/core/server';
+import {
+  UiSettingsServiceSetup,
+  UiSettingsServiceStart,
+  SavedObjectsClientContract,
+} from 'src/core/server';
 import { ExpressionsServiceSetup } from 'src/plugins/expressions/common';
 import {
   AggsCommonService,
@@ -48,6 +52,7 @@ import { AggsSetup, AggsStart } from './types';
 /** @internal */
 export interface AggsSetupDependencies {
   registerFunction: ExpressionsServiceSetup['registerFunction'];
+  uiSettings: UiSettingsServiceSetup;
 }
 
 /** @internal */
@@ -86,7 +91,10 @@ export class AggsService {
           return uiSettingsCache[key];
         };
 
-        const { calculateAutoTimeExpression, types } = this.aggsCommonService.start({ getConfig });
+        const { calculateAutoTimeExpression, types } = this.aggsCommonService.start({
+          getConfig,
+          uiSettings: uiSettingsClient,
+        });
 
         const aggTypesDependencies: AggTypesDependencies = {
           calculateBounds: this.calculateBounds,

--- a/src/plugins/visualizations/common/constants.ts
+++ b/src/plugins/visualizations/common/constants.ts
@@ -31,3 +31,4 @@
  */
 
 export const VISUALIZE_ENABLE_LABS_SETTING = 'visualize:enableLabs';
+export const VISUALIZE_DISABLE_BUCKET_AGG_SETTING = 'visualize:disableBucketAggSettings';

--- a/src/plugins/visualizations/common/constants.ts
+++ b/src/plugins/visualizations/common/constants.ts
@@ -31,4 +31,4 @@
  */
 
 export const VISUALIZE_ENABLE_LABS_SETTING = 'visualize:enableLabs';
-export const VISUALIZE_DISABLE_BUCKET_AGG_SETTING = 'visualize:disableBucketAggSettings';
+export const VISUALIZE_DISABLE_BUCKET_AGG_SETTING = 'visualize:disableBucketAgg';

--- a/src/plugins/visualizations/server/index.ts
+++ b/src/plugins/visualizations/server/index.ts
@@ -33,7 +33,10 @@
 import { PluginInitializerContext } from '../../../core/server';
 import { VisualizationsPlugin } from './plugin';
 
-export { VISUALIZE_ENABLE_LABS_SETTING } from '../common/constants';
+export {
+  VISUALIZE_ENABLE_LABS_SETTING,
+  VISUALIZE_DISABLE_BUCKET_AGG_SETTING,
+} from '../common/constants';
 
 //  This exports static code and TypeScript types,
 //  as well as, OpenSearch Dashboards Platform `plugin()` initializer.

--- a/src/plugins/visualizations/server/plugin.ts
+++ b/src/plugins/visualizations/server/plugin.ts
@@ -46,7 +46,6 @@ import {
   VISUALIZE_ENABLE_LABS_SETTING,
   VISUALIZE_DISABLE_BUCKET_AGG_SETTING,
 } from '../common/constants';
-import { BUCKET_TYPES } from '../../data/common/search/aggs/buckets';
 
 import { visualizationSavedObjectType } from './saved_objects';
 

--- a/src/plugins/visualizations/server/plugin.ts
+++ b/src/plugins/visualizations/server/plugin.ts
@@ -42,7 +42,11 @@ import {
   Logger,
 } from '../../../core/server';
 
-import { VISUALIZE_ENABLE_LABS_SETTING } from '../common/constants';
+import {
+  VISUALIZE_ENABLE_LABS_SETTING,
+  VISUALIZE_DISABLE_BUCKET_AGG_SETTING,
+} from '../common/constants';
+import { BUCKET_TYPES } from '../../data/common/search/aggs/buckets';
 
 import { visualizationSavedObjectType } from './saved_objects';
 
@@ -76,6 +80,17 @@ export class VisualizationsPlugin
         }),
         category: ['visualization'],
         schema: schema.boolean(),
+      },
+      [VISUALIZE_DISABLE_BUCKET_AGG_SETTING]: {
+        name: i18n.translate('visualizations.advancedSettings.visualizeDisableBucketAgg', {
+          defaultMessage: 'Disable visualizations bucket aggregation types',
+        }),
+        value: [],
+        description: i18n.translate('visualizations.advancedSettings.visualizeDisableBucketAgg', {
+          defaultMessage: `only visualizations' bucket aggregations that are not disabled will be available to the user.`,
+        }),
+        category: ['visualization'],
+        schema: schema.arrayOf(schema.string()),
       },
     });
 

--- a/src/plugins/visualizations/server/plugin.ts
+++ b/src/plugins/visualizations/server/plugin.ts
@@ -86,7 +86,7 @@ export class VisualizationsPlugin
         }),
         value: [],
         description: i18n.translate('visualizations.advancedSettings.visualizeDisableBucketAgg', {
-          defaultMessage: `only visualizations' bucket aggregations that are not disabled will be available to the user.`,
+          defaultMessage: `Deactivates the specified bucket aggregations from visualizations.`,
         }),
         category: ['visualization'],
         schema: schema.arrayOf(schema.string()),

--- a/src/plugins/visualizations/server/plugin.ts
+++ b/src/plugins/visualizations/server/plugin.ts
@@ -86,7 +86,8 @@ export class VisualizationsPlugin
         }),
         value: [],
         description: i18n.translate('visualizations.advancedSettings.visualizeDisableBucketAgg', {
-          defaultMessage: `Deactivates the specified bucket aggregations from visualizations.`,
+          defaultMessage: `A comma-separated list of bucket aggregations' names. e.g. significant_terms, terms.
+            Deactivates the specified bucket aggregations from visualizations.`,
         }),
         category: ['visualization'],
         schema: schema.arrayOf(schema.string()),


### PR DESCRIPTION
Signed-off-by: sitbubu <royi.sitbon@logz.io>

### Description
We don't have an option to remove bucket aggregation types by demand. e.g. we want to disable the option of choosing ‘significant_terms’ bucket aggregation because it can be very heavy when run on large indices.

We wish to add a configuration in order to disable nonrelevant bucket aggregation types.

Further explanation inside the attached issue.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1195