### PR TITLE
[Plugins] fix default path to plugins

### DIFF
--- a/src/cli_plugin/install/settings.js
+++ b/src/cli_plugin/install/settings.js
@@ -47,7 +47,7 @@ function generatePluginUrl(version, plugin) {
   if (platform !== 'linux') {
     throw new Error('Plugins are only available for Linux');
   }
-  return `${LATEST_PLUGIN_BASE_URL}/${version}/latest/${platform}/${arch}/builds/opensearch-dashboards/plugins/${plugin}-${version}.zip`;
+  return `${LATEST_PLUGIN_BASE_URL}/${version}/latest/${platform}/${arch}/tar/builds/opensearch-dashboards/plugins/${plugin}-${version}.zip`;
 }
 
 export function parseMilliseconds(val) {

--- a/src/cli_plugin/install/settings.test.js
+++ b/src/cli_plugin/install/settings.test.js
@@ -94,7 +94,7 @@ describe('parse function', function () {
         "timeout": 0,
         "urls": Array [
           "plugin name",
-          "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1234/latest/linux/x64/builds/opensearch-dashboards/plugins/plugin name-1234.zip",
+          "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1234/latest/linux/x64/tar/builds/opensearch-dashboards/plugins/plugin name-1234.zip",
         ],
         "version": 1234,
         "workingPath": <absolute path>/plugins/.plugin.installing,
@@ -129,7 +129,7 @@ describe('parse function', function () {
         "timeout": 0,
         "urls": Array [
           "plugin name",
-          "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1234/latest/linux/x64/builds/opensearch-dashboards/plugins/plugin name-1234.zip",
+          "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1234/latest/linux/x64/tar/builds/opensearch-dashboards/plugins/plugin name-1234.zip",
         ],
         "version": 1234,
         "workingPath": <absolute path>/plugins/.plugin.installing,
@@ -171,7 +171,7 @@ describe('parse function', function () {
         "timeout": 0,
         "urls": Array [
           "plugin name",
-          "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1234/latest/linux/arm64/builds/opensearch-dashboards/plugins/plugin name-1234.zip",
+          "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1234/latest/linux/arm64/tar/builds/opensearch-dashboards/plugins/plugin name-1234.zip",
         ],
         "version": 1234,
         "workingPath": <absolute path>/plugins/.plugin.installing,


### PR DESCRIPTION
### Description
Location of artifacts was updated here:
https://github.com/opensearch-project/opensearch-build/pull/1944

Updating the CLI for the out of the box experience with the same
warning as before:

At the time that this is committed there is no gurantee
that the latest build is the build that was select as the
final build.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 