### PR TITLE
[Bug] fix missing discover context icon

### DIFF
--- a/src/plugins/discover/public/get_inner_angular.ts
+++ b/src/plugins/discover/public/get_inner_angular.ts
@@ -147,6 +147,7 @@ export function initializeInnerAngularModule(
     ])
     .config(watchMultiDecorator)
     .run(registerListenEventListener)
+    .directive('icon', (reactDirective) => reactDirective(EuiIcon))
     .directive('renderComplete', createRenderCompleteDirective)
     .directive('discoverLegacy', createDiscoverLegacyDirective)
     .directive('contextErrorMessage', createContextErrorMessageDirective);


### PR DESCRIPTION
Add back icon directive, which injects SVG for EUI icons

Signed-off-by: Josh Romero <rmerqg@amazon.com>

### Description
Corrects rendering of discover context table row expansion buttons. The directive appears to have been removed when partially de-angularizing discover, without realizing the impact on the context doc table rendering.
 
### Issues Resolved
fixes #1281 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 