### PR TITLE
Deprecates non-inclusive config names

### DIFF
--- a/packages/osd-config/src/deprecation/deprecation_factory.ts
+++ b/packages/osd-config/src/deprecation/deprecation_factory.ts
@@ -67,6 +67,37 @@ const _rename = (
   return config;
 };
 
+const _renameWithoutMap = (
+  config: Record<string, any>,
+  rootPath: string,
+  log: ConfigDeprecationLogger,
+  oldKey: string,
+  newKey: string,
+  silent?: boolean
+) => {
+  const fullOldPath = getPath(rootPath, oldKey);
+  const oldValue = get(config, fullOldPath);
+
+  const fullNewPath = getPath(rootPath, newKey);
+  const newValue = get(config, fullNewPath);
+
+  if (oldValue !== undefined) {
+    if (!silent) {
+      log(`"${fullOldPath}" is deprecated and has been replaced by "${fullNewPath}"`);
+    }
+
+    return config;
+  }
+
+  if (newValue === undefined) {
+    return config;
+  }
+
+  unset(config, fullNewPath);
+  set(config, fullOldPath, newValue);
+  return config;
+};
+
 const _unused = (
   config: Record<string, any>,
   rootPath: string,
@@ -81,6 +112,19 @@ const _unused = (
   log(`${fullPath} is deprecated and is no longer used`);
   return config;
 };
+
+const renameWithoutMap = (oldKey: string, newKey: string): ConfigDeprecation => (
+  config,
+  rootPath,
+  log
+) => _renameWithoutMap(config, rootPath, log, oldKey, newKey);
+
+const renameFromRootWithoutMap = (
+  oldKey: string,
+  newKey: string,
+  silent?: boolean
+): ConfigDeprecation => (config, rootPath, log) =>
+  _renameWithoutMap(config, '', log, oldKey, newKey, silent);
 
 const rename = (oldKey: string, newKey: string): ConfigDeprecation => (config, rootPath, log) =>
   _rename(config, rootPath, log, oldKey, newKey);
@@ -108,6 +152,8 @@ const getPath = (rootPath: string, subPath: string) =>
 export const configDeprecationFactory: ConfigDeprecationFactory = {
   rename,
   renameFromRoot,
+  renameWithoutMap,
+  renameFromRootWithoutMap,
   unused,
   unusedFromRoot,
 };

--- a/packages/osd-config/src/deprecation/types.ts
+++ b/packages/osd-config/src/deprecation/types.ts
@@ -115,6 +115,35 @@ export interface ConfigDeprecationFactory {
    */
   renameFromRoot(oldKey: string, newKey: string, silent?: boolean): ConfigDeprecation;
   /**
+   * Rename a configuration property from inside a plugin's configuration path.
+   * Will log a deprecation warning if the oldKey was found and deprecation applied.
+   *
+   * @example
+   * Rename 'myplugin.oldKey' to 'myplugin.newKey'
+   * ```typescript
+   * const provider: ConfigDeprecationProvider = ({ rename }) => [
+   *   rename('oldKey', 'newKey'),
+   * ]
+   * ```
+   */
+  renameWithoutMap(oldKey: string, newKey: string): ConfigDeprecation;
+  /**
+   * Rename a configuration property from the root configuration.
+   * Will log a deprecation warning if the oldKey was found and deprecation applied.
+   *
+   * This should be only used when renaming properties from different configuration's path.
+   * To rename properties from inside a plugin's configuration, use 'rename' instead.
+   *
+   * @example
+   * Rename 'oldplugin.key' to 'newplugin.key'
+   * ```typescript
+   * const provider: ConfigDeprecationProvider = ({ renameFromRoot }) => [
+   *   renameFromRoot('oldplugin.key', 'newplugin.key'),
+   * ]
+   * ```
+   */
+  renameFromRootWithoutMap(oldKey: string, newKey: string, silent?: boolean): ConfigDeprecation;
+  /**
    * Remove a configuration property from inside a plugin's configuration path.
    * Will log a deprecation warning if the unused key was found and deprecation applied.
    *

--- a/src/core/server/config/deprecation/core_deprecations.test.ts
+++ b/src/core/server/config/deprecation/core_deprecations.test.ts
@@ -98,6 +98,7 @@ describe('core deprecations', () => {
       });
       expect(messages).toMatchInlineSnapshot(`
         Array [
+          "\\"server.xsrf.whitelist\\" is deprecated and has been replaced by \\"server.xsrf.allowlist\\"",
           "It is not recommended to disable xsrf protections for API endpoints via [server.xsrf.whitelist]. Instead, supply the \\"osd-xsrf\\" header.",
         ]
       `);

--- a/src/core/server/config/deprecation/core_deprecations.ts
+++ b/src/core/server/config/deprecation/core_deprecations.ts
@@ -127,6 +127,7 @@ const mapManifestServiceUrlDeprecation: ConfigDeprecation = (settings, fromPath,
 export const coreDeprecationProvider: ConfigDeprecationProvider = ({
   unusedFromRoot,
   renameFromRoot,
+  renameFromRootWithoutMap,
 }) => [
   unusedFromRoot('savedObjects.indexCheckTimeout'),
   unusedFromRoot('server.xsrf.token'),
@@ -154,6 +155,11 @@ export const coreDeprecationProvider: ConfigDeprecationProvider = ({
   renameFromRoot('cpuacct.cgroup.path.override', 'ops.cGroupOverrides.cpuAcctPath'),
   unusedFromRoot('opensearch.preserveHost'),
   unusedFromRoot('opensearch.startupTimeout'),
+  renameFromRootWithoutMap('server.xsrf.whitelist', 'server.xsrf.allowlist'),
+  renameFromRootWithoutMap(
+    'server.compression.referrerWhitelist',
+    'server.compression.referrerAllowlist'
+  ),
   configPathDeprecation,
   dataPathDeprecation,
   rewriteBasePathDeprecation,

--- a/src/core/server/opensearch/opensearch_config.test.ts
+++ b/src/core/server/opensearch/opensearch_config.test.ts
@@ -441,6 +441,7 @@ describe('deprecations', () => {
     expect(messages).toMatchInlineSnapshot(`
       Array [
         "\\"elasticsearch.requestHeadersWhitelist\\" is deprecated and has been replaced by \\"opensearch.requestHeadersWhitelist\\"",
+        "\\"opensearch.requestHeadersWhitelist\\" is deprecated and has been replaced by \\"opensearch.requestHeadersAllowlist\\"",
       ]
     `);
   });

--- a/src/core/server/opensearch/opensearch_config.ts
+++ b/src/core/server/opensearch/opensearch_config.ts
@@ -137,7 +137,7 @@ export const configSchema = schema.object({
   ),
 });
 
-const deprecations: ConfigDeprecationProvider = ({ renameFromRoot }) => [
+const deprecations: ConfigDeprecationProvider = ({ renameFromRoot, renameFromRootWithoutMap }) => [
   renameFromRoot('elasticsearch.sniffOnStart', 'opensearch.sniffOnStart'),
   renameFromRoot('elasticsearch.sniffInterval', 'opensearch.sniffInterval'),
   renameFromRoot('elasticsearch.sniffOnConnectionFault', 'opensearch.sniffOnConnectionFault'),
@@ -145,6 +145,10 @@ const deprecations: ConfigDeprecationProvider = ({ renameFromRoot }) => [
   renameFromRoot('elasticsearch.username', 'opensearch.username'),
   renameFromRoot('elasticsearch.password', 'opensearch.password'),
   renameFromRoot('elasticsearch.requestHeadersWhitelist', 'opensearch.requestHeadersWhitelist'),
+  renameFromRootWithoutMap(
+    'opensearch.requestHeadersWhitelist',
+    'opensearch.requestHeadersAllowlist'
+  ),
   renameFromRoot('elasticsearch.customHeaders', 'opensearch.customHeaders'),
   renameFromRoot('elasticsearch.shardTimeout', 'opensearch.shardTimeout'),
   renameFromRoot('elasticsearch.requestTimeout', 'opensearch.requestTimeout'),


### PR DESCRIPTION
Adds deprecation functionality that uses new name without replacing old

Deprecates but not changes `opensearch.requestHeadersWhitelist`

Deprecates but not changes `server.xsrf.whitelist`

Deprecates but not changes `server.compression.referrerWhitelist`

Currently, this change is allowing the user to use `allowlist` version of the config names but under the hood, we're mapping the new value back to the old value used in code so that we don't have breaking changes for plugins. If the old non-inclusive config is used, a deprecation warning will be logged.

Signed-off-by: Bishoy Boktor <boktorbb@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [X] All tests pass
    - [X] `yarn test:jest`
    - [X] `yarn test:jest_integration`
    - [X] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 