### PR TITLE
[Plugins] update default url for installing plugins

### DIFF
--- a/packages/osd-opensearch/src/artifact.test.js
+++ b/packages/osd-opensearch/src/artifact.test.js
@@ -42,7 +42,7 @@ let MOCKS;
 
 const DAILY_SNAPSHOT_BASE_URL = 'https://artifacts.opensearch.org/snapshots/core/opensearch';
 
-const ORIGINAL_PLATFROM = process.platform;
+const ORIGINAL_PLATFORM = process.platform;
 const ORIGINAL_ARCHITECTURE = process.arch;
 const PLATFORM = process.platform === 'win32' ? 'windows' : process.platform;
 const ARCHITECTURE = process.arch === 'arm64' ? 'arm64' : 'x64';
@@ -157,7 +157,7 @@ describe('Artifact', () => {
       afterAll(() => {
         Object.defineProperties(process, {
           platform: {
-            value: ORIGINAL_PLATFROM,
+            value: ORIGINAL_PLATFORM,
           },
           arch: {
             value: ORIGINAL_ARCHITECTURE,
@@ -182,7 +182,7 @@ describe('Artifact', () => {
       it('should not throw when on a non-x64 arch', async () => {
         Object.defineProperties(process, {
           platform: {
-            value: ORIGINAL_PLATFROM,
+            value: ORIGINAL_PLATFORM,
           },
           arch: {
             value: 'arm64',

--- a/src/cli_plugin/install/settings.js
+++ b/src/cli_plugin/install/settings.js
@@ -36,11 +36,20 @@ import expiry from 'expiry-js';
 
 import { fromRoot } from '../../core/server/utils';
 
+const LATEST_PLUGIN_BASE_URL =
+  'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards';
+
 function generateUrls({ version, plugin }) {
-  return [
-    plugin,
-    `https://artifacts.opensearch.org/downloads/kibana-plugins/${plugin}/${plugin}-${version}.zip`,
-  ];
+  return [plugin, generatePluginUrl(version, plugin)];
+}
+
+function generatePluginUrl(version, plugin) {
+  const platform = process.platform === 'win32' ? 'windows' : process.platform;
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  if (platform !== 'linux') {
+    throw new Error('Plugins are only available for Linux');
+  }
+  return `${LATEST_PLUGIN_BASE_URL}/${version}/latest/${platform}/${arch}/builds/opensearch-dashboards/plugins/${plugin}-${version}.zip`;
 }
 
 export function parseMilliseconds(val) {


### PR DESCRIPTION
### Description
Update old and invalid reference to custom plugins within
the OpenSearch Project.

Note: At the time that this is committed there is no gurantee
that the latest build is the build that was select as the
final build.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1038
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 