### PR TITLE
Re-enable WhiteSource check fails on commits/PRs

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -6,7 +6,7 @@
     "baseBranches": []
   },
   "checkRunSettings": {
-    "vulnerableCheckRunConclusionLevel": "success",
+    "vulnerableCheckRunConclusionLevel": "failure",
     "displayMode": "diff"
   },
   "issueSettings": {


### PR DESCRIPTION
### Description
* WhiteSource seems to have resolved the previous bug, and we are still able to merge even if the check fails.

Example of a correct check: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1172/checks?check_run_id=5096076004
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 