### PR TITLE
[Bug] Solve saved query bug

### DIFF
--- a/src/plugins/data/public/query/saved_query/saved_query_service.ts
+++ b/src/plugins/data/public/query/saved_query/saved_query_service.ts
@@ -30,6 +30,7 @@
  * GitHub history for details.
  */
 
+import { isObject } from 'lodash';
 import { SavedObjectsClientContract, SavedObjectAttributes } from 'src/core/public';
 import { SavedQueryAttributes, SavedQuery, SavedQueryService } from './types';
 
@@ -143,20 +144,24 @@ export const createSavedQueryService = (
     id: string;
     attributes: SerializedSavedQueryAttributes;
   }) => {
-    let queryString;
+    const queryString = savedQuery.attributes.query.query;
+    let parsedQuery;
     try {
-      queryString = JSON.parse(savedQuery.attributes.query.query);
+      parsedQuery = JSON.parse(queryString);
+      parsedQuery = isObject(parsedQuery) ? parsedQuery : queryString;
     } catch (error) {
-      queryString = savedQuery.attributes.query.query;
+      parsedQuery = queryString;
     }
+
     const savedQueryItems: SavedQueryAttributes = {
       title: savedQuery.attributes.title || '',
       description: savedQuery.attributes.description || '',
       query: {
-        query: queryString,
+        query: parsedQuery,
         language: savedQuery.attributes.query.language,
       },
     };
+
     if (savedQuery.attributes.filters) {
       savedQueryItems.filters = savedQuery.attributes.filters;
     }


### PR DESCRIPTION
### Description
In Discover, when loading a saved query with double quotes, double quotes are gone and term query becomes match query. 
<img width="1344" alt="Screen Shot 2022-03-07 at 5 40 41 PM" src="https://user-images.githubusercontent.com/79961084/157170659-92a4d53f-da52-4d2f-83e2-de4f48041504.png">

To do a term query, we need to keep the quotes.  When parsing a string with quotes, JSON.parse function will trim the quotes and return its value. For example, `"Men's Shoes"` is parsed to `Men's Shoes`. Then dashboards will break the term using its analyzer and search each word which causes the issue. Please check the [comments](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1254#issuecomment-1061191659) in the resolved issue for more details. 

To solve this, we added an `isObject` checker which filters a regular string from a json string. After we get the regular string, the query will use its original value and quotes are able to be kept. After change:

<img width="1349" alt="Screen Shot 2022-03-07 at 9 13 49 PM" src="https://user-images.githubusercontent.com/79961084/157170920-f9509c5b-2d0a-4131-8d45-eeef85ebc1f8.png">



### Issue Resolved: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1254

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 