### PR TITLE
[Tests][BWC][CI] use ODFE 1.0.2

### DIFF
--- a/bwctest.sh
+++ b/bwctest.sh
@@ -13,7 +13,7 @@
 
 set -e
 
-DEFAULT_VERSIONS="osd-1.1.0,odfe-1.13.2,odfe-0.10.0"
+DEFAULT_VERSIONS="osd-1.1.0,odfe-1.13.2,odfe-1.0.2"
 
 function usage() {
     echo ""


### PR DESCRIPTION
### Description
Previously users could migrate from 6.8 to OpenSearch.
But for OpenSearch 2.x, users need to at least migrate to 7.0 in
the legacy application.

For BWC tests, we were previously testing 6.8 but now we start
from 7.0.

Related issue:
https://github.com/opensearch-project/OpenSearch/issues/1674

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 