### PR TITLE
[Admin] add current maintainers as of 04/2022

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,5 +9,7 @@
 | Rocky | [kavilla](https://github.com/kavilla) | Amazon |
 | Sean Neumann | [seanneumann](https://github.com/seanneumann) | Amazon | 
 | Tommy Markley | [tmarkley](https://github.com/tmarkley) | Amazon | 
+| Miki Barahmand | [AMoo-Miki](https://github.com/AMoo-Miki) | Amazon |
+| Ashwin P Chandran | [ashwin-pc](https://github.com/ashwin-pc) | Amazon |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
### Description
Adding Miki Barahmand and Ashwin P Chandran
to the maintainers doc.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 