### PR TITLE
[Tests] remove include_type_name from OpenSearch Archiver

### DIFF
--- a/packages/osd-opensearch-archiver/src/lib/indices/__tests__/create_index_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/__tests__/create_index_stream.ts
@@ -125,7 +125,6 @@ describe('opensearchArchiver: createCreateIndexStream()', () => {
       sinon.assert.calledWith(client.indices.create as sinon.SinonSpy, {
         method: 'PUT',
         index: 'index',
-        include_type_name: false,
         body: {
           settings: undefined,
           mappings: undefined,

--- a/packages/osd-opensearch-archiver/src/lib/indices/create_index_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/create_index_stream.ts
@@ -79,8 +79,6 @@ export function createCreateIndexStream({
   async function handleIndex(record: DocRecord) {
     const { index, settings, mappings, aliases } = record.value;
 
-    // Determine if the mapping belongs to a pre-7.0 instance, for BWC tests, mainly
-    const isPre7Mapping = !!mappings && Object.keys(mappings).length > 0 && !mappings.properties;
     const isOpenSearchDashboards = index.startsWith('.kibana');
 
     async function attemptToCreate(attemptNumber = 1) {
@@ -93,13 +91,12 @@ export function createCreateIndexStream({
         await client.indices.create({
           method: 'PUT',
           index,
-          include_type_name: isPre7Mapping,
           body: {
             settings,
             mappings,
             aliases,
           },
-        } as any); // include_type_name is not properly defined
+        } as any);
 
         stats.createdIndex(index, { settings });
       } catch (err) {


### PR DESCRIPTION
### Description
include_type_name was removed in https://github.com/opensearch-project/OpenSearch/pull/2397

OpenSearch Archiver loads data to OpenSearch from data.json into OpenSearch for
E2E tests and integration tests but will need to verify if this causes breakage in
migration from older versions of the application.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 