### PR TITLE
[Deprecation] Deprecate setupMaster in favor of setupClusterManager

### DIFF
--- a/src/cli/cluster/cluster.mock.ts
+++ b/src/cli/cluster/cluster.mock.ts
@@ -78,5 +78,7 @@ class MockClusterFork extends EventEmitter {
 
 export class MockCluster extends EventEmitter {
   fork = jest.fn(() => new MockClusterFork(this));
+  /** @deprecated use setupClusterManager */
   setupMaster = jest.fn();
+  setupClusterManager = jest.fn();
 }

--- a/src/cli/cluster/cluster_manager.ts
+++ b/src/cli/cluster/cluster_manager.ts
@@ -135,7 +135,7 @@ export class ClusterManager {
     });
 
     // When receive that event from server worker
-    // forward a reloadLoggingConfig message to master
+    // forward a reloadLoggingConfig message to cluster manager
     // and all workers. This is only used by LogRotator service
     // when the cluster mode is enabled
     this.server.on('reloadLoggingConfigFromServerWorker', () => {

--- a/src/cli/cluster/worker.ts
+++ b/src/cli/cluster/worker.ts
@@ -30,6 +30,7 @@
 
 import _ from 'lodash';
 import cluster from 'cluster';
+import { setupMaster as setupClusterManager } from 'cluster';
 import { EventEmitter } from 'events';
 
 import { BinderFor } from './binder_for';
@@ -44,7 +45,7 @@ export type ClusterWorker = cluster.Worker & {
   exitCode?: number;
 };
 
-cluster.setupMaster({
+setupClusterManager({
   exec: cliPath,
   silent: false,
 });


### PR DESCRIPTION
Signed-off-by: manasvis <manasvis@amazon.com>

### Description
As part of the meta issue https://github.com/opensearch-project/OpenSearch/issues/2589 to track the plan and progress of applying inclusive naming across OpenSearch Repositories

Every repository that uses non-inclusive words should replace all the non-inclusive usages in the code base.

We are deprecating setupMaster in favor of setupClusterManager
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1689
 
### Parent
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1318
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff 