### PR TITLE
[Deprecation] Deprecate the apiVersion: master value and replace with main

### DIFF
--- a/src/core/server/core_usage_data/core_usage_data_service.mock.ts
+++ b/src/core/server/core_usage_data/core_usage_data_service.mock.ts
@@ -39,7 +39,7 @@ const createStartContractMock = () => {
       new BehaviorSubject<CoreUsageData>({
         config: {
           opensearch: {
-            apiVersion: 'master',
+            apiVersion: 'main',
             customHeadersConfigured: false,
             healthCheckDelayMs: 2500,
             logQueries: false,

--- a/src/core/server/opensearch/legacy/cluster_client.test.ts
+++ b/src/core/server/opensearch/legacy/cluster_client.test.ts
@@ -48,7 +48,7 @@ const logger = loggingSystemMock.create();
 afterEach(() => jest.clearAllMocks());
 
 test('#constructor creates client with parsed config', () => {
-  const mockOpenSearchClientConfig = { apiVersion: 'opensearch-client-master' };
+  const mockOpenSearchClientConfig = { apiVersion: 'opensearch-client-main' };
   mockParseOpenSearchClientConfig.mockReturnValue(mockOpenSearchClientConfig);
 
   const mockOpenSearchConfig = { apiVersion: 'opensearch-version' } as any;

--- a/src/core/server/opensearch/legacy/opensearch_client_config.test.ts
+++ b/src/core/server/opensearch/legacy/opensearch_client_config.test.ts
@@ -42,7 +42,7 @@ test('parses minimally specified config', () => {
   expect(
     parseOpenSearchClientConfig(
       {
-        apiVersion: 'master',
+        apiVersion: 'main',
         customHeaders: { xsrf: 'something' },
         logQueries: false,
         sniffOnStart: false,
@@ -50,11 +50,12 @@ test('parses minimally specified config', () => {
         hosts: ['http://localhost/opensearch'],
         requestHeadersWhitelist: [],
       },
+
       logger.get()
     )
   ).toMatchInlineSnapshot(`
     Object {
-      "apiVersion": "master",
+      "apiVersion": "main",
       "hosts": Array [
         Object {
           "headers": Object {
@@ -180,7 +181,7 @@ test('parses config timeouts of moment.Duration type', () => {
   expect(
     parseOpenSearchClientConfig(
       {
-        apiVersion: 'master',
+        apiVersion: 'main',
         customHeaders: { xsrf: 'something' },
         logQueries: false,
         sniffOnStart: false,
@@ -191,11 +192,12 @@ test('parses config timeouts of moment.Duration type', () => {
         hosts: ['http://localhost:9200/opensearch'],
         requestHeadersWhitelist: [],
       },
+
       logger.get()
     )
   ).toMatchInlineSnapshot(`
     Object {
-      "apiVersion": "master",
+      "apiVersion": "main",
       "hosts": Array [
         Object {
           "headers": Object {
@@ -359,7 +361,7 @@ describe('#customHeaders', () => {
     const headerKey = Object.keys(DEFAULT_HEADERS)[0];
     const parsedConfig = parseOpenSearchClientConfig(
       {
-        apiVersion: 'master',
+        apiVersion: 'main',
         customHeaders: { [headerKey]: 'foo' },
         logQueries: false,
         sniffOnStart: false,
@@ -379,7 +381,7 @@ describe('#log', () => {
   test('default logger with #logQueries = false', () => {
     const parsedConfig = parseOpenSearchClientConfig(
       {
-        apiVersion: 'master',
+        apiVersion: 'main',
         customHeaders: { xsrf: 'something' },
         logQueries: false,
         sniffOnStart: false,
@@ -423,7 +425,7 @@ describe('#log', () => {
   test('default logger with #logQueries = true', () => {
     const parsedConfig = parseOpenSearchClientConfig(
       {
-        apiVersion: 'master',
+        apiVersion: 'main',
         customHeaders: { xsrf: 'something' },
         logQueries: true,
         sniffOnStart: false,
@@ -482,7 +484,7 @@ describe('#log', () => {
 
     const parsedConfig = parseOpenSearchClientConfig(
       {
-        apiVersion: 'master',
+        apiVersion: 'main',
         customHeaders: { xsrf: 'something' },
         logQueries: true,
         sniffOnStart: false,

--- a/src/core/server/opensearch/opensearch_config.ts
+++ b/src/core/server/opensearch/opensearch_config.ts
@@ -208,7 +208,7 @@ export class OpenSearchConfig {
   public readonly ignoreVersionMismatch: boolean;
 
   /**
-   * Version of the OpenSearch (6.7, 7.1 or `master`) client will be connecting to.
+   * Version of the OpenSearch (1.1, 2.1 or `main`) client will be connecting to.
    */
   public readonly apiVersion: string;
 


### PR DESCRIPTION
Signed-off-by: Manasvini B Suryanarayana <manasvis@amazon.com>

### Description
As part of the meta issue https://github.com/opensearch-project/OpenSearch/issues/2589 to track the plan and progress of applying inclusive naming across OpenSearch Repositories.

In this change, we are replacing 'apiVersion: master' with 'apiVersion:main'. 
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1687
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff 