### PR TITLE
[1.x] update re2 build for arm under node 10

### DIFF
--- a/src/dev/build/tasks/patch_native_modules_tasks.test.ts
+++ b/src/dev/build/tasks/patch_native_modules_tasks.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ToolingLog,
+  ToolingLogCollectingWriter,
+  createAnyInstanceSerializer,
+  createAbsolutePathSerializer,
+} from '@osd/dev-utils';
+import { Build, Config } from '../lib';
+import { PatchNativeModules } from './patch_native_modules_task';
+
+const log = new ToolingLog();
+const testWriter = new ToolingLogCollectingWriter();
+log.setWriters([testWriter]);
+expect.addSnapshotSerializer(createAnyInstanceSerializer(Config));
+expect.addSnapshotSerializer(createAnyInstanceSerializer(ToolingLog));
+expect.addSnapshotSerializer(createAbsolutePathSerializer());
+
+jest.mock('../lib/download');
+jest.mock('../lib/fs', () => ({
+  ...jest.requireActual('../lib/fs'),
+  untar: jest.fn(),
+  gunzip: jest.fn(),
+}));
+
+const { untar } = jest.requireMock('../lib/fs');
+const { gunzip } = jest.requireMock('../lib/fs');
+const { download } = jest.requireMock('../lib/download');
+
+async function setup() {
+  const config = await Config.create({
+    isRelease: true,
+    targetAllPlatforms: false,
+    targetPlatforms: {
+      linux: false,
+      linuxArm: false,
+      darwin: false,
+    },
+  });
+
+  const build = new Build(config);
+
+  download.mockImplementation(() => {});
+  untar.mockImplementation(() => {});
+  gunzip.mockImplementation(() => {});
+
+  return { config, build };
+}
+
+beforeEach(() => {
+  testWriter.messages.length = 0;
+  jest.clearAllMocks();
+});
+
+it('patch native modules task downloads the correct platform package', async () => {
+  const { config, build } = await setup();
+  config.targetPlatforms.linuxArm = true;
+  await PatchNativeModules.run(config, log, build);
+  expect(download.mock.calls.length).toBe(1);
+  expect(download.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "destination": <absolute path>/.native_modules/re2/linux-arm64-64.tar.gz,
+            "log": <ToolingLog>,
+            "retries": 3,
+            "sha256": "24edcdf45a09e69b6329385ab3ece24b424602a2656c8a297111d7aac174723b",
+            "url": "https://d1v1sj258etie.cloudfront.net/node-re2/releases/download/1.15.4/linux-arm64-64.tar.gz",
+          },
+        ],
+      ]
+    `);
+});
+
+it('for .tar.gz artifact, patch native modules task unzip it via untar', async () => {
+  const { config, build } = await setup();
+  config.targetPlatforms.linuxArm = true;
+  await PatchNativeModules.run(config, log, build);
+  expect(untar.mock.calls.length).toBe(1);
+  expect(gunzip.mock.calls.length).toBe(0);
+});
+
+it('for .gz artifact, patch native modules task unzip it via gunzip', async () => {
+  const { config, build } = await setup();
+  config.targetPlatforms.linux = true;
+  await PatchNativeModules.run(config, log, build);
+  expect(untar.mock.calls.length).toBe(0);
+  expect(gunzip.mock.calls.length).toBe(1);
+});


### PR DESCRIPTION
### Description
This is a backport for the fix we made on 2.0. Please check
the Backport PR for more details. The difference between this
version and 2.0 is node bump.

From originial PR: We build and restore re2 for arm. With a license
built in, we zip the build artifact as .tar.gz. The original patchModule
method has a default extract method and path which causes issues
for extracting and using re2 arm build artifact. Therefore, we
modify the method in this PR by passing an overriddenExtractMethod
and an overriddenDestinationPath.

### Issues Resolved
Backport PR: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1454
Issue Resolved: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1436

Signed-off-by: Anan Zhuang <ananzh@amazon.com>


 

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 