### PR TITLE
Removes irrelevant upsell in the timeout message

### DIFF
--- a/.lycheeexclude
+++ b/.lycheeexclude
@@ -84,7 +84,6 @@ http://evil.com/
 https://opensearch.org/cool/path
 https://opensearch.org/redirect
 http://www.opensearch.org/painlessDocs
-https://opensearch.org/subscriptions
 https://www.hostedgraphite.com/
 
 # External urls

--- a/release-notes/opensearch-dashboards.release-notes-2.0.0.md
+++ b/release-notes/opensearch-dashboards.release-notes-2.0.0.md
@@ -54,6 +54,7 @@
 * [Circuit-Breaker] Add memory circuit breaker configuration ([#1347](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1347))
 
 ### 🐛 Bug Fixes
+* Removes irrelevant upsell in the timeout message ([#1599](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1599))
 * [Bug] fix missing discover context icon ([#1545](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1545))
 * Fix: Re-rendering visualization when expression changes and improves typing ([#1491](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1491))
 * fix(actions): Better type checks for icons ([#1496](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1496))

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -387,7 +387,6 @@ export {
   // errors
   SearchError,
   SearchTimeoutError,
-  TimeoutErrorMode,
   PainlessError,
 } from './search';
 

--- a/src/plugins/data/public/public.api.md
+++ b/src/plugins/data/public/public.api.md
@@ -2014,8 +2014,6 @@ export class SearchInterceptor {
     // (undocumented)
     protected readonly deps: SearchInterceptorDeps;
     // (undocumented)
-    protected getTimeoutMode(): TimeoutErrorMode;
-    // (undocumented)
     protected handleSearchError(e: any, request: IOpenSearchDashboardsSearchRequest, timeoutSignal: AbortSignal, appAbortSignal?: AbortSignal): Error;
     // @internal
     protected pendingCount$: BehaviorSubject<number>;
@@ -2150,11 +2148,9 @@ export interface SearchSourceFields {
 //
 // @public
 export class SearchTimeoutError extends OsdError {
-    constructor(err: Error, mode: TimeoutErrorMode);
+    constructor(err: Error);
     // (undocumented)
     getErrorMessage(application: ApplicationStart): JSX.Element;
-    // (undocumented)
-    mode: TimeoutErrorMode;
     }
 
 // Warning: (ae-missing-release-tag) "SortDirection" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2228,18 +2224,6 @@ export class TimeHistory {
 //
 // @public (undocumented)
 export type TimeHistoryContract = PublicMethodsOf<TimeHistory>;
-
-// Warning: (ae-missing-release-tag) "TimeoutErrorMode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export enum TimeoutErrorMode {
-    // (undocumented)
-    CHANGE = 2,
-    // (undocumented)
-    CONTACT = 1,
-    // (undocumented)
-    UPGRADE = 0
-}
 
 // Warning: (ae-missing-release-tag) "TimeRange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/src/plugins/data/public/search/errors/timeout_error.test.tsx
+++ b/src/plugins/data/public/search/errors/timeout_error.test.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import { SearchTimeoutError, TimeoutErrorMode } from './timeout_error';
+import { SearchTimeoutError, TIMEOUT_MESSAGE } from './timeout_error';
 
 import { coreMock } from '../../../../../core/public/mocks';
 const startMock = coreMock.createStart();
@@ -42,32 +42,9 @@ describe('SearchTimeoutError', () => {
     startMock.application.navigateToApp.mockImplementation(jest.fn());
   });
 
-  it('Should navigate to upgrade', () => {
-    const e = new SearchTimeoutError(new AbortError(), TimeoutErrorMode.UPGRADE);
+  it('Should create timeout message', () => {
+    const e = new SearchTimeoutError(new AbortError());
     const component = mount(e.getErrorMessage(startMock.application));
-
-    expect(component.find('EuiButton').length).toBe(1);
-    component.find('EuiButton').simulate('click');
-    expect(startMock.application.navigateToUrl).toHaveBeenCalledWith(
-      'https://opensearch.org/subscriptions'
-    );
-  });
-
-  it('Should create contact admin message', () => {
-    const e = new SearchTimeoutError(new AbortError(), TimeoutErrorMode.CONTACT);
-    const component = mount(e.getErrorMessage(startMock.application));
-
-    expect(component.find('EuiButton').length).toBe(0);
-  });
-
-  it('Should navigate to settings', () => {
-    const e = new SearchTimeoutError(new AbortError(), TimeoutErrorMode.CHANGE);
-    const component = mount(e.getErrorMessage(startMock.application));
-
-    expect(component.find('EuiButton').length).toBe(1);
-    component.find('EuiButton').simulate('click');
-    expect(startMock.application.navigateToApp).toHaveBeenCalledWith('management', {
-      path: '/opensearch-dashboards/settings',
-    });
+    expect(component.html()).toEqual(TIMEOUT_MESSAGE);
   });
 });

--- a/src/plugins/data/public/search/errors/timeout_error.tsx
+++ b/src/plugins/data/public/search/errors/timeout_error.tsx
@@ -30,96 +30,23 @@
 
 import React from 'react';
 import { i18n } from '@osd/i18n';
-import { EuiButton, EuiSpacer, EuiText } from '@elastic/eui';
 import { ApplicationStart } from 'opensearch-dashboards/public';
 import { OsdError } from '../../../../opensearch_dashboards_utils/common';
 
-export enum TimeoutErrorMode {
-  UPGRADE,
-  CONTACT,
-  CHANGE,
-}
-
+export const TIMEOUT_MESSAGE: string =
+  'Your query has timed out. Contact your system administrator to review your index strategy or increase the run time.';
 /**
  * Request Failure - When an entire multi request fails
  * @param {Error} err - the Error that came back
  */
 export class SearchTimeoutError extends OsdError {
-  public mode: TimeoutErrorMode;
-  constructor(err: Error, mode: TimeoutErrorMode) {
+  constructor(err: Error) {
     super(`Request timeout: ${JSON.stringify(err?.message)}`);
-    this.mode = mode;
-  }
-
-  private getMessage() {
-    switch (this.mode) {
-      case TimeoutErrorMode.UPGRADE:
-        return i18n.translate('data.search.upgradeLicense', {
-          defaultMessage:
-            'Your query has timed out. With our free Basic tier, your queries never time out.',
-        });
-      case TimeoutErrorMode.CONTACT:
-        return i18n.translate('data.search.timeoutContactAdmin', {
-          defaultMessage:
-            'Your query has timed out. Contact your system administrator to increase the run time.',
-        });
-      case TimeoutErrorMode.CHANGE:
-        return i18n.translate('data.search.timeoutIncreaseSetting', {
-          defaultMessage:
-            'Your query has timed out. Increase run time with the search timeout advanced setting.',
-        });
-    }
-  }
-
-  private getActionText() {
-    switch (this.mode) {
-      case TimeoutErrorMode.UPGRADE:
-        return i18n.translate('data.search.upgradeLicenseActionText', {
-          defaultMessage: 'Upgrade now',
-        });
-        break;
-      case TimeoutErrorMode.CHANGE:
-        return i18n.translate('data.search.timeoutIncreaseSettingActionText', {
-          defaultMessage: 'Edit setting',
-        });
-        break;
-    }
-  }
-
-  private onClick(application: ApplicationStart) {
-    switch (this.mode) {
-      case TimeoutErrorMode.UPGRADE:
-        application.navigateToUrl('https://opensearch.org/subscriptions');
-        break;
-      case TimeoutErrorMode.CHANGE:
-        application.navigateToApp('management', {
-          path: `/opensearch-dashboards/settings`,
-        });
-        break;
-    }
   }
 
   public getErrorMessage(application: ApplicationStart) {
-    const actionText = this.getActionText();
     return (
-      <>
-        {this.getMessage()}
-        {actionText && (
-          <>
-            <EuiSpacer size="s" />
-            <EuiText textAlign="right">
-              <EuiButton
-                color="danger"
-                onClick={() => this.onClick(application)}
-                size="s"
-                data-test-subj="searchTimeoutError"
-              >
-                {actionText}
-              </EuiButton>
-            </EuiText>
-          </>
-        )}
-      </>
+      <>{i18n.translate('data.search.timeoutContactAdmin', { defaultMessage: TIMEOUT_MESSAGE })}</>
     );
   }
 }

--- a/src/plugins/data/public/search/search_interceptor.ts
+++ b/src/plugins/data/public/search/search_interceptor.ts
@@ -41,7 +41,7 @@ import {
   OPENSEARCH_SEARCH_STRATEGY,
 } from '../../common';
 import { SearchUsageCollector } from './collectors';
-import { SearchTimeoutError, PainlessError, isPainlessError, TimeoutErrorMode } from './errors';
+import { SearchTimeoutError, PainlessError, isPainlessError } from './errors';
 import { toMountPoint } from '../../../opensearch_dashboards_react/public';
 
 export interface SearchInterceptorDeps {
@@ -82,14 +82,6 @@ export class SearchInterceptor {
   }
 
   /*
-   * @returns `TimeoutErrorMode` indicating what action should be taken in case of a request timeout based on license and permissions.
-   * @internal
-   */
-  protected getTimeoutMode() {
-    return TimeoutErrorMode.UPGRADE;
-  }
-
-  /*
    * @returns `Error` a search service specific error or the original error, if a specific error can't be recognized.
    * @internal
    */
@@ -101,8 +93,7 @@ export class SearchInterceptor {
   ): Error {
     if (timeoutSignal.aborted || get(e, 'body.message') === 'Request timed out') {
       // Handle a client or a server side timeout
-      const err = new SearchTimeoutError(e, this.getTimeoutMode());
-
+      const err = new SearchTimeoutError(e);
       // Show the timeout error here, so that it's shown regardless of how an application chooses to handle errors.
       this.showTimeoutError(err);
       return err;


### PR DESCRIPTION
### Description
Replaces the upsell with a more helpful message: `Your query has timed out. Contact your system administrator to review your index strategy or increase the run time.`
 
### Issues Resolved
Resolves #1594
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 