### PR TITLE
[nodejs client] modify tsconfig to route types to new.d.ts

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,8 @@
       "test_utils/*": [
         "src/test_utils/public/*"
       ],
-      "fixtures/*": ["src/fixtures/*"]
+      "fixtures/*": ["src/fixtures/*"],
+      "@opensearch-project/opensearch": ["node_modules/@opensearch-project/opensearch/api/new"]
     },
     // Support .tsx files and transform JSX into calls to React.createElement
     "jsx": "react",


### PR DESCRIPTION
# Description
add path in tsconfig.base.json to let nodejs types point to api/new.d.ts which is the new defined types

# Partially Resolved:https://github.com/opensearch-project/OpenSearch-Dashboards/issues/837

Signed-off-by: Anan Zhuang <ananzh@amazon.com>


 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [x] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 