### PR TITLE
update re2 build for arm under node 14

### DIFF
--- a/src/dev/build/tasks/patch_native_modules_task.test.ts
+++ b/src/dev/build/tasks/patch_native_modules_task.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ToolingLog,
+  ToolingLogCollectingWriter,
+  createAnyInstanceSerializer,
+  createAbsolutePathSerializer,
+} from '@osd/dev-utils';
+import { Build, Config } from '../lib';
+import { PatchNativeModules } from './patch_native_modules_task';
+
+const log = new ToolingLog();
+const testWriter = new ToolingLogCollectingWriter();
+log.setWriters([testWriter]);
+expect.addSnapshotSerializer(createAnyInstanceSerializer(Config));
+expect.addSnapshotSerializer(createAnyInstanceSerializer(ToolingLog));
+expect.addSnapshotSerializer(createAbsolutePathSerializer());
+
+jest.mock('../lib/download');
+jest.mock('../lib/fs', () => ({
+  ...jest.requireActual('../lib/fs'),
+  untar: jest.fn(),
+  gunzip: jest.fn(),
+}));
+
+const { untar } = jest.requireMock('../lib/fs');
+const { gunzip } = jest.requireMock('../lib/fs');
+const { download } = jest.requireMock('../lib/download');
+
+async function setup() {
+  const config = await Config.create({
+    isRelease: true,
+    targetAllPlatforms: false,
+    targetPlatforms: {
+      linux: false,
+      linuxArm: false,
+      darwin: false,
+    },
+  });
+
+  const build = new Build(config);
+
+  download.mockImplementation(() => {});
+  untar.mockImplementation(() => {});
+  gunzip.mockImplementation(() => {});
+
+  return { config, build };
+}
+
+beforeEach(() => {
+  testWriter.messages.length = 0;
+  jest.clearAllMocks();
+});
+
+it('patch native modules task downloads the correct platform package', async () => {
+  const { config, build } = await setup();
+  config.targetPlatforms.linuxArm = true;
+  await PatchNativeModules.run(config, log, build);
+  expect(download.mock.calls.length).toBe(1);
+  expect(download.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          "destination": <absolute path>/.native_modules/re2/linux-arm64-83.tar.gz,
+          "log": <ToolingLog>,
+          "retries": 3,
+          "sha256": "f25124adc64d269a513b99abd4a5eed8d7a929db565207f8ece1f3b7b7931668",
+          "url": "https://d1v1sj258etie.cloudfront.net/node-re2/releases/download/1.15.4/linux-arm64-83.tar.gz",
+        },
+      ],
+    ]
+  `);
+});
+
+it('for .tar.gz artifact, patch native modules task unzip it via untar', async () => {
+  const { config, build } = await setup();
+  config.targetPlatforms.linuxArm = true;
+  await PatchNativeModules.run(config, log, build);
+  expect(untar.mock.calls.length).toBe(1);
+  expect(gunzip.mock.calls.length).toBe(0);
+});
+
+it('for .gz artifact, patch native modules task unzip it via gunzip', async () => {
+  const { config, build } = await setup();
+  config.targetPlatforms.linux = true;
+  await PatchNativeModules.run(config, log, build);
+  expect(untar.mock.calls.length).toBe(0);
+  expect(gunzip.mock.calls.length).toBe(1);
+});

--- a/src/dev/build/tasks/patch_native_modules_task.ts
+++ b/src/dev/build/tasks/patch_native_modules_task.ts
@@ -46,6 +46,8 @@ interface Package {
     {
       url: string;
       sha256: string;
+      overriddenExtractMethod?: string;
+      overriddenDestinationPath?: string;
     }
   >;
 }
@@ -66,8 +68,11 @@ const packages: Package[] = [
         sha256: 'e743587bc96314edf10c3e659c03168bc374a5cd9a6623ee99d989251e331f28',
       },
       'linux-arm64': {
-        url: 'https://d1v1sj258etie.cloudfront.net/node-re2/1.15.4/linux-arm64-64.gz',
-        sha256: '19fa97f39d4965276382429bcd932dd696915f711663e7cef9b0a304b3e8e6f7',
+        url:
+          'https://d1v1sj258etie.cloudfront.net/node-re2/releases/download/1.15.4/linux-arm64-83.tar.gz',
+        sha256: 'f25124adc64d269a513b99abd4a5eed8d7a929db565207f8ece1f3b7b7931668',
+        overriddenExtractMethod: 'untar',
+        overriddenDestinationPath: 'node_modules/re2/build/Release',
       },
       'win32-x64': {
         url: 'https://github.com/uhop/node-re2/releases/download/1.15.4/win32-x64-64.gz',
@@ -103,7 +108,11 @@ async function patchModule(
   const archive = pkg.archives[platformName];
   const archiveName = path.basename(archive.url);
   const downloadPath = config.resolveFromRepo(DOWNLOAD_DIRECTORY, pkg.name, archiveName);
-  const extractPath = build.resolvePathForPlatform(platform, pkg.destinationPath);
+  const extractMethod = archive.overriddenExtractMethod || pkg.extractMethod;
+  const extractPath = build.resolvePathForPlatform(
+    platform,
+    archive.overriddenDestinationPath || pkg.destinationPath
+  );
   log.debug(`Patching ${pkg.name} binaries from ${archive.url} to ${extractPath}`);
 
   await deleteAll([extractPath], log);
@@ -114,7 +123,7 @@ async function patchModule(
     sha256: archive.sha256,
     retries: 3,
   });
-  switch (pkg.extractMethod) {
+  switch (extractMethod) {
     case 'gunzip':
       await gunzip(downloadPath, extractPath);
       break;
@@ -122,7 +131,7 @@ async function patchModule(
       await untar(downloadPath, extractPath);
       break;
     default:
-      throw new Error(`Extract method of ${pkg.extractMethod} is not supported`);
+      throw new Error(`Extract method of ${extractMethod} is not supported`);
   }
 }
 


### PR DESCRIPTION
### Description
We build and restore re2 for arm. With a license built in,
we zip the build artifact as .tar.gz. The original patchModule
method has a default extract method and path which causes issues
for extracting and using re2 arm build artifact. Therefore, we
modify the method in this PR by passing an overriddenExtractMethod
and an overriddenDestinationPath.

<img width="1587" alt="Screen Shot 2022-04-13 at 14 29 40" src="https://user-images.githubusercontent.com/79961084/163276926-1f70b0dd-1cf3-4d80-919e-82c9ecc4b0bd.png">

 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1436
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 