### PR TITLE
[CI][Github] Use OpenSearch Docker Image

### DIFF
--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -49,19 +49,19 @@ jobs:
 
       - name: Get if previous job was successful
         id: job_successful
-        run: cat job_successful 2>/dev/null || echo 'false'
+        run: cat ./artifacts/job_successful 2>/dev/null || echo 'false'
 
       - name: Get the previous linter results 
         id: linter_results
-        run: cat linter_results 2>/dev/null || echo 'default'
+        run: cat ./artifacts/linter_results 2>/dev/null || echo 'default'
 
       - name: Get the previous unit tests results 
         id: unit_tests_results
-        run: cat unit_tests_results 2>/dev/null || echo 'default'
+        run: cat ./artifacts/unit_tests_results 2>/dev/null || echo 'default'
 
       - name: Get the previous integration tests results 
         id: integration_tests_results
-        run: cat integration_tests_results 2>/dev/null || echo 'default'
+        run: cat ./artifacts/integration_tests_results 2>/dev/null || echo 'default'
 
       - name: Checkout code
         if: steps.job_successful.outputs.job_successful != 'true'
@@ -152,7 +152,7 @@ jobs:
 
       - name: Get the cached tests results 
         id: ftr_tests_results
-        run: cat ftr_tests_results 2>/dev/null || echo 'default'
+        run: cat ./artifacts/ftr_tests_results 2>/dev/null || echo 'default'
 
       - name: Checkout code
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'

--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -24,6 +24,9 @@ env:
 jobs:
   build-lint-test:
     runs-on: ubuntu-latest
+    container:
+      image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
+      options: --user 1001
     name: Build and Verify
     steps:
       # Access a cache of set results from a previous run of the job
@@ -95,20 +98,6 @@ jobs:
 
       - run: echo Unit tests completed unsuccessfully. However, unit tests are inconsistent on the CI so please verify locally with `yarn test:jest`.
         if: steps.unit_tests_results.outputs.unit_tests_results != 'success' && steps.unit-tests.outcome != 'success'
-      
-      # TODO: This gets rejected, we need approval to add this
-      # - name: Add comment if unit tests did not succeed
-      #   if: steps.unit_tests_results.outputs.unit_tests_results != 'success' && steps.unit-tests.outcome != 'success'
-      #   uses: actions/github-script@v5
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     script: |
-      #       github.rest.issues.createComment({
-      #         issue_number: context.issue.number,
-      #         owner: context.repo.owner,
-      #         repo: context.repo.repo,
-      #         body: 'Unit tests completed unsuccessfully. However, unit tests are inconsistent on the CI so please verify locally with `yarn test:jest`.'
-      #       })
 
       - name: Run integration tests
         if: steps.integration_tests_results.outputs.integration_tests_results != 'success'
@@ -131,6 +120,9 @@ jobs:
   functional-tests:
     needs: [ build-lint-test ]
     runs-on: ubuntu-latest
+    container:
+      image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
+      options: --user 1001
     name: Run functional tests
     strategy: 
       matrix:
@@ -187,10 +179,9 @@ jobs:
             ${{ runner.os }}-yarn-
             ${{ runner.os }}-
 
-      # github virtual env is the latest chrome
+      # image has the latest chrome v99
       - name: Setup chromedriver
-        if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'
-        run: yarn add --dev chromedriver@100.0.0
+        run: yarn add --dev chromedriver@99.0.0
 
       - name: Run bootstrap
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'

--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
-      options: --user 1001
+      options: --user root
     name: Build and Verify
     steps:
       # Access a cache of set results from a previous run of the job
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
-      options: --user 1001
+      options: --user root
     name: Run functional tests
     strategy: 
       matrix:

--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -39,10 +39,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ./artificats/job_successful
-            ./artificats/linter_results
-            ./artificats/unit_tests_results
-            ./artificats/integration_tests_results
+            ./artifacts/job_successful
+            ./artifacts/linter_results
+            ./artifacts/unit_tests_results
+            ./artifacts/integration_tests_results
           key: ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
             ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}

--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -25,8 +25,8 @@ jobs:
   build-lint-test:
     runs-on: ubuntu-latest
     container:
-      image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
-      options: --user root
+      image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
+      options: --user 1001
     name: Build and Verify
     steps:
       # Access a cache of set results from a previous run of the job
@@ -121,8 +121,8 @@ jobs:
     needs: [ build-lint-test ]
     runs-on: ubuntu-latest
     container:
