### PR TITLE
Allow running e2e on top of Unix-like systems

### DIFF
--- a/packages/osd-opensearch/src/artifact.js
+++ b/packages/osd-opensearch/src/artifact.js
@@ -185,10 +185,10 @@ async function getArtifactSpecForSnapshotFromUrl(urlVersion, log) {
 
   // [RENAMEME] Need replacement for other platforms.
   // issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/475
-  const platform = process.platform === 'win32' ? 'windows' : process.platform;
+  const platform = process.platform === 'win32' ? 'windows' : 'linux';
   const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
   if (platform !== 'linux') {
-    throw createCliError(`Snapshots are only available for Linux`);
+    throw createCliError(`Snapshots are only available for linux and unix like operating systems`);
   }
 
   const latestUrl = `${DAILY_SNAPSHOTS_BASE_URL}/${desiredVersion}-SNAPSHOT`;

--- a/test/plugin_functional/test_suites/panel_actions/index.js
+++ b/test/plugin_functional/test_suites/panel_actions/index.js
@@ -32,11 +32,11 @@
 
 import path from 'path';
 
-export const OPENSEARCH_DASHBOARDS_ARCHIVE_PATH = path.resolve(
+const OPENSEARCH_DASHBOARDS_ARCHIVE_PATH = path.resolve(
   __dirname,
   '../../../functional/fixtures/opensearch_archiver/dashboard/current/opensearch_dashboards'
 );
-export const DATA_ARCHIVE_PATH = path.resolve(
+const DATA_ARCHIVE_PATH = path.resolve(
   __dirname,
   '../../../functional/fixtures/opensearch_archiver/dashboard/current/data'
 );


### PR DESCRIPTION
Signed-off-by: sitbubu <royi.sitbon@logz.io>

### Description
Trying to run e2e on my darwin OS local environment using the next 2 commands:
node scripts/functional_tests_server.js --config test/plugin_functional/config.ts
node scripts/functional_test_runner.js --config test/plugin_functional/config.ts
and got several failures along the way.

1. Browser chrome driver was not supported, since my chrome version was higher than the one inside our package.json.
<img width="1051" alt="Screen Shot 2022-02-18 at 16 47 59" src="https://user-images.githubusercontent.com/12782945/154710221-5e113957-4f6d-40fa-8cbb-2fd26b4a4a98.png">

2. OS was not supported, although it was a Unix-like system, and running the Linux snapshot on top of it as a test server works great.
<img width="926" alt="Screen Shot 2022-02-18 at 16 18 16" src="https://user-images.githubusercontent.com/12782945/154710328-58c24dc8-6306-41cb-a8cd-9cda70d43f0d.png">

3. Failed to run tests because we have non-functions exports inside our tests files, and this is bad behavior:
<img width="1077" alt="Screen Shot 2022-02-18 at 16 56 27" src="https://user-images.githubusercontent.com/12782945/154710439-1e29bd2f-618d-4d1c-93f7-b3030de15698.png">

 linked issue:
 https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1263