### PR TITLE
[Docs] update branch version to 1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "private": true,
   "version": "1.3.0",
-  "branch": "1.2",
+  "branch": "1.3",
   "types": "./opensearch_dashboards.d.ts",
   "tsdocMetadata": "./build/tsdoc-metadata.json",
   "build": {


### PR DESCRIPTION
### Description
`branch` in the package.json is used for pointing links to the right
site. For example: `https://opensearch.org/docs/1.3/dashboards/index/`.

NOTE: At the time this commit was made the doc site for `1.3`, is
not available.

There is an existing issue here:
https://github.com/opensearch-project/documentation-website/issues/296

We can point this to `latest` but the problem with that is that we
don't re-release versions. When the next major or minor release
occurs then `latest` will point to that version and now all
OpenSearch Dashboards 1.3 downloads will point to the newest version.

So to avoid that, I suggest we point this to `1.3` and I got confirmation
that it will be `1.3`.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 