### PR TITLE
[Deprecation] Deprecate master_timeout in favor of cluster_manager_timeout

### DIFF
--- a/packages/osd-spec-to-console/test/fixtures/cluster_health_autocomplete.json
+++ b/packages/osd-spec-to-console/test/fixtures/cluster_health_autocomplete.json
@@ -14,6 +14,7 @@
       ],
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": "",
       "wait_for_active_shards": "",
       "wait_for_nodes": "",

--- a/packages/osd-spec-to-console/test/fixtures/cluster_health_spec.json
+++ b/packages/osd-spec-to-console/test/fixtures/cluster_health_spec.json
@@ -57,6 +57,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster manager node"
+      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.allocation.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.allocation.json
@@ -5,7 +5,7 @@
       "bytes": [
         "b",
         "k",
-        "osd",
+        "kb",
         "m",
         "mb",
         "g",
@@ -17,6 +17,7 @@
       ],
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "h": [],
       "help": "__flag__",
       "s": [],

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.indices.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.indices.json
@@ -5,7 +5,7 @@
       "bytes": [
         "b",
         "k",
-        "osd",
+        "kb",
         "m",
         "mb",
         "g",
@@ -17,6 +17,7 @@
       ],
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "h": [],
       "health": [
         "green",

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.nodeattrs.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.nodeattrs.json
@@ -4,6 +4,7 @@
       "format": "",
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "h": [],
       "help": "__flag__",
       "s": [],

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.nodes.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.nodes.json
@@ -4,7 +4,7 @@
       "bytes": [
         "b",
         "k",
-        "osd",
+        "kb",
         "m",
         "mb",
         "g",
@@ -18,6 +18,7 @@
       "full_id": "__flag__",
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "h": [],
       "help": "__flag__",
       "s": [],

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.pending_tasks.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.pending_tasks.json
@@ -4,6 +4,7 @@
       "format": "",
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "h": [],
       "help": "__flag__",
       "s": [],

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.plugins.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.plugins.json
@@ -4,6 +4,7 @@
       "format": "",
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "h": [],
       "help": "__flag__",
       "s": [],

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.repositories.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.repositories.json
@@ -4,6 +4,7 @@
       "format": "",
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "h": [],
       "help": "__flag__",
       "s": [],

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.shards.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.shards.json
@@ -5,7 +5,7 @@
       "bytes": [
         "b",
         "k",
-        "osd",
+        "kb",
         "m",
         "mb",
         "g",
@@ -17,6 +17,7 @@
       ],
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "h": [],
       "help": "__flag__",
       "s": [],

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.snapshots.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.snapshots.json
@@ -4,6 +4,7 @@
       "format": "",
       "ignore_unavailable": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "h": [],
       "help": "__flag__",
       "s": [],

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.templates.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.templates.json
@@ -4,6 +4,7 @@
       "format": "",
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "h": [],
       "help": "__flag__",
       "s": [],

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.thread_pool.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.thread_pool.json
@@ -12,6 +12,7 @@
       ],
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "h": [],
       "help": "__flag__",
       "s": [],

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.delete_component_template.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.delete_component_template.json
@@ -2,7 +2,8 @@
   "cluster.delete_component_template": {
     "url_params": {
       "timeout": "",
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "DELETE"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.get_settings.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.get_settings.json
@@ -3,6 +3,7 @@
     "url_params": {
       "flat_settings": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": "",
       "include_defaults": "__flag__"
     },

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.health.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.health.json
@@ -15,6 +15,7 @@
       ],
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": "",
       "wait_for_active_shards": "",
       "wait_for_nodes": "",

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.pending_tasks.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.pending_tasks.json
@@ -2,7 +2,8 @@
   "cluster.pending_tasks": {
     "url_params": {
       "local": "__flag__",
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "GET"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.put_settings.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.put_settings.json
@@ -3,6 +3,7 @@
     "url_params": {
       "flat_settings": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.reroute.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.reroute.json
@@ -6,6 +6,7 @@
       "retry_failed": "__flag__",
       "metric": [],
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.state.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.state.json
@@ -3,6 +3,7 @@
     "url_params": {
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "flat_settings": "__flag__",
       "wait_for_metadata_version": "",
       "wait_for_timeout": "",
@@ -28,8 +29,8 @@
       "metrics": [
         "_all",
         "blocks",
-        "master_node",
         "cluster_manager_node",
+        "master_node",
         "metadata",
         "nodes",
         "routing_nodes",

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/delete_script.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/delete_script.json
@@ -2,7 +2,8 @@
   "delete_script": {
     "url_params": {
       "timeout": "",
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "DELETE"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/get_script.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/get_script.json
@@ -1,7 +1,8 @@
 {
   "get_script": {
     "url_params": {
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "GET"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.clone.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.clone.json
@@ -3,6 +3,7 @@
     "url_params": {
       "timeout": "",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "wait_for_active_shards": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.close.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.close.json
@@ -3,6 +3,7 @@
     "url_params": {
       "timeout": "",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "ignore_unavailable": "__flag__",
       "allow_no_indices": "__flag__",
       "expand_wildcards": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.create.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.create.json
@@ -1,10 +1,10 @@
 {
   "indices.create": {
     "url_params": {
-      "include_type_name": "__flag__",
       "wait_for_active_shards": "",
       "timeout": "",
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "PUT"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.delete_alias.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.delete_alias.json
@@ -2,7 +2,8 @@
   "indices.delete_alias": {
     "url_params": {
       "timeout": "",
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "DELETE"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.delete_template.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.delete_template.json
@@ -2,7 +2,8 @@
   "indices.delete_template": {
     "url_params": {
       "timeout": "",
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "DELETE"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get.json
@@ -1,7 +1,6 @@
 {
   "indices.get": {
     "url_params": {
-      "include_type_name": "__flag__",
       "local": "__flag__",
       "ignore_unavailable": "__flag__",
       "allow_no_indices": "__flag__",
@@ -14,7 +13,8 @@
       ],
       "flat_settings": "__flag__",
       "include_defaults": "__flag__",
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "GET"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get_mapping.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get_mapping.json
@@ -1,7 +1,6 @@
 {
   "indices.get_mapping": {
     "url_params": {
-      "include_type_name": "__flag__",
       "ignore_unavailable": "__flag__",
       "allow_no_indices": "__flag__",
       "expand_wildcards": [
@@ -12,6 +11,7 @@
         "all"
       ],
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "local": "__flag__"
     },
     "methods": [
@@ -19,9 +19,7 @@
     ],
     "patterns": [
       "_mapping",
-      "{indices}/_mapping",
-      "_mapping/{type}",
-      "{indices}/_mapping/{type}"
+      "{indices}/_mapping"
     ],
     "documentation": "https://opensearch.org/docs/latest/guide/en/elasticsearch/reference/master/indices-get-mapping.html"
   }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get_settings.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get_settings.json
@@ -2,6 +2,7 @@
   "indices.get_settings": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "ignore_unavailable": "__flag__",
       "allow_no_indices": "__flag__",
       "expand_wildcards": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get_template.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get_template.json
@@ -1,9 +1,9 @@
 {
   "indices.get_template": {
     "url_params": {
-      "include_type_name": "__flag__",
       "flat_settings": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "local": "__flag__"
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.put_alias.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.put_alias.json
@@ -2,7 +2,8 @@
   "indices.put_alias": {
     "url_params": {
       "timeout": "",
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "PUT",

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.put_mapping.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.put_mapping.json
@@ -1,9 +1,9 @@
 {
   "indices.put_mapping": {
     "url_params": {
-      "include_type_name": "__flag__",
       "timeout": "",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "ignore_unavailable": "__flag__",
       "allow_no_indices": "__flag__",
       "expand_wildcards": [
@@ -12,21 +12,15 @@
         "hidden",
         "none",
         "all"
-      ]
+      ],
+      "write_index_only": "__flag__"
     },
     "methods": [
       "PUT",
       "POST"
     ],
     "patterns": [
-      "{indices}/_mapping",
-      "{indices}/{type}/_mapping",
-      "{indices}/_mapping/{type}",
-      "{indices}/{type}/_mappings",
-      "{indices}/_mappings/{type}",
-      "_mappings/{type}",
-      "{indices}/_mappings",
-      "_mapping/{type}"
+      "{indices}/_mapping"
     ],
     "documentation": "https://opensearch.org/docs/latest/guide/en/elasticsearch/reference/master/indices-put-mapping.html"
   }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.put_settings.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.put_settings.json
@@ -2,6 +2,7 @@
   "indices.put_settings": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": "",
       "preserve_existing": "__flag__",
       "ignore_unavailable": "__flag__",

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.put_template.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.put_template.json
@@ -1,11 +1,10 @@
 {
   "indices.put_template": {
     "url_params": {
-      "include_type_name": "__flag__",
       "order": "",
       "create": "__flag__",
       "master_timeout": "",
-      "flat_settings": "__flag__"
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "PUT",

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.rollover.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.rollover.json
@@ -1,10 +1,10 @@
 {
   "indices.rollover": {
     "url_params": {
-      "include_type_name": "__flag__",
       "timeout": "",
       "dry_run": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "wait_for_active_shards": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.shrink.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.shrink.json
@@ -4,6 +4,7 @@
       "copy_settings": "__flag__",
       "timeout": "",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "wait_for_active_shards": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.split.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.split.json
@@ -4,6 +4,7 @@
       "copy_settings": "__flag__",
       "timeout": "",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "wait_for_active_shards": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.update_aliases.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.update_aliases.json
@@ -2,7 +2,8 @@
   "indices.update_aliases": {
     "url_params": {
       "timeout": "",
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "POST"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/ingest.delete_pipeline.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/ingest.delete_pipeline.json
@@ -2,6 +2,7 @@
   "ingest.delete_pipeline": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/ingest.get_pipeline.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/ingest.get_pipeline.json
@@ -1,7 +1,8 @@
 {
   "ingest.get_pipeline": {
     "url_params": {
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "GET"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/ingest.put_pipeline.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/ingest.put_pipeline.json
@@ -2,6 +2,7 @@
   "ingest.put_pipeline": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/put_script.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/put_script.json
@@ -3,6 +3,7 @@
     "url_params": {
       "timeout": "",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "context": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.cleanup_repository.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.cleanup_repository.json
@@ -2,6 +2,7 @@
   "snapshot.cleanup_repository": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.create.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.create.json
@@ -2,6 +2,7 @@
   "snapshot.create": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "wait_for_completion": "__flag__"
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.create_repository.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.create_repository.json
@@ -2,6 +2,7 @@
   "snapshot.create_repository": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": "",
       "verify": "__flag__"
     },

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.delete.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.delete.json
@@ -1,7 +1,8 @@
 {
   "snapshot.delete": {
     "url_params": {
-      "master_timeout": ""
+      "master_timeout": "",
+      "cluster_manager_timeout": ""
     },
     "methods": [
       "DELETE"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.delete_repository.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.delete_repository.json
@@ -2,6 +2,7 @@
   "snapshot.delete_repository": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.get.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.get.json
@@ -2,6 +2,7 @@
   "snapshot.get": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "ignore_unavailable": "__flag__",
       "verbose": "__flag__"
     },

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.get_repository.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.get_repository.json
@@ -2,6 +2,7 @@
   "snapshot.get_repository": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "local": "__flag__"
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.restore.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.restore.json
@@ -2,6 +2,7 @@
   "snapshot.restore": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "wait_for_completion": "__flag__"
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.status.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.status.json
@@ -2,6 +2,7 @@
   "snapshot.status": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "ignore_unavailable": "__flag__"
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.verify_repository.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.verify_repository.json
@@ -2,6 +2,7 @@
   "snapshot.verify_repository": {
     "url_params": {
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": ""
     },
     "methods": [

--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/cluster.health.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/cluster.health.json
@@ -15,6 +15,7 @@
       ],
       "local": "__flag__",
       "master_timeout": "",
+      "cluster_manager_timeout": "",
       "timeout": "",
       "wait_for_active_shards": "",
       "wait_for_nodes": "",


### PR DESCRIPTION
Signed-off-by: manasvinibs <manasvis@amazon.com>

### Description
As part of the meta issue opensearch-project/OpenSearch#2589 to track the plan and progress of applying inclusive naming across OpenSearch Repositories.

 
In this change we are generating the json files for the _cat API 's specs by running following sample cmd:
```node scripts/spec_to_console.js -g "../OpenSearch/rest-api-spec/src/main/resources/rest-api-spec/api/cat.cluster_manager.json" -d "src/plugins/console/server/lib/spec_definitions/json/generated"```


### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1685
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff 