### PR TITLE
[CVE] Resolves grunt to 1.5.3

### DIFF
--- a/release-notes/opensearch-dashboards.release-notes-2.0.0.md
+++ b/release-notes/opensearch-dashboards.release-notes-2.0.0.md
@@ -18,6 +18,7 @@
 * Removes UI Framework KUI doc site ([#1379](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1379))
 
 ### 🛡 Security
+* [CVE-2022-1537] Resolves grunt to 1.5.3 ([#1580](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1580))
 * [CVE-2022-1214] Bumps chromedriver to v100 and axios to v0.27.2 ([#1552](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1552))
 * [CVE-2021-44531] [CVE-2022-21824] [CVE-2022-0778] [CVE-2021-44532] [CVE-2021-44533] Bumps Node.js from v14.18.2 to v14.19.1 ([#1487](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1487))
 * [CVE-2022-0436] Bumps grunt from v1.4.1 to v1.5.2 ([#1451](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1451))

--- a/yarn.lock
+++ b/yarn.lock
@@ -9498,9 +9498,9 @@ grunt-run@^0.8.1:
     strip-ansi "^3.0.0"
 
 grunt@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/grunt/-/grunt-1.5.2.tgz#46b014e28d17c85baac19d5e891bb3f04923c098"
-  integrity sha512-XCtfaIu72OyDqK24MjWiGC9SwlkuhkS1mrULr1xzuJ2XqAFhP3ZAchZGHJeSCY6mkaOXU4F7SbmmCF7xIVoC9w==
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/grunt/-/grunt-1.5.3.tgz#3214101d11257b7e83cf2b38ea173b824deab76a"
+  integrity sha512-mKwmo4X2d8/4c/BmcOETHek675uOqw0RuA/zy12jaspWqvTp4+ZeQF1W+OTpcbncnaBsfbQJ6l0l4j+Sn/GmaQ==
   dependencies:
     dateformat "~3.0.3"
     eventemitter2 "~0.4.13"


### PR DESCRIPTION
### Description
Addresses CVE-2022-1537

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1579
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 