### PR TITLE
[Tests][BWC][CI] update performance analzyer location

### DIFF
--- a/scripts/bwc/opensearch_service.sh
+++ b/scripts/bwc/opensearch_service.sh
@@ -7,6 +7,9 @@ set -e
 
 function setup_opensearch() {
   cd "$OPENSEARCH_DIR"
+  echo "network.host: 0.0.0.0" >> config/opensearch.yml
+  echo "discovery.type: single-node" >> config/opensearch.yml
+  [ $SECURITY_ENABLED == "false" ] && [ -d "plugins/opensearch-security" ] && echo "plugins.security.disabled: true" >> config/opensearch.yml
   # Required for IM
   [ -d "plugins/opensearch-index-management" ] && echo "path.repo: [/tmp]" >> config/opensearch.yml
   # Required for Alerting
@@ -14,10 +17,7 @@ function setup_opensearch() {
   # Required for SQL
   [ -d "plugins/opensearch-sql" ] && echo "script.context.field.max_compilations_rate: 1000/1m" >> config/opensearch.yml
   # Required for PA
-  [ -d "plugins/opensearch-performance-analyzer" ] && echo "webservice-bind-host = 0.0.0.0" >> plugins/opensearch-performance-analyzer/pa_config/performance-analyzer.properties
-  echo "network.host: 0.0.0.0" >> config/opensearch.yml
-  echo "discovery.type: single-node" >> config/opensearch.yml
-  [ $SECURITY_ENABLED == "false" ] && [ -d "plugins/opensearch-security" ] && echo "plugins.security.disabled: true" >> config/opensearch.yml
+  [ -d "plugins/opensearch-performance-analyzer" ] && echo "webservice-bind-host = 0.0.0.0" >> config/opensearch-performance-analyzer/performance-analyzer.properties
 }
 
 # Starts OpenSearch, if verifying a distribution it will install the certs then start.


### PR DESCRIPTION
### Description
Performance analyzer was moved. It was causing a silent failure
which prevented the disable security plugin from being set.
Thus BWC tests were timing out with security disabled.

So I also moved to the security plugin config setup to the top
of the function to ensure this gets executed.

Source:
https://github.com/opensearch-project/performance-analyzer/commit/81d019af51a62d42592905cffc51f9c77cb8aaac
https://github.com/opensearch-project/opensearch-build/commit/6183df2bcb71c17d6b829f8184fb119c3b9a0a06

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 