### PR TITLE
Fixes inconsistent plugin installation tests

### DIFF
--- a/src/cli_plugin/install/settings.test.js
+++ b/src/cli_plugin/install/settings.test.js
@@ -77,6 +77,14 @@ describe('parse function', function () {
   });
 
   it('produces expected defaults', function () {
+    Object.defineProperties(process, {
+      platform: {
+        value: 'linux',
+      },
+      arch: {
+        value: 'x64',
+      },
+    });
     expect(parse(command, { ...defaultOptions }, osdPackage)).toMatchInlineSnapshot(`
       Object {
         "config": "",
@@ -97,6 +105,14 @@ describe('parse function', function () {
   });
 
   it('consumes overrides', function () {
+    Object.defineProperties(process, {
+      platform: {
+        value: 'linux',
+      },
+      arch: {
+        value: 'x64',
+      },
+    });
     const options = {
       quiet: true,
       silent: true,
@@ -129,7 +145,7 @@ describe('parse function', function () {
         value: 'win32',
       },
       arch: {
-        value: ORIGINAL_ARCHITECTURE,
+        value: 'x64',
       },
     });
     expect(() => parse(command, { ...defaultOptions }, osdPackage)).toThrow(
@@ -140,7 +156,7 @@ describe('parse function', function () {
   it('should not throw when on a non-x64 arch', function () {
     Object.defineProperties(process, {
       platform: {
-        value: ORIGINAL_PLATFORM,
+        value: 'linux',
       },
       arch: {
         value: 'arm64',


### PR DESCRIPTION
### Description
* The tests assumed that the platform/architecture combo the tests were run from was always linux/x64.
* Introduced in #1316.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 