### PR TITLE
[Branding] assets folder and SSL support

### DIFF
--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/src/core/server/core_app/core_app.ts
+++ b/src/core/server/core_app/core_app.ts
@@ -89,6 +89,7 @@ export class CoreApp {
   }
   private registerStaticDirs(coreSetup: InternalCoreSetup) {
     coreSetup.http.registerStaticDir('/ui/{path*}', Path.resolve(__dirname, './assets'));
+    coreSetup.http.registerStaticDir('/ui/assets/{path*}', fromRoot('assets'));
 
     coreSetup.http.registerStaticDir(
       '/node_modules/@osd/ui-framework/dist/{path*}',

--- a/src/dev/build/tasks/clean_tasks.ts
+++ b/src/dev/build/tasks/clean_tasks.ts
@@ -204,11 +204,12 @@ export const CleanEmptyFolders: Task = {
 
   async run(config, log, build) {
     // Delete every single empty folder from
-    // the distributable except the plugins
-    // and data folder.
+    // the distributable except the plugins,
+    // data, and assets folder.
     await deleteEmptyFolders(log, build.resolvePath('.'), [
       build.resolvePath('plugins'),
       build.resolvePath('data'),
+      build.resolvePath('assets'),
     ]);
   },
 };

--- a/src/dev/build/tasks/create_empty_dirs_and_files_task.ts
+++ b/src/dev/build/tasks/create_empty_dirs_and_files_task.ts
@@ -31,6 +31,10 @@ export const CreateEmptyDirsAndFiles: Task = {
   description: 'Creating some empty directories and files to prevent file-permission issues',
 
   async run(config, log, build) {
-    await Promise.all([mkdirp(build.resolvePath('plugins')), mkdirp(build.resolvePath('data'))]);
+    await Promise.all([
+      mkdirp(build.resolvePath('plugins')),
+      mkdirp(build.resolvePath('data')),
+      mkdirp(build.resolvePath('assets')),
+    ]);
   },
 };

--- a/src/dev/build/tasks/os_packages/run_fpm.ts
+++ b/src/dev/build/tasks/os_packages/run_fpm.ts
@@ -126,6 +126,8 @@ export async function runFpm(
     `usr/share/opensearch-dashboards/config`,
     '--exclude',
     `usr/share/opensearch-dashboards/data`,
+    '--exclude',
+    `usr/share/opensearch-dashboards/assets`,
 
     // flags specific to the package we are building, supplied by tasks below
     ...pkgSpecificFlags,

--- a/test/server_integration/http/ssl/index.js
+++ b/test/server_integration/http/ssl/index.js
@@ -37,5 +37,13 @@ export default function ({ getService }) {
     it('handles requests using ssl', async () => {
       await supertest.get('/').expect(302);
     });
+
+    it('handles UI requests using ssl', async () => {
+      await supertest.get('ui/').expect(302);
+    });
+
+    it('handles UI assests requests using ssl', async () => {
+      await supertest.get('ui/assets').expect(302);
+    });
   });
 }


### PR DESCRIPTION
### Description
Adding `assets` folder that gets served up under UI for ease of us.

SSL support when OpenSearch Dashboards SSL is enabled.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1164
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 