### PR TITLE
Configurable top header colors

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -162,8 +162,15 @@
   # faviconUrl: ""
   # applicationTitle: ""
   # colors:
-    # headerBackgroundColor: ""
-    # headerLinkColor: ""
+    # headerBackground:
+      # defaultColor: ""
+      # darkModeColor: ""
+    # headerLink:
+      # defaultColor: ""
+      # darkModeColor: ""
+    # headerBorder:
+      # defaultColor: ""
+      # darkModeColor: ""
 
 # Set the value of this setting to true to capture region blocked warnings and errors 
 # for your map rendering services.

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -35,7 +35,7 @@
 # Setting for an optimized healthcheck that only uses the local OpenSearch node to do Dashboards healthcheck.
 # This settings should be used for large clusters or for clusters with ingest heavy nodes.
 # It allows Dashboards to only healthcheck using the local OpenSearch node rather than fan out requests across all nodes.
-#  
+# 
 # It requires the user to create an OpenSearch node attribute with the same name as the value used in the setting
 # This node attribute should assign all nodes of the same cluster an integer value that increments with each new cluster that is spun up
 # e.g. in opensearch.yml file you would set the value to a setting using node.attr.cluster_id: 
@@ -161,6 +161,9 @@
     # darkModeUrl: ""
   # faviconUrl: ""
   # applicationTitle: ""
+  # colors:
+    # headerBackgroundColor: ""
+    # headerLinkColor: ""
 
 # Set the value of this setting to true to capture region blocked warnings and errors 
 # for your map rendering services.

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -1669,7 +1669,19 @@ exports[`Header renders 1`] = `
     <div
       id="globalHeaderBars"
     >
-      <EuiHeader
+      <CustomHeader
+        branding={
+          Object {
+            "applicationTitle": "OpenSearch Dashboards",
+            "darkMode": false,
+            "logo": Object {
+              "defaultUrl": "/",
+            },
+            "mark": Object {
+              "defaultUrl": "/",
+            },
+          }
+        }
         position="fixed"
         sections={
           Array [
@@ -2776,24 +2788,14 @@ exports[`Header renders 1`] = `
             },
           ]
         }
-        theme="dark"
       >
