### PR TITLE
[Bug] fix copy as curl

### DIFF
--- a/src/plugins/console/public/application/components/console_menu.tsx
+++ b/src/plugins/console/public/application/components/console_menu.tsx
@@ -78,6 +78,16 @@ export class ConsoleMenu extends Component<Props, State> {
 
   async copyText(text: string) {
     if (window.navigator?.clipboard) {
+      /**
+       * Browser Compatibility Chart
+       *
+       * Chrome: 66
+       * Edge: 79
+       * Firefox: 63
+       * Opera: 53
+       * Internet Explorer: Not supported
+       *
+       */
       await window.navigator.clipboard.writeText(text);
     }
   }
@@ -127,6 +137,7 @@ export class ConsoleMenu extends Component<Props, State> {
       <EuiContextMenuItem
         key="Copy as cURL"
         id="ConCopyAsCurl"
+        data-test-subj="copyAsCurl"
         disabled={!window.navigator?.clipboard}
         onClick={() => {
           this.closePopover();

--- a/src/plugins/console/public/application/components/console_menu.tsx
+++ b/src/plugins/console/public/application/components/console_menu.tsx
@@ -64,8 +64,8 @@ export class ConsoleMenu extends Component<Props, State> {
     });
   };
 
-  copyAsCurl() {
-    this.copyText(this.state.curlCode);
+  async copyAsCurl() {
+    await this.copyText(this.state.curlCode);
     const { addNotification } = this.props;
     if (addNotification) {
       addNotification({
@@ -76,13 +76,10 @@ export class ConsoleMenu extends Component<Props, State> {
     }
   }
 
-  copyText(text: string) {
-    const textField = document.createElement('textarea');
-    textField.innerText = text;
-    document.body.appendChild(textField);
-    textField.select();
-    document.execCommand('copy');
-    textField.remove();
+  async copyText(text: string) {
+    if (window.navigator?.clipboard) {
+      await window.navigator.clipboard.writeText(text);
+    }
   }
 
   onButtonClick = () => {
@@ -130,7 +127,7 @@ export class ConsoleMenu extends Component<Props, State> {
       <EuiContextMenuItem
         key="Copy as cURL"
         id="ConCopyAsCurl"
-        disabled={!document.queryCommandSupported('copy')}
+        disabled={!window.navigator?.clipboard}
         onClick={() => {
           this.closePopover();
           this.copyAsCurl();


### PR DESCRIPTION
### Description
Copy as curl doesn't work in Dev Tools console due to usage of a
deprecated method:

https://developer.mozilla.org/en-US/docs/Web/API/Document/queryCommandSupported#browser_compatibility

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1471
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 