### PR TITLE
[BUG] Internationalization not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dashboarding"
   ],
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "branch": "main",
   "types": "./opensearch_dashboards.d.ts",
   "tsdocMetadata": "./build/tsdoc-metadata.json",

--- a/src/legacy/server/i18n/index.ts
+++ b/src/legacy/server/i18n/index.ts
@@ -50,17 +50,17 @@ export async function i18nMixin(
   const translationPaths = await Promise.all([
     getTranslationPaths({
       cwd: fromRoot('.'),
-      glob: `*/${I18N_RC}`,
+      glob: `**/${I18N_RC}`,
     }),
     ...(config.get('plugins.paths') as string[]).map((cwd) =>
       getTranslationPaths({ cwd, glob: I18N_RC })
     ),
     ...(config.get('plugins.scanDirs') as string[]).map((cwd) =>
-      getTranslationPaths({ cwd, glob: `*/${I18N_RC}` })
+      getTranslationPaths({ cwd, glob: `**/${I18N_RC}` })
     ),
     getTranslationPaths({
       cwd: fromRoot('../opensearch-dashboards-extra'),
-      glob: `*/${I18N_RC}`,
+      glob: `**/${I18N_RC}`,
     }),
   ]);
 


### PR DESCRIPTION
Signed-off-by: Rafael Schleuss <rschleuss@gmail.com>

### Description
Fixed issue with internationalization. The pattern used in the globby lib was wrong and the .i18nrc.json resource files were not found. 
 
### Issues Resolved
[[BUG] Internationalization not working](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/772)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 