### PR TITLE
Fix cache.ts for Resource temporarily unavailable

### DIFF
--- a/packages/osd-optimizer/src/node/cache.ts
+++ b/packages/osd-optimizer/src/node/cache.ts
@@ -178,7 +178,7 @@ export class Cache {
     this.debug(`ERROR/${type}`, db, `${String(key)}: ${error.stack}`);
     process.stderr.write(
       chalk.red(
-        `[@kbn/optimizer/node] ${type} error [${dbName(db)}/${String(key)}]: ${error.stack}\n`
+        `[@osd/optimizer/node] ${type} error [${dbName(db)}/${String(key)}]: ${error.stack}\n`
       )
     );
   }


### PR DESCRIPTION
Replace kbn to osd to solve Resource temporarily unavailable error
when functional test fails.

### Issue Resolved:https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1287


 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 