### PR TITLE
Adds src/test_utils/ and src/core paths to the target clean patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
         "built_assets",
         ".eslintcache",
         ".node_binaries",
-        "src/plugins/*/target"
+        "src/plugins/*/target",
+        "src/core/target",
+        "src/test_utils/target"
       ]
     }
   },


### PR DESCRIPTION
Signed-off-by: Bishoy Boktor <boktorbb@amazon.com>

### Description
Adds the src/test_utils and src/core directories to the list of paths that should have their target directories cleaned. This fixes the Cheerio failure during `yarn osd bootstrap` and is recommended for the extensive restyling that comes with the stylelint change.
 
### Issues Resolved
#1418 
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
    - [X] `yarn test:jest`
    - [X] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 