### PR TITLE
Runs functional test jobs in parallel w/ build job

### DIFF
--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -60,7 +60,6 @@ jobs:
         run: yarn test:jest_integration:ci
 
   functional-tests:
-    needs: [ build-lint-test ]
     runs-on: ubuntu-latest
     name: Run functional tests
     strategy: 
@@ -68,10 +67,6 @@ jobs:
         group: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
     steps:
       - run: echo Running functional tests for ciGroup${{ matrix.group }}
-
-      - name: Get the cached tests results 
-        id: ftr_tests_results
-        run: cat ftr_tests_results 2>/dev/null || echo 'default'
 
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
### Description
* Runs the functional test jobs in parallel instead of waiting for the Build and Verify job to complete in order to reduce time to success/failure.
* Deletes a leftover cache step that was not removed in #1306.
 
### Issues Resolved
Resolves #1355
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 