### PR TITLE
Revert "Bump moment from 2.29.1 to 2.29.2 (#1439)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "lodash": "^4.17.21",
     "lru-cache": "^4.1.5",
     "minimatch": "^3.0.4",
-    "moment": "^2.29.2",
+    "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
     "mustache": "^2.3.2",
     "node-fetch": "^2.6.7",

--- a/packages/osd-config/package.json
+++ b/packages/osd-config/package.json
@@ -17,7 +17,7 @@
     "js-yaml": "^3.14.0",
     "load-json-file": "^6.2.0",
     "lodash": "^4.17.21",
-    "moment": "^2.29.2",
+    "moment": "^2.24.0",
     "rxjs": "^6.5.5",
     "type-detect": "^4.0.8"
   },

--- a/packages/osd-dev-utils/package.json
+++ b/packages/osd-dev-utils/package.json
@@ -25,7 +25,7 @@
     "globby": "^8.0.1",
     "load-json-file": "^6.2.0",
     "markdown-it": "^12.3.2",
-    "moment": "^2.29.2",
+    "moment": "^2.24.0",
     "normalize-path": "^3.0.0",
     "rxjs": "^6.5.5",
     "strip-ansi": "^6.0.0",

--- a/packages/osd-telemetry-tools/package.json
+++ b/packages/osd-telemetry-tools/package.json
@@ -19,7 +19,7 @@
     "@types/normalize-path": "^3.0.0",
     "normalize-path": "^3.0.0",
     "@types/lodash": "^4.14.170",
-    "moment": "^2.29.2",
+    "moment": "^2.24.0",
     "typescript": "4.0.2"
   }
 }

--- a/packages/osd-ui-shared-deps/package.json
+++ b/packages/osd-ui-shared-deps/package.json
@@ -23,7 +23,7 @@
     "jquery": "^3.5.0",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "^1.6.0",
-    "moment": "^2.29.2",
+    "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
     "react": "^16.14.0",
     "react-dom": "^16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13569,10 +13569,10 @@ moment-timezone@*, moment-timezone@^0.5.27:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.10.6, moment@^2.29.2:
-  version "2.29.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
-  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
+"moment@>= 2.9.0", moment@^2.10.6, moment@^2.24.0:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 monaco-editor@~0.17.0:
   version "0.17.1"


### PR DESCRIPTION
### Description
This reverts commit 1f013aefac1f138a222cc12ce7c617c2b3407847.
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 