### PR TITLE
docs(Dev Guide): Updates how to run OpenSearch

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -22,15 +22,12 @@ If you would like to install and run this project, please see the [Downloads Pag
 
 #### Prerequisites
 
-You need to have an OpenSearch server up and running to be able to run OpenSearch
-Dashboards. The easiest way to do it is [using Docker](https://opensearch.org/docs/latest/opensearch/install/docker).
-
 We recommend using [Node Version Manager](https://github.com/nvm-sh/nvm) to install
 the node version we need.
 
 ### Bootstrap OpenSearch Dashboards
 
-While OpenSearch is starting, you can already bootstrap OpenSearch Dashboards:
+First we need to clone and bootstrap OpenSearch Dashboards:
 ```bash
 $ git clone https://github.com/opensearch-project/OpenSearch-Dashboards.git
 $ cd OpenSearch-Dashboards
@@ -51,6 +48,15 @@ opensearch.hosts: ["https://localhost:9200"]
 opensearch.username: "admin" # Default username on the docker image
 opensearch.password: "admin" # Default password on the docker image
 opensearch.ssl.verificationMode: none
+```
+
+### Run Opensearch
+
+You need to have an OpenSearch server up and running to be able to run OpenSearch
+Dashboards. In a separate terminal you can run the latest nightly build using
+
+```bash
+$ yarn opensearch snapshot 
 ```
 
 ### Run OpenSearch Dashboards

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -50,7 +50,7 @@ opensearch.password: "admin" # Default password on the docker image
 opensearch.ssl.verificationMode: none
 ```
 
-### Run Opensearch
+### Run OpenSearch
 
 You need to have an OpenSearch server up and running to be able to run OpenSearch
 Dashboards. In a separate terminal you can run the latest snapshot built using:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -53,11 +53,13 @@ opensearch.ssl.verificationMode: none
 ### Run Opensearch
 
 You need to have an OpenSearch server up and running to be able to run OpenSearch
-Dashboards. In a separate terminal you can run the latest nightly build using
+Dashboards. In a separate terminal you can run the latest snapshot built using:
 
 ```bash
 $ yarn opensearch snapshot 
 ```
+
+**Warning:** Starting the Dashboards instance before or during the initialization of the OpenSearch Server can cause Dashboards to sometimes misbehave. Ensure that the OpenSearch server instance is up and running first before starting up the Dashboards dev server from the next step.
 
 ### Run OpenSearch Dashboards
 


### PR DESCRIPTION
Signed-off-by: Ashwin PC <ashwinpc@amazon.com>

### Description
Updates the developer docs to use the latest nightly snapshot build for OpenSearch instead of the docker container. The current developer guide mentions the docker container as the easiest way to setup the OpenSearch Server for development. This however is broken since the main branch for OpenSearch Dashboards is on version 2.0 while the latest Docker container is on version 1.1 causing a version mismatch on startup. 
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [x] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 