### PR TITLE
Bump version to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dashboarding"
   ],
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "branch": "2.0",
   "types": "./opensearch_dashboards.d.ts",
   "tsdocMetadata": "./build/tsdoc-metadata.json",


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Bump the version for opensearch dashboards to 2.0.1 after 2.0.0 will be released.

### Issues Resolved
Part of post release item for [opensearch-project/opensearch-build/#2086](https://github.com/opensearch-project/opensearch-build/issues/2086)
 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 