### PR TITLE
[Improvement] node healthcheck optimization

### DIFF
--- a/src/core/server/opensearch/version_check/ensure_opensearch_version.ts
+++ b/src/core/server/opensearch/version_check/ensure_opensearch_version.ts
@@ -63,6 +63,7 @@ export const getNodeId = async (
 ): Promise<string | null> => {
   try {
     const state = (await internalClient.cluster.state({
+      metric: 'nodes',
       filter_path: [`nodes.*.attributes.${healthcheckAttributeName}`],
     })) as ApiResponse;
     /* Aggregate different cluster_ids from the OpenSearch nodes
@@ -223,6 +224,7 @@ export const pollOpenSearchNodesVersion = ({
             from(
               internalClient.nodes.info<NodesInfo>({
                 node_id: nodeId,
+                metric: 'process',
                 filter_path: ['nodes.*.version', 'nodes.*.http.publish_address', 'nodes.*.ip'],
               })
             ).pipe(


### PR DESCRIPTION
### Description
Health check when enabled checked the entire cluster to get
the value set from the nodeId. Switching the health check to
query /_cluster/state/nodes should provide the same data needed
for the health check without transmitting the rest of the
cluster state data over the network.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1354
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 