### PR TITLE
[Improvement] Adding noreferrer on doc links

### DIFF
--- a/src/core/server/ui_settings/settings/notifications.ts
+++ b/src/core/server/ui_settings/settings/notifications.ts
@@ -49,7 +49,7 @@ export const getNotificationsSettings = (): Record<string, UiSettingsParams> => 
         values: {
           markdownLink:
             `<a href="https://help.github.com/articles/basic-writing-and-formatting-syntax/"
-            target="_blank" rel="noopener">` +
+            target="_blank" rel="noopener noreferrer">` +
             i18n.translate('core.ui_settings.params.notifications.banner.markdownLinkText', {
               defaultMessage: 'Markdown supported',
             }) +

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -104,7 +104,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'data.advancedSettings.query.queryStringOptionsText',
         values: {
           optionsLink:
-            '<a href="https://opensearch.org/docs/latest/opensearch/query-dsl/index/" target="_blank" rel="noopener">' +
+            '<a href="https://opensearch.org/docs/latest/opensearch/query-dsl/index/" target="_blank" rel="noopener noreferrer">' +
             i18n.translate('data.advancedSettings.query.queryStringOptions.optionsLinkText', {
               defaultMessage: 'Options',
             }) +
@@ -163,7 +163,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'data.advancedSettings.sortOptionsText',
         values: {
           optionsLink:
-            '<a href="https://opensearch.org/docs/latest/opensearch/ux/#sort-results" target="_blank" rel="noopener">' +
+            '<a href="https://opensearch.org/docs/latest/opensearch/ux/#sort-results" target="_blank" rel="noopener noreferrer">' +
             i18n.translate('data.advancedSettings.sortOptions.optionsLinkText', {
               defaultMessage: 'Options',
             }) +
@@ -245,7 +245,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           setRequestReferenceSetting: `<strong>${UI_SETTINGS.COURIER_SET_REQUEST_PREFERENCE}</strong>`,
           customSettingValue: '"custom"',
           requestPreferenceLink:
-            '<a href="https://opensearch.org/docs/latest/opensearch/popular-api" target="_blank" rel="noopener">' +
+            '<a href="https://opensearch.org/docs/latest/opensearch/popular-api" target="_blank" rel="noopener noreferrer">' +
             i18n.translate(
               'data.advancedSettings.courier.customRequestPreference.requestPreferenceLinkText',
               {
@@ -270,7 +270,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           'Set to 0 to disable this config and use the OpenSearch default.',
         values: {
           maxRequestsLink: `<a href="https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#multi-match"
-            target="_blank" rel="noopener" >max_concurrent_shard_requests</a>`,
+            target="_blank" rel="noopener noreferrer" >max_concurrent_shard_requests</a>`,
         },
       }),
       category: ['search'],
