### PR TITLE
Adds Josh Romero as co-maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,5 +11,6 @@
 | Tommy Markley | [tmarkley](https://github.com/tmarkley) | Amazon | 
 | Miki Barahmand | [AMoo-Miki](https://github.com/AMoo-Miki) | Amazon |
 | Ashwin P Chandran | [ashwin-pc](https://github.com/ashwin-pc) | Amazon |
+| Josh Romero | [joshuarrrr](https://github.com/joshuarrrr) | Amazon |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
### Description
I nominate Josh Romero (@joshuarrrr) as co-maintainer and the OpenSearch Dashboards maintainers unanimously approve this nomination.

Josh has consistently contributed high-quality PRs and is actively improving both the developer and user experience through contributions such as migrating all mocha tests to jest (#215)  and working with the community to redesign the OpenSearch Dashboards global header (#1583).

https://github.com/opensearch-project/OpenSearch-Dashboards/pulls/joshuarrrr

Josh privately accepted this nomination.

Thank you for your contributions Josh!
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 