### PR TITLE
[Tests] fix mocha tests related to `type`

### DIFF
--- a/packages/osd-opensearch-archiver/src/lib/docs/__tests__/generate_doc_records_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/docs/__tests__/generate_doc_records_stream.ts
@@ -137,7 +137,9 @@ describe('opensearchArchiver: createGenerateDocRecordsStream()', () => {
         type: 'doc',
         value: {
           index: '.opensearch_dashboards_1',
-          type: undefined,
+          // TODO: verify no BWC issues here
+          // Removed: https://github.com/opensearch-project/OpenSearch/pull/2239
+          // type: undefined,
           id: 1,
           source: undefined,
         },
@@ -146,7 +148,9 @@ describe('opensearchArchiver: createGenerateDocRecordsStream()', () => {
         type: 'doc',
         value: {
           index: 'foo',
-          type: undefined,
+          // TODO: verify no BWC issues here
+          // Removed: https://github.com/opensearch-project/OpenSearch/pull/2239
+          // type: undefined,
           id: 2,
           source: undefined,
         },


### PR DESCRIPTION
### Description
Failure introduced here:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1289/files

OpenSearch Archiver loads data to OpenSearch from data.json into OpenSearch for
E2E tests and integration tests but will need to verify if this causes breakage in
migration from older versions of the application.

Mocha tests do not run in the current CI so these were missed.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 