### PR TITLE
[BUG] fix median.ts to work for scripted field

### DIFF
--- a/src/plugins/data/common/search/aggs/metrics/__snapshots__/median.test.ts.snap
+++ b/src/plugins/data/common/search/aggs/metrics/__snapshots__/median.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AggTypeMetricMedianProvider class supports scripted fields 1`] = `
+Object {
+  "median": Object {
+    "percentiles": Object {
+      "percents": Array [
+        50,
+      ],
+      "script": Object {
+        "lang": undefined,
+        "source": "return 456",
+      },
+    },
+  },
+}
+`;

--- a/src/plugins/data/common/search/aggs/metrics/median.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/median.test.ts
@@ -89,4 +89,41 @@ describe('AggTypeMetricMedianProvider class', () => {
       })
     ).toEqual(10);
   });
+
+  it('supports scripted fields', () => {
+    const typesRegistry = mockAggTypesRegistry();
+    const field = {
+      name: 'bytes',
+      scripted: true,
+      language: 'painless',
+      script: 'return 456',
+    };
+    const indexPattern = {
+      id: '1234',
+      title: 'logstash-*',
+      fields: {
+        getByName: () => field,
+        filter: () => [field],
+      },
+    } as any;
+
+    aggConfigs = new AggConfigs(
+      indexPattern,
+      [
+        {
+          id: METRIC_TYPES.MEDIAN,
+          type: METRIC_TYPES.MEDIAN,
+          schema: 'metric',
+          params: {
+            field: 'bytes',
+          },
+        },
+      ],
+      {
+        typesRegistry,
+      }
+    );
+
+    expect(aggConfigs.toDsl()).toMatchSnapshot();
+  });
 });

--- a/src/plugins/data/common/search/aggs/metrics/median.ts
+++ b/src/plugins/data/common/search/aggs/metrics/median.ts
@@ -60,10 +60,10 @@ export const getMedianMetricAgg = () => {
         name: 'field',
         type: 'field',
         filterFieldTypes: [OSD_FIELD_TYPES.NUMBER, OSD_FIELD_TYPES.DATE, OSD_FIELD_TYPES.HISTOGRAM],
-        write(agg, output) {
-          output.params.field = agg.getParam('field').name;
-          output.params.percents = [50];
-        },
+      },
+      {
+        name: 'percents',
+        default: [50],
       },
     ],
     getValue(agg, bucket) {


### PR DESCRIPTION
### Issue Resolved: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1296

### Results
Create a script using sample eCommerce data:
```
if (doc.containsKey('base_price') && !doc['base_price'].empty) {
    if (doc['base_price'].value <30) {
    return -10;
}
}
return 10;

```
Previously, the result is:
<img width="1688" alt="Screen Shot 2022-03-01 at 11 48 44 AM" src="https://user-images.githubusercontent.com/79961084/156241093-e7d55855-d0e3-4bce-a25a-5874d9ddb789.png">

After fix, now we could see the correct median:
<img width="897" alt="Screen Shot 2022-03-01 at 11 43 25 AM" src="https://user-images.githubusercontent.com/79961084/156240831-2a4ad944-8aa4-4f7c-849e-e85f3ad7c6e7.png">

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 