### PR TITLE
Fix wms maps can't load when can't request default map service

### DIFF
--- a/.lycheeexclude
+++ b/.lycheeexclude
@@ -6,7 +6,7 @@ http://localhost
 https://localhost
 http://127.0.0.1/
 https://127.0.0.1/
-http://127.0.0.1:10002/bar 
+http://127.0.0.1:10002/bar
 http://127.0.0.1:10002/
 http://opensearch
 https://opensearch
@@ -35,6 +35,7 @@ http://noone.nowhere.none/
 http://bar
 http://foo
 http://test.com/
+https://manifest.foobar
 https://files.foobar/
 https://tiles.foobar/
 https://1.1.1.1:9200/
@@ -51,7 +52,7 @@ http://buildurl/
 https://dryrun/
 https://url/
 http://url/
-http://notfound.svg/ 
+http://notfound.svg/
 https://validurl/
 https://myopensearch-dashboardsdomain.com
 http://myopensearch-dashboardsdomain.com

--- a/src/plugins/maps_legacy/public/common/opensearch_maps_client.js
+++ b/src/plugins/maps_legacy/public/common/opensearch_maps_client.js
@@ -20,8 +20,9 @@ export class OpenSearchMapsClient extends EMSClient {
     try {
       result = await this._fetchWithTimeout(this._manifestServiceUrl);
     } catch (e) {
-      // silently ignoring the exception and returning false.
-      return false;
+      // silently ignoring the exception and returning true to make sure
+      // OpenSearchMapsClient is still enabled when can't access OpenSearch maps service.
+      return true;
     }
     if (result.ok) {
       const resultJson = await result.json();

--- a/src/plugins/maps_legacy/public/common/opensearch_maps_client.test.js
+++ b/src/plugins/maps_legacy/public/common/opensearch_maps_client.test.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OpenSearchMapsClient } from './opensearch_maps_client.js';
+
+describe('opensearch_maps_client test without Internet', function () {
+  const noInternetManifestUrl = 'https://manifest.foobar';
+  const defaultClientConfig = {
+    appName: 'opensearch-dashboards',
+    osdVersion: '1.2.3',
+    language: 'en',
+    landingPageUrl: '',
+    fetchFunction: function (...args) {
+      return fetch(...args);
+    },
+  };
+
+  function makeOpenSearchMapsClient() {
+    const openSearchMapsClient = new OpenSearchMapsClient({
+      ...defaultClientConfig,
+      manifestServiceUrl: noInternetManifestUrl,
+    });
+    return openSearchMapsClient;
+  }
+
+  it('isEnabled() should return true when catch error', async function () {
+    const mapsClient = makeOpenSearchMapsClient();
+    const osmIsEnabled = await mapsClient.isEnabled();
+    expect(osmIsEnabled).toEqual(true);
+  });
+});

--- a/src/plugins/maps_legacy/public/map/service_settings.js
+++ b/src/plugins/maps_legacy/public/map/service_settings.js
@@ -38,6 +38,19 @@ import { ORIGIN } from '../common/constants/origin';
 
 const TMS_IN_YML_ID = 'TMS in config/opensearch_dashboards.yml';
 
+// When unable to fetch OpenSearch maps service, return default values to
+// make sure wms can be set up.
+export const DEFAULT_SERVICE = [
+  {
+    origin: 'elastic_maps_service',
+    id: 'road_map',
+    minZoom: 0,
+    maxZoom: 22,
+    attribution:
+      '<a rel="noreferrer noopener" href="https://www.openstreetmap.org/copyright">Map data © OpenStreetMap contributors</a>',
+  },
+];
+
 export class ServiceSettings {
   constructor(mapConfig, tilemapsConfig) {
     this._mapConfig = mapConfig;
@@ -153,8 +166,12 @@ export class ServiceSettings {
     }
 
     await this._setMapServices();
-    const fileLayers = await this._emsClient.getFileLayers();
-    return fileLayers.map(this._backfillSettings);
+    try {
+      const fileLayers = await this._emsClient.getFileLayers();
+      return fileLayers.map(this._backfillSettings);
+    } catch (e) {
+      return [];
+    }
   }
 
   /**
@@ -173,7 +190,12 @@ export class ServiceSettings {
 
     await this._setMapServices();
     if (this._mapConfig.includeOpenSearchMapsService) {
-      const servicesFromManifest = await this._emsClient.getTMSServices();
+      let servicesFromManifest = [];
+      try {
+        servicesFromManifest = await this._emsClient.getTMSServices();
+      } catch (e) {
+        return DEFAULT_SERVICE;
+      }
       const strippedServiceFromManifest = await Promise.all(
         servicesFromManifest
           .filter((tmsService) => tmsService.getId() === this._mapConfig.emsTileLayerId.bright)
@@ -205,12 +227,17 @@ export class ServiceSettings {
   }
 
   async getFileLayerFromConfig(fileLayerConfig) {
-    const fileLayers = await this._emsClient.getFileLayers();
-    return fileLayers.find((fileLayer) => {
-      const hasIdByName = fileLayer.hasId(fileLayerConfig.name); //legacy
-      const hasIdById = fileLayer.hasId(fileLayerConfig.id);
-      return hasIdByName || hasIdById;
-    });
+    let fileLayers = [];
+    try {
+      fileLayers = await this._emsClient.getFileLayers();
+      return fileLayers.find((fileLayer) => {
+        const hasIdByName = fileLayer.hasId(fileLayerConfig.name); //legacy
+        const hasIdById = fileLayer.hasId(fileLayerConfig.id);
+        return hasIdByName || hasIdById;
+      });
+    } catch (err) {
+      return null;
+    }
   }
 
   async getEMSHotLink(fileLayerConfig) {
@@ -226,7 +253,12 @@ export class ServiceSettings {
 
   async _getAttributesForEMSTMSLayer(isDesaturated, isDarkMode) {
     await this._setMapServices();
-    const tmsServices = await this._emsClient.getTMSServices();
+    let tmsServices = [];
+    try {
+      tmsServices = await this._emsClient.getTMSServices();
+    } catch (e) {
+      return DEFAULT_SERVICE;
+    }
     const emsTileLayerId = this._mapConfig.emsTileLayerId;
     let serviceId;
     if (isDarkMode) {

--- a/src/plugins/maps_legacy/public/map/service_settings.test.js
+++ b/src/plugins/maps_legacy/public/map/service_settings.test.js
@@ -44,12 +44,6 @@ import EMS_STYLE_DARK_MAP from '../__tests__/map/ems_mocks/sample_style_dark';
 import { ORIGIN } from '../common/constants/origin';
 import { ServiceSettings, DEFAULT_SERVICE } from './service_settings';
 
-function assertObject(actual, expected) {
-  Object.keys(expected).forEach((key) => {
-    expect(actual[key]).toEqual(expected[key]);
-  });
-}
-
 describe('service_settings (FKA tile_map test)', function () {
   const emsFileApiUrl = 'https://files.foobar';
   const emsTileApiUrl = 'https://tiles.foobar';
@@ -305,11 +299,11 @@ describe('service_settings (FKA tile_map test)', function () {
       it('should return default service', async () => {
         const serviceSettings = makeServiceSettings({}, {}, { noInternet: true });
         const tileMapServices = await serviceSettings.getTMSServices();
-        assertObject(tileMapServices[0], expectedDefaultTmService);
+        expect(tileMapServices[0]).toMatchObject(expectedDefaultTmService);
         const isDesaturated = true;
         const isDarkMode = true;
         const attrs = await serviceSettings._getAttributesForEMSTMSLayer(isDesaturated, isDarkMode);
-        assertObject(attrs[0], expectedDefaultTmService);
+        expect(attrs[0]).toMatchObject(expectedDefaultTmService);
       });
     });
   });
@@ -385,16 +379,18 @@ describe('service_settings (FKA tile_map test)', function () {
       );
     });
 
-    it('should return empty arr when unable fetch maps manifest', async () => {
+    describe('when unable to access maps service', function () {
       const serviceSettings = makeServiceSettings({}, {}, { noInternet: true });
-      const fileLayers = await serviceSettings.getFileLayers();
-      expect(fileLayers).toEqual([]);
-    });
 
-    it('should return null when unable fetch maps manifest', async () => {
-      const serviceSettings = makeServiceSettings({}, {}, { noInternet: true });
-      const fileLayer = await serviceSettings.getFileLayerFromConfig(null);
-      expect(fileLayer).toEqual(null);
+      it('should return empty arr', async () => {
+        const fileLayers = await serviceSettings.getFileLayers();
+        expect(fileLayers).toEqual([]);
+      });
+
+      it('should return null', async () => {
+        const fileLayer = await serviceSettings.getFileLayerFromConfig(null);
+        expect(fileLayer).toEqual(null);
+      });
     });
   });
 });

--- a/src/plugins/region_map/public/region_map_visualization.js
+++ b/src/plugins/region_map/public/region_map_visualization.js
@@ -114,8 +114,10 @@ export function createRegionMapVisualization({
       const { escape } = await import('lodash');
 
       if (
-        fileLayerConfig.isEMS || //Hosted by EMS. Metadata needs to be resolved through EMS
-        (fileLayerConfig.layerId && fileLayerConfig.layerId.startsWith(`${ORIGIN.EMS}.`)) //fallback for older saved objects
+        fileLayerConfig &&
+        (fileLayerConfig.isEMS || //Hosted by EMS. Metadata needs to be resolved through EMS
+          (fileLayerConfig.layerId && fileLayerConfig.layerId.startsWith(`${ORIGIN.EMS}.`)))
+        //fallback for older saved objects
       ) {
         const serviceSettings = await getServiceSettings();
         return await serviceSettings.loadFileLayerConfig(fileLayerConfig);


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Fix the bug that users can't load their own map tiles service by custom WMS when the environment unable access to default maps service(VPC or air-gapped region).


### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1506
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [X] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [X] Commits are signed per the DCO using --signoff 