### PR TITLE
fix(Tooltip): Fixes tooltip when split series charts are used

### DIFF
--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.js
@@ -28,7 +28,6 @@
  * under the License.
  */
 
-import { get } from 'lodash';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -57,7 +56,7 @@ export function pointSeriesTooltipFormatter() {
       let label = currentSeries.label;
 
       // For stacked charts the y axis data is only available in the raw table
-      const tableColumns = get(datum, 'yRaw.table.columns');
+      const tableColumns = datum?.yRaw?.table?.columns;
       if (tableColumns && tableColumns.length > 2) {
         const yColumn = datum.yRaw.column ? tableColumns[datum.yRaw.column] : {};
         label = yColumn.name || label;

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.js
@@ -28,6 +28,7 @@
  * under the License.
  */
 
+import { get } from 'lodash';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -38,7 +39,7 @@ export function pointSeriesTooltipFormatter() {
     const details = [];
 
     const currentSeries =
-      data.series && data.series.find((serie) => serie.rawId === datum.seriesId);
+      data.series && data.series.find((series) => series.rawId === datum.seriesId);
     const addDetail = (label, value) => details.push({ label, value });
 
     if (datum.extraMetrics) {
@@ -53,7 +54,15 @@ export function pointSeriesTooltipFormatter() {
 
     if (datum.y !== null && datum.y !== undefined) {
       const value = datum.yScale ? datum.yScale * datum.y : datum.y;
-      addDetail(currentSeries.label, currentSeries.yAxisFormatter(value));
+      let label = currentSeries.label;
+
+      // For stacked charts the y axis data is only available in the raw table
+      const tableColumns = get(datum, 'yRaw.table.columns');
+      if (tableColumns && tableColumns.length > 2) {
+        const yColumn = datum.yRaw.column ? tableColumns[datum.yRaw.column] : {};
+        label = yColumn.name || label;
+      }
+      addDetail(label, currentSeries.yAxisFormatter(value));
     }
 
     if (datum.z !== null && datum.z !== undefined) {

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.test.js
@@ -93,4 +93,58 @@ describe('tooltipFormatter', function () {
     const $rows = $el.find('tr');
     expect($rows.length).toBe(3);
   });
+
+  it('renders correctly on split series data', function () {
+    const rawTable = {
+      columns: [
+        {
+          id: 'col-1',
+          name: 'first',
+        },
+        {
+          id: 'col-2',
+          name: 'second',
+        },
+        {
+          id: 'col-3',
+          name: 'third',
+        },
+      ],
+      rows: [
+        {
+          'col-1': 'A',
+          'col-2': 'C',
+          'col-3': 10,
+        },
+        {
+          'col-1': 'B',
+          'col-2': 'C',
+          'col-3': 20,
+        },
+      ],
+    };
+
+    const event = _.cloneDeep(baseEvent);
+
+    event.datum.yRaw = {
+      table: rawTable,
+      column: 2,
+    };
+
+    const $el = $(tooltipFormatter(event));
+    const $rows = $el.find('tr');
+    expect($rows.length).toBe(3);
+
+    const $row1 = $rows.eq(0).find('td');
+    expect(cell($row1, 0)).toBe('inner');
+    expect(cell($row1, 1)).toBe('3');
+
+    const $row2 = $rows.eq(1).find('td');
+    expect(cell($row2, 0)).toBe('third');
+    expect(cell($row2, 1)).toBe('2');
+
+    const $row3 = $rows.eq(2).find('td');
+    expect(cell($row3, 0)).toBe('top');
+    expect(cell($row3, 1)).toBe('1');
+  });
 });


### PR DESCRIPTION
Signed-off-by: Ashwin Pc <ashwinpc@amazon.com>

### Description
On split series charts, the y axis label is incorrect. This change uses the value from the raw table data to correctly assign the value
 
### Issues Resolved
#1262 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 