### PR TITLE
[Tests] Update Dockerfile chrome version to match

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Specify the version of Chrome that matches the version of chromedriver in the package.json.
-# A list of Chrome versions can be found here: 
+# A list of Chrome versions can be found here:
 # https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-ARG CHROME_VERSION=91.0.4472.114-1
+ARG CHROME_VERSION=100.0.4896.127-1
 RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && wget -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
   && apt-get update \


### PR DESCRIPTION
package.json and yarn.lock already updated to 100.0.0

Signed-off-by: Josh Romero <rmerqg@amazon.com>

### Description
Updates the version of Chrome installed by Dockerfile, which is used for running Jenkins tests
 
### Issues Resolved
Fixes #1623

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 