-        <div
-          className="euiHeader euiHeader--dark euiHeader--fixed"
-        >
-          <EuiHeaderSection
-            key="items-0"
-          >
-            <div
-              className="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--left"
-            >
-              <EuiHeaderSectionItem
-                border="none"
-                key="0"
-              >
-                <div
-                  className="euiHeaderSectionItem"
-                >
+        <Styled(EuiHeader)
+          position="fixed"
+          sections={
+            Array [
+              Object {
+                "borders": "none",
+                "items": Array [
                   <HeaderLogo
                     branding={
                       Object {
@@ -2951,52 +2953,7 @@ exports[`Header renders 1`] = `
                       }
                     }
                     navigateToApp={[MockFunction]}
-                  >
-                    <a
-                      aria-label="Go to home page"
-                      className="logoContainer"
-                      data-test-subj="logo"
-                      href="/"
-                      onClick={[Function]}
-                    >
-                      <CustomLogo
-                        applicationTitle="OpenSearch Dashboards"
-                        darkMode={false}
-                        logo={
-                          Object {
-                            "defaultUrl": "/",
-                          }
-                        }
-                        mark={
-                          Object {
-                            "defaultUrl": "/",
-                          }
-                        }
-                      >
-                        <div
-                          className="logoContainer"
-                        >
-                          <img
-                            alt="OpenSearch Dashboards logo"
-                            className="logoImage"
-                            data-test-image-url="/"
-                            data-test-subj="customLogo"
-                            loading="lazy"
-                            src="/"
-                          />
-                        </div>
-                      </CustomLogo>
-                    </a>
-                  </HeaderLogo>
-                </div>
-              </EuiHeaderSectionItem>
-              <EuiHeaderSectionItem
-                border="none"
-                key="1"
-              >
-                <div
-                  className="euiHeaderSectionItem"
-                >
+                  />,
                   <LoadingIndicator
                     loadingCount$={
                       BehaviorSubject {
@@ -3048,38 +3005,12 @@ exports[`Header renders 1`] = `
                       }
                     }
                     showAsBar={false}
-                  >
-                    <EuiLoadingSpinner
-                      aria-hidden={true}
-                      aria-label="Loading content"
-                      className="osdLoadingIndicator-hidden"
-                      data-test-subj="globalLoadingIndicator-hidden"
-                    >
-                      <span
-                        aria-hidden={true}
-                        aria-label="Loading content"
-                        className="euiLoadingSpinner euiLoadingSpinner--medium osdLoadingIndicator-hidden"
-                        data-test-subj="globalLoadingIndicator-hidden"
-                      />
-                    </EuiLoadingSpinner>
-                  </LoadingIndicator>
-                </div>
-              </EuiHeaderSectionItem>
-            </div>
-          </EuiHeaderSection>
-          <EuiHeaderSection
-            key="items-1"
-          >
-            <div
-              className="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--left"
-            >
-              <EuiHeaderSectionItem
-                border="none"
-                key="0"
-              >
-                <div
-                  className="euiHeaderSectionItem"
-                >
+                  />,
+                ],
+              },
+              Object {
+                "borders": "none",
+                "items": Array [
                   <EuiShowFor
                     sizes={
                       Array [
@@ -3140,24 +3071,12 @@ exports[`Header renders 1`] = `
                         }
                       }
                     />
-                  </EuiShowFor>
-                </div>
-              </EuiHeaderSectionItem>
-            </div>
-          </EuiHeaderSection>
-          <EuiHeaderSection
-            key="items-2"
-          >
-            <div
-              className="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--left"
-            >
-              <EuiHeaderSectionItem
-                border="none"
-                key="0"
-              >
-                <div
-                  className="euiHeaderSectionItem"
-                >
+                  </EuiShowFor>,
+                ],
+              },
+              Object {
+                "borders": "none",
+                "items": Array [
                   <EuiHideFor
                     sizes={
                       Array [
@@ -3166,16 +3085,59 @@ exports[`Header renders 1`] = `
                         "xl",
                       ]
                     }
-                  />
-                </div>
-              </EuiHeaderSectionItem>
-              <EuiHeaderSectionItem
-                border="none"
-                key="1"
-              >
-                <div
-                  className="euiHeaderSectionItem"
-                >
+                  >
+                    <HeaderNavControls
+                      navControls$={
+                        BehaviorSubject {
+                          "_isScalar": false,
+                          "_value": Array [],
+                          "closed": false,
+                          "hasError": false,
+                          "isStopped": false,
+                          "observers": Array [
+                            Subscriber {
+                              "_parentOrParents": null,
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": SafeSubscriber {
+                                "_complete": undefined,
+                                "_context": [Circular],
+                                "_error": undefined,
+                                "_next": [Function],
+                                "_parentOrParents": null,
+                                "_parentSubscriber": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                          ],
+                          "thrownError": null,
+                        }
+                      }
+                    />
+                  </EuiHideFor>,
                   <InjectIntl(HeaderHelpMenuUI)
                     helpExtension$={
                       BehaviorSubject {
@@ -3878,8 +3840,415 @@ exports[`Header renders 1`] = `
                     opensearchDashboardsDocLink="/docs"
                     opensearchDashboardsVersion="1.0.0"
                     useDefaultContent={true}
-                  >
-                    <HeaderHelpMenuUI
+                  />,
+                  <HeaderNavControls
+                    navControls$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": Array [],
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
+                              "_subscriptions": null,
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            "isStopped": false,
+                            "syncErrorThrowable": true,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                        ],
+                        "thrownError": null,
+                      }
+                    }
+                  />,
+                ],
+              },
+            ]
+          }
+          theme="default"
+        >
+          <EuiHeader
+            className="sc-bczRLJ lnGSGL"
+            position="fixed"
+            sections={
+              Array [
+                Object {
+                  "borders": "none",
+                  "items": Array [
+                    <HeaderLogo
+                      branding={
+                        Object {
+                          "applicationTitle": "OpenSearch Dashboards",
+                          "darkMode": false,
+                          "logo": Object {
+                            "defaultUrl": "/",
+                          },
+                          "mark": Object {
+                            "defaultUrl": "/",
+                          },
+                        }
+                      }
+                      forceNavigation$={
+                        BehaviorSubject {
+                          "_isScalar": false,
+                          "_value": false,
+                          "closed": false,
+                          "hasError": false,
+                          "isStopped": false,
+                          "observers": Array [
+                            Subscriber {
+                              "_parentOrParents": null,
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": SafeSubscriber {
+                                "_complete": undefined,
+                                "_context": [Circular],
+                                "_error": undefined,
+                                "_next": [Function],
+                                "_parentOrParents": null,
+                                "_parentSubscriber": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                          ],
+                          "thrownError": null,
+                        }
+                      }
+                      href="/"
+                      navLinks$={
+                        BehaviorSubject {
+                          "_isScalar": false,
+                          "_value": Array [
+                            Object {
+                              "baseUrl": "",
+                              "href": "",
+                              "id": "opensearchDashboards",
+                              "title": "opensearchDashboards",
+                            },
+                          ],
+                          "closed": false,
+                          "hasError": false,
+                          "isStopped": false,
+                          "observers": Array [
+                            Subscriber {
+                              "_parentOrParents": null,
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": SafeSubscriber {
+                                "_complete": undefined,
+                                "_context": [Circular],
+                                "_error": undefined,
+                                "_next": [Function],
+                                "_parentOrParents": null,
+                                "_parentSubscriber": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            Subscriber {
+                              "_parentOrParents": null,
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": SafeSubscriber {
+                                "_complete": undefined,
+                                "_context": [Circular],
+                                "_error": undefined,
+                                "_next": [Function],
+                                "_parentOrParents": null,
+                                "_parentSubscriber": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                          ],
+                          "thrownError": null,
+                        }
+                      }
+                      navigateToApp={[MockFunction]}
+                    />,
+                    <LoadingIndicator
+                      loadingCount$={
+                        BehaviorSubject {
+                          "_isScalar": false,
+                          "_value": 0,
+                          "closed": false,
+                          "hasError": false,
+                          "isStopped": false,
+                          "observers": Array [
+                            Subscriber {
+                              "_parentOrParents": null,
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": SafeSubscriber {
+                                "_complete": undefined,
+                                "_context": [Circular],
+                                "_error": undefined,
+                                "_next": [Function],
+                                "_parentOrParents": null,
+                                "_parentSubscriber": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                          ],
+                          "thrownError": null,
+                        }
+                      }
+                      showAsBar={false}
+                    />,
+                  ],
+                },
+                Object {
+                  "borders": "none",
+                  "items": Array [
+                    <EuiShowFor
+                      sizes={
+                        Array [
+                          "m",
+                          "l",
+                          "xl",
+                        ]
+                      }
+                    >
+                      <HeaderNavControls
+                        navControls$={
+                          BehaviorSubject {
+                            "_isScalar": false,
+                            "_value": Array [],
+                            "closed": false,
+                            "hasError": false,
+                            "isStopped": false,
+                            "observers": Array [
+                              Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  SubjectSubscription {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "subject": [Circular],
+                                    "subscriber": [Circular],
+                                  },
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                            ],
+                            "thrownError": null,
+                          }
+                        }
+                      />
+                    </EuiShowFor>,
+                  ],
+                },
+                Object {
+                  "borders": "none",
+                  "items": Array [
+                    <EuiHideFor
+                      sizes={
+                        Array [
+                          "m",
+                          "l",
+                          "xl",
+                        ]
+                      }
+                    >
+                      <HeaderNavControls
+                        navControls$={
+                          BehaviorSubject {
+                            "_isScalar": false,
+                            "_value": Array [],
+                            "closed": false,
+                            "hasError": false,
+                            "isStopped": false,
+                            "observers": Array [
+                              Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  SubjectSubscription {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "subject": [Circular],
+                                    "subscriber": [Circular],
+                                  },
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                            ],
+                            "thrownError": null,
+                          }
+                        }
+                      />
+                    </EuiHideFor>,
+                    <InjectIntl(HeaderHelpMenuUI)
                       helpExtension$={
                         BehaviorSubject {
                           "_isScalar": false,
@@ -4578,301 +4947,2164 @@ exports[`Header renders 1`] = `
                           "thrownError": null,
                         }
                       }
-                      intl={
-                        Object {
-                          "defaultFormats": Object {},
-                          "defaultLocale": "en",
-                          "formatDate": [Function],
-                          "formatHTMLMessage": [Function],
-                          "formatMessage": [Function],
-                          "formatNumber": [Function],
-                          "formatPlural": [Function],
-                          "formatRelative": [Function],
-                          "formatTime": [Function],
-                          "formats": Object {
-                            "date": Object {
-                              "full": Object {
-                                "day": "numeric",
-                                "month": "long",
-                                "weekday": "long",
-                                "year": "numeric",
-                              },
-                              "long": Object {
-                                "day": "numeric",
-                                "month": "long",
-                                "year": "numeric",
-                              },
-                              "medium": Object {
-                                "day": "numeric",
-                                "month": "short",
-                                "year": "numeric",
-                              },
-                              "short": Object {
-                                "day": "numeric",
-                                "month": "numeric",
-                                "year": "2-digit",
-                              },
-                            },
-                            "number": Object {
-                              "currency": Object {
-                                "style": "currency",
-                              },
-                              "percent": Object {
-                                "style": "percent",
-                              },
-                            },
-                            "relative": Object {
-                              "days": Object {
-                                "units": "day",
-                              },
-                              "hours": Object {
-                                "units": "hour",
-                              },
-                              "minutes": Object {
-                                "units": "minute",
-                              },
-                              "months": Object {
-                                "units": "month",
-                              },
-                              "seconds": Object {
-                                "units": "second",
-                              },
-                              "years": Object {
-                                "units": "year",
-                              },
-                            },
-                            "time": Object {
-                              "full": Object {
-                                "hour": "numeric",
-                                "minute": "numeric",
-                                "second": "numeric",
-                                "timeZoneName": "short",
-                              },
-                              "long": Object {
-                                "hour": "numeric",
-                                "minute": "numeric",
-                                "second": "numeric",
-                                "timeZoneName": "short",
-                              },
-                              "medium": Object {
-                                "hour": "numeric",
-                                "minute": "numeric",
-                                "second": "numeric",
-                              },
-                              "short": Object {
-                                "hour": "numeric",
-                                "minute": "numeric",
-                              },
-                            },
-                          },
-                          "formatters": Object {
-                            "getDateTimeFormat": [Function],
-                            "getMessageFormat": [Function],
-                            "getNumberFormat": [Function],
-                            "getPluralFormat": [Function],
-                            "getRelativeFormat": [Function],
-                          },
-                          "locale": "en",
-                          "messages": Object {},
-                          "now": [Function],
-                          "onError": [Function],
-                          "textComponent": Symbol(react.fragment),
-                          "timeZone": null,
-                        }
-                      }
                       opensearchDashboardsDocLink="/docs"
                       opensearchDashboardsVersion="1.0.0"
                       useDefaultContent={true}
-                    >
-                      <EuiPopover
-                        anchorPosition="downRight"
-                        button={
-                          <EuiHeaderSectionItemButton
-                            aria-expanded={false}
-                            aria-haspopup="true"
-                            aria-label="Help menu"
-                            onClick={[Function]}
-                          >
-                            <EuiIcon
-                              size="m"
-                              type="help"
-                            />
-                          </EuiHeaderSectionItemButton>
-                        }
-                        closePopover={[Function]}
-                        data-test-subj="helpMenuButton"
-                        display="inlineBlock"
-                        hasArrow={true}
-                        id="headerHelpMenu"
-                        isOpen={false}
-                        ownFocus={true}
-                        panelPaddingSize="m"
-                        repositionOnScroll={true}
-                      >
-                        <div
-                          className="euiPopover euiPopover--anchorDownRight"
-                          data-test-subj="helpMenuButton"
-                          id="headerHelpMenu"
-                        >
-                          <div
-                            className="euiPopover__anchor"
-                          >
-                            <EuiHeaderSectionItemButton
-                              aria-expanded={false}
-                              aria-haspopup="true"
-                              aria-label="Help menu"
-                              onClick={[Function]}
-                            >
-                              <EuiButtonEmpty
-                                aria-expanded={false}
-                                aria-haspopup="true"
-                                aria-label="Help menu"
-                                buttonRef={
-                                  Object {
-                                    "current": <button
-                                      aria-expanded="false"
-                                      aria-haspopup="true"
-                                      aria-label="Help menu"
-                                      class="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
-                                      type="button"
-                                    >
-                                      <span
-                                        class="euiButtonContent euiButtonEmpty__content"
-                                      >
-                                        <span
-                                          class="euiButtonEmpty__text"
-                                        >
-                                          <span
-                                            class="euiHeaderSectionItemButton__content"
-                                          >
-                                            <span
-                                              data-euiicon-type="help"
-                                            />
-                                          </span>
-                                        </span>
-                                      </span>
-                                    </button>,
-                                  }
-                                }
-                                className="euiHeaderSectionItemButton"
-                                color="text"
-                                onClick={[Function]}
-                              >
-                                <button
-                                  aria-expanded={false}
-                                  aria-haspopup="true"
-                                  aria-label="Help menu"
-                                  className="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <EuiButtonContent
-                                    className="euiButtonEmpty__content"
-                                    iconSide="left"
-                                    iconSize="m"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButtonEmpty__text",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButtonEmpty__content"
-                                    >
-                                      <span
-                                        className="euiButtonEmpty__text"
-                                      >
-                                        <span
-                                          className="euiHeaderSectionItemButton__content"
-                                        >
-                                          <EuiIcon
-                                            size="m"
-                                            type="help"
-                                          >
-                                            <span
-                                              data-euiicon-type="help"
-                                              size="m"
-                                            />
-                                          </EuiIcon>
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonEmpty>
-                            </EuiHeaderSectionItemButton>
-                          </div>
-                        </div>
-                      </EuiPopover>
-                    </HeaderHelpMenuUI>
-                  </InjectIntl(HeaderHelpMenuUI)>
-                </div>
-              </EuiHeaderSectionItem>
-              <EuiHeaderSectionItem
-                border="none"
-                key="2"
-              >
-                <div
-                  className="euiHeaderSectionItem"
-                >
-                  <HeaderNavControls
-                    navControls$={
-                      BehaviorSubject {
-                        "_isScalar": false,
-                        "_value": Array [],
-                        "closed": false,
-                        "hasError": false,
-                        "isStopped": false,
-                        "observers": Array [
-                          Subscriber {
-                            "_parentOrParents": null,
-                            "_subscriptions": Array [
-                              SubjectSubscription {
-                                "_parentOrParents": [Circular],
+                    />,
+                    <HeaderNavControls
+                      navControls$={
+                        BehaviorSubject {
+                          "_isScalar": false,
+                          "_value": Array [],
+                          "closed": false,
+                          "hasError": false,
+                          "isStopped": false,
+                          "observers": Array [
+                            Subscriber {
+                              "_parentOrParents": null,
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": SafeSubscriber {
+                                "_complete": undefined,
+                                "_context": [Circular],
+                                "_error": undefined,
+                                "_next": [Function],
+                                "_parentOrParents": null,
+                                "_parentSubscriber": [Circular],
                                 "_subscriptions": null,
                                 "closed": false,
-                                "subject": [Circular],
-                                "subscriber": [Circular],
-                              },
-                            ],
-                            "closed": false,
-                            "destination": SafeSubscriber {
-                              "_complete": undefined,
-                              "_context": [Circular],
-                              "_error": undefined,
-                              "_next": [Function],
-                              "_parentOrParents": null,
-                              "_parentSubscriber": [Circular],
-                              "_subscriptions": null,
-                              "closed": false,
-                              "destination": Object {
-                                "closed": true,
-                                "complete": [Function],
-                                "error": [Function],
-                                "next": [Function],
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
                               },
                               "isStopped": false,
-                              "syncErrorThrowable": false,
+                              "syncErrorThrowable": true,
                               "syncErrorThrown": false,
                               "syncErrorValue": null,
                             },
-                            "isStopped": false,
-                            "syncErrorThrowable": true,
-                            "syncErrorThrown": false,
-                            "syncErrorValue": null,
-                          },
-                        ],
-                        "thrownError": null,
+                          ],
+                          "thrownError": null,
+                        }
                       }
-                    }
-                  />
+                    />,
+                  ],
+                },
+              ]
+            }
+            theme="default"
+          >
+            <div
+              className="euiHeader euiHeader--default euiHeader--fixed sc-bczRLJ lnGSGL"
+            >
+              <EuiHeaderSection
+                key="items-0"
+              >
+                <div
+                  className="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--left"
+                >
+                  <EuiHeaderSectionItem
+                    border="none"
+                    key="0"
+                  >
+                    <div
+                      className="euiHeaderSectionItem"
+                    >
+                      <HeaderLogo
+                        branding={
+                          Object {
+                            "applicationTitle": "OpenSearch Dashboards",
+                            "darkMode": false,
+                            "logo": Object {
+                              "defaultUrl": "/",
+                            },
+                            "mark": Object {
+                              "defaultUrl": "/",
+                            },
+                          }
+                        }
+                        forceNavigation$={
+                          BehaviorSubject {
+                            "_isScalar": false,
+                            "_value": false,
+                            "closed": false,
+                            "hasError": false,
+                            "isStopped": false,
+                            "observers": Array [
+                              Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  SubjectSubscription {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "subject": [Circular],
+                                    "subscriber": [Circular],
+                                  },
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                            ],
+                            "thrownError": null,
+                          }
+                        }
+                        href="/"
+                        navLinks$={
+                          BehaviorSubject {
+                            "_isScalar": false,
+                            "_value": Array [
+                              Object {
+                                "baseUrl": "",
+                                "href": "",
+                                "id": "opensearchDashboards",
+                                "title": "opensearchDashboards",
+                              },
+                            ],
+                            "closed": false,
+                            "hasError": false,
+                            "isStopped": false,
+                            "observers": Array [
+                              Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  SubjectSubscription {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "subject": [Circular],
+                                    "subscriber": [Circular],
+                                  },
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  SubjectSubscription {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "subject": [Circular],
+                                    "subscriber": [Circular],
+                                  },
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                            ],
+                            "thrownError": null,
+                          }
+                        }
+                        navigateToApp={[MockFunction]}
+                      >
+                        <a
+                          aria-label="Go to home page"
+                          className="logoContainer"
+                          data-test-subj="logo"
+                          href="/"
+                          onClick={[Function]}
+                        >
+                          <CustomLogo
+                            applicationTitle="OpenSearch Dashboards"
+                            darkMode={false}
+                            logo={
+                              Object {
+                                "defaultUrl": "/",
+                              }
+                            }
+                            mark={
+                              Object {
+                                "defaultUrl": "/",
+                              }
+                            }
+                          >
+                            <div
+                              className="logoContainer"
+                            >
+                              <img
+                                alt="OpenSearch Dashboards logo"
+                                className="logoImage"
+                                data-test-image-url="/"
+                                data-test-subj="customLogo"
+                                loading="lazy"
+                                src="/"
+                              />
+                            </div>
+                          </CustomLogo>
+                        </a>
+                      </HeaderLogo>
+                    </div>
+                  </EuiHeaderSectionItem>
+                  <EuiHeaderSectionItem
+                    border="none"
+                    key="1"
+                  >
+                    <div
+                      className="euiHeaderSectionItem"
+                    >
+                      <LoadingIndicator
+                        loadingCount$={
+                          BehaviorSubject {
+                            "_isScalar": false,
+                            "_value": 0,
+                            "closed": false,
+                            "hasError": false,
+                            "isStopped": false,
+                            "observers": Array [
+                              Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  SubjectSubscription {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "subject": [Circular],
+                                    "subscriber": [Circular],
+                                  },
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                            ],
+                            "thrownError": null,
+                          }
+                        }
+                        showAsBar={false}
+                      >
+                        <EuiLoadingSpinner
+                          aria-hidden={true}
+                          aria-label="Loading content"
+                          className="osdLoadingIndicator-hidden"
+                          data-test-subj="globalLoadingIndicator-hidden"
+                        >
+                          <span
+                            aria-hidden={true}
+                            aria-label="Loading content"
+                            className="euiLoadingSpinner euiLoadingSpinner--medium osdLoadingIndicator-hidden"
+                            data-test-subj="globalLoadingIndicator-hidden"
+                          />
+                        </EuiLoadingSpinner>
+                      </LoadingIndicator>
+                    </div>
+                  </EuiHeaderSectionItem>
                 </div>
-              </EuiHeaderSectionItem>
+              </EuiHeaderSection>
+              <EuiHeaderSection
+                key="items-1"
+              >
+                <div
+                  className="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--left"
+                >
+                  <EuiHeaderSectionItem
+                    border="none"
+                    key="0"
+                  >
+                    <div
+                      className="euiHeaderSectionItem"
+                    >
+                      <EuiShowFor
+                        sizes={
+                          Array [
+                            "m",
+                            "l",
+                            "xl",
+                          ]
+                        }
+                      >
+                        <HeaderNavControls
+                          navControls$={
+                            BehaviorSubject {
+                              "_isScalar": false,
+                              "_value": Array [],
+                              "closed": false,
+                              "hasError": false,
+                              "isStopped": false,
+                              "observers": Array [
+                                Subscriber {
+                                  "_parentOrParents": null,
+                                  "_subscriptions": Array [
+                                    SubjectSubscription {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "subject": [Circular],
+                                      "subscriber": [Circular],
+                                    },
+                                  ],
+                                  "closed": false,
+                                  "destination": SafeSubscriber {
+                                    "_complete": undefined,
+                                    "_context": [Circular],
+                                    "_error": undefined,
+                                    "_next": [Function],
+                                    "_parentOrParents": null,
+                                    "_parentSubscriber": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                              ],
+                              "thrownError": null,
+                            }
+                          }
+                        />
+                      </EuiShowFor>
+                    </div>
+                  </EuiHeaderSectionItem>
+                </div>
+              </EuiHeaderSection>
+              <EuiHeaderSection
+                key="items-2"
+              >
+                <div
+                  className="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--left"
+                >
+                  <EuiHeaderSectionItem
+                    border="none"
+                    key="0"
+                  >
+                    <div
+                      className="euiHeaderSectionItem"
+                    >
+                      <EuiHideFor
+                        sizes={
+                          Array [
+                            "m",
+                            "l",
+                            "xl",
+                          ]
+                        }
+                      />
+                    </div>
+                  </EuiHeaderSectionItem>
+                  <EuiHeaderSectionItem
+                    border="none"
+                    key="1"
+                  >
+                    <div
+                      className="euiHeaderSectionItem"
+                    >
+                      <InjectIntl(HeaderHelpMenuUI)
+                        helpExtension$={
+                          BehaviorSubject {
+                            "_isScalar": false,
+                            "_value": undefined,
+                            "closed": false,
+                            "hasError": false,
+                            "isStopped": false,
+                            "observers": Array [
+                              InnerSubscriber {
+                                "_parentOrParents": CombineLatestSubscriber {
+                                  "_parentOrParents": Subscriber {
+                                    "_parentOrParents": null,
+                                    "_subscriptions": Array [
+                                      [Circular],
+                                    ],
+                                    "closed": false,
+                                    "destination": SafeSubscriber {
+                                      "_complete": undefined,
+                                      "_context": [Circular],
+                                      "_error": undefined,
+                                      "_next": [Function],
+                                      "_parentOrParents": null,
+                                      "_parentSubscriber": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "_subscriptions": Array [
+                                    [Circular],
+                                    InnerSubscriber {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": Array [
+                                        SubjectSubscription {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": null,
+                                          "closed": false,
+                                          "subject": BehaviorSubject {
+                                            "_isScalar": false,
+                                            "_value": "",
+                                            "closed": false,
+                                            "hasError": false,
+                                            "isStopped": false,
+                                            "observers": Array [
+                                              [Circular],
+                                            ],
+                                            "thrownError": null,
+                                          },
+                                          "subscriber": [Circular],
+                                        },
+                                      ],
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "index": 1,
+                                      "isStopped": false,
+                                      "outerIndex": 1,
+                                      "outerValue": undefined,
+                                      "parent": [Circular],
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                  ],
+                                  "active": 2,
+                                  "closed": false,
+                                  "destination": Subscriber {
+                                    "_parentOrParents": null,
+                                    "_subscriptions": Array [
+                                      [Circular],
+                                    ],
+                                    "closed": false,
+                                    "destination": SafeSubscriber {
+                                      "_complete": undefined,
+                                      "_context": [Circular],
+                                      "_error": undefined,
+                                      "_next": [Function],
+                                      "_parentOrParents": null,
+                                      "_parentSubscriber": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": true,
+                                  "observables": Array [
+                                    [Circular],
+                                    BehaviorSubject {
+                                      "_isScalar": false,
+                                      "_value": "",
+                                      "closed": false,
+                                      "hasError": false,
+                                      "isStopped": false,
+                                      "observers": Array [
+                                        InnerSubscriber {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": Array [
+                                            SubjectSubscription {
+                                              "_parentOrParents": [Circular],
+                                              "_subscriptions": null,
+                                              "closed": false,
+                                              "subject": [Circular],
+                                              "subscriber": [Circular],
+                                            },
+                                          ],
+                                          "closed": false,
+                                          "destination": Object {
+                                            "closed": true,
+                                            "complete": [Function],
+                                            "error": [Function],
+                                            "next": [Function],
+                                          },
+                                          "index": 1,
+                                          "isStopped": false,
+                                          "outerIndex": 1,
+                                          "outerValue": undefined,
+                                          "parent": [Circular],
+                                          "syncErrorThrowable": false,
+                                          "syncErrorThrown": false,
+                                          "syncErrorValue": null,
+                                        },
+                                      ],
+                                      "thrownError": null,
+                                    },
+                                  ],
+                                  "resultSelector": undefined,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                  "toRespond": 0,
+                                  "values": Array [
+                                    undefined,
+                                    "",
+                                  ],
+                                },
+                                "_subscriptions": Array [
+                                  SubjectSubscription {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "subject": [Circular],
+                                    "subscriber": [Circular],
+                                  },
+                                ],
+                                "closed": false,
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "index": 1,
+                                "isStopped": false,
+                                "outerIndex": 0,
+                                "outerValue": undefined,
+                                "parent": CombineLatestSubscriber {
+                                  "_parentOrParents": Subscriber {
+                                    "_parentOrParents": null,
+                                    "_subscriptions": Array [
+                                      [Circular],
+                                    ],
+                                    "closed": false,
+                                    "destination": SafeSubscriber {
+                                      "_complete": undefined,
+                                      "_context": [Circular],
+                                      "_error": undefined,
+                                      "_next": [Function],
+                                      "_parentOrParents": null,
+                                      "_parentSubscriber": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "_subscriptions": Array [
+                                    [Circular],
+                                    InnerSubscriber {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": Array [
+                                        SubjectSubscription {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": null,
+                                          "closed": false,
+                                          "subject": BehaviorSubject {
+                                            "_isScalar": false,
+                                            "_value": "",
+                                            "closed": false,
+                                            "hasError": false,
+                                            "isStopped": false,
+                                            "observers": Array [
+                                              [Circular],
+                                            ],
+                                            "thrownError": null,
+                                          },
+                                          "subscriber": [Circular],
+                                        },
+                                      ],
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "index": 1,
+                                      "isStopped": false,
+                                      "outerIndex": 1,
+                                      "outerValue": undefined,
+                                      "parent": [Circular],
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                  ],
+                                  "active": 2,
+                                  "closed": false,
+                                  "destination": Subscriber {
+                                    "_parentOrParents": null,
+                                    "_subscriptions": Array [
+                                      [Circular],
+                                    ],
+                                    "closed": false,
+                                    "destination": SafeSubscriber {
+                                      "_complete": undefined,
+                                      "_context": [Circular],
+                                      "_error": undefined,
+                                      "_next": [Function],
+                                      "_parentOrParents": null,
+                                      "_parentSubscriber": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": true,
+                                  "observables": Array [
+                                    [Circular],
+                                    BehaviorSubject {
+                                      "_isScalar": false,
+                                      "_value": "",
+                                      "closed": false,
+                                      "hasError": false,
+                                      "isStopped": false,
+                                      "observers": Array [
+                                        InnerSubscriber {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": Array [
+                                            SubjectSubscription {
+                                              "_parentOrParents": [Circular],
+                                              "_subscriptions": null,
+                                              "closed": false,
+                                              "subject": [Circular],
+                                              "subscriber": [Circular],
+                                            },
+                                          ],
+                                          "closed": false,
+                                          "destination": Object {
+                                            "closed": true,
+                                            "complete": [Function],
+                                            "error": [Function],
+                                            "next": [Function],
+                                          },
+                                          "index": 1,
+                                          "isStopped": false,
+                                          "outerIndex": 1,
+                                          "outerValue": undefined,
+                                          "parent": [Circular],
+                                          "syncErrorThrowable": false,
+                                          "syncErrorThrown": false,
+                                          "syncErrorValue": null,
+                                        },
+                                      ],
+                                      "thrownError": null,
+                                    },
+                                  ],
+                                  "resultSelector": undefined,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                  "toRespond": 0,
+                                  "values": Array [
+                                    undefined,
+                                    "",
+                                  ],
+                                },
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                            ],
+                            "thrownError": null,
+                          }
+                        }
+                        helpSupportUrl$={
+                          BehaviorSubject {
+                            "_isScalar": false,
+                            "_value": "",
+                            "closed": false,
+                            "hasError": false,
+                            "isStopped": false,
+                            "observers": Array [
+                              InnerSubscriber {
+                                "_parentOrParents": CombineLatestSubscriber {
+                                  "_parentOrParents": Subscriber {
+                                    "_parentOrParents": null,
+                                    "_subscriptions": Array [
+                                      [Circular],
+                                    ],
+                                    "closed": false,
+                                    "destination": SafeSubscriber {
+                                      "_complete": undefined,
+                                      "_context": [Circular],
+                                      "_error": undefined,
+                                      "_next": [Function],
+                                      "_parentOrParents": null,
+                                      "_parentSubscriber": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "_subscriptions": Array [
+                                    InnerSubscriber {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": Array [
+                                        SubjectSubscription {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": null,
+                                          "closed": false,
+                                          "subject": BehaviorSubject {
+                                            "_isScalar": false,
+                                            "_value": undefined,
+                                            "closed": false,
+                                            "hasError": false,
+                                            "isStopped": false,
+                                            "observers": Array [
+                                              [Circular],
+                                            ],
+                                            "thrownError": null,
+                                          },
+                                          "subscriber": [Circular],
+                                        },
+                                      ],
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "index": 1,
+                                      "isStopped": false,
+                                      "outerIndex": 0,
+                                      "outerValue": undefined,
+                                      "parent": [Circular],
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    [Circular],
+                                  ],
+                                  "active": 2,
+                                  "closed": false,
+                                  "destination": Subscriber {
+                                    "_parentOrParents": null,
+                                    "_subscriptions": Array [
+                                      [Circular],
+                                    ],
+                                    "closed": false,
+                                    "destination": SafeSubscriber {
+                                      "_complete": undefined,
+                                      "_context": [Circular],
+                                      "_error": undefined,
+                                      "_next": [Function],
+                                      "_parentOrParents": null,
+                                      "_parentSubscriber": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": true,
+                                  "observables": Array [
+                                    BehaviorSubject {
+                                      "_isScalar": false,
+                                      "_value": undefined,
+                                      "closed": false,
+                                      "hasError": false,
+                                      "isStopped": false,
+                                      "observers": Array [
+                                        InnerSubscriber {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": Array [
+                                            SubjectSubscription {
+                                              "_parentOrParents": [Circular],
+                                              "_subscriptions": null,
+                                              "closed": false,
+                                              "subject": [Circular],
+                                              "subscriber": [Circular],
+                                            },
+                                          ],
+                                          "closed": false,
+                                          "destination": Object {
+                                            "closed": true,
+                                            "complete": [Function],
+                                            "error": [Function],
+                                            "next": [Function],
+                                          },
+                                          "index": 1,
+                                          "isStopped": false,
+                                          "outerIndex": 0,
+                                          "outerValue": undefined,
+                                          "parent": [Circular],
+                                          "syncErrorThrowable": false,
+                                          "syncErrorThrown": false,
+                                          "syncErrorValue": null,
+                                        },
+                                      ],
+                                      "thrownError": null,
+                                    },
+                                    [Circular],
+                                  ],
+                                  "resultSelector": undefined,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                  "toRespond": 0,
+                                  "values": Array [
+                                    undefined,
+                                    "",
+                                  ],
+                                },
+                                "_subscriptions": Array [
+                                  SubjectSubscription {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "subject": [Circular],
+                                    "subscriber": [Circular],
+                                  },
+                                ],
+                                "closed": false,
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "index": 1,
+                                "isStopped": false,
+                                "outerIndex": 1,
+                                "outerValue": undefined,
+                                "parent": CombineLatestSubscriber {
+                                  "_parentOrParents": Subscriber {
+                                    "_parentOrParents": null,
+                                    "_subscriptions": Array [
+                                      [Circular],
+                                    ],
+                                    "closed": false,
+                                    "destination": SafeSubscriber {
+                                      "_complete": undefined,
+                                      "_context": [Circular],
+                                      "_error": undefined,
+                                      "_next": [Function],
+                                      "_parentOrParents": null,
+                                      "_parentSubscriber": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "_subscriptions": Array [
+                                    InnerSubscriber {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": Array [
+                                        SubjectSubscription {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": null,
+                                          "closed": false,
+                                          "subject": BehaviorSubject {
+                                            "_isScalar": false,
+                                            "_value": undefined,
+                                            "closed": false,
+                                            "hasError": false,
+                                            "isStopped": false,
+                                            "observers": Array [
+                                              [Circular],
+                                            ],
+                                            "thrownError": null,
+                                          },
+                                          "subscriber": [Circular],
+                                        },
+                                      ],
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "index": 1,
+                                      "isStopped": false,
+                                      "outerIndex": 0,
+                                      "outerValue": undefined,
+                                      "parent": [Circular],
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    [Circular],
+                                  ],
+                                  "active": 2,
+                                  "closed": false,
+                                  "destination": Subscriber {
+                                    "_parentOrParents": null,
+                                    "_subscriptions": Array [
+                                      [Circular],
+                                    ],
+                                    "closed": false,
+                                    "destination": SafeSubscriber {
+                                      "_complete": undefined,
+                                      "_context": [Circular],
+                                      "_error": undefined,
+                                      "_next": [Function],
+                                      "_parentOrParents": null,
+                                      "_parentSubscriber": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": true,
+                                  "observables": Array [
+                                    BehaviorSubject {
+                                      "_isScalar": false,
+                                      "_value": undefined,
+                                      "closed": false,
+                                      "hasError": false,
+                                      "isStopped": false,
+                                      "observers": Array [
+                                        InnerSubscriber {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": Array [
+                                            SubjectSubscription {
+                                              "_parentOrParents": [Circular],
+                                              "_subscriptions": null,
+                                              "closed": false,
+                                              "subject": [Circular],
+                                              "subscriber": [Circular],
+                                            },
+                                          ],
+                                          "closed": false,
+                                          "destination": Object {
+                                            "closed": true,
+                                            "complete": [Function],
+                                            "error": [Function],
+                                            "next": [Function],
+                                          },
+                                          "index": 1,
+                                          "isStopped": false,
+                                          "outerIndex": 0,
+                                          "outerValue": undefined,
+                                          "parent": [Circular],
+                                          "syncErrorThrowable": false,
+                                          "syncErrorThrown": false,
+                                          "syncErrorValue": null,
+                                        },
+                                      ],
+                                      "thrownError": null,
+                                    },
+                                    [Circular],
+                                  ],
+                                  "resultSelector": undefined,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                  "toRespond": 0,
+                                  "values": Array [
+                                    undefined,
+                                    "",
+                                  ],
+                                },
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                            ],
+                            "thrownError": null,
+                          }
+                        }
+                        opensearchDashboardsDocLink="/docs"
+                        opensearchDashboardsVersion="1.0.0"
+                        useDefaultContent={true}
+                      >
+                        <HeaderHelpMenuUI
+                          helpExtension$={
+                            BehaviorSubject {
+                              "_isScalar": false,
+                              "_value": undefined,
+                              "closed": false,
+                              "hasError": false,
+                              "isStopped": false,
+                              "observers": Array [
+                                InnerSubscriber {
+                                  "_parentOrParents": CombineLatestSubscriber {
+                                    "_parentOrParents": Subscriber {
+                                      "_parentOrParents": null,
+                                      "_subscriptions": Array [
+                                        [Circular],
+                                      ],
+                                      "closed": false,
+                                      "destination": SafeSubscriber {
+                                        "_complete": undefined,
+                                        "_context": [Circular],
+                                        "_error": undefined,
+                                        "_next": [Function],
+                                        "_parentOrParents": null,
+                                        "_parentSubscriber": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "isStopped": false,
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": true,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "_subscriptions": Array [
+                                      [Circular],
+                                      InnerSubscriber {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": Array [
+                                          SubjectSubscription {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": null,
+                                            "closed": false,
+                                            "subject": BehaviorSubject {
+                                              "_isScalar": false,
+                                              "_value": "",
+                                              "closed": false,
+                                              "hasError": false,
+                                              "isStopped": false,
+                                              "observers": Array [
+                                                [Circular],
+                                              ],
+                                              "thrownError": null,
+                                            },
+                                            "subscriber": [Circular],
+                                          },
+                                        ],
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "index": 1,
+                                        "isStopped": false,
+                                        "outerIndex": 1,
+                                        "outerValue": undefined,
+                                        "parent": [Circular],
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                    ],
+                                    "active": 2,
+                                    "closed": false,
+                                    "destination": Subscriber {
+                                      "_parentOrParents": null,
+                                      "_subscriptions": Array [
+                                        [Circular],
+                                      ],
+                                      "closed": false,
+                                      "destination": SafeSubscriber {
+                                        "_complete": undefined,
+                                        "_context": [Circular],
+                                        "_error": undefined,
+                                        "_next": [Function],
+                                        "_parentOrParents": null,
+                                        "_parentSubscriber": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "isStopped": false,
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": true,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": true,
+                                    "observables": Array [
+                                      [Circular],
+                                      BehaviorSubject {
+                                        "_isScalar": false,
+                                        "_value": "",
+                                        "closed": false,
+                                        "hasError": false,
+                                        "isStopped": false,
+                                        "observers": Array [
+                                          InnerSubscriber {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": Array [
+                                              SubjectSubscription {
+                                                "_parentOrParents": [Circular],
+                                                "_subscriptions": null,
+                                                "closed": false,
+                                                "subject": [Circular],
+                                                "subscriber": [Circular],
+                                              },
+                                            ],
+                                            "closed": false,
+                                            "destination": Object {
+                                              "closed": true,
+                                              "complete": [Function],
+                                              "error": [Function],
+                                              "next": [Function],
+                                            },
+                                            "index": 1,
+                                            "isStopped": false,
+                                            "outerIndex": 1,
+                                            "outerValue": undefined,
+                                            "parent": [Circular],
+                                            "syncErrorThrowable": false,
+                                            "syncErrorThrown": false,
+                                            "syncErrorValue": null,
+                                          },
+                                        ],
+                                        "thrownError": null,
+                                      },
+                                    ],
+                                    "resultSelector": undefined,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                    "toRespond": 0,
+                                    "values": Array [
+                                      undefined,
+                                      "",
+                                    ],
+                                  },
+                                  "_subscriptions": Array [
+                                    SubjectSubscription {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "subject": [Circular],
+                                      "subscriber": [Circular],
+                                    },
+                                  ],
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "index": 1,
+                                  "isStopped": false,
+                                  "outerIndex": 0,
+                                  "outerValue": undefined,
+                                  "parent": CombineLatestSubscriber {
+                                    "_parentOrParents": Subscriber {
+                                      "_parentOrParents": null,
+                                      "_subscriptions": Array [
+                                        [Circular],
+                                      ],
+                                      "closed": false,
+                                      "destination": SafeSubscriber {
+                                        "_complete": undefined,
+                                        "_context": [Circular],
+                                        "_error": undefined,
+                                        "_next": [Function],
+                                        "_parentOrParents": null,
+                                        "_parentSubscriber": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "isStopped": false,
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": true,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "_subscriptions": Array [
+                                      [Circular],
+                                      InnerSubscriber {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": Array [
+                                          SubjectSubscription {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": null,
+                                            "closed": false,
+                                            "subject": BehaviorSubject {
+                                              "_isScalar": false,
+                                              "_value": "",
+                                              "closed": false,
+                                              "hasError": false,
+                                              "isStopped": false,
+                                              "observers": Array [
+                                                [Circular],
+                                              ],
+                                              "thrownError": null,
+                                            },
+                                            "subscriber": [Circular],
+                                          },
+                                        ],
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "index": 1,
+                                        "isStopped": false,
+                                        "outerIndex": 1,
+                                        "outerValue": undefined,
+                                        "parent": [Circular],
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                    ],
+                                    "active": 2,
+                                    "closed": false,
+                                    "destination": Subscriber {
+                                      "_parentOrParents": null,
+                                      "_subscriptions": Array [
+                                        [Circular],
+                                      ],
+                                      "closed": false,
+                                      "destination": SafeSubscriber {
+                                        "_complete": undefined,
+                                        "_context": [Circular],
+                                        "_error": undefined,
+                                        "_next": [Function],
+                                        "_parentOrParents": null,
+                                        "_parentSubscriber": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "isStopped": false,
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": true,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": true,
+                                    "observables": Array [
+                                      [Circular],
+                                      BehaviorSubject {
+                                        "_isScalar": false,
+                                        "_value": "",
+                                        "closed": false,
+                                        "hasError": false,
+                                        "isStopped": false,
+                                        "observers": Array [
+                                          InnerSubscriber {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": Array [
+                                              SubjectSubscription {
+                                                "_parentOrParents": [Circular],
+                                                "_subscriptions": null,
+                                                "closed": false,
+                                                "subject": [Circular],
+                                                "subscriber": [Circular],
+                                              },
+                                            ],
+                                            "closed": false,
+                                            "destination": Object {
+                                              "closed": true,
+                                              "complete": [Function],
+                                              "error": [Function],
+                                              "next": [Function],
+                                            },
+                                            "index": 1,
+                                            "isStopped": false,
+                                            "outerIndex": 1,
+                                            "outerValue": undefined,
+                                            "parent": [Circular],
+                                            "syncErrorThrowable": false,
+                                            "syncErrorThrown": false,
+                                            "syncErrorValue": null,
+                                          },
+                                        ],
+                                        "thrownError": null,
+                                      },
+                                    ],
+                                    "resultSelector": undefined,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                    "toRespond": 0,
+                                    "values": Array [
+                                      undefined,
+                                      "",
+                                    ],
+                                  },
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                              ],
+                              "thrownError": null,
+                            }
+                          }
+                          helpSupportUrl$={
+                            BehaviorSubject {
+                              "_isScalar": false,
+                              "_value": "",
+                              "closed": false,
+                              "hasError": false,
+                              "isStopped": false,
+                              "observers": Array [
+                                InnerSubscriber {
+                                  "_parentOrParents": CombineLatestSubscriber {
+                                    "_parentOrParents": Subscriber {
+                                      "_parentOrParents": null,
+                                      "_subscriptions": Array [
+                                        [Circular],
+                                      ],
+                                      "closed": false,
+                                      "destination": SafeSubscriber {
+                                        "_complete": undefined,
+                                        "_context": [Circular],
+                                        "_error": undefined,
+                                        "_next": [Function],
+                                        "_parentOrParents": null,
+                                        "_parentSubscriber": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "isStopped": false,
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": true,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "_subscriptions": Array [
+                                      InnerSubscriber {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": Array [
+                                          SubjectSubscription {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": null,
+                                            "closed": false,
+                                            "subject": BehaviorSubject {
+                                              "_isScalar": false,
+                                              "_value": undefined,
+                                              "closed": false,
+                                              "hasError": false,
+                                              "isStopped": false,
+                                              "observers": Array [
+                                                [Circular],
+                                              ],
+                                              "thrownError": null,
+                                            },
+                                            "subscriber": [Circular],
+                                          },
+                                        ],
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "index": 1,
+                                        "isStopped": false,
+                                        "outerIndex": 0,
+                                        "outerValue": undefined,
+                                        "parent": [Circular],
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                      [Circular],
+                                    ],
+                                    "active": 2,
+                                    "closed": false,
+                                    "destination": Subscriber {
+                                      "_parentOrParents": null,
+                                      "_subscriptions": Array [
+                                        [Circular],
+                                      ],
+                                      "closed": false,
+                                      "destination": SafeSubscriber {
+                                        "_complete": undefined,
+                                        "_context": [Circular],
+                                        "_error": undefined,
+                                        "_next": [Function],
+                                        "_parentOrParents": null,
+                                        "_parentSubscriber": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "isStopped": false,
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": true,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": true,
+                                    "observables": Array [
+                                      BehaviorSubject {
+                                        "_isScalar": false,
+                                        "_value": undefined,
+                                        "closed": false,
+                                        "hasError": false,
+                                        "isStopped": false,
+                                        "observers": Array [
+                                          InnerSubscriber {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": Array [
+                                              SubjectSubscription {
+                                                "_parentOrParents": [Circular],
+                                                "_subscriptions": null,
+                                                "closed": false,
+                                                "subject": [Circular],
+                                                "subscriber": [Circular],
+                                              },
+                                            ],
+                                            "closed": false,
+                                            "destination": Object {
+                                              "closed": true,
+                                              "complete": [Function],
+                                              "error": [Function],
+                                              "next": [Function],
+                                            },
+                                            "index": 1,
+                                            "isStopped": false,
+                                            "outerIndex": 0,
+                                            "outerValue": undefined,
+                                            "parent": [Circular],
+                                            "syncErrorThrowable": false,
+                                            "syncErrorThrown": false,
+                                            "syncErrorValue": null,
+                                          },
+                                        ],
+                                        "thrownError": null,
+                                      },
+                                      [Circular],
+                                    ],
+                                    "resultSelector": undefined,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                    "toRespond": 0,
+                                    "values": Array [
+                                      undefined,
+                                      "",
+                                    ],
+                                  },
+                                  "_subscriptions": Array [
+                                    SubjectSubscription {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "subject": [Circular],
+                                      "subscriber": [Circular],
+                                    },
+                                  ],
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "index": 1,
+                                  "isStopped": false,
+                                  "outerIndex": 1,
+                                  "outerValue": undefined,
+                                  "parent": CombineLatestSubscriber {
+                                    "_parentOrParents": Subscriber {
+                                      "_parentOrParents": null,
+                                      "_subscriptions": Array [
+                                        [Circular],
+                                      ],
+                                      "closed": false,
+                                      "destination": SafeSubscriber {
+                                        "_complete": undefined,
+                                        "_context": [Circular],
+                                        "_error": undefined,
+                                        "_next": [Function],
+                                        "_parentOrParents": null,
+                                        "_parentSubscriber": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "isStopped": false,
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": true,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "_subscriptions": Array [
+                                      InnerSubscriber {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": Array [
+                                          SubjectSubscription {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": null,
+                                            "closed": false,
+                                            "subject": BehaviorSubject {
+                                              "_isScalar": false,
+                                              "_value": undefined,
+                                              "closed": false,
+                                              "hasError": false,
+                                              "isStopped": false,
+                                              "observers": Array [
+                                                [Circular],
+                                              ],
+                                              "thrownError": null,
+                                            },
+                                            "subscriber": [Circular],
+                                          },
+                                        ],
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "index": 1,
+                                        "isStopped": false,
+                                        "outerIndex": 0,
+                                        "outerValue": undefined,
+                                        "parent": [Circular],
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                      [Circular],
+                                    ],
+                                    "active": 2,
+                                    "closed": false,
+                                    "destination": Subscriber {
+                                      "_parentOrParents": null,
+                                      "_subscriptions": Array [
+                                        [Circular],
+                                      ],
+                                      "closed": false,
+                                      "destination": SafeSubscriber {
+                                        "_complete": undefined,
+                                        "_context": [Circular],
+                                        "_error": undefined,
+                                        "_next": [Function],
+                                        "_parentOrParents": null,
+                                        "_parentSubscriber": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "isStopped": false,
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                      "isStopped": false,
+                                      "syncErrorThrowable": true,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                    "isStopped": true,
+                                    "observables": Array [
+                                      BehaviorSubject {
+                                        "_isScalar": false,
+                                        "_value": undefined,
+                                        "closed": false,
+                                        "hasError": false,
+                                        "isStopped": false,
+                                        "observers": Array [
+                                          InnerSubscriber {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": Array [
+                                              SubjectSubscription {
+                                                "_parentOrParents": [Circular],
+                                                "_subscriptions": null,
+                                                "closed": false,
+                                                "subject": [Circular],
+                                                "subscriber": [Circular],
+                                              },
+                                            ],
+                                            "closed": false,
+                                            "destination": Object {
+                                              "closed": true,
+                                              "complete": [Function],
+                                              "error": [Function],
+                                              "next": [Function],
+                                            },
+                                            "index": 1,
+                                            "isStopped": false,
+                                            "outerIndex": 0,
+                                            "outerValue": undefined,
+                                            "parent": [Circular],
+                                            "syncErrorThrowable": false,
+                                            "syncErrorThrown": false,
+                                            "syncErrorValue": null,
+                                          },
+                                        ],
+                                        "thrownError": null,
+                                      },
+                                      [Circular],
+                                    ],
+                                    "resultSelector": undefined,
+                                    "syncErrorThrowable": true,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                    "toRespond": 0,
+                                    "values": Array [
+                                      undefined,
+                                      "",
+                                    ],
+                                  },
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                              ],
+                              "thrownError": null,
+                            }
+                          }
+                          intl={
+                            Object {
+                              "defaultFormats": Object {},
+                              "defaultLocale": "en",
+                              "formatDate": [Function],
+                              "formatHTMLMessage": [Function],
+                              "formatMessage": [Function],
+                              "formatNumber": [Function],
+                              "formatPlural": [Function],
+                              "formatRelative": [Function],
+                              "formatTime": [Function],
+                              "formats": Object {
+                                "date": Object {
+                                  "full": Object {
+                                    "day": "numeric",
+                                    "month": "long",
+                                    "weekday": "long",
+                                    "year": "numeric",
+                                  },
+                                  "long": Object {
+                                    "day": "numeric",
+                                    "month": "long",
+                                    "year": "numeric",
+                                  },
+                                  "medium": Object {
+                                    "day": "numeric",
+                                    "month": "short",
+                                    "year": "numeric",
+                                  },
+                                  "short": Object {
+                                    "day": "numeric",
+                                    "month": "numeric",
+                                    "year": "2-digit",
+                                  },
+                                },
+                                "number": Object {
+                                  "currency": Object {
+                                    "style": "currency",
+                                  },
+                                  "percent": Object {
+                                    "style": "percent",
+                                  },
+                                },
+                                "relative": Object {
+                                  "days": Object {
+                                    "units": "day",
+                                  },
+                                  "hours": Object {
+                                    "units": "hour",
+                                  },
+                                  "minutes": Object {
+                                    "units": "minute",
+                                  },
+                                  "months": Object {
+                                    "units": "month",
+                                  },
+                                  "seconds": Object {
+                                    "units": "second",
+                                  },
+                                  "years": Object {
+                                    "units": "year",
+                                  },
+                                },
+                                "time": Object {
+                                  "full": Object {
+                                    "hour": "numeric",
+                                    "minute": "numeric",
+                                    "second": "numeric",
+                                    "timeZoneName": "short",
+                                  },
+                                  "long": Object {
+                                    "hour": "numeric",
+                                    "minute": "numeric",
+                                    "second": "numeric",
+                                    "timeZoneName": "short",
+                                  },
+                                  "medium": Object {
+                                    "hour": "numeric",
+                                    "minute": "numeric",
+                                    "second": "numeric",
+                                  },
+                                  "short": Object {
+                                    "hour": "numeric",
+                                    "minute": "numeric",
+                                  },
+                                },
+                              },
+                              "formatters": Object {
+                                "getDateTimeFormat": [Function],
+                                "getMessageFormat": [Function],
+                                "getNumberFormat": [Function],
+                                "getPluralFormat": [Function],
+                                "getRelativeFormat": [Function],
+                              },
+                              "locale": "en",
+                              "messages": Object {},
+                              "now": [Function],
+                              "onError": [Function],
+                              "textComponent": Symbol(react.fragment),
+                              "timeZone": null,
+                            }
+                          }
+                          opensearchDashboardsDocLink="/docs"
+                          opensearchDashboardsVersion="1.0.0"
+                          useDefaultContent={true}
+                        >
+                          <EuiPopover
+                            anchorPosition="downRight"
+                            button={
+                              <EuiHeaderSectionItemButton
+                                aria-expanded={false}
+                                aria-haspopup="true"
+                                aria-label="Help menu"
+                                onClick={[Function]}
+                              >
+                                <EuiIcon
+                                  size="m"
+                                  type="help"
+                                />
+                              </EuiHeaderSectionItemButton>
+                            }
+                            closePopover={[Function]}
+                            data-test-subj="helpMenuButton"
+                            display="inlineBlock"
+                            hasArrow={true}
+                            id="headerHelpMenu"
+                            isOpen={false}
+                            ownFocus={true}
+                            panelPaddingSize="m"
+                            repositionOnScroll={true}
+                          >
+                            <div
+                              className="euiPopover euiPopover--anchorDownRight"
+                              data-test-subj="helpMenuButton"
+                              id="headerHelpMenu"
+                            >
+                              <div
+                                className="euiPopover__anchor"
+                              >
+                                <EuiHeaderSectionItemButton
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
+                                  aria-label="Help menu"
+                                  onClick={[Function]}
+                                >
+                                  <EuiButtonEmpty
+                                    aria-expanded={false}
+                                    aria-haspopup="true"
+                                    aria-label="Help menu"
+                                    buttonRef={
+                                      Object {
+                                        "current": <button
+                                          aria-expanded="false"
+                                          aria-haspopup="true"
+                                          aria-label="Help menu"
+                                          class="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
+                                          type="button"
+                                        >
+                                          <span
+                                            class="euiButtonContent euiButtonEmpty__content"
+                                          >
+                                            <span
+                                              class="euiButtonEmpty__text"
+                                            >
+                                              <span
+                                                class="euiHeaderSectionItemButton__content"
+                                              >
+                                                <span
+                                                  data-euiicon-type="help"
+                                                />
+                                              </span>
+                                            </span>
+                                          </span>
+                                        </button>,
+                                      }
+                                    }
+                                    className="euiHeaderSectionItemButton"
+                                    color="text"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      aria-expanded={false}
+                                      aria-haspopup="true"
+                                      aria-label="Help menu"
+                                      className="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="left"
+                                        iconSize="m"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonEmpty__content"
+                                        >
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            <span
+                                              className="euiHeaderSectionItemButton__content"
+                                            >
+                                              <EuiIcon
+                                                size="m"
+                                                type="help"
+                                              >
+                                                <span
+                                                  data-euiicon-type="help"
+                                                  size="m"
+                                                />
+                                              </EuiIcon>
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </EuiHeaderSectionItemButton>
+                              </div>
+                            </div>
+                          </EuiPopover>
+                        </HeaderHelpMenuUI>
+                      </InjectIntl(HeaderHelpMenuUI)>
+                    </div>
+                  </EuiHeaderSectionItem>
+                  <EuiHeaderSectionItem
+                    border="none"
+                    key="2"
+                  >
+                    <div
+                      className="euiHeaderSectionItem"
+                    >
+                      <HeaderNavControls
+                        navControls$={
+                          BehaviorSubject {
+                            "_isScalar": false,
+                            "_value": Array [],
+                            "closed": false,
+                            "hasError": false,
+                            "isStopped": false,
+                            "observers": Array [
+                              Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  SubjectSubscription {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "subject": [Circular],
+                                    "subscriber": [Circular],
+                                  },
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                            ],
+                            "thrownError": null,
+                          }
+                        }
+                      />
+                    </div>
+                  </EuiHeaderSectionItem>
+                </div>
+              </EuiHeaderSection>
             </div>
-          </EuiHeaderSection>
-        </div>
-      </EuiHeader>
+          </EuiHeader>
+        </Styled(EuiHeader)>
+      </CustomHeader>
       <EuiHeader
         position="fixed"
       >

--- a/src/core/public/chrome/ui/header/branding/__snapshots__/opensearch_dashboards_custom_header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/branding/__snapshots__/opensearch_dashboards_custom_header.test.tsx.snap
@@ -1,0 +1,875 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Styled header rendered using custom colors 1`] = `
+<CustomHeader
+  branding={
+    Object {
+      "colors": Object {
+        "headerBackgroundColor": "#000000",
+        "headerLinkColor": "#ffffff",
+      },
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+>
+  <Styled(EuiHeader)
+    $branding={
+      Object {
+        "colors": Object {
+          "headerBackgroundColor": "#000000",
+          "headerLinkColor": "#ffffff",
+        },
+      }
+    }
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {
+          "date": Object {
+            "full": Object {
+              "day": "numeric",
+              "month": "long",
+              "weekday": "long",
+              "year": "numeric",
+            },
+            "long": Object {
+              "day": "numeric",
+              "month": "long",
+              "year": "numeric",
+            },
+            "medium": Object {
+              "day": "numeric",
+              "month": "short",
+              "year": "numeric",
+            },
+            "short": Object {
+              "day": "numeric",
+              "month": "numeric",
+              "year": "2-digit",
+            },
+          },
+          "number": Object {
+            "currency": Object {
+              "style": "currency",
+            },
+            "percent": Object {
+              "style": "percent",
+            },
+          },
+          "relative": Object {
+            "days": Object {
+              "units": "day",
+            },
+            "hours": Object {
+              "units": "hour",
+            },
+            "minutes": Object {
+              "units": "minute",
+            },
+            "months": Object {
+              "units": "month",
+            },
+            "seconds": Object {
+              "units": "second",
+            },
+            "years": Object {
+              "units": "year",
+            },
+          },
+          "time": Object {
+            "full": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "long": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "medium": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+            },
+            "short": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+            },
+          },
+        },
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": Symbol(react.fragment),
+        "timeZone": null,
+      }
+    }
+  >
+    <EuiHeader
+      className="sc-bczRLJ hHcqzY"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {
+            "date": Object {
+              "full": Object {
+                "day": "numeric",
+                "month": "long",
+                "weekday": "long",
+                "year": "numeric",
+              },
+              "long": Object {
+                "day": "numeric",
+                "month": "long",
+                "year": "numeric",
+              },
+              "medium": Object {
+                "day": "numeric",
+                "month": "short",
+                "year": "numeric",
+              },
+              "short": Object {
+                "day": "numeric",
+                "month": "numeric",
+                "year": "2-digit",
+              },
+            },
+            "number": Object {
+              "currency": Object {
+                "style": "currency",
+              },
+              "percent": Object {
+                "style": "percent",
+              },
+            },
+            "relative": Object {
+              "days": Object {
+                "units": "day",
+              },
+              "hours": Object {
+                "units": "hour",
+              },
+              "minutes": Object {
+                "units": "minute",
+              },
+              "months": Object {
+                "units": "month",
+              },
+              "seconds": Object {
+                "units": "second",
+              },
+              "years": Object {
+                "units": "year",
+              },
+            },
+            "time": Object {
+              "full": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "long": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "medium": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+              },
+              "short": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+              },
+            },
+          },
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {},
+          "now": [Function],
+          "onError": [Function],
+          "textComponent": Symbol(react.fragment),
+          "timeZone": null,
+        }
+      }
+    >
+      <div
+        className="euiHeader euiHeader--default euiHeader--static sc-bczRLJ hHcqzY"
+        intl={
+          Object {
+            "defaultFormats": Object {},
+            "defaultLocale": "en",
+            "formatDate": [Function],
+            "formatHTMLMessage": [Function],
+            "formatMessage": [Function],
+            "formatNumber": [Function],
+            "formatPlural": [Function],
+            "formatRelative": [Function],
+            "formatTime": [Function],
+            "formats": Object {
+              "date": Object {
+                "full": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "weekday": "long",
+                  "year": "numeric",
+                },
+                "long": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "year": "numeric",
+                },
+                "medium": Object {
+                  "day": "numeric",
+                  "month": "short",
+                  "year": "numeric",
+                },
+                "short": Object {
+                  "day": "numeric",
+                  "month": "numeric",
+                  "year": "2-digit",
+                },
+              },
+              "number": Object {
+                "currency": Object {
+                  "style": "currency",
+                },
+                "percent": Object {
+                  "style": "percent",
+                },
+              },
+              "relative": Object {
+                "days": Object {
+                  "units": "day",
+                },
+                "hours": Object {
+                  "units": "hour",
+                },
+                "minutes": Object {
+                  "units": "minute",
+                },
+                "months": Object {
+                  "units": "month",
+                },
+                "seconds": Object {
+                  "units": "second",
+                },
+                "years": Object {
+                  "units": "year",
+                },
+              },
+              "time": Object {
+                "full": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "long": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "medium": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                },
+                "short": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                },
+              },
+            },
+            "formatters": Object {
+              "getDateTimeFormat": [Function],
+              "getMessageFormat": [Function],
+              "getNumberFormat": [Function],
+              "getPluralFormat": [Function],
+              "getRelativeFormat": [Function],
+            },
+            "locale": "en",
+            "messages": Object {},
+            "now": [Function],
+            "onError": [Function],
+            "textComponent": Symbol(react.fragment),
+            "timeZone": null,
+          }
+        }
+      />
+    </EuiHeader>
+  </Styled(EuiHeader)>
+</CustomHeader>
+`;
+
+exports[`Styled header rendered using default colors 1`] = `
+<CustomHeader
+  branding={
+    Object {
+      "colors": Object {},
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+>
+  <Styled(EuiHeader)
+    $branding={
+      Object {
+        "colors": Object {},
+      }
+    }
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {
+          "date": Object {
+            "full": Object {
+              "day": "numeric",
+              "month": "long",
+              "weekday": "long",
+              "year": "numeric",
+            },
+            "long": Object {
+              "day": "numeric",
+              "month": "long",
+              "year": "numeric",
+            },
+            "medium": Object {
+              "day": "numeric",
+              "month": "short",
+              "year": "numeric",
+            },
+            "short": Object {
+              "day": "numeric",
+              "month": "numeric",
+              "year": "2-digit",
+            },
+          },
+          "number": Object {
+            "currency": Object {
+              "style": "currency",
+            },
+            "percent": Object {
+              "style": "percent",
+            },
+          },
+          "relative": Object {
+            "days": Object {
+              "units": "day",
+            },
+            "hours": Object {
+              "units": "hour",
+            },
+            "minutes": Object {
+              "units": "minute",
+            },
+            "months": Object {
+              "units": "month",
+            },
+            "seconds": Object {
+              "units": "second",
+            },
+            "years": Object {
+              "units": "year",
+            },
+          },
+          "time": Object {
+            "full": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "long": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "medium": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+            },
+            "short": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+            },
+          },
+        },
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": Symbol(react.fragment),
+        "timeZone": null,
+      }
+    }
+  >
+    <EuiHeader
+      className="sc-bczRLJ lnGSGL"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {
+            "date": Object {
+              "full": Object {
+                "day": "numeric",
+                "month": "long",
+                "weekday": "long",
+                "year": "numeric",
+              },
+              "long": Object {
+                "day": "numeric",
+                "month": "long",
+                "year": "numeric",
+              },
+              "medium": Object {
+                "day": "numeric",
+                "month": "short",
+                "year": "numeric",
+              },
+              "short": Object {
+                "day": "numeric",
+                "month": "numeric",
+                "year": "2-digit",
+              },
+            },
+            "number": Object {
+              "currency": Object {
+                "style": "currency",
+              },
+              "percent": Object {
+                "style": "percent",
+              },
+            },
+            "relative": Object {
+              "days": Object {
+                "units": "day",
+              },
+              "hours": Object {
+                "units": "hour",
+              },
+              "minutes": Object {
+                "units": "minute",
+              },
+              "months": Object {
+                "units": "month",
+              },
+              "seconds": Object {
+                "units": "second",
+              },
+              "years": Object {
+                "units": "year",
+              },
+            },
+            "time": Object {
+              "full": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "long": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "medium": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+              },
+              "short": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+              },
+            },
+          },
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {},
+          "now": [Function],
+          "onError": [Function],
+          "textComponent": Symbol(react.fragment),
+          "timeZone": null,
+        }
+      }
+    >
+      <div
+        className="euiHeader euiHeader--default euiHeader--static sc-bczRLJ lnGSGL"
+        intl={
+          Object {
+            "defaultFormats": Object {},
+            "defaultLocale": "en",
+            "formatDate": [Function],
+            "formatHTMLMessage": [Function],
+            "formatMessage": [Function],
+            "formatNumber": [Function],
+            "formatPlural": [Function],
+            "formatRelative": [Function],
+            "formatTime": [Function],
+            "formats": Object {
+              "date": Object {
+                "full": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "weekday": "long",
+                  "year": "numeric",
+                },
+                "long": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "year": "numeric",
+                },
+                "medium": Object {
+                  "day": "numeric",
+                  "month": "short",
+                  "year": "numeric",
+                },
+                "short": Object {
+                  "day": "numeric",
+                  "month": "numeric",
+                  "year": "2-digit",
+                },
+              },
+              "number": Object {
+                "currency": Object {
+                  "style": "currency",
+                },
+                "percent": Object {
+                  "style": "percent",
+                },
+              },
+              "relative": Object {
+                "days": Object {
+                  "units": "day",
+                },
+                "hours": Object {
+                  "units": "hour",
+                },
+                "minutes": Object {
+                  "units": "minute",
+                },
+                "months": Object {
+                  "units": "month",
+                },
+                "seconds": Object {
+                  "units": "second",
+                },
+                "years": Object {
+                  "units": "year",
+                },
+              },
+              "time": Object {
+                "full": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "long": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "medium": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                },
+                "short": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                },
+              },
+            },
+            "formatters": Object {
+              "getDateTimeFormat": [Function],
+              "getMessageFormat": [Function],
+              "getNumberFormat": [Function],
+              "getPluralFormat": [Function],
+              "getRelativeFormat": [Function],
+            },
+            "locale": "en",
+            "messages": Object {},
+            "now": [Function],
+            "onError": [Function],
+            "textComponent": Symbol(react.fragment),
+            "timeZone": null,
+          }
+        }
+      />
+    </EuiHeader>
+  </Styled(EuiHeader)>
+</CustomHeader>
+`;

--- a/src/core/public/chrome/ui/header/branding/__snapshots__/opensearch_dashboards_custom_header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/branding/__snapshots__/opensearch_dashboards_custom_header.test.tsx.snap
@@ -1,13 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Styled header rendered using custom colors 1`] = `
+exports[`Styled header in dark mode  rendered using header background dark mode color 1`] = `
 <CustomHeader
   branding={
     Object {
-      "colors": Object {
-        "headerBackgroundColor": "#000000",
-        "headerLinkColor": "#ffffff",
+      "darkMode": true,
+      "headerBackground": Object {
+        "darkModeColor": "#FFFFFF",
+        "defaultColor": "#000000",
       },
+      "headerBorder": Object {},
+      "headerLink": Object {},
     }
   }
   intl={
@@ -114,14 +117,6 @@ exports[`Styled header rendered using custom colors 1`] = `
   }
 >
   <Styled(EuiHeader)
-    $branding={
-      Object {
-        "colors": Object {
-          "headerBackgroundColor": "#000000",
-          "headerLinkColor": "#ffffff",
-        },
-      }
-    }
     intl={
       Object {
         "defaultFormats": Object {},
@@ -224,9 +219,10 @@ exports[`Styled header rendered using custom colors 1`] = `
         "timeZone": null,
       }
     }
+    theme="dark"
   >
     <EuiHeader
-      className="sc-bczRLJ hHcqzY"
+      className="sc-bczRLJ lnGSGL"
       intl={
         Object {
           "defaultFormats": Object {},
@@ -329,9 +325,10 @@ exports[`Styled header rendered using custom colors 1`] = `
           "timeZone": null,
         }
       }
+      theme="dark"
     >
       <div
-        className="euiHeader euiHeader--default euiHeader--static sc-bczRLJ hHcqzY"
+        className="euiHeader euiHeader--dark euiHeader--static sc-bczRLJ lnGSGL"
         intl={
           Object {
             "defaultFormats": Object {},
@@ -440,11 +437,16 @@ exports[`Styled header rendered using custom colors 1`] = `
 </CustomHeader>
 `;
 
-exports[`Styled header rendered using default colors 1`] = `
+exports[`Styled header in dark mode  rendered using header background default color 1`] = `
 <CustomHeader
   branding={
     Object {
-      "colors": Object {},
+      "darkMode": true,
+      "headerBackground": Object {
+        "defaultColor": "#000000",
+      },
+      "headerBorder": Object {},
+      "headerLink": Object {},
     }
   }
   intl={
@@ -551,11 +553,6 @@ exports[`Styled header rendered using default colors 1`] = `
   }
 >
   <Styled(EuiHeader)
-    $branding={
-      Object {
-        "colors": Object {},
-      }
-    }
     intl={
       Object {
         "defaultFormats": Object {},
@@ -658,6 +655,7 @@ exports[`Styled header rendered using default colors 1`] = `
         "timeZone": null,
       }
     }
+    theme="dark"
   >
     <EuiHeader
       className="sc-bczRLJ lnGSGL"
@@ -763,6 +761,3061 @@ exports[`Styled header rendered using default colors 1`] = `
           "timeZone": null,
         }
       }
+      theme="dark"
+    >
+      <div
+        className="euiHeader euiHeader--dark euiHeader--static sc-bczRLJ lnGSGL"
+        intl={
+          Object {
+            "defaultFormats": Object {},
+            "defaultLocale": "en",
+            "formatDate": [Function],
+            "formatHTMLMessage": [Function],
+            "formatMessage": [Function],
+            "formatNumber": [Function],
+            "formatPlural": [Function],
+            "formatRelative": [Function],
+            "formatTime": [Function],
+            "formats": Object {
+              "date": Object {
+                "full": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "weekday": "long",
+                  "year": "numeric",
+                },
+                "long": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "year": "numeric",
+                },
+                "medium": Object {
+                  "day": "numeric",
+                  "month": "short",
+                  "year": "numeric",
+                },
+                "short": Object {
+                  "day": "numeric",
+                  "month": "numeric",
+                  "year": "2-digit",
+                },
+              },
+              "number": Object {
+                "currency": Object {
+                  "style": "currency",
+                },
+                "percent": Object {
+                  "style": "percent",
+                },
+              },
+              "relative": Object {
+                "days": Object {
+                  "units": "day",
+                },
+                "hours": Object {
+                  "units": "hour",
+                },
+                "minutes": Object {
+                  "units": "minute",
+                },
+                "months": Object {
+                  "units": "month",
+                },
+                "seconds": Object {
+                  "units": "second",
+                },
+                "years": Object {
+                  "units": "year",
+                },
+              },
+              "time": Object {
+                "full": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "long": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "medium": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                },
+                "short": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                },
+              },
+            },
+            "formatters": Object {
+              "getDateTimeFormat": [Function],
+              "getMessageFormat": [Function],
+              "getNumberFormat": [Function],
+              "getPluralFormat": [Function],
+              "getRelativeFormat": [Function],
+            },
+            "locale": "en",
+            "messages": Object {},
+            "now": [Function],
+            "onError": [Function],
+            "textComponent": Symbol(react.fragment),
+            "timeZone": null,
+          }
+        }
+      />
+    </EuiHeader>
+  </Styled(EuiHeader)>
+</CustomHeader>
+`;
+
+exports[`Styled header in dark mode  rendered using header border dark mode color 1`] = `
+<CustomHeader
+  branding={
+    Object {
+      "darkMode": true,
+      "headerBackground": Object {},
+      "headerBorder": Object {
+        "darkModeColor": "#FFFFFF",
+        "defaultColor": "#000000",
+      },
+      "headerLink": Object {},
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+>
+  <Styled(EuiHeader)
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {
+          "date": Object {
+            "full": Object {
+              "day": "numeric",
+              "month": "long",
+              "weekday": "long",
+              "year": "numeric",
+            },
+            "long": Object {
+              "day": "numeric",
+              "month": "long",
+              "year": "numeric",
+            },
+            "medium": Object {
+              "day": "numeric",
+              "month": "short",
+              "year": "numeric",
+            },
+            "short": Object {
+              "day": "numeric",
+              "month": "numeric",
+              "year": "2-digit",
+            },
+          },
+          "number": Object {
+            "currency": Object {
+              "style": "currency",
+            },
+            "percent": Object {
+              "style": "percent",
+            },
+          },
+          "relative": Object {
+            "days": Object {
+              "units": "day",
+            },
+            "hours": Object {
+              "units": "hour",
+            },
+            "minutes": Object {
+              "units": "minute",
+            },
+            "months": Object {
+              "units": "month",
+            },
+            "seconds": Object {
+              "units": "second",
+            },
+            "years": Object {
+              "units": "year",
+            },
+          },
+          "time": Object {
+            "full": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "long": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "medium": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+            },
+            "short": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+            },
+          },
+        },
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": Symbol(react.fragment),
+        "timeZone": null,
+      }
+    }
+    theme="dark"
+  >
+    <EuiHeader
+      className="sc-bczRLJ lnGSGL"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {
+            "date": Object {
+              "full": Object {
+                "day": "numeric",
+                "month": "long",
+                "weekday": "long",
+                "year": "numeric",
+              },
+              "long": Object {
+                "day": "numeric",
+                "month": "long",
+                "year": "numeric",
+              },
+              "medium": Object {
+                "day": "numeric",
+                "month": "short",
+                "year": "numeric",
+              },
+              "short": Object {
+                "day": "numeric",
+                "month": "numeric",
+                "year": "2-digit",
+              },
+            },
+            "number": Object {
+              "currency": Object {
+                "style": "currency",
+              },
+              "percent": Object {
+                "style": "percent",
+              },
+            },
+            "relative": Object {
+              "days": Object {
+                "units": "day",
+              },
+              "hours": Object {
+                "units": "hour",
+              },
+              "minutes": Object {
+                "units": "minute",
+              },
+              "months": Object {
+                "units": "month",
+              },
+              "seconds": Object {
+                "units": "second",
+              },
+              "years": Object {
+                "units": "year",
+              },
+            },
+            "time": Object {
+              "full": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "long": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "medium": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+              },
+              "short": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+              },
+            },
+          },
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {},
+          "now": [Function],
+          "onError": [Function],
+          "textComponent": Symbol(react.fragment),
+          "timeZone": null,
+        }
+      }
+      theme="dark"
+    >
+      <div
+        className="euiHeader euiHeader--dark euiHeader--static sc-bczRLJ lnGSGL"
+        intl={
+          Object {
+            "defaultFormats": Object {},
+            "defaultLocale": "en",
+            "formatDate": [Function],
+            "formatHTMLMessage": [Function],
+            "formatMessage": [Function],
+            "formatNumber": [Function],
+            "formatPlural": [Function],
+            "formatRelative": [Function],
+            "formatTime": [Function],
+            "formats": Object {
+              "date": Object {
+                "full": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "weekday": "long",
+                  "year": "numeric",
+                },
+                "long": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "year": "numeric",
+                },
+                "medium": Object {
+                  "day": "numeric",
+                  "month": "short",
+                  "year": "numeric",
+                },
+                "short": Object {
+                  "day": "numeric",
+                  "month": "numeric",
+                  "year": "2-digit",
+                },
+              },
+              "number": Object {
+                "currency": Object {
+                  "style": "currency",
+                },
+                "percent": Object {
+                  "style": "percent",
+                },
+              },
+              "relative": Object {
+                "days": Object {
+                  "units": "day",
+                },
+                "hours": Object {
+                  "units": "hour",
+                },
+                "minutes": Object {
+                  "units": "minute",
+                },
+                "months": Object {
+                  "units": "month",
+                },
+                "seconds": Object {
+                  "units": "second",
+                },
+                "years": Object {
+                  "units": "year",
+                },
+              },
+              "time": Object {
+                "full": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "long": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "medium": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                },
+                "short": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                },
+              },
+            },
+            "formatters": Object {
+              "getDateTimeFormat": [Function],
+              "getMessageFormat": [Function],
+              "getNumberFormat": [Function],
+              "getPluralFormat": [Function],
+              "getRelativeFormat": [Function],
+            },
+            "locale": "en",
+            "messages": Object {},
+            "now": [Function],
+            "onError": [Function],
+            "textComponent": Symbol(react.fragment),
+            "timeZone": null,
+          }
+        }
+      />
+    </EuiHeader>
+  </Styled(EuiHeader)>
+</CustomHeader>
+`;
+
+exports[`Styled header in dark mode  rendered using header border default color 1`] = `
+<CustomHeader
+  branding={
+    Object {
+      "darkMode": true,
+      "headerBackground": Object {},
+      "headerBorder": Object {
+        "defaultColor": "#000000",
+      },
+      "headerLink": Object {},
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+>
+  <Styled(EuiHeader)
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {
+          "date": Object {
+            "full": Object {
+              "day": "numeric",
+              "month": "long",
+              "weekday": "long",
+              "year": "numeric",
+            },
+            "long": Object {
+              "day": "numeric",
+              "month": "long",
+              "year": "numeric",
+            },
+            "medium": Object {
+              "day": "numeric",
+              "month": "short",
+              "year": "numeric",
+            },
+            "short": Object {
+              "day": "numeric",
+              "month": "numeric",
+              "year": "2-digit",
+            },
+          },
+          "number": Object {
+            "currency": Object {
+              "style": "currency",
+            },
+            "percent": Object {
+              "style": "percent",
+            },
+          },
+          "relative": Object {
+            "days": Object {
+              "units": "day",
+            },
+            "hours": Object {
+              "units": "hour",
+            },
+            "minutes": Object {
+              "units": "minute",
+            },
+            "months": Object {
+              "units": "month",
+            },
+            "seconds": Object {
+              "units": "second",
+            },
+            "years": Object {
+              "units": "year",
+            },
+          },
+          "time": Object {
+            "full": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "long": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "medium": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+            },
+            "short": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+            },
+          },
+        },
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": Symbol(react.fragment),
+        "timeZone": null,
+      }
+    }
+    theme="dark"
+  >
+    <EuiHeader
+      className="sc-bczRLJ lnGSGL"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {
+            "date": Object {
+              "full": Object {
+                "day": "numeric",
+                "month": "long",
+                "weekday": "long",
+                "year": "numeric",
+              },
+              "long": Object {
+                "day": "numeric",
+                "month": "long",
+                "year": "numeric",
+              },
+              "medium": Object {
+                "day": "numeric",
+                "month": "short",
+                "year": "numeric",
+              },
+              "short": Object {
+                "day": "numeric",
+                "month": "numeric",
+                "year": "2-digit",
+              },
+            },
+            "number": Object {
+              "currency": Object {
+                "style": "currency",
+              },
+              "percent": Object {
+                "style": "percent",
+              },
+            },
+            "relative": Object {
+              "days": Object {
+                "units": "day",
+              },
+              "hours": Object {
+                "units": "hour",
+              },
+              "minutes": Object {
+                "units": "minute",
+              },
+              "months": Object {
+                "units": "month",
+              },
+              "seconds": Object {
+                "units": "second",
+              },
+              "years": Object {
+                "units": "year",
+              },
+            },
+            "time": Object {
+              "full": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "long": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "medium": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+              },
+              "short": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+              },
+            },
+          },
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {},
+          "now": [Function],
+          "onError": [Function],
+          "textComponent": Symbol(react.fragment),
+          "timeZone": null,
+        }
+      }
+      theme="dark"
+    >
+      <div
+        className="euiHeader euiHeader--dark euiHeader--static sc-bczRLJ lnGSGL"
+        intl={
+          Object {
+            "defaultFormats": Object {},
+            "defaultLocale": "en",
+            "formatDate": [Function],
+            "formatHTMLMessage": [Function],
+            "formatMessage": [Function],
+            "formatNumber": [Function],
+            "formatPlural": [Function],
+            "formatRelative": [Function],
+            "formatTime": [Function],
+            "formats": Object {
+              "date": Object {
+                "full": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "weekday": "long",
+                  "year": "numeric",
+                },
+                "long": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "year": "numeric",
+                },
+                "medium": Object {
+                  "day": "numeric",
+                  "month": "short",
+                  "year": "numeric",
+                },
+                "short": Object {
+                  "day": "numeric",
+                  "month": "numeric",
+                  "year": "2-digit",
+                },
+              },
+              "number": Object {
+                "currency": Object {
+                  "style": "currency",
+                },
+                "percent": Object {
+                  "style": "percent",
+                },
+              },
+              "relative": Object {
+                "days": Object {
+                  "units": "day",
+                },
+                "hours": Object {
+                  "units": "hour",
+                },
+                "minutes": Object {
+                  "units": "minute",
+                },
+                "months": Object {
+                  "units": "month",
+                },
+                "seconds": Object {
+                  "units": "second",
+                },
+                "years": Object {
+                  "units": "year",
+                },
+              },
+              "time": Object {
+                "full": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "long": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "medium": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                },
+                "short": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                },
+              },
+            },
+            "formatters": Object {
+              "getDateTimeFormat": [Function],
+              "getMessageFormat": [Function],
+              "getNumberFormat": [Function],
+              "getPluralFormat": [Function],
+              "getRelativeFormat": [Function],
+            },
+            "locale": "en",
+            "messages": Object {},
+            "now": [Function],
+            "onError": [Function],
+            "textComponent": Symbol(react.fragment),
+            "timeZone": null,
+          }
+        }
+      />
+    </EuiHeader>
+  </Styled(EuiHeader)>
+</CustomHeader>
+`;
+
+exports[`Styled header in dark mode  rendered using header link dark mode color 1`] = `
+<CustomHeader
+  branding={
+    Object {
+      "darkMode": true,
+      "headerBackground": Object {},
+      "headerBorder": Object {},
+      "headerLink": Object {
+        "darkModeColor": "#FFFFFF",
+        "defaultColor": "#000000",
+      },
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+>
+  <Styled(EuiHeader)
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {
+          "date": Object {
+            "full": Object {
+              "day": "numeric",
+              "month": "long",
+              "weekday": "long",
+              "year": "numeric",
+            },
+            "long": Object {
+              "day": "numeric",
+              "month": "long",
+              "year": "numeric",
+            },
+            "medium": Object {
+              "day": "numeric",
+              "month": "short",
+              "year": "numeric",
+            },
+            "short": Object {
+              "day": "numeric",
+              "month": "numeric",
+              "year": "2-digit",
+            },
+          },
+          "number": Object {
+            "currency": Object {
+              "style": "currency",
+            },
+            "percent": Object {
+              "style": "percent",
+            },
+          },
+          "relative": Object {
+            "days": Object {
+              "units": "day",
+            },
+            "hours": Object {
+              "units": "hour",
+            },
+            "minutes": Object {
+              "units": "minute",
+            },
+            "months": Object {
+              "units": "month",
+            },
+            "seconds": Object {
+              "units": "second",
+            },
+            "years": Object {
+              "units": "year",
+            },
+          },
+          "time": Object {
+            "full": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "long": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "medium": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+            },
+            "short": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+            },
+          },
+        },
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": Symbol(react.fragment),
+        "timeZone": null,
+      }
+    }
+    theme="dark"
+  >
+    <EuiHeader
+      className="sc-bczRLJ lnGSGL"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {
+            "date": Object {
+              "full": Object {
+                "day": "numeric",
+                "month": "long",
+                "weekday": "long",
+                "year": "numeric",
+              },
+              "long": Object {
+                "day": "numeric",
+                "month": "long",
+                "year": "numeric",
+              },
+              "medium": Object {
+                "day": "numeric",
+                "month": "short",
+                "year": "numeric",
+              },
+              "short": Object {
+                "day": "numeric",
+                "month": "numeric",
+                "year": "2-digit",
+              },
+            },
+            "number": Object {
+              "currency": Object {
+                "style": "currency",
+              },
+              "percent": Object {
+                "style": "percent",
+              },
+            },
+            "relative": Object {
+              "days": Object {
+                "units": "day",
+              },
+              "hours": Object {
+                "units": "hour",
+              },
+              "minutes": Object {
+                "units": "minute",
+              },
+              "months": Object {
+                "units": "month",
+              },
+              "seconds": Object {
+                "units": "second",
+              },
+              "years": Object {
+                "units": "year",
+              },
+            },
+            "time": Object {
+              "full": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "long": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "medium": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+              },
+              "short": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+              },
+            },
+          },
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {},
+          "now": [Function],
+          "onError": [Function],
+          "textComponent": Symbol(react.fragment),
+          "timeZone": null,
+        }
+      }
+      theme="dark"
+    >
+      <div
+        className="euiHeader euiHeader--dark euiHeader--static sc-bczRLJ lnGSGL"
+        intl={
+          Object {
+            "defaultFormats": Object {},
+            "defaultLocale": "en",
+            "formatDate": [Function],
+            "formatHTMLMessage": [Function],
+            "formatMessage": [Function],
+            "formatNumber": [Function],
+            "formatPlural": [Function],
+            "formatRelative": [Function],
+            "formatTime": [Function],
+            "formats": Object {
+              "date": Object {
+                "full": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "weekday": "long",
+                  "year": "numeric",
+                },
+                "long": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "year": "numeric",
+                },
+                "medium": Object {
+                  "day": "numeric",
+                  "month": "short",
+                  "year": "numeric",
+                },
+                "short": Object {
+                  "day": "numeric",
+                  "month": "numeric",
+                  "year": "2-digit",
+                },
+              },
+              "number": Object {
+                "currency": Object {
+                  "style": "currency",
+                },
+                "percent": Object {
+                  "style": "percent",
+                },
+              },
+              "relative": Object {
+                "days": Object {
+                  "units": "day",
+                },
+                "hours": Object {
+                  "units": "hour",
+                },
+                "minutes": Object {
+                  "units": "minute",
+                },
+                "months": Object {
+                  "units": "month",
+                },
+                "seconds": Object {
+                  "units": "second",
+                },
+                "years": Object {
+                  "units": "year",
+                },
+              },
+              "time": Object {
+                "full": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "long": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "medium": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                },
+                "short": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                },
+              },
+            },
+            "formatters": Object {
+              "getDateTimeFormat": [Function],
+              "getMessageFormat": [Function],
+              "getNumberFormat": [Function],
+              "getPluralFormat": [Function],
+              "getRelativeFormat": [Function],
+            },
+            "locale": "en",
+            "messages": Object {},
+            "now": [Function],
+            "onError": [Function],
+            "textComponent": Symbol(react.fragment),
+            "timeZone": null,
+          }
+        }
+      />
+    </EuiHeader>
+  </Styled(EuiHeader)>
+</CustomHeader>
+`;
+
+exports[`Styled header in dark mode  rendered using header link default color 1`] = `
+<CustomHeader
+  branding={
+    Object {
+      "darkMode": true,
+      "headerBackground": Object {},
+      "headerBorder": Object {},
+      "headerLink": Object {
+        "defaultColor": "#000000",
+      },
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+>
+  <Styled(EuiHeader)
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {
+          "date": Object {
+            "full": Object {
+              "day": "numeric",
+              "month": "long",
+              "weekday": "long",
+              "year": "numeric",
+            },
+            "long": Object {
+              "day": "numeric",
+              "month": "long",
+              "year": "numeric",
+            },
+            "medium": Object {
+              "day": "numeric",
+              "month": "short",
+              "year": "numeric",
+            },
+            "short": Object {
+              "day": "numeric",
+              "month": "numeric",
+              "year": "2-digit",
+            },
+          },
+          "number": Object {
+            "currency": Object {
+              "style": "currency",
+            },
+            "percent": Object {
+              "style": "percent",
+            },
+          },
+          "relative": Object {
+            "days": Object {
+              "units": "day",
+            },
+            "hours": Object {
+              "units": "hour",
+            },
+            "minutes": Object {
+              "units": "minute",
+            },
+            "months": Object {
+              "units": "month",
+            },
+            "seconds": Object {
+              "units": "second",
+            },
+            "years": Object {
+              "units": "year",
+            },
+          },
+          "time": Object {
+            "full": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "long": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "medium": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+            },
+            "short": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+            },
+          },
+        },
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": Symbol(react.fragment),
+        "timeZone": null,
+      }
+    }
+    theme="dark"
+  >
+    <EuiHeader
+      className="sc-bczRLJ lnGSGL"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {
+            "date": Object {
+              "full": Object {
+                "day": "numeric",
+                "month": "long",
+                "weekday": "long",
+                "year": "numeric",
+              },
+              "long": Object {
+                "day": "numeric",
+                "month": "long",
+                "year": "numeric",
+              },
+              "medium": Object {
+                "day": "numeric",
+                "month": "short",
+                "year": "numeric",
+              },
+              "short": Object {
+                "day": "numeric",
+                "month": "numeric",
+                "year": "2-digit",
+              },
+            },
+            "number": Object {
+              "currency": Object {
+                "style": "currency",
+              },
+              "percent": Object {
+                "style": "percent",
+              },
+            },
+            "relative": Object {
+              "days": Object {
+                "units": "day",
+              },
+              "hours": Object {
+                "units": "hour",
+              },
+              "minutes": Object {
+                "units": "minute",
+              },
+              "months": Object {
+                "units": "month",
+              },
+              "seconds": Object {
+                "units": "second",
+              },
+              "years": Object {
+                "units": "year",
+              },
+            },
+            "time": Object {
+              "full": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "long": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "medium": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+              },
+              "short": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+              },
+            },
+          },
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {},
+          "now": [Function],
+          "onError": [Function],
+          "textComponent": Symbol(react.fragment),
+          "timeZone": null,
+        }
+      }
+      theme="dark"
+    >
+      <div
+        className="euiHeader euiHeader--dark euiHeader--static sc-bczRLJ lnGSGL"
+        intl={
+          Object {
+            "defaultFormats": Object {},
+            "defaultLocale": "en",
+            "formatDate": [Function],
+            "formatHTMLMessage": [Function],
+            "formatMessage": [Function],
+            "formatNumber": [Function],
+            "formatPlural": [Function],
+            "formatRelative": [Function],
+            "formatTime": [Function],
+            "formats": Object {
+              "date": Object {
+                "full": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "weekday": "long",
+                  "year": "numeric",
+                },
+                "long": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "year": "numeric",
+                },
+                "medium": Object {
+                  "day": "numeric",
+                  "month": "short",
+                  "year": "numeric",
+                },
+                "short": Object {
+                  "day": "numeric",
+                  "month": "numeric",
+                  "year": "2-digit",
+                },
+              },
+              "number": Object {
+                "currency": Object {
+                  "style": "currency",
+                },
+                "percent": Object {
+                  "style": "percent",
+                },
+              },
+              "relative": Object {
+                "days": Object {
+                  "units": "day",
+                },
+                "hours": Object {
+                  "units": "hour",
+                },
+                "minutes": Object {
+                  "units": "minute",
+                },
+                "months": Object {
+                  "units": "month",
+                },
+                "seconds": Object {
+                  "units": "second",
+                },
+                "years": Object {
+                  "units": "year",
+                },
+              },
+              "time": Object {
+                "full": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "long": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "medium": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                },
+                "short": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                },
+              },
+            },
+            "formatters": Object {
+              "getDateTimeFormat": [Function],
+              "getMessageFormat": [Function],
+              "getNumberFormat": [Function],
+              "getPluralFormat": [Function],
+              "getRelativeFormat": [Function],
+            },
+            "locale": "en",
+            "messages": Object {},
+            "now": [Function],
+            "onError": [Function],
+            "textComponent": Symbol(react.fragment),
+            "timeZone": null,
+          }
+        }
+      />
+    </EuiHeader>
+  </Styled(EuiHeader)>
+</CustomHeader>
+`;
+
+exports[`Styled header in default mode  rendered using header background default color 1`] = `
+<CustomHeader
+  branding={
+    Object {
+      "darkMode": false,
+      "headerBackground": Object {
+        "defaultColor": "#000000",
+      },
+      "headerBorder": Object {},
+      "headerLink": Object {},
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+>
+  <Styled(EuiHeader)
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {
+          "date": Object {
+            "full": Object {
+              "day": "numeric",
+              "month": "long",
+              "weekday": "long",
+              "year": "numeric",
+            },
+            "long": Object {
+              "day": "numeric",
+              "month": "long",
+              "year": "numeric",
+            },
+            "medium": Object {
+              "day": "numeric",
+              "month": "short",
+              "year": "numeric",
+            },
+            "short": Object {
+              "day": "numeric",
+              "month": "numeric",
+              "year": "2-digit",
+            },
+          },
+          "number": Object {
+            "currency": Object {
+              "style": "currency",
+            },
+            "percent": Object {
+              "style": "percent",
+            },
+          },
+          "relative": Object {
+            "days": Object {
+              "units": "day",
+            },
+            "hours": Object {
+              "units": "hour",
+            },
+            "minutes": Object {
+              "units": "minute",
+            },
+            "months": Object {
+              "units": "month",
+            },
+            "seconds": Object {
+              "units": "second",
+            },
+            "years": Object {
+              "units": "year",
+            },
+          },
+          "time": Object {
+            "full": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "long": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "medium": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+            },
+            "short": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+            },
+          },
+        },
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": Symbol(react.fragment),
+        "timeZone": null,
+      }
+    }
+    theme="default"
+  >
+    <EuiHeader
+      className="sc-bczRLJ lnGSGL"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {
+            "date": Object {
+              "full": Object {
+                "day": "numeric",
+                "month": "long",
+                "weekday": "long",
+                "year": "numeric",
+              },
+              "long": Object {
+                "day": "numeric",
+                "month": "long",
+                "year": "numeric",
+              },
+              "medium": Object {
+                "day": "numeric",
+                "month": "short",
+                "year": "numeric",
+              },
+              "short": Object {
+                "day": "numeric",
+                "month": "numeric",
+                "year": "2-digit",
+              },
+            },
+            "number": Object {
+              "currency": Object {
+                "style": "currency",
+              },
+              "percent": Object {
+                "style": "percent",
+              },
+            },
+            "relative": Object {
+              "days": Object {
+                "units": "day",
+              },
+              "hours": Object {
+                "units": "hour",
+              },
+              "minutes": Object {
+                "units": "minute",
+              },
+              "months": Object {
+                "units": "month",
+              },
+              "seconds": Object {
+                "units": "second",
+              },
+              "years": Object {
+                "units": "year",
+              },
+            },
+            "time": Object {
+              "full": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "long": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "medium": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+              },
+              "short": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+              },
+            },
+          },
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {},
+          "now": [Function],
+          "onError": [Function],
+          "textComponent": Symbol(react.fragment),
+          "timeZone": null,
+        }
+      }
+      theme="default"
+    >
+      <div
+        className="euiHeader euiHeader--default euiHeader--static sc-bczRLJ lnGSGL"
+        intl={
+          Object {
+            "defaultFormats": Object {},
+            "defaultLocale": "en",
+            "formatDate": [Function],
+            "formatHTMLMessage": [Function],
+            "formatMessage": [Function],
+            "formatNumber": [Function],
+            "formatPlural": [Function],
+            "formatRelative": [Function],
+            "formatTime": [Function],
+            "formats": Object {
+              "date": Object {
+                "full": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "weekday": "long",
+                  "year": "numeric",
+                },
+                "long": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "year": "numeric",
+                },
+                "medium": Object {
+                  "day": "numeric",
+                  "month": "short",
+                  "year": "numeric",
+                },
+                "short": Object {
+                  "day": "numeric",
+                  "month": "numeric",
+                  "year": "2-digit",
+                },
+              },
+              "number": Object {
+                "currency": Object {
+                  "style": "currency",
+                },
+                "percent": Object {
+                  "style": "percent",
+                },
+              },
+              "relative": Object {
+                "days": Object {
+                  "units": "day",
+                },
+                "hours": Object {
+                  "units": "hour",
+                },
+                "minutes": Object {
+                  "units": "minute",
+                },
+                "months": Object {
+                  "units": "month",
+                },
+                "seconds": Object {
+                  "units": "second",
+                },
+                "years": Object {
+                  "units": "year",
+                },
+              },
+              "time": Object {
+                "full": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "long": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "medium": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                },
+                "short": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                },
+              },
+            },
+            "formatters": Object {
+              "getDateTimeFormat": [Function],
+              "getMessageFormat": [Function],
+              "getNumberFormat": [Function],
+              "getPluralFormat": [Function],
+              "getRelativeFormat": [Function],
+            },
+            "locale": "en",
+            "messages": Object {},
+            "now": [Function],
+            "onError": [Function],
+            "textComponent": Symbol(react.fragment),
+            "timeZone": null,
+          }
+        }
+      />
+    </EuiHeader>
+  </Styled(EuiHeader)>
+</CustomHeader>
+`;
+
+exports[`Styled header in default mode  rendered using header border default color 1`] = `
+<CustomHeader
+  branding={
+    Object {
+      "darkMode": false,
+      "headerBackground": Object {},
+      "headerBorder": Object {
+        "defaultColor": "#000000",
+      },
+      "headerLink": Object {},
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+>
+  <Styled(EuiHeader)
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {
+          "date": Object {
+            "full": Object {
+              "day": "numeric",
+              "month": "long",
+              "weekday": "long",
+              "year": "numeric",
+            },
+            "long": Object {
+              "day": "numeric",
+              "month": "long",
+              "year": "numeric",
+            },
+            "medium": Object {
+              "day": "numeric",
+              "month": "short",
+              "year": "numeric",
+            },
+            "short": Object {
+              "day": "numeric",
+              "month": "numeric",
+              "year": "2-digit",
+            },
+          },
+          "number": Object {
+            "currency": Object {
+              "style": "currency",
+            },
+            "percent": Object {
+              "style": "percent",
+            },
+          },
+          "relative": Object {
+            "days": Object {
+              "units": "day",
+            },
+            "hours": Object {
+              "units": "hour",
+            },
+            "minutes": Object {
+              "units": "minute",
+            },
+            "months": Object {
+              "units": "month",
+            },
+            "seconds": Object {
+              "units": "second",
+            },
+            "years": Object {
+              "units": "year",
+            },
+          },
+          "time": Object {
+            "full": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "long": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "medium": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+            },
+            "short": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+            },
+          },
+        },
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": Symbol(react.fragment),
+        "timeZone": null,
+      }
+    }
+    theme="default"
+  >
+    <EuiHeader
+      className="sc-bczRLJ lnGSGL"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {
+            "date": Object {
+              "full": Object {
+                "day": "numeric",
+                "month": "long",
+                "weekday": "long",
+                "year": "numeric",
+              },
+              "long": Object {
+                "day": "numeric",
+                "month": "long",
+                "year": "numeric",
+              },
+              "medium": Object {
+                "day": "numeric",
+                "month": "short",
+                "year": "numeric",
+              },
+              "short": Object {
+                "day": "numeric",
+                "month": "numeric",
+                "year": "2-digit",
+              },
+            },
+            "number": Object {
+              "currency": Object {
+                "style": "currency",
+              },
+              "percent": Object {
+                "style": "percent",
+              },
+            },
+            "relative": Object {
+              "days": Object {
+                "units": "day",
+              },
+              "hours": Object {
+                "units": "hour",
+              },
+              "minutes": Object {
+                "units": "minute",
+              },
+              "months": Object {
+                "units": "month",
+              },
+              "seconds": Object {
+                "units": "second",
+              },
+              "years": Object {
+                "units": "year",
+              },
+            },
+            "time": Object {
+              "full": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "long": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "medium": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+              },
+              "short": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+              },
+            },
+          },
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {},
+          "now": [Function],
+          "onError": [Function],
+          "textComponent": Symbol(react.fragment),
+          "timeZone": null,
+        }
+      }
+      theme="default"
+    >
+      <div
+        className="euiHeader euiHeader--default euiHeader--static sc-bczRLJ lnGSGL"
+        intl={
+          Object {
+            "defaultFormats": Object {},
+            "defaultLocale": "en",
+            "formatDate": [Function],
+            "formatHTMLMessage": [Function],
+            "formatMessage": [Function],
+            "formatNumber": [Function],
+            "formatPlural": [Function],
+            "formatRelative": [Function],
+            "formatTime": [Function],
+            "formats": Object {
+              "date": Object {
+                "full": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "weekday": "long",
+                  "year": "numeric",
+                },
+                "long": Object {
+                  "day": "numeric",
+                  "month": "long",
+                  "year": "numeric",
+                },
+                "medium": Object {
+                  "day": "numeric",
+                  "month": "short",
+                  "year": "numeric",
+                },
+                "short": Object {
+                  "day": "numeric",
+                  "month": "numeric",
+                  "year": "2-digit",
+                },
+              },
+              "number": Object {
+                "currency": Object {
+                  "style": "currency",
+                },
+                "percent": Object {
+                  "style": "percent",
+                },
+              },
+              "relative": Object {
+                "days": Object {
+                  "units": "day",
+                },
+                "hours": Object {
+                  "units": "hour",
+                },
+                "minutes": Object {
+                  "units": "minute",
+                },
+                "months": Object {
+                  "units": "month",
+                },
+                "seconds": Object {
+                  "units": "second",
+                },
+                "years": Object {
+                  "units": "year",
+                },
+              },
+              "time": Object {
+                "full": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "long": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                  "timeZoneName": "short",
+                },
+                "medium": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                  "second": "numeric",
+                },
+                "short": Object {
+                  "hour": "numeric",
+                  "minute": "numeric",
+                },
+              },
+            },
+            "formatters": Object {
+              "getDateTimeFormat": [Function],
+              "getMessageFormat": [Function],
+              "getNumberFormat": [Function],
+              "getPluralFormat": [Function],
+              "getRelativeFormat": [Function],
+            },
+            "locale": "en",
+            "messages": Object {},
+            "now": [Function],
+            "onError": [Function],
+            "textComponent": Symbol(react.fragment),
+            "timeZone": null,
+          }
+        }
+      />
+    </EuiHeader>
+  </Styled(EuiHeader)>
+</CustomHeader>
+`;
+
+exports[`Styled header in default mode  rendered using header link default color 1`] = `
+<CustomHeader
+  branding={
+    Object {
+      "darkMode": false,
+      "headerBackground": Object {},
+      "headerBorder": Object {},
+      "headerLink": Object {
+        "defaultColor": "#000000",
+      },
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+>
+  <Styled(EuiHeader)
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {
+          "date": Object {
+            "full": Object {
+              "day": "numeric",
+              "month": "long",
+              "weekday": "long",
+              "year": "numeric",
+            },
+            "long": Object {
+              "day": "numeric",
+              "month": "long",
+              "year": "numeric",
+            },
+            "medium": Object {
+              "day": "numeric",
+              "month": "short",
+              "year": "numeric",
+            },
+            "short": Object {
+              "day": "numeric",
+              "month": "numeric",
+              "year": "2-digit",
+            },
+          },
+          "number": Object {
+            "currency": Object {
+              "style": "currency",
+            },
+            "percent": Object {
+              "style": "percent",
+            },
+          },
+          "relative": Object {
+            "days": Object {
+              "units": "day",
+            },
+            "hours": Object {
+              "units": "hour",
+            },
+            "minutes": Object {
+              "units": "minute",
+            },
+            "months": Object {
+              "units": "month",
+            },
+            "seconds": Object {
+              "units": "second",
+            },
+            "years": Object {
+              "units": "year",
+            },
+          },
+          "time": Object {
+            "full": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "long": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "medium": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+            },
+            "short": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+            },
+          },
+        },
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": Symbol(react.fragment),
+        "timeZone": null,
+      }
+    }
+    theme="default"
+  >
+    <EuiHeader
+      className="sc-bczRLJ lnGSGL"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {
+            "date": Object {
+              "full": Object {
+                "day": "numeric",
+                "month": "long",
+                "weekday": "long",
+                "year": "numeric",
+              },
+              "long": Object {
+                "day": "numeric",
+                "month": "long",
+                "year": "numeric",
+              },
+              "medium": Object {
+                "day": "numeric",
+                "month": "short",
+                "year": "numeric",
+              },
+              "short": Object {
+                "day": "numeric",
+                "month": "numeric",
+                "year": "2-digit",
+              },
+            },
+            "number": Object {
+              "currency": Object {
+                "style": "currency",
+              },
+              "percent": Object {
+                "style": "percent",
+              },
+            },
+            "relative": Object {
+              "days": Object {
+                "units": "day",
+              },
+              "hours": Object {
+                "units": "hour",
+              },
+              "minutes": Object {
+                "units": "minute",
+              },
+              "months": Object {
+                "units": "month",
+              },
+              "seconds": Object {
+                "units": "second",
+              },
+              "years": Object {
+                "units": "year",
+              },
+            },
+            "time": Object {
+              "full": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "long": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "medium": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+              },
+              "short": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+              },
+            },
+          },
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {},
+          "now": [Function],
+          "onError": [Function],
+          "textComponent": Symbol(react.fragment),
+          "timeZone": null,
+        }
+      }
+      theme="default"
     >
       <div
         className="euiHeader euiHeader--default euiHeader--static sc-bczRLJ lnGSGL"

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_header.test.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_header.test.tsx
@@ -8,24 +8,154 @@ import { mountWithIntl } from 'test_utils/enzyme_helpers';
 import { CustomHeader } from './opensearch_dashboards_custom_header';
 
 describe('Styled header', () => {
-  it('rendered using default colors', () => {
-    const props = {
-      branding: { colors: {} },
-    };
-    const component = mountWithIntl(<CustomHeader {...props} />);
-    expect(component).toMatchSnapshot();
+  describe('in default mode ', () => {
+    it('rendered using header background default color', () => {
+      const props = {
+        branding: {
+          darkMode: false,
+          headerBackground: {
+            defaultColor: '#000000',
+          },
+          headerLink: {},
+          headerBorder: {},
+        },
+      };
+
+      const component = mountWithIntl(<CustomHeader {...props} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using header link default color', () => {
+      const props = {
+        branding: {
+          darkMode: false,
+          headerBackground: {},
+          headerLink: {
+            defaultColor: '#000000',
+          },
+          headerBorder: {},
+        },
+      };
+
+      const component = mountWithIntl(<CustomHeader {...props} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using header border default color', () => {
+      const props = {
+        branding: {
+          darkMode: false,
+          headerBackground: {},
+          headerLink: {},
+          headerBorder: {
+            defaultColor: '#000000',
+          },
+        },
+      };
+
+      const component = mountWithIntl(<CustomHeader {...props} />);
+      expect(component).toMatchSnapshot();
+    });
   });
 
-  it('rendered using custom colors', () => {
-    const props = {
-      branding: {
-        colors: {
-          headerBackgroundColor: '#000000',
-          headerLinkColor: '#ffffff',
+  describe('in dark mode ', () => {
+    it('rendered using header background dark mode color', () => {
+      const props = {
+        branding: {
+          darkMode: true,
+          headerBackground: {
+            defaultColor: '#000000',
+            darkModeColor: '#FFFFFF',
+          },
+          headerLink: {},
+          headerBorder: {},
         },
-      },
-    };
-    const component = mountWithIntl(<CustomHeader {...props} />);
-    expect(component).toMatchSnapshot();
+      };
+
+      const component = mountWithIntl(<CustomHeader {...props} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using header background default color', () => {
+      const props = {
+        branding: {
+          darkMode: true,
+          headerBackground: {
+            defaultColor: '#000000',
+          },
+          headerLink: {},
+          headerBorder: {},
+        },
+      };
+
+      const component = mountWithIntl(<CustomHeader {...props} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using header link dark mode color', () => {
+      const props = {
+        branding: {
+          darkMode: true,
+          headerBackground: {},
+          headerLink: {
+            defaultColor: '#000000',
+            darkModeColor: '#FFFFFF',
+          },
+          headerBorder: {},
+        },
+      };
+
+      const component = mountWithIntl(<CustomHeader {...props} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using header link default color', () => {
+      const props = {
+        branding: {
+          darkMode: true,
+          headerBackground: {},
+          headerLink: {
+            defaultColor: '#000000',
+          },
+          headerBorder: {},
+        },
+      };
+
+      const component = mountWithIntl(<CustomHeader {...props} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using header border dark mode color', () => {
+      const props = {
+        branding: {
+          darkMode: true,
+          headerBackground: {},
+          headerLink: {},
+          headerBorder: {
+            defaultColor: '#000000',
+            darkModeColor: '#FFFFFF',
+          },
+        },
+      };
+
+      const component = mountWithIntl(<CustomHeader {...props} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    it('rendered using header border default color', () => {
+      const props = {
+        branding: {
+          darkMode: true,
+          headerBackground: {},
+          headerLink: {},
+          headerBorder: {
+            defaultColor: '#000000',
+          },
+        },
+      };
+
+      const component = mountWithIntl(<CustomHeader {...props} />);
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_header.test.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_header.test.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
+import { CustomHeader } from './opensearch_dashboards_custom_header';
+
+describe('Styled header', () => {
+  it('rendered using default colors', () => {
+    const props = {
+      branding: { colors: {} },
+    };
+    const component = mountWithIntl(<CustomHeader {...props} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('rendered using custom colors', () => {
+    const props = {
+      branding: {
+        colors: {
+          headerBackgroundColor: '#000000',
+          headerLinkColor: '#ffffff',
+        },
+      },
+    };
+    const component = mountWithIntl(<CustomHeader {...props} />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_header.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_header.tsx
@@ -8,7 +8,9 @@ import styled from 'styled-components';
 import { ChromeBranding } from '../../../chrome_service';
 
 interface StyledHeaderProps {
-  $branding: ChromeBranding;
+  $backgroundColor: string | undefined;
+  $borderColor: string | undefined;
+  $linkColor: string | undefined;
 }
 
 export type CustomHeaderProps = EuiHeaderProps & {
@@ -16,16 +18,47 @@ export type CustomHeaderProps = EuiHeaderProps & {
 };
 
 const StyledHeader = styled(EuiHeader)<StyledHeaderProps>`
-  background-color: ${(props) => props.$branding.colors?.headerBackgroundColor};
-  border-bottom-color: ${(props) => props.$branding.colors?.headerBackgroundColor};
+  background-color: ${(props) => props.$backgroundColor};
+  border-bottom-color: ${(props) => props.$borderColor};
   .euiHeaderLink,
   .euiHeaderSectionItemButton {
-    color: ${(props) => props.$branding.colors?.headerLinkColor};
+    color: ${(props) => props.$linkColor};
   }
 `;
 
 export const CustomHeader = (props: CustomHeaderProps) => {
   const { branding, ...rest } = props;
+  const darkMode = branding.darkMode;
+  const backgroundDefault = branding.colors?.headerBackground?.defaultColor;
+  const backgroundDarkMode = branding.colors?.headerBackground?.darkModeColor;
+  const linkDefault = branding.colors?.headerLink?.defaultColor;
+  const linkDarkMode = branding.colors?.headerLink?.darkModeColor;
+  const borderDefault = branding.colors?.headerBorder?.defaultColor;
+  const borderDarkMode = branding.colors?.headerBorder?.darkModeColor;
 
-  return <StyledHeader $branding={branding} {...rest} />;
+  const theme = () => {
+    return darkMode ? 'dark' : 'default';
+  };
+
+  const backgroundColor = () => {
+    return darkMode ? backgroundDarkMode ?? backgroundDefault : backgroundDefault;
+  };
+
+  const linkColor = () => {
+    return darkMode ? linkDarkMode ?? linkDefault : linkDefault;
+  };
+
+  const borderColor = () => {
+    return darkMode ? borderDarkMode ?? borderDefault : borderDefault;
+  };
+
+  return (
+    <StyledHeader
+      $backgroundColor={backgroundColor()}
+      $linkColor={linkColor()}
+      $borderColor={borderColor()}
+      theme={theme()}
+      {...rest}
+    />
+  );
 };

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_header.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_header.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { EuiHeader, EuiHeaderProps } from '@elastic/eui';
+import React from 'react';
+import styled from 'styled-components';
+import { ChromeBranding } from '../../../chrome_service';
+
+interface StyledHeaderProps {
+  $branding: ChromeBranding;
+}
+
+export type CustomHeaderProps = EuiHeaderProps & {
+  branding: ChromeBranding;
+};
+
+const StyledHeader = styled(EuiHeader)<StyledHeaderProps>`
+  background-color: ${(props) => props.$branding.colors?.headerBackgroundColor};
+  border-bottom-color: ${(props) => props.$branding.colors?.headerBackgroundColor};
+  .euiHeaderLink,
+  .euiHeaderSectionItemButton {
+    color: ${(props) => props.$branding.colors?.headerLinkColor};
+  }
+`;
+
+export const CustomHeader = (props: CustomHeaderProps) => {
+  const { branding, ...rest } = props;
+
+  return <StyledHeader $branding={branding} {...rest} />;
+};

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -62,6 +62,7 @@ import { HeaderHelpMenu } from './header_help_menu';
 import { HeaderLogo } from './header_logo';
 import { HeaderNavControls } from './header_nav_controls';
 import { HeaderActionMenu } from './header_action_menu';
+import { CustomHeader } from './branding/opensearch_dashboards_custom_header';
 
 export interface HeaderProps {
   opensearchDashboardsVersion: string;
@@ -114,7 +115,7 @@ export function Header({
     <>
       <header className={className} data-test-subj="headerGlobalNav">
         <div id="globalHeaderBars">
-          <EuiHeader
+          <CustomHeader
             theme="dark"
             position="fixed"
             sections={[
@@ -157,6 +158,7 @@ export function Header({
                 borders: 'none',
               },
             ]}
+            branding={branding}
           />
 
           <EuiHeader position="fixed">

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -116,7 +116,6 @@ export function Header({
       <header className={className} data-test-subj="headerGlobalNav">
         <div id="globalHeaderBars">
           <CustomHeader
-            theme="dark"
             position="fixed"
             sections={[
               {

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -81,6 +81,14 @@ export const config = {
       applicationTitle: schema.string({
         defaultValue: '',
       }),
+      colors: schema.object({
+        headerBackgroundColor: schema.string({
+          defaultValue: '',
+        }),
+        headerLinkColor: schema.string({
+          defaultValue: '',
+        }),
+      }),
     }),
   }),
   deprecations,

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -82,11 +82,29 @@ export const config = {
         defaultValue: '',
       }),
       colors: schema.object({
-        headerBackgroundColor: schema.string({
-          defaultValue: '',
+        headerBackground: schema.object({
+          defaultColor: schema.string({
+            defaultValue: '',
+          }),
+          darkModeColor: schema.string({
+            defaultValue: '',
+          }),
         }),
-        headerLinkColor: schema.string({
-          defaultValue: '',
+        headerLink: schema.object({
+          defaultColor: schema.string({
+            defaultValue: '',
+          }),
+          darkModeColor: schema.string({
+            defaultValue: '',
+          }),
+        }),
+        headerBorder: schema.object({
+          defaultColor: schema.string({
+            defaultValue: '',
+          }),
+          darkModeColor: schema.string({
+            defaultValue: '',
+          }),
         }),
       }),
     }),

--- a/src/core/server/rendering/__mocks__/rendering_service.ts
+++ b/src/core/server/rendering/__mocks__/rendering_service.ts
@@ -42,11 +42,13 @@ export const mockSetup = jest.fn().mockResolvedValue(setupMock);
 export const mockStop = jest.fn();
 export const mockIsUrlValid = jest.fn();
 export const mockIsTitleValid = jest.fn();
+export const mockIsColorValid = jest.fn();
 export const mockRenderingService: jest.Mocked<IRenderingService> = {
   setup: mockSetup,
   stop: mockStop,
   isUrlValid: mockIsUrlValid,
   isTitleValid: mockIsTitleValid,
+  isColorValid: mockIsColorValid,
 };
 export const RenderingService = jest.fn<IRenderingService, [typeof mockRenderingServiceParams]>(
   () => mockRenderingService

--- a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
@@ -8,7 +8,11 @@ Object {
   "branding": Object {
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
-    "colors": Object {},
+    "colors": Object {
+      "headerBackground": Object {},
+      "headerBorder": Object {},
+      "headerLink": Object {},
+    },
     "darkMode": false,
     "loadingLogo": Object {},
     "logo": Object {},
@@ -60,7 +64,11 @@ Object {
   "branding": Object {
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
-    "colors": Object {},
+    "colors": Object {
+      "headerBackground": Object {},
+      "headerBorder": Object {},
+      "headerLink": Object {},
+    },
     "darkMode": false,
     "loadingLogo": Object {},
     "logo": Object {},
@@ -112,7 +120,11 @@ Object {
   "branding": Object {
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
-    "colors": Object {},
+    "colors": Object {
+      "headerBackground": Object {},
+      "headerBorder": Object {},
+      "headerLink": Object {},
+    },
     "darkMode": true,
     "loadingLogo": Object {},
     "logo": Object {},
@@ -168,7 +180,11 @@ Object {
   "branding": Object {
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/ui/default_branding",
-    "colors": Object {},
+    "colors": Object {
+      "headerBackground": Object {},
+      "headerBorder": Object {},
+      "headerLink": Object {},
+    },
     "darkMode": false,
     "loadingLogo": Object {},
     "logo": Object {},
@@ -220,7 +236,11 @@ Object {
   "branding": Object {
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
-    "colors": Object {},
+    "colors": Object {
+      "headerBackground": Object {},
+      "headerBorder": Object {},
+      "headerLink": Object {},
+    },
     "darkMode": false,
     "loadingLogo": Object {},
     "logo": Object {},

--- a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
@@ -8,6 +8,7 @@ Object {
   "branding": Object {
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
+    "colors": Object {},
     "darkMode": false,
     "loadingLogo": Object {},
     "logo": Object {},
@@ -59,6 +60,7 @@ Object {
   "branding": Object {
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
+    "colors": Object {},
     "darkMode": false,
     "loadingLogo": Object {},
     "logo": Object {},
@@ -110,6 +112,7 @@ Object {
   "branding": Object {
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
+    "colors": Object {},
     "darkMode": true,
     "loadingLogo": Object {},
     "logo": Object {},
@@ -165,6 +168,7 @@ Object {
   "branding": Object {
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/ui/default_branding",
+    "colors": Object {},
     "darkMode": false,
     "loadingLogo": Object {},
     "logo": Object {},
@@ -216,6 +220,7 @@ Object {
   "branding": Object {
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
+    "colors": Object {},
     "darkMode": false,
     "loadingLogo": Object {},
     "logo": Object {},

--- a/src/core/server/rendering/rendering_service.test.ts
+++ b/src/core/server/rendering/rendering_service.test.ts
@@ -184,4 +184,31 @@ describe('RenderingService', () => {
       expect(result).toEqual(false);
     });
   });
+
+  describe('isColorValid()', () => {
+    it('checks valid HEX color code', async () => {
+      const result = await service.isColorValid('#000000', 'config');
+      expect(result).toEqual(true);
+    });
+
+    it('checks valid 3 digit HEX color code', async () => {
+      const result = await service.isColorValid('#000', 'config');
+      expect(result).toEqual(true);
+    });
+
+    it('checks valid RGB color code', async () => {
+      const result = await service.isColorValid('rgb(0, 0, 0)', 'config');
+      expect(result).toEqual(true);
+    });
+
+    it('checks valid RGB color code with percentages', async () => {
+      const result = await service.isColorValid('rgb(0%, 0%, 0%)', 'config');
+      expect(result).toEqual(true);
+    });
+
+    it('checks invalid color code', async () => {
+      const result = await service.isColorValid('invalid', 'config');
+      expect(result).toEqual(false);
+    });
+  });
 });

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -149,8 +149,18 @@ export class RenderingService {
               faviconUrl: brandingAssignment.favicon,
               applicationTitle: brandingAssignment.applicationTitle,
               colors: {
-                headerBackgroundColor: brandingAssignment.headerBackgroundColor,
-                headerLinkColor: brandingAssignment.headerLinkColor,
+                headerBackground: {
+                  defaultColor: brandingAssignment.headerBackgroundColorDefault,
+                  darkModeColor: brandingAssignment.headerBackgroundColorDark,
+                },
+                headerLink: {
+                  defaultColor: brandingAssignment.headerLinkColorDefault,
+                  darkModeColor: brandingAssignment.headerLinkColorDark,
+                },
+                headerBorder: {
+                  defaultColor: brandingAssignment.headerBorderColorDefault,
+                  darkModeColor: brandingAssignment.headerBorderColorDark,
+                },
               },
             },
           },
@@ -269,14 +279,64 @@ export class RenderingService {
       ? branding.applicationTitle
       : DEFAULT_TITLE;
 
-    // assign theme colors based on brandingValidation function result
-    const headerBackgroundColor = brandingValidation.isHeaderColorValid
-      ? branding.colors.headerBackgroundColor
+    // assign default colors based on brandingValidation function result
+    const headerBackgroundColorDefault = brandingValidation.isHeaderColorDefaultValid
+      ? branding.colors.headerBackground.defaultColor
       : undefined;
 
-    const headerLinkColor = brandingValidation.isLinkColorValid
-      ? branding.colors.headerLinkColor
+    const headerLinkColorDefault = brandingValidation.isLinkColorDefaultValid
+      ? branding.colors.headerLink.defaultColor
       : undefined;
+
+    const headerBorderColorDefault = brandingValidation.isBorderColorDefaultValid
+      ? branding.colors.headerBorder.defaultColor
+      : undefined;
+
+    // assign dark mode colors based on brandingValidation function result
+    let headerBackgroundColorDark = brandingValidation.isHeaderColorDarkValid
+      ? branding.colors.headerBackground.darkModeColor
+      : undefined;
+
+    let headerLinkColorDark = brandingValidation.isLinkColorDarkValid
+      ? branding.colors.headerLink.darkModeColor
+      : undefined;
+
+    let headerBorderColorDark = brandingValidation.isBorderColorDarkValid
+      ? branding.colors.headerBorder.darkModeColor
+      : undefined;
+
+    /**
+     * For dark mode colors, we added another validation:
+     * user can only provide a dark mode color after providing a valid default mode color,
+     * If user provides a valid dark mode color but fails to provide a valid default mode color,
+     * return undefined for the dark mode color
+     */
+    if (headerBackgroundColorDark && !headerBackgroundColorDefault) {
+      this.logger
+        .get('branding')
+        .error(
+          'Must provide a valid header background default mode color before providing a header background dark mode color'
+        );
+      headerBackgroundColorDark = undefined;
+    }
+
+    if (headerLinkColorDark && !headerLinkColorDefault) {
+      this.logger
+        .get('branding')
+        .error(
+          'Must provide a valid header link default mode color before providing a header link dark mode color'
+        );
+      headerLinkColorDark = undefined;
+    }
+
+    if (headerBorderColorDark && !headerBorderColorDefault) {
+      this.logger
+        .get('branding')
+        .error(
+          'Must provide a valid header border default mode color before providing a header border dark mode color'
+        );
+      headerBorderColorDark = undefined;
+    }
 
     const brandingAssignment: BrandingAssignment = {
       logoDefault,
@@ -287,8 +347,12 @@ export class RenderingService {
       loadingLogoDarkmode,
       favicon,
       applicationTitle,
-      headerBackgroundColor,
-      headerLinkColor,
+      headerBackgroundColorDefault,
+      headerBackgroundColorDark,
+      headerLinkColorDefault,
+      headerLinkColorDark,
+      headerBorderColorDefault,
+      headerBorderColorDark,
     };
 
     return brandingAssignment;
@@ -333,14 +397,34 @@ export class RenderingService {
 
     const isTitleValid = this.isTitleValid(branding.applicationTitle, 'applicationTitle');
 
-    const isHeaderColorValid = this.isColorValid(
-      branding.colors.headerBackgroundColor,
-      'header background color'
+    const isHeaderColorDefaultValid = this.isColorValid(
+      branding.colors.headerBackground.defaultColor,
+      'header background color default'
     );
 
-    const isLinkColorValid = this.isColorValid(
-      branding.colors.headerLinkColor,
-      'header link color'
+    const isHeaderColorDarkValid = this.isColorValid(
+      branding.colors.headerBackground.darkModeColor,
+      'header background color dark mode'
+    );
+
+    const isLinkColorDefaultValid = this.isColorValid(
+      branding.colors.headerLink.defaultColor,
+      'header link color default'
+    );
+
+    const isLinkColorDarkValid = this.isColorValid(
+      branding.colors.headerLink.darkModeColor,
+      'header link color dark mode'
+    );
+
+    const isBorderColorDefaultValid = this.isColorValid(
+      branding.colors.headerBorder.defaultColor,
+      'header border color default'
+    );
+
+    const isBorderColorDarkValid = this.isColorValid(
+      branding.colors.headerBorder.darkModeColor,
+      'header border color dark mode'
     );
 
     const brandingValidation: BrandingValidation = {
@@ -352,8 +436,12 @@ export class RenderingService {
       isLoadingLogoDarkmodeValid,
       isFaviconValid,
       isTitleValid,
-      isHeaderColorValid,
-      isLinkColorValid,
+      isHeaderColorDefaultValid,
+      isHeaderColorDarkValid,
+      isLinkColorDefaultValid,
+      isLinkColorDarkValid,
+      isBorderColorDefaultValid,
+      isBorderColorDarkValid,
     };
 
     return brandingValidation;

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -148,6 +148,10 @@ export class RenderingService {
               },
               faviconUrl: brandingAssignment.favicon,
               applicationTitle: brandingAssignment.applicationTitle,
+              colors: {
+                headerBackgroundColor: brandingAssignment.headerBackgroundColor,
+                headerLinkColor: brandingAssignment.headerLinkColor,
+              },
             },
           },
         };
@@ -265,6 +269,15 @@ export class RenderingService {
       ? branding.applicationTitle
       : DEFAULT_TITLE;
 
+    // assign theme colors based on brandingValidation function result
+    const headerBackgroundColor = brandingValidation.isHeaderColorValid
+      ? branding.colors.headerBackgroundColor
+      : undefined;
+
+    const headerLinkColor = brandingValidation.isLinkColorValid
+      ? branding.colors.headerLinkColor
+      : undefined;
+
     const brandingAssignment: BrandingAssignment = {
       logoDefault,
       logoDarkmode,
@@ -274,6 +287,8 @@ export class RenderingService {
       loadingLogoDarkmode,
       favicon,
       applicationTitle,
+      headerBackgroundColor,
+      headerLinkColor,
     };
 
     return brandingAssignment;
@@ -318,6 +333,16 @@ export class RenderingService {
 
     const isTitleValid = this.isTitleValid(branding.applicationTitle, 'applicationTitle');
 
+    const isHeaderColorValid = this.isColorValid(
+      branding.colors.headerBackgroundColor,
+      'header background color'
+    );
+
+    const isLinkColorValid = this.isColorValid(
+      branding.colors.headerLinkColor,
+      'header link color'
+    );
+
     const brandingValidation: BrandingValidation = {
       isLogoDefaultValid,
       isLogoDarkmodeValid,
@@ -327,6 +352,8 @@ export class RenderingService {
       isLoadingLogoDarkmodeValid,
       isFaviconValid,
       isTitleValid,
+      isHeaderColorValid,
+      isLinkColorValid,
     };
 
     return brandingValidation;
@@ -388,6 +415,25 @@ export class RenderingService {
         .error(
           `${configName} config is not found or invalid. Title length should be between 1 to 36 characters. Using default title.`
         );
+      return false;
+    }
+    return true;
+  };
+
+  /**
+   * Validation function for HEX colors.
+   *
+   * @param {string} color code
+   * @param {string} configName
+   * @returns {boolean} indicate if the color code is valid/invalid
+   */
+  public isColorValid = (color: string, configName?: string): boolean => {
+    const validColor = /^(#[0-9a-f]{3}|#([0-9a-f]{2}){2,4}|rgb\((-?\d+\s*,\s*){2}(-?\d+\s*)\)|rgb\((-?\d+%\s*,\s*){2}(-?\d+%\s*)\)|)$/i;
+    if (!color) {
+      return false;
+    }
+    if (color.match(validColor) === null) {
+      this.logger.get('branding').error(`${configName} config is invalid. Using default branding.`);
       return false;
     }
     return true;

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -133,8 +133,12 @@ export interface BrandingValidation {
   isLoadingLogoDarkmodeValid: boolean;
   isFaviconValid: boolean;
   isTitleValid: boolean;
-  isHeaderColorValid: boolean;
-  isLinkColorValid: boolean;
+  isHeaderColorDefaultValid: boolean;
+  isHeaderColorDarkValid: boolean;
+  isLinkColorDefaultValid: boolean;
+  isLinkColorDarkValid: boolean;
+  isBorderColorDefaultValid: boolean;
+  isBorderColorDarkValid: boolean;
 }
 
 /**
@@ -151,6 +155,10 @@ export interface BrandingAssignment {
   loadingLogoDarkmode?: string;
   favicon?: string;
   applicationTitle?: string;
-  headerBackgroundColor?: string;
-  headerLinkColor?: string;
+  headerBackgroundColorDefault?: string;
+  headerBackgroundColorDark?: string;
+  headerLinkColorDefault?: string;
+  headerLinkColorDark?: string;
+  headerBorderColorDefault?: string;
+  headerBorderColorDark?: string;
 }

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -133,6 +133,8 @@ export interface BrandingValidation {
   isLoadingLogoDarkmodeValid: boolean;
   isFaviconValid: boolean;
   isTitleValid: boolean;
+  isHeaderColorValid: boolean;
+  isLinkColorValid: boolean;
 }
 
 /**
@@ -149,4 +151,6 @@ export interface BrandingAssignment {
   loadingLogoDarkmode?: string;
   favicon?: string;
   applicationTitle?: string;
+  headerBackgroundColor?: string;
+  headerLinkColor?: string;
 }

--- a/src/core/types/custom_branding.ts
+++ b/src/core/types/custom_branding.ts
@@ -59,7 +59,17 @@ export interface Branding {
   applicationTitle?: string;
   /** Custom nav bar header colors */
   colors?: {
-    headerBackgroundColor?: string;
-    headerLinkColor?: string;
+    headerBackground?: {
+      defaultColor?: string;
+      darkModeColor?: string;
+    };
+    headerLink?: {
+      defaultColor?: string;
+      darkModeColor?: string;
+    };
+    headerBorder?: {
+      defaultColor?: string;
+      darkModeColor?: string;
+    };
   };
 }

--- a/src/core/types/custom_branding.ts
+++ b/src/core/types/custom_branding.ts
@@ -57,4 +57,9 @@ export interface Branding {
   faviconUrl?: string;
   /** Application title that will replace the default opensearch dashboard string */
   applicationTitle?: string;
+  /** Custom nav bar header colors */
+  colors?: {
+    headerBackgroundColor?: string;
+    headerLinkColor?: string;
+  };
 }

--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -246,8 +246,18 @@ export default () =>
         faviconUrl: Joi.any().default('/'),
         applicationTitle: Joi.any().default(''),
         colors: Joi.object({
-          headerBackgroundColor: Joi.any().default(''),
-          headerLinkColor: Joi.any().default(''),
+          headerBackground: Joi.object({
+            defaultColor: Joi.any().default(''),
+            darkModeColor: Joi.any().default(''),
+          }),
+          headerLink: Joi.object({
+            defaultColor: Joi.any().default(''),
+            darkModeColor: Joi.any().default(''),
+          }),
+          headerBorder: Joi.object({
+            defaultColor: Joi.any().default(''),
+            darkModeColor: Joi.any().default(''),
+          }),
         }),
       }),
     }).default(),

--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -245,6 +245,10 @@ export default () =>
         }),
         faviconUrl: Joi.any().default('/'),
         applicationTitle: Joi.any().default(''),
+        colors: Joi.object({
+          headerBackgroundColor: Joi.any().default(''),
+          headerLinkColor: Joi.any().default(''),
+        }),
       }),
     }).default(),
 


### PR DESCRIPTION
### Description
Adds two new configs `branding.colors.headerBackgroundColor` and `branding.colors.headerLinkColor` in the yaml file to
make the top header background and link colors configurable.
Valid values are HEX and RGB color codes.

![imagen](https://user-images.githubusercontent.com/26812577/162980189-401b0407-be01-4bf3-a65d-80b23fd4baa7.png)
 
### Issues Resolved
 #1368
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 