-      image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
-      options: --user root
+      image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
+      options: --user 1001
     name: Run functional tests
     strategy: 
       matrix:

--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -32,53 +32,54 @@ jobs:
       # Access a cache of set results from a previous run of the job
       # This is to prevent re-running steps that were already successful since it is not native to github actions
       # Can be used to verify flaky steps with reduced times
-      # - name: Restore the cached run
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       job_successful
-      #       linter_results
-      #       unit_tests_results
-      #       integration_tests_results
-      #     key: ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}
-      #     restore-keys: |
-      #       ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}
+      - name: Restore the cached run
+        uses: actions/cache@v2
+        with:
+          path: |
+            job_successful
+            linter_results
+            unit_tests_results
+            integration_tests_results
+          key: ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}
 
-      # - name: Get if previous job was successful
-      #   id: job_successful
-      #   run: cat job_successful 2>/dev/null || echo 'false'
+      - name: Get if previous job was successful
+        id: job_successful
+        run: cat job_successful 2>/dev/null || echo 'false'
 
-      # - name: Get the previous linter results 
-      #   id: linter_results
-      #   run: cat linter_results 2>/dev/null || echo 'default'
+      - name: Get the previous linter results 
+        id: linter_results
+        run: cat linter_results 2>/dev/null || echo 'default'
 
-      # - name: Get the previous unit tests results 
-      #   id: unit_tests_results
-      #   run: cat unit_tests_results 2>/dev/null || echo 'default'
+      - name: Get the previous unit tests results 
+        id: unit_tests_results
+        run: cat unit_tests_results 2>/dev/null || echo 'default'
 
-      # - name: Get the previous integration tests results 
-      #   id: integration_tests_results
-      #   run: cat integration_tests_results 2>/dev/null || echo 'default'
+      - name: Get the previous integration tests results 
+        id: integration_tests_results
+        run: cat integration_tests_results 2>/dev/null || echo 'default'
 
       - name: Checkout code
-        # if: steps.job_successful.outputs.job_successful != 'true'
+        if: steps.job_successful.outputs.job_successful != 'true'
         uses: actions/checkout@v2
 
       - name: Setup Node
-        # if: steps.job_successful.outputs.job_successful != 'true'
+        if: steps.job_successful.outputs.job_successful != 'true'
         uses: actions/setup-node@v2
         with:
           node-version-file: ".nvmrc"
           registry-url: 'https://registry.npmjs.org'
+          cache: '${{ github.run_id }}-${{ github.job }}-${{ github.sha }}'
 
       - name: Setup Yarn
-        # if: steps.job_successful.outputs.job_successful != 'true'
+        if: steps.job_successful.outputs.job_successful != 'true'
         run: |
           npm uninstall -g yarn
           npm i -g yarn@1.22.10
 
       - name: Run bootstrap
-        # if: steps.job_successful.outputs.job_successful != 'true'
+        if: steps.job_successful.outputs.job_successful != 'true'
         run: yarn osd bootstrap
 
       - name: Run linter

--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -39,10 +39,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            job_successful
-            linter_results
-            unit_tests_results
-            integration_tests_results
+            ./artificats/job_successful
+            ./artificats/linter_results
+            ./artificats/unit_tests_results
+            ./artificats/integration_tests_results
           key: ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
             ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}
@@ -145,7 +145,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ftr_tests_results
+            ./artifacts/ftr_tests_results
           key: ${{ github.run_id }}-${{ github.job }}-${{ matrix.group }}-${{ github.sha }}
           restore-keys: |
             ${{ github.run_id }}-${{ github.job }}-${{ matrix.group }}-${{ github.sha }}

--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -25,7 +25,7 @@ jobs:
   build-lint-test:
     runs-on: ubuntu-latest
     container:
-      image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
+      image: docker://opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2
       options: --user 1001
     name: Build and Verify
     steps:
@@ -121,7 +121,7 @@ jobs:
     needs: [ build-lint-test ]
     runs-on: ubuntu-latest
     container:
-      image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
+      image: docker://opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2
       options: --user 1001
     name: Run functional tests
     strategy: 

--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -25,60 +25,60 @@ jobs:
   build-lint-test:
     runs-on: ubuntu-latest
     container:
-      image: docker://opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2
+      image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
       options: --user 1001
     name: Build and Verify
     steps:
       # Access a cache of set results from a previous run of the job
       # This is to prevent re-running steps that were already successful since it is not native to github actions
       # Can be used to verify flaky steps with reduced times
-      - name: Restore the cached run
-        uses: actions/cache@v2
-        with:
-          path: |
-            job_successful
-            linter_results
-            unit_tests_results
-            integration_tests_results
-          key: ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}
+      # - name: Restore the cached run
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       job_successful
+      #       linter_results
+      #       unit_tests_results
+      #       integration_tests_results
+      #     key: ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}
+      #     restore-keys: |
+      #       ${{ github.run_id }}-${{ github.job }}-${{ github.sha }}
 
-      - name: Get if previous job was successful
-        id: job_successful
-        run: cat job_successful 2>/dev/null || echo 'false'
+      # - name: Get if previous job was successful
+      #   id: job_successful
+      #   run: cat job_successful 2>/dev/null || echo 'false'
 
-      - name: Get the previous linter results 
-        id: linter_results
-        run: cat linter_results 2>/dev/null || echo 'default'
+      # - name: Get the previous linter results 
+      #   id: linter_results
+      #   run: cat linter_results 2>/dev/null || echo 'default'
 
-      - name: Get the previous unit tests results 
-        id: unit_tests_results
-        run: cat unit_tests_results 2>/dev/null || echo 'default'
+      # - name: Get the previous unit tests results 
+      #   id: unit_tests_results
+      #   run: cat unit_tests_results 2>/dev/null || echo 'default'
 
-      - name: Get the previous integration tests results 
-        id: integration_tests_results
-        run: cat integration_tests_results 2>/dev/null || echo 'default'
+      # - name: Get the previous integration tests results 
+      #   id: integration_tests_results
+      #   run: cat integration_tests_results 2>/dev/null || echo 'default'
 
       - name: Checkout code
-        if: steps.job_successful.outputs.job_successful != 'true'
+        # if: steps.job_successful.outputs.job_successful != 'true'
         uses: actions/checkout@v2
 
       - name: Setup Node
-        if: steps.job_successful.outputs.job_successful != 'true'
+        # if: steps.job_successful.outputs.job_successful != 'true'
         uses: actions/setup-node@v2
         with:
           node-version-file: ".nvmrc"
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup Yarn
-        if: steps.job_successful.outputs.job_successful != 'true'
+        # if: steps.job_successful.outputs.job_successful != 'true'
         run: |
           npm uninstall -g yarn
           npm i -g yarn@1.22.10
 
       - name: Run bootstrap
-        if: steps.job_successful.outputs.job_successful != 'true'
+        # if: steps.job_successful.outputs.job_successful != 'true'
         run: yarn osd bootstrap
 
       - name: Run linter
@@ -121,7 +121,7 @@ jobs:
     needs: [ build-lint-test ]
     runs-on: ubuntu-latest
     container:
-      image: docker://opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2
+      image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
       options: --user 1001
     name: Run functional tests
     strategy: 

--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -27,6 +27,9 @@ jobs:
     container:
       image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
       options: --user 1001
+    defaults:
+      run:
+        working-directory: ./artifacts
     name: Build and Verify
     steps:
       # Access a cache of set results from a previous run of the job
@@ -63,14 +66,15 @@ jobs:
       - name: Checkout code
         if: steps.job_successful.outputs.job_successful != 'true'
         uses: actions/checkout@v2
+        with:
+          path: ./artifacts
 
       - name: Setup Node
         if: steps.job_successful.outputs.job_successful != 'true'
         uses: actions/setup-node@v2
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: "./artifacts/.nvmrc"
           registry-url: 'https://registry.npmjs.org'
-          cache: '${{ github.run_id }}-${{ github.job }}-${{ github.sha }}'
 
       - name: Setup Yarn
         if: steps.job_successful.outputs.job_successful != 'true'
@@ -124,6 +128,9 @@ jobs:
     container:
       image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
       options: --user 1001
+    defaults:
+      run:
+        working-directory: ./artifacts
     name: Run functional tests
     strategy: 
       matrix:
@@ -150,12 +157,14 @@ jobs:
       - name: Checkout code
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'
         uses: actions/checkout@v2
+        with:
+          path: ./artifacts
 
       - name: Setup Node
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'
         uses: actions/setup-node@v2
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: "./artifacts/.nvmrc"
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup Yarn


### PR DESCRIPTION
### Description
Changes originating from:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1624

This allows the workflow to run using the published images from:
https://hub.docker.com/r/opensearchstaging/ci-runner/tags. To avoid
the issues when GitHub virtual environments are updated.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1746
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 