### PR TITLE
[BUG] Remove duplicate var in the opensearch-dashboards-docker

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/bin/opensearch-dashboards-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/bin/opensearch-dashboards-docker
@@ -98,7 +98,6 @@ opensearch_dashboards_vars=(
     regionmap
     security.showInsecureClusterWarning
     server.basePath
-    server.customResponseHeaders
     server.compression.enabled
     server.compression.referrerWhitelist
     server.cors


### PR DESCRIPTION
Signed-off-by: manasvis <manasvis@amazon.com>

### Description
Removes duplicate variable defined in the opensearch-dashboards-docker file
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1429
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
    - [X] `yarn test:jest`
    - [X] `yarn test:jest_integration`
    - [X] `yarn test:ftr`
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff 