### PR TITLE
[2.x] support legacy config

### DIFF
--- a/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.test.ts
+++ b/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.test.ts
@@ -56,6 +56,18 @@ describe('plugins/opensearch', () => {
       it('when majors and minors are not equal, but the engine is on legacy version 8.0.0 and OpenSearch Dashboards is on 1.0.0', () => {
         expect(opensearchVersionCompatibleWithOpenSearchDashboards('8.0.0', '1.0.0')).toBe(false);
       });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 6.10.3 and OpenSearch Dashboards is on 2.0.0', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('6.10.3', '2.0.0')).toBe(false);
+      });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 7.10.3 and OpenSearch Dashboards is on 2.0.0', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('7.10.3', '2.0.0')).toBe(false);
+      });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 8.0.0 and OpenSearch Dashboards is on 2.0.0', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('8.0.0', '2.0.0')).toBe(false);
+      });
     });
 
     describe('returns true', () => {
@@ -85,6 +97,18 @@ describe('plugins/opensearch', () => {
 
       it('when majors and minors are not equal, but the engine is on legacy version 7.10.2 and OpenSearch Dashboards is on 1.1.0', () => {
         expect(opensearchVersionCompatibleWithOpenSearchDashboards('7.10.2', '1.1.0')).toBe(true);
+      });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 7.10.2 and OpenSearch Dashboards is on 2.0.0', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('7.10.2', '2.0.0')).toBe(true);
+      });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 7.10.2 and OpenSearch Dashboards is on 2.0.1', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('7.10.2', '2.0.1')).toBe(true);
+      });
+
+      it('when majors and minors are not equal, but the engine is on legacy version 7.10.2 and OpenSearch Dashboards is on 2.1.0', () => {
+        expect(opensearchVersionCompatibleWithOpenSearchDashboards('7.10.2', '2.1.0')).toBe(true);
       });
     });
   });

--- a/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.ts
+++ b/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.ts
@@ -110,6 +110,7 @@ function legacyVersionCompatibleWithOpenSearchDashboards(
     legacyVersionNumbers.major === 7 &&
     legacyVersionNumbers.minor === 10 &&
     legacyVersionNumbers.patch === 2 &&
-    opensearchDashboardsVersionNumbers.major === 1
+    (opensearchDashboardsVersionNumbers.major === 1 ||
+      opensearchDashboardsVersionNumbers.major === 2)
   );
 }

--- a/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.ts
+++ b/src/core/server/opensearch/version_check/opensearch_opensearch_dashboards_version_compatability.ts
@@ -38,6 +38,16 @@ interface VersionNumbers {
 }
 
 /**
+ * @private
+ *
+ * List of OpenSearch Dashboards major versions that can connect to legacy version
+ * 7.10.2.
+ *
+ * WARNING: OpenSearchDashboards 7.x could cause conflicts.
+ */
+const osdLegacyCompatibleMajorVersions = [1, 2];
+
+/**
  * Checks for the compatibilitiy between OpenSearch and OpenSearchDashboards versions
  * 1. Major version differences will never work together.
  * 2. Older versions of OpenSearch won't work with newer versions of OpenSearch Dashboards.
@@ -110,7 +120,6 @@ function legacyVersionCompatibleWithOpenSearchDashboards(
     legacyVersionNumbers.major === 7 &&
     legacyVersionNumbers.minor === 10 &&
     legacyVersionNumbers.patch === 2 &&
-    (opensearchDashboardsVersionNumbers.major === 1 ||
-      opensearchDashboardsVersionNumbers.major === 2)
+    osdLegacyCompatibleMajorVersions.includes(opensearchDashboardsVersionNumbers.major)
   );
 }

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/is_config_version_upgradeable.test.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/is_config_version_upgradeable.test.ts
@@ -88,5 +88,6 @@ describe('savedObjects/health_check/isConfigVersionUpgradeable', function () {
   isUpgradeableTest('1.0.0-rc1', '1.0.0', true);
   isUpgradeableTest('1.0.1', '1.0.0', false);
   isUpgradeableTest('7.10.2', '1.1.0', true);
-  isUpgradeableTest('7.10.2', '2.0.0', false);
+  isUpgradeableTest('7.10.2', '2.0.0', true);
+  isUpgradeableTest('7.10.2', '3.0.0', false);
 });

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/is_config_version_upgradeable.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/is_config_version_upgradeable.ts
@@ -73,10 +73,12 @@ export function isConfigVersionUpgradeable(
   // If the saved config is from the fork and from 6.8.0 to 7.10.2 then we should be able to upgrade.
   const savedIsFromPrefork =
     semver.gte(savedReleaseVersion, '6.8.0') && semver.lte(savedReleaseVersion, '7.10.2');
-  const currentVersionIsVersion1 = semver.major(opensearchDashboardsReleaseVersion) === 1;
+  const currentVersionIsValidOSDVersion =
+    semver.major(opensearchDashboardsReleaseVersion) === 1 ||
+    semver.major(opensearchDashboardsReleaseVersion) === 2;
   return (
     savedIsLessThanOpenSearchDashboards ||
     (savedIsSameAsOpenSearchDashboards && savedRcIsLessThanOpenSearchDashboards) ||
-    (savedIsFromPrefork && currentVersionIsVersion1)
+    (savedIsFromPrefork && currentVersionIsValidOSDVersion)
   );
 }

--- a/src/core/server/ui_settings/create_or_upgrade_saved_config/is_config_version_upgradeable.ts
+++ b/src/core/server/ui_settings/create_or_upgrade_saved_config/is_config_version_upgradeable.ts
@@ -29,6 +29,13 @@
  */
 
 import semver from 'semver';
+/**
+ * List of OpenSearch Dashboards major versions that can pull the
+ * config from a legacy version that is higher in semvar.
+ *
+ * WARNING: OpenSearchDashboards 7.x could cause conflicts.
+ */
+const osdValidMajorVersions = [1, 2];
 const rcVersionRegex = /^(\d+\.\d+\.\d+)\-rc(\d+)$/i;
 
 function extractRcNumber(version: string): [string, number] {
@@ -73,9 +80,9 @@ export function isConfigVersionUpgradeable(
   // If the saved config is from the fork and from 6.8.0 to 7.10.2 then we should be able to upgrade.
   const savedIsFromPrefork =
     semver.gte(savedReleaseVersion, '6.8.0') && semver.lte(savedReleaseVersion, '7.10.2');
-  const currentVersionIsValidOSDVersion =
-    semver.major(opensearchDashboardsReleaseVersion) === 1 ||
-    semver.major(opensearchDashboardsReleaseVersion) === 2;
+  const currentVersionIsValidOSDVersion = osdValidMajorVersions.includes(
+    semver.major(opensearchDashboardsReleaseVersion)
+  );
   return (
     savedIsLessThanOpenSearchDashboards ||
     (savedIsSameAsOpenSearchDashboards && savedRcIsLessThanOpenSearchDashboards) ||


### PR DESCRIPTION
### Description
Allows for migrating from legacy app 6.8 to 7.10 to OSD 2.0,
without losing any settings.

Caught with BWC tests.

We should probably evalulate the strategy when we plan to split
from version sync from OpenSearch and if we want to make a
configurable matrix here. But for now making this an explicit
commit is preferable.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 