@@ -293,7 +293,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
     [UI_SETTINGS.SEARCH_INCLUDE_FROZEN]: {
       name: 'Search in frozen indices',
       description: `Will include <a href="https://opensearch.org/docs/latest/opensearch/index-data"
-        target="_blank" rel="noopener">frozen indices</a> in results if enabled. Searching through frozen indices
+        target="_blank" rel="noopener noreferrer">frozen indices</a> in results if enabled. Searching through frozen indices
         might increase the search time.`,
       value: false,
       category: ['search'],
@@ -642,7 +642,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
         values: {
           acceptedFormatsLink:
             `<a href="https://opensearch.org/docs/latest/opensearch/units"
-            target="_blank" rel="noopener">` +
+            target="_blank" rel="noopener noreferrer">` +
             i18n.translate('data.advancedSettings.timepicker.quickRanges.acceptedFormatsLinkText', {
               defaultMessage: 'accepted formats',
             }) +

--- a/src/plugins/home/public/application/components/__snapshots__/welcome.test.tsx.snap
+++ b/src/plugins/home/public/application/components/__snapshots__/welcome.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`Welcome page  should render a Welcome screen  with the telemetry discla
               values={Object {}}
             />
             <EuiLink
-              rel="noopener"
+              rel="noopener noreferrer"
               target="_blank"
             >
               <FormattedMessage
@@ -238,7 +238,7 @@ exports[`Welcome page  should render a Welcome screen  with the telemetry discla
               values={Object {}}
             />
             <EuiLink
-              rel="noopener"
+              rel="noopener noreferrer"
               target="_blank"
             >
               <FormattedMessage

--- a/src/plugins/home/public/application/components/welcome.tsx
+++ b/src/plugins/home/public/application/components/welcome.tsx
@@ -260,7 +260,7 @@ export class Welcome extends React.Component<Props> {
                       <EuiLink
                         href={telemetry.telemetryConstants.getPrivacyStatementUrl()}
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                       >
                         <FormattedMessage
                           id="home.dataManagementDisclaimerPrivacyLink"

--- a/src/plugins/maps_legacy/server/ui_settings.ts
+++ b/src/plugins/maps_legacy/server/ui_settings.ts
@@ -50,7 +50,7 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
           values: {
             cellDimensionsLink:
               `<a href="https://opensearch.org/docs/latest/dashboards/maptiles"
-            target="_blank" rel="noopener">` +
+            target="_blank" rel="noopener noreferrer">` +
               i18n.translate(
                 'maps_legacy.advancedSettings.visualization.tileMap.maxPrecision.cellDimensionsLinkText',
                 {

--- a/src/plugins/telemetry/public/components/__snapshots__/opt_in_message.test.tsx.snap
+++ b/src/plugins/telemetry/public/components/__snapshots__/opt_in_message.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`OptInMessage renders as expected 1`] = `
       Object {
         "privacyStatementLink": <EuiLink
           href=""
-          rel="noopener"
+          rel="noopener noreferrer"
           target="_blank"
         >
           <FormattedMessage

--- a/src/plugins/telemetry/public/components/__snapshots__/opted_in_notice_banner.test.tsx.snap
+++ b/src/plugins/telemetry/public/components/__snapshots__/opted_in_notice_banner.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`OptInDetailsComponent renders as expected 1`] = `
         "privacyStatementLink": <EuiLink
           href=""
           onClick={[Function]}
-          rel="noopener"
+          rel="noopener noreferrer"
           target="_blank"
         >
           <FormattedMessage

--- a/src/plugins/telemetry/public/components/opt_in_message.tsx
+++ b/src/plugins/telemetry/public/components/opt_in_message.tsx
@@ -42,7 +42,7 @@ export class OptInMessage extends React.PureComponent {
           defaultMessage="Want to help us improve the OpenSearch Stack? Data usage collection is currently disabled. Enabling data usage collection helps us manage and improve our products and services. See our {privacyStatementLink} for more details."
           values={{
             privacyStatementLink: (
-              <EuiLink href={PRIVACY_STATEMENT_URL} target="_blank" rel="noopener">
+              <EuiLink href={PRIVACY_STATEMENT_URL} target="_blank" rel="noopener noreferrer">
                 <FormattedMessage
                   id="telemetry.welcomeBanner.telemetryConfigDetailsDescription.telemetryPrivacyStatementLinkText"
                   defaultMessage="Privacy Statement"

--- a/src/plugins/telemetry/public/components/opted_in_notice_banner.tsx
+++ b/src/plugins/telemetry/public/components/opted_in_notice_banner.tsx
@@ -58,7 +58,7 @@ export class OptedInNoticeBanner extends React.PureComponent<Props> {
                 onClick={onSeenBanner}
                 href={PRIVACY_STATEMENT_URL}
                 target="_blank"
-                rel="noopener"
+                rel="noopener noreferrer"
               >
                 <FormattedMessage
                   id="telemetry.telemetryOptedInPrivacyStatement"

--- a/src/plugins/vis_default_editor/public/components/agg_select.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_select.tsx
@@ -89,7 +89,7 @@ function DefaultEditorAggSelect({
 
   const helpLink = value && aggHelpLink && (
     <EuiText size="xs">
-      <EuiLink href={aggHelpLink} target="_blank" rel="noopener">
+      <EuiLink href={aggHelpLink} target="_blank" rel="noopener noreferrer">
         <FormattedMessage
           id="visDefaultEditor.aggSelect.helpLinkLabel"
           defaultMessage="{aggTitle} help"


### PR DESCRIPTION
Signed-off-by: manasvis <manasvis@amazon.com>

### Description
Stemming from this PR: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/565. Links inconsistently have noreferrer on the reference.
This change might not include adding noreferrer to all the links in the package, but links which already have 'rel="noopener"' in it to make it consistent throughout the repo as called out in the above PR.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/567

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 