### PR TITLE
update re2 for linux, darwin, and windows

### DIFF
--- a/src/dev/build/tasks/patch_native_modules_task.ts
+++ b/src/dev/build/tasks/patch_native_modules_task.ts
@@ -58,20 +58,20 @@ const packages: Package[] = [
     extractMethod: 'gunzip',
     archives: {
       'darwin-x64': {
-        url: 'https://github.com/uhop/node-re2/releases/download/1.15.4/darwin-x64-64.gz',
-        sha256: '595c6653d796493ddb288fc0732a0d1df8560099796f55a1dd242357d96bb8d6',
+        url: 'https://github.com/uhop/node-re2/releases/download/1.15.4/darwin-x64-83.gz',
+        sha256: 'b45cd8296fd6eb2a091399c20111af43093ba30c99ed9e5d969278f5ff69ba8f',
       },
       'linux-x64': {
-        url: 'https://github.com/uhop/node-re2/releases/download/1.15.4/linux-x64-64.gz',
-        sha256: 'e743587bc96314edf10c3e659c03168bc374a5cd9a6623ee99d989251e331f28',
+        url: 'https://github.com/uhop/node-re2/releases/download/1.15.4/linux-x64-83.gz',
+        sha256: '1bbc3f90f0ba105772b37c04e3a718f69544b4df01dda00435c2b8e50b2ad0d9',
       },
       'linux-arm64': {
         url: 'https://d1v1sj258etie.cloudfront.net/node-re2/1.15.4/linux-arm64-64.gz',
         sha256: '19fa97f39d4965276382429bcd932dd696915f711663e7cef9b0a304b3e8e6f7',
       },
       'win32-x64': {
-        url: 'https://github.com/uhop/node-re2/releases/download/1.15.4/win32-x64-64.gz',
-        sha256: 'b33de62cda24fb02dc80a19fb79977d686468ac746e97cd211059d2d4c75d529',
+        url: 'https://github.com/uhop/node-re2/releases/download/1.15.4/win32-x64-83.gz',
+        sha256: 'efe939d3cda1d64ee3ee3e60a20613b95166d55632e702c670763ea7e69fca06',
       },
     },
   },


### PR DESCRIPTION
### Description
Update re2 to 83

<img width="1587" alt="Screen Shot 2022-04-13 at 11 53 52" src="https://user-images.githubusercontent.com/79961084/163250464-e9dbbb72-0447-4b4e-b710-7b42046d8d8e.png">

 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1452
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 