### PR TITLE
[Non-Inclusive Language] Replace isDevClusterMaster with isDevClusterManager

### DIFF
--- a/packages/osd-config/src/__mocks__/env.ts
+++ b/packages/osd-config/src/__mocks__/env.ts
@@ -54,5 +54,7 @@ export function getEnvOptions(options: DeepPartial<EnvOptions> = {}): EnvOptions
     },
     isDevClusterMaster:
       options.isDevClusterMaster !== undefined ? options.isDevClusterMaster : false,
+    isDevClusterManager:
+      options.isDevClusterManager !== undefined ? options.isDevClusterManager : false,
   };
 }

--- a/packages/osd-config/src/__snapshots__/env.test.ts.snap
+++ b/packages/osd-config/src/__snapshots__/env.test.ts.snap
@@ -21,7 +21,7 @@ Env {
     "/some/other/path/some-opensearch-dashboards.yml",
   ],
   "homeDir": "/test/opensearchDashboardsRoot",
-  "isDevClusterMaster": false,
+  "isDevClusterManager": false,
   "logDir": "/test/opensearchDashboardsRoot/log",
   "mode": Object {
     "dev": true,
@@ -64,7 +64,7 @@ Env {
     "/some/other/path/some-opensearch-dashboards.yml",
   ],
   "homeDir": "/test/opensearchDashboardsRoot",
-  "isDevClusterMaster": false,
+  "isDevClusterManager": false,
   "logDir": "/test/opensearchDashboardsRoot/log",
   "mode": Object {
     "dev": false,
@@ -86,7 +86,7 @@ Env {
 }
 `;
 
-exports[`correctly creates default environment in dev mode.: env properties 1`] = `
+exports[`correctly creates default environment in dev mode when isDevClusterManager and isDevClusterMaster both are true: env properties 1`] = `
 Env {
   "binDir": "/test/opensearchDashboardsRoot/bin",
   "cliArgs": Object {
@@ -106,7 +106,91 @@ Env {
     "/test/cwd/config/opensearch_dashboards.yml",
   ],
   "homeDir": "/test/opensearchDashboardsRoot",
-  "isDevClusterMaster": true,
+  "isDevClusterManager": true,
+  "logDir": "/test/opensearchDashboardsRoot/log",
+  "mode": Object {
+    "dev": true,
+    "name": "development",
+    "prod": false,
+  },
+  "packageInfo": Object {
+    "branch": "some-branch",
+    "buildNum": 9007199254740991,
+    "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    "dist": false,
+    "version": "some-version",
+  },
+  "pluginSearchPaths": Array [
+    "/test/opensearchDashboardsRoot/src/plugins",
+    "/test/opensearchDashboardsRoot/plugins",
+    "/test/opensearchDashboardsRoot/../opensearch-dashboards-extra",
+  ],
+}
+`;
+
+exports[`correctly creates default environment in dev mode when isDevClusterManager is true: env properties 1`] = `
+Env {
+  "binDir": "/test/opensearchDashboardsRoot/bin",
+  "cliArgs": Object {
+    "basePath": false,
+    "cache": true,
+    "dev": true,
+    "disableOptimizer": true,
+    "dist": false,
+    "quiet": false,
+    "repl": false,
+    "runExamples": false,
+    "silent": false,
+    "watch": false,
+  },
+  "configDir": "/test/opensearchDashboardsRoot/config",
+  "configs": Array [
+    "/test/cwd/config/opensearch_dashboards.yml",
+  ],
+  "homeDir": "/test/opensearchDashboardsRoot",
+  "isDevClusterManager": true,
+  "logDir": "/test/opensearchDashboardsRoot/log",
+  "mode": Object {
+    "dev": true,
+    "name": "development",
+    "prod": false,
+  },
+  "packageInfo": Object {
+    "branch": "some-branch",
+    "buildNum": 9007199254740991,
+    "buildSha": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    "dist": false,
+    "version": "some-version",
+  },
+  "pluginSearchPaths": Array [
+    "/test/opensearchDashboardsRoot/src/plugins",
+    "/test/opensearchDashboardsRoot/plugins",
+    "/test/opensearchDashboardsRoot/../opensearch-dashboards-extra",
+  ],
+}
+`;
+
+exports[`correctly creates default environment in dev mode when isDevClusterMaster (deprecated) is true: env properties 1`] = `
+Env {
+  "binDir": "/test/opensearchDashboardsRoot/bin",
+  "cliArgs": Object {
+    "basePath": false,
+    "cache": true,
+    "dev": true,
+    "disableOptimizer": true,
+    "dist": false,
+    "quiet": false,
+    "repl": false,
+    "runExamples": false,
+    "silent": false,
+    "watch": false,
+  },
+  "configDir": "/test/opensearchDashboardsRoot/config",
+  "configs": Array [
+    "/test/cwd/config/opensearch_dashboards.yml",
+  ],
+  "homeDir": "/test/opensearchDashboardsRoot",
+  "isDevClusterManager": true,
   "logDir": "/test/opensearchDashboardsRoot/log",
   "mode": Object {
     "dev": true,
@@ -148,7 +232,7 @@ Env {
     "/some/other/path/some-opensearch-dashboards.yml",
   ],
   "homeDir": "/test/opensearchDashboardsRoot",
-  "isDevClusterMaster": false,
+  "isDevClusterManager": false,
   "logDir": "/test/opensearchDashboardsRoot/log",
   "mode": Object {
     "dev": false,
@@ -190,7 +274,7 @@ Env {
     "/some/other/path/some-opensearch-dashboards.yml",
   ],
   "homeDir": "/test/opensearchDashboardsRoot",
-  "isDevClusterMaster": false,
+  "isDevClusterManager": false,
   "logDir": "/test/opensearchDashboardsRoot/log",
   "mode": Object {
     "dev": false,
@@ -232,7 +316,7 @@ Env {
     "/some/other/path/some-opensearch-dashboards.yml",
   ],
   "homeDir": "/some/home/dir",
-  "isDevClusterMaster": false,
+  "isDevClusterManager": false,
   "logDir": "/some/home/dir/log",
   "mode": Object {
     "dev": false,

--- a/packages/osd-config/src/env.test.ts
+++ b/packages/osd-config/src/env.test.ts
@@ -48,7 +48,7 @@ beforeEach(() => {
   mockPackage.raw = {};
 });
 
-test('correctly creates default environment in dev mode.', () => {
+test('correctly creates default environment in dev mode when isDevClusterMaster (deprecated) is true', () => {
   mockPackage.raw = {
     branch: 'some-branch',
     version: 'some-version',
@@ -59,10 +59,50 @@ test('correctly creates default environment in dev mode.', () => {
     getEnvOptions({
       configs: ['/test/cwd/config/opensearch_dashboards.yml'],
       isDevClusterMaster: true,
+      isDevClusterManager: false,
     })
   );
 
   expect(defaultEnv).toMatchSnapshot('env properties');
+  expect(defaultEnv.isDevClusterManager).toBeTruthy();
+});
+
+test('correctly creates default environment in dev mode when isDevClusterManager is true', () => {
+  mockPackage.raw = {
+    branch: 'some-branch',
+    version: 'some-version',
+  };
+
+  const defaultEnv = Env.createDefault(
+    REPO_ROOT,
+    getEnvOptions({
+      configs: ['/test/cwd/config/opensearch_dashboards.yml'],
+      isDevClusterMaster: false,
+      isDevClusterManager: true,
+    })
+  );
+
+  expect(defaultEnv).toMatchSnapshot('env properties');
+  expect(defaultEnv.isDevClusterManager).toBeTruthy();
+});
+
+test('correctly creates default environment in dev mode when isDevClusterManager and isDevClusterMaster both are true', () => {
+  mockPackage.raw = {
+    branch: 'some-branch',
+    version: 'some-version',
+  };
+
+  const defaultEnv = Env.createDefault(
+    REPO_ROOT,
+    getEnvOptions({
+      configs: ['/test/cwd/config/opensearch_dashboards.yml'],
+      isDevClusterMaster: true,
+      isDevClusterManager: true,
+    })
+  );
+
+  expect(defaultEnv).toMatchSnapshot('env properties');
+  expect(defaultEnv.isDevClusterManager).toBeTruthy();
 });
 
 test('correctly creates default environment in prod distributable mode.', () => {

--- a/packages/osd-config/src/env.ts
+++ b/packages/osd-config/src/env.ts
@@ -36,7 +36,9 @@ import { PackageInfo, EnvironmentMode } from './types';
 export interface EnvOptions {
   configs: string[];
   cliArgs: CliArgs;
+  /** @deprecated use isDevClusterManager */
   isDevClusterMaster: boolean;
+  isDevClusterManager: boolean;
 }
 
 /** @internal */
@@ -110,10 +112,10 @@ export class Env {
   public readonly configs: readonly string[];
 
   /**
-   * Indicates that this OpenSearch Dashboards  instance is run as development Node Cluster master.
+   * Indicates that this OpenSearch Dashboards  instance is run as development Node Cluster manager.
    * @internal
    */
-  public readonly isDevClusterMaster: boolean;
+  public readonly isDevClusterManager: boolean;
 
   /**
    * @internal
@@ -137,7 +139,7 @@ export class Env {
 
     this.cliArgs = Object.freeze(options.cliArgs);
     this.configs = Object.freeze(options.configs);
-    this.isDevClusterMaster = options.isDevClusterMaster;
+    this.isDevClusterManager = options.isDevClusterManager || options.isDevClusterMaster;
 
     const isDevMode = this.cliArgs.dev || this.cliArgs.envName === 'development';
     this.mode = Object.freeze<EnvironmentMode>({

--- a/src/core/server/bootstrap.ts
+++ b/src/core/server/bootstrap.ts
@@ -29,7 +29,7 @@
  */
 
 import chalk from 'chalk';
-import { isMaster } from 'cluster';
+import { isMaster as isClusterManager } from 'cluster';
 import { CliArgs, Env, RawConfigService } from './config';
 import { Root } from './root';
 import { CriticalError } from './errors';
@@ -82,7 +82,8 @@ export async function bootstrap({
   const env = Env.createDefault(REPO_ROOT, {
     configs,
     cliArgs,
-    isDevClusterMaster: isMaster && cliArgs.dev && features.isClusterModeSupported,
+    isDevClusterMaster: isClusterManager && cliArgs.dev && features.isClusterModeSupported,
+    isDevClusterManager: isClusterManager && cliArgs.dev && features.isClusterModeSupported,
   });
 
   const rawConfigService = new RawConfigService(env.configs, applyConfigOverrides);

--- a/src/core/server/http/http_service.test.ts
+++ b/src/core/server/http/http_service.test.ts
@@ -262,7 +262,7 @@ test('returns http server contract on setup', async () => {
   });
 });
 
-test('does not start http server if process is dev cluster master', async () => {
+test('does not start http server if process is dev cluster master (deprecated) or dev cluster manager', async () => {
   const configService = createConfigService();
   const httpServer = {
     isListening: () => false,
@@ -275,7 +275,71 @@ test('does not start http server if process is dev cluster master', async () => 
   const service = new HttpService({
     coreId,
     configService,
-    env: Env.createDefault(REPO_ROOT, getEnvOptions({ isDevClusterMaster: true })),
+    env: Env.createDefault(
+      REPO_ROOT,
+      getEnvOptions({
+        isDevClusterManager: true,
+        isDevClusterMaster: true,
+      })
+    ),
+    logger,
+  });
+
+  await service.setup(setupDeps);
+  await service.start();
+
+  expect(httpServer.start).not.toHaveBeenCalled();
+});
+
+test('does not start http server if process is dev cluster manager', async () => {
+  const configService = createConfigService();
+  const httpServer = {
+    isListening: () => false,
+    setup: jest.fn().mockReturnValue({}),
+    start: jest.fn(),
+    stop: noop,
+  };
+  mockHttpServer.mockImplementation(() => httpServer);
+
+  const service = new HttpService({
+    coreId,
+    configService,
+    env: Env.createDefault(
+      REPO_ROOT,
+      getEnvOptions({
+        isDevClusterManager: true,
+        isDevClusterMaster: false,
+      })
+    ),
+    logger,
+  });
+
+  await service.setup(setupDeps);
+  await service.start();
+
+  expect(httpServer.start).not.toHaveBeenCalled();
+});
+
+test('does not start http server if process is dev cluster master (deprecated)', async () => {
+  const configService = createConfigService();
+  const httpServer = {
+    isListening: () => false,
+    setup: jest.fn().mockReturnValue({}),
+    start: jest.fn(),
+    stop: noop,
+  };
+  mockHttpServer.mockImplementation(() => httpServer);
+
+  const service = new HttpService({
+    coreId,
+    configService,
+    env: Env.createDefault(
+      REPO_ROOT,
+      getEnvOptions({
+        isDevClusterManager: false,
+        isDevClusterMaster: true,
+      })
+    ),
     logger,
   });
 

--- a/src/core/server/http/http_service.ts
+++ b/src/core/server/http/http_service.ts
@@ -169,7 +169,7 @@ export class HttpService
    * @internal
    * */
   private shouldListen(config: HttpConfig) {
-    return !this.coreContext.env.isDevClusterMaster && config.autoListen;
+    return !this.coreContext.env.isDevClusterManager && config.autoListen;
   }
 
   public async stop() {

--- a/src/core/server/legacy/legacy_service.test.ts
+++ b/src/core/server/legacy/legacy_service.test.ts
@@ -373,6 +373,7 @@ describe('once LegacyService is set up in `devClusterMaster` mode', () => {
         REPO_ROOT,
         getEnvOptions({
           cliArgs: { silent: true, basePath: false },
+          isDevClusterManager: false,
           isDevClusterMaster: true,
         })
       ),
@@ -402,7 +403,8 @@ describe('once LegacyService is set up in `devClusterMaster` mode', () => {
         REPO_ROOT,
         getEnvOptions({
           cliArgs: { quiet: true, basePath: true },
-          isDevClusterMaster: true,
+          isDevClusterManager: true,
+          isDevClusterMaster: false,
         })
       ),
       logger,

--- a/src/core/server/legacy/legacy_service.ts
+++ b/src/core/server/legacy/legacy_service.ts
@@ -155,7 +155,7 @@ export class LegacyService implements CoreService {
     this.log.debug('starting legacy service');
 
     // Receive initial config and create osdServer/ClusterManager.
-    if (this.coreContext.env.isDevClusterMaster) {
+    if (this.coreContext.env.isDevClusterManager) {
       await this.createClusterManager(this.legacyRawConfig!);
     } else {
       this.osdServer = await this.createOsdServer(

--- a/src/core/server/plugins/plugins_service.ts
+++ b/src/core/server/plugins/plugins_service.ts
@@ -137,7 +137,7 @@ export class PluginsService implements CoreService<PluginsServiceSetup, PluginsS
     const config = await this.config$.pipe(first()).toPromise();
 
     let contracts = new Map<PluginName, unknown>();
-    const initialize = config.initialize && !this.coreContext.env.isDevClusterMaster;
+    const initialize = config.initialize && !this.coreContext.env.isDevClusterManager;
     if (initialize) {
       contracts = await this.pluginsSystem.setupPlugins(deps);
       this.registerPluginStaticDirs(deps);

--- a/src/core/test_helpers/osd_server.ts
+++ b/src/core/test_helpers/osd_server.ts
@@ -91,6 +91,7 @@ export function createRootWithSettings(
       ...cliArgs,
     },
     isDevClusterMaster: false,
+    isDevClusterManager: false,
   });
 
   return new Root(

--- a/src/legacy/server/logging/rotate/index.ts
+++ b/src/legacy/server/logging/rotate/index.ts
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import { isMaster, isWorker } from 'cluster';
+import { isMaster as isClusterManager, isWorker } from 'cluster';
 import { Server } from '@hapi/hapi';
 import { LogRotator } from './log_rotator';
 import { OpenSearchDashboardsConfig } from '../../osd_server';
@@ -43,7 +43,7 @@ export async function setupLoggingRotate(server: Server, config: OpenSearchDashb
 
   // We just want to start the logging rotate service once
   // and we choose to use the master (prod) or the worker server (dev)
-  if (!isMaster && isWorker && process.env.osdWorkerType !== 'server') {
+  if (!isClusterManager && isWorker && process.env.osdWorkerType !== 'server') {
     return;
   }
 

--- a/src/legacy/server/logging/rotate/log_rotator.ts
+++ b/src/legacy/server/logging/rotate/log_rotator.ts
@@ -29,7 +29,7 @@
  */
 
 import * as chokidar from 'chokidar';
-import { isMaster } from 'cluster';
+import { isMaster as isClusterManager } from 'cluster';
 import fs from 'fs';
 import { Server } from '@hapi/hapi';
 import { throttle } from 'lodash';
@@ -359,7 +359,7 @@ export class LogRotator {
   }
 
   _sendReloadLogConfigSignal() {
-    if (isMaster) {
+    if (isClusterManager) {
       (process as NodeJS.EventEmitter).emit('SIGHUP');
       return;
     }


### PR DESCRIPTION
Signed-off-by: manasvis <manasvis@amazon.com>

### Description
Coming from https://github.com/opensearch-project/OpenSearch/issues/2589.

[OpenSearch](https://github.com/opensearch-project/OpenSearch) repository is going to replace the terminology "master" with "cluster manager".
issue: https://github.com/opensearch-project/OpenSearch/issues/472#issuecomment-960298995, with the plan for its terminology replacement.

In this change we are replacing the instances of the terminology "isDevClusterMaster" with "isDevClusterManager".
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-dashboards/issues/1690

Parent https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1318
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff 