### PR TITLE
[Purify] hide option for theme version in settings

### DIFF
--- a/release-notes/opensearch-dashboards.release-notes-2.0.0.md
+++ b/release-notes/opensearch-dashboards.release-notes-2.0.0.md
@@ -16,6 +16,7 @@
 #### Deprecations
 * Deprecates non-inclusive config names ([#1467](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1467))
 * Removes UI Framework KUI doc site ([#1379](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1379))
+* [Purify] hide option for theme version in settings ([#1598](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1598))
 
 ### 🛡 Security
 * [CVE-2022-1537] Resolves grunt to 1.5.3 ([#1580](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1580))

--- a/src/core/server/ui_settings/settings/theme.ts
+++ b/src/core/server/ui_settings/settings/theme.ts
@@ -57,6 +57,7 @@ export const getThemeSettings = (): Record<string, UiSettingsParams> => {
       }),
       requiresPageReload: true,
       schema: schema.oneOf([schema.literal('v7'), schema.literal('v8 (beta)')]),
+      readonly: true,
     },
   };
 };


### PR DESCRIPTION
### Description
There is currently to a PR to remove the v7 and v8 (beta) theme
versions within the application but it is getting stale:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/978

Since the v8 (beta) theme isn't actually planned and has the incorrect
version, we do not want end users to be able to change this setting.
In the essence of time, this will prevent this setting from showing in
the Advanced Settings page but will also not break users who set this
version already (however it will lock them into theme until they switched
by manually updating or deleting the config doc). Removing this setting
will force the default to be v8 (beta).

Temporary fix for:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/494

But it should be removed completely.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Related
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/494

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 