### PR TITLE
[Backport 1.3] Bump nanoid from 3.1.30 to 3.2.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -17370,9 +17370,9 @@ nano-css@^5.2.1:
     stylis "3.5.0"
 
 nanoid@^3.1.22:
-  version "3.1.23"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
-  integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
+  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
 nanomatch@^1.2.9:
   version "1.2.9"


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/OpenSearch-Dashboards/commit/0c3f901c569838b2708a079d058c7d09970b944c from #1173 
 
### Issues Resolved
Resolves #1160 - CVE-2021-23566
 
### Check List
- [x] Commits are signed per the DCO using --signoff 