### PR TITLE
[CI] Update labels for doc issue creation workflow

### DIFF
--- a/.github/workflows/create_doc_issue.yml
+++ b/.github/workflows/create_doc_issue.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           title: Add documentation related to new feature
           content-filepath: ./.github/doc_issue_template.md
-          labels: documentation
+          labels: dashboards
           repository: opensearch-project/documentation-website
           token: ${{ steps.github_app_token.outputs.token }}
       


### PR DESCRIPTION
### Description
Example:
https://github.com/opensearch-project/OpenSearch-Dashboards/runs/7015324767?check_suite_focus=true

If we checkout the run, we can see the run fails with:
`Resource not accessible by integration`

Which I believe because the `documentation` label is not available in the doc repo. So instead of
creating a `documentation` label which seems redudant for a doc repo issue, we should use
`dashboards` because it exists and makes it more specific for the doc repo maintainers.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 