### PR TITLE
[Tests][BWC][CI] handle distributions with qualifiers

### DIFF
--- a/bwctest.sh
+++ b/bwctest.sh
@@ -79,16 +79,18 @@ done
 # If no OpenSearch build was passed then this constructs the version
 if [ -z "$OPENSEARCH" ]; then
     IFS='/' read -ra SLASH_ARR <<< "$DASHBOARDS"
-    # Expected to be opensearch-x.y.z-platform-arch.tar.gz
+    # Expected to be opensearch-x.y.z-platform-arch.tar.gz or opensearch-x.y.z-qualifier-platform-arch.tar.gz
     # Playground is supported path to enable sandbox testing
     [[ "$DASHBOARDS" == *"Playground"* ]] && TARBALL="${SLASH_ARR[14]}" || TARBALL="${SLASH_ARR[13]}"
     IFS='-' read -ra DASH_ARR <<< "$TARBALL"
+    # If it contains a qualifer it will be length of 6
+    [[ ${#DASH_ARR[@]} == 6 ]] && HAS_QUALIFER=true || HAS_QUALIFER=false
     # Expected to be arch.tar.gz
-    DOTS="${DASH_ARR[4]}"
+    [ $HAS_QUALIFER == true ] && DOTS="${DASH_ARR[5]}" || DOTS="${DASH_ARR[4]}"
     IFS='.' read -ra DOTS_ARR <<< "$DOTS"
 
-    VERSION="${DASH_ARR[2]}"
-    PLATFORM="${DASH_ARR[3]}"
+    [ $HAS_QUALIFER == true ] && VERSION="${DASH_ARR[2]}-${DASH_ARR[3]}" || VERSION="${DASH_ARR[2]}"
+    [ $HAS_QUALIFER == true ] && PLATFORM="${DASH_ARR[4]}" || PLATFORM="${DASH_ARR[3]}"
     ARCH="${DOTS_ARR[0]}"
 
     OPENSEARCH="https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/$VERSION/latest/$PLATFORM/$ARCH/tar/dist/opensearch/opensearch-$VERSION-$PLATFORM-$ARCH.tar.gz"

--- a/scripts/bwctest_osd.sh
+++ b/scripts/bwctest_osd.sh
@@ -187,10 +187,10 @@ function run_cypress() {
     do
       SPEC_FILES+="$TEST_DIR/cypress/integration/$DASHBOARDS_TYPE/*$test.js,"
     done
-    [ ! $IS_CORE ] && echo "Running tests from plugins"
-    [ $IS_CORE ] && spec="$SPEC_FILES" || "$TEST_DIR/cypress/integration/$DASHBOARDS_TYPE/plugins/*.js"
-    [ $IS_CORE ] && success_msg="BWC tests for core passed ($spec)" || success_msg="BWC tests for plugin passed ($spec)"
-    [ $IS_CORE ] && error_msg="BWC tests for core failed ($spec)" || error_msg="BWC tests for plugin failed ($spec)"
+    [ $IS_CORE == false ] && echo "Running tests from plugins"
+    [ $IS_CORE == true ] && spec="$SPEC_FILES" || "$TEST_DIR/cypress/integration/$DASHBOARDS_TYPE/plugins/*.js"
+    [ $IS_CORE == true ] && success_msg="BWC tests for core passed ($spec)" || success_msg="BWC tests for plugin passed ($spec)"
+    [ $IS_CORE == true ] && error_msg="BWC tests for core failed ($spec)" || error_msg="BWC tests for plugin failed ($spec)"
     [ $CI == 1 ] && cypress_args="--browser chromium" || cypress_args=""
     env NO_COLOR=1 npx cypress run $cypress_args --headless --spec $spec || test_failures=$?
     [ -z $test_failures ] && test_failures=0


### PR DESCRIPTION
### Description
The original BWC scripts did not expect qualifiers from the CI.
This allows for CI pass distributions with qualifiers for example:
`opensearch-dashboards-2.0.0-rc1`

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 