### PR TITLE
[Tests] fix JUnit Reporter test

### DIFF
--- a/src/dev/jest/integration_tests/__fixtures__/test.js
+++ b/src/dev/jest/integration_tests/__fixtures__/test.js
@@ -30,6 +30,9 @@
  * GitHub history for details.
  */
 
-it('fails', () => {
+it('fails', (done) => {
+  setTimeout(() => {
+    done();
+  }, 200);
   throw new Error('failure');
 });


### PR DESCRIPTION
### Description
Interesting flakiness in the test. After the jest upgrade, our tests
got more performant.

The JUnit Report integ test was actually expecting `anything` for a field
`time`. This `time` was calculated on elapsed time to the `0.00x` value
anything faster would actually be undefined and at that point `anything`
fails because `anything` cannot be undefined.

tl;dr: This test became flakey because our tests now run too fast.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 