### PR TITLE
[Deprecation] Deprecate cat master API in favor of cat cluster_manager

### DIFF
--- a/src/core/server/opensearch/legacy/api_types.ts
+++ b/src/core/server/opensearch/legacy/api_types.ts
@@ -232,6 +232,7 @@ export interface LegacyAPICaller {
   (endpoint: 'cat.help', params: CatHelpParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['help']>;
   (endpoint: 'cat.indices', params: CatIndicesParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['indices']>;
   (endpoint: 'cat.master', params: CatCommonParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['master']>;
+  (endpoint: 'cat.cluster_manager', params: CatCommonParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['master']>;
   (endpoint: 'cat.nodeattrs', params: CatCommonParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['nodeattrs']>;
   (endpoint: 'cat.nodes', params: CatCommonParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['nodes']>;
   (endpoint: 'cat.pendingTasks', params: CatCommonParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['pendingTasks']>;

--- a/src/core/server/server.api.md
+++ b/src/core/server/server.api.md
@@ -1041,8 +1041,10 @@ export interface LegacyAPICaller {
     (endpoint: 'cat.help', params: CatHelpParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['help']>;
     // (undocumented)
     (endpoint: 'cat.indices', params: CatIndicesParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['indices']>;
-    // (undocumented)
+    // @deprecated (undocumented)
     (endpoint: 'cat.master', params: CatCommonParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['master']>;
+    // (undocumented)
+    (endpoint: 'cat.cluster_manager', params: CatCommonParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['master']>;
     // (undocumented)
     (endpoint: 'cat.nodeattrs', params: CatCommonParams, options?: LegacyCallAPIOptions): ReturnType<Client['cat']['nodeattrs']>;
     // (undocumented)

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cat.cluster_manager.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cat.cluster_manager.json
@@ -1,0 +1,21 @@
+{
+  "cat.cluster_manager": {
+    "url_params": {
+      "format": "",
+      "local": "__flag__",
+      "master_timeout": "",
+      "cluster_manager_timeout": "",
+      "h": [],
+      "help": "__flag__",
+      "s": [],
+      "v": "__flag__"
+    },
+    "methods": [
+      "GET"
+    ],
+    "patterns": [
+      "_cat/cluster_manager"
+    ],
+    "documentation": "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/"
+  }
+}


### PR DESCRIPTION

Signed-off-by: Manasvini B Suryanarayana <manasvis@amazon.com>

### Description
As part of the meta issue https://github.com/opensearch-project/OpenSearch/issues/2589 to track the plan and progress of applying inclusive naming across OpenSearch Repositories.

In this change, we are deprecating cat/_master API and adding _cat/cluster_manager endpoint.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1686
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff 