### PR TITLE
[Backport 1.x] Bumps `json-schema` from 0.2.3 to 0.4.0 (#1385)

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "**/hoist-non-react-statics": "^3.3.2",
     "**/immer": "^8.0.1",
     "**/istanbul-instrumenter-loader/schema-utils": "^1.0.0",
+    "**/json-schema": "^0.4.0",
     "**/kind-of": ">=6.0.3",
     "**/lodash": "^4.17.21",
     "**/merge": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15416,10 +15416,10 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+json-schema@0.2.3, json-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Backport https://github.com/opensearch-project/OpenSearch-Dashboards/commit/9e4e5ff43900b3875c1653b251aa5c71efa2569e from #1385 