### PR TITLE
[Deprecation] Deprecate master nodes and replace with cluster_manager nodes

### DIFF
--- a/src/plugins/console/public/lib/osd/osd.js
+++ b/src/plugins/console/public/lib/osd/osd.js
@@ -101,7 +101,17 @@ const parametrizedComponentFactories = {
   nodes: function (name, parent) {
     return new ListComponent(
       name,
-      ['_local', '_master', 'data:true', 'data:false', 'master:true', 'master:false'],
+      [
+        '_local',
+        '_master',
+        '_cluster_manager',
+        'data:true',
+        'data:false',
+        'master:true',
+        'cluster_manager:true',
+        'master:false',
+        'cluster_manager:false',
+      ],
       parent
     );
   },

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.state.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.state.json
@@ -29,6 +29,7 @@
         "_all",
         "blocks",
         "master_node",
+        "cluster_manager_node",
         "metadata",
         "nodes",
         "routing_nodes",


### PR DESCRIPTION



Signed-off-by: manasvinibs <manasvis@amazon.com>

### Description
As part of the meta issue opensearch-project/OpenSearch#2589 to track the plan and progress of applying inclusive naming across OpenSearch Repositories.

In this change we are replacing the instance of 'master' node with 'cluster_manager'.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1688
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff 