### PR TITLE
[Backport 1.3] Bump minimist from 1.2.5 to 1.2.6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -17056,9 +17056,9 @@ minimist-options@^3.0.1:
     is-plain-obj "^1.1.0"
 
 minimist@0.0.8, minimist@1.1.x, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/OpenSearch-Dashboards/commit/ae8917263e1e20872aa5918cb517adb7148d35c8 from #1377 
 
### Issues Resolved
Resolves #1364 - CVE-2021-44906
 
### Check List
- [x] Commits are signed per the DCO using --signoff 