### PR TITLE
[Backport] Don't terminate the server on NodeDeprecationWarning (#1185)

### DIFF
--- a/src/setup_node_env/exit_on_warning.js
+++ b/src/setup_node_env/exit_on_warning.js
@@ -31,7 +31,7 @@
  */
 
 if (process.noProcessWarnings !== true) {
-  var ignore = ['MaxListenersExceededWarning'];
+  var ignore = ['MaxListenersExceededWarning', 'NodeDeprecationWarning'];
 
   process.on('warning', function (warn) {
     if (ignore.includes(warn.name)) return;


### PR DESCRIPTION
The last AWS SDK for Javascript that supports Node 10 (v3.45.0) emits a NodeDeprecationWarning to indicate that Node 10
is no longer supported. Without this workaround, this crashes the OSD server, so it becomes impossible to interact with
other AWS services from within OSD (e.g., in a custom plugin) until the Node 14 upgrade is done.

Signed-off-by: Thilo-Alexander Ginkel <tg@tgbyte.de>

### Description
Backport of #1185 
 
### Issues Resolved
Backport of #1185 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 