### PR TITLE
[Backport 1.3] [Improvement] node healthcheck optimization (#1386)

### DIFF
--- a/src/core/server/opensearch/version_check/ensure_opensearch_version.ts
+++ b/src/core/server/opensearch/version_check/ensure_opensearch_version.ts
@@ -62,6 +62,7 @@ export const getNodeId = async (
 ): Promise<string | null> => {
   try {
     const state = await internalClient.cluster.state({
+      metric: 'nodes',
       filter_path: [`nodes.*.attributes.${healthcheckAttributeName}`],
     });
     /* Aggregate different cluster_ids from the OpenSearch nodes
@@ -221,6 +222,7 @@ export const pollOpenSearchNodesVersion = ({
             from(
               internalClient.nodes.info<NodesInfo>({
                 node_id: nodeId,
+                metric: 'process',
                 filter_path: ['nodes.*.version', 'nodes.*.http.publish_address', 'nodes.*.ip'],
               })
             ).pipe(


### PR DESCRIPTION
Health check when enabled checked the entire cluster to get
the value set from the nodeId. Switching the health check to
query /_cluster/state/nodes should provide the same data needed
for the health check without transmitting the rest of the
cluster state data over the network.

Issue:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1354

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
(cherry picked from commit 920cd5e45d28784ebd6406e332d2275efecd6026)