### PR TITLE
[Bug] Fix metric vizualization cut off text

### DIFF
--- a/src/plugins/vis_type_metric/public/components/metric_vis.scss
+++ b/src/plugins/vis_type_metric/public/components/metric_vis.scss
@@ -20,8 +20,10 @@
 }
 
 .mtrVis__container {
-  text-align: center;
+  line-height: normal;
+  max-width: 100%;
   padding: $euiSize;
+  text-align: center;
 }
 
 .mtrVis__container--light {


### PR DESCRIPTION
Add container width to enable correct truncation
Normalize line height to prevent clipped descenders

Fixes #1643

Signed-off-by: Josh Romero <rmerqg@amazon.com>

### Description

Because of https://github.com/opensearch-project/OpenSearch-Dashboards/blob/6d1675cd989cdb8c271ee0d89227166162658b17/src/plugins/vis_type_metric/public/components/metric_vis.scss#L16-L17
The truncating styles set overflow to hidden. By adding container width, we enable the intended truncation effect, and normalizing the line-height prevents the descenders from overflowing.

Before:
![metric-text-before](https://user-images.githubusercontent.com/1679762/171519704-693ba8cf-9261-447f-9bc1-132b8f391aa8.gif)
After:
![metric-text-after](https://user-images.githubusercontent.com/1679762/171519698-eb1af382-e7cf-4c7a-a3ce-7c7ad4a5c5d0.gif)

Note that in some cases, such as the currency metric with large text size in the After example, truncation doesn't behave great, because it's unaware of the underlying metric formatting. In the future, we may consider some sort of autosizing/autoformatting instead, but it's out of scope for this fix.

 
### Issues Resolved

Fixes #1643
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 