### PR TITLE
[CI][Build] Use BUILD_NUMBER for building bundles

### DIFF
--- a/src/dev/build/lib/get_build_number.test.ts
+++ b/src/dev/build/lib/get_build_number.test.ts
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { getBuildNumber } from './get_build_number';
+
+const BUILD_NUMBER_ENV_KEY = 'BUILD_NUMBER';
+const itif = process.env.CI === '1' ? it.skip : it;
+
+describe('getBuildNumber', () => {
+  let previousBuildNumber: string;
+
+  beforeEach(() => {
+    if (BUILD_NUMBER_ENV_KEY in process.env) {
+      previousBuildNumber = process.env[BUILD_NUMBER_ENV_KEY] as string;
+      delete process.env[BUILD_NUMBER_ENV_KEY];
+    }
+  });
+
+  afterEach(() => {
+    if (BUILD_NUMBER_ENV_KEY in process.env) {
+      process.env[BUILD_NUMBER_ENV_KEY] = previousBuildNumber;
+    }
+  });
+
+  it('returns env BUILD_NUMBER count', async () => {
+    process.env.BUILD_NUMBER = '123';
+    const buildNumber = await getBuildNumber();
+    expect(buildNumber).toBe(123);
+  });
+
+  // If test is ran on the CI, it only gets 1 commit
+  itif('returns git commit count', async () => {
+    const buildNumber = await getBuildNumber();
+    expect(buildNumber).toBeGreaterThan(1000);
+  });
+});

--- a/src/dev/build/lib/get_build_number.ts
+++ b/src/dev/build/lib/get_build_number.ts
@@ -29,6 +29,10 @@ import os from 'os';
 import execa from 'execa';
 
 export async function getBuildNumber() {
+  if ('BUILD_NUMBER' in process.env) {
+    return parseFloat(process.env.BUILD_NUMBER as string);
+  }
+
   if (/^win/.test(os.platform())) {
     // Windows does not have the wc process and `find /C /V ""` does not consistently work
     const log = await execa('git', ['log', '--format="%h"']);


### PR DESCRIPTION
### Description
When running a release build for example:

```
yarn build-platform --linux --skip-os-packages --release
```

The build task runs through get_build_number and
checks how many commits you have locally and determines the
build number. From there, and this is the value that
is used to as a cache busting mechanism.

However, in the release build repo
https://github.com/opensearch-project/opensearch-build

When this gets packaged and verified it actually pulls
from the specified branch and only retrieves the HEAD
commit. Thus making the count of commits locally equal
to `1` and get_build_number always return `1` for releases
essentially breaking the cache buster.

The build repo however, sets an env variable of `BUILD_NUMBER`
so if this value is available it will use it instead of commit
count.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
* https://github.com/opensearch-project/opensearch-build/issues/1769
* https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1363
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 