### PR TITLE
[CI] Bump chromedriver to 102

### DIFF
--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -95,20 +95,6 @@ jobs:
 
       - run: echo Unit tests completed unsuccessfully. However, unit tests are inconsistent on the CI so please verify locally with `yarn test:jest`.
         if: steps.unit_tests_results.outputs.unit_tests_results != 'success' && steps.unit-tests.outcome != 'success'
-      
-      # TODO: This gets rejected, we need approval to add this
-      # - name: Add comment if unit tests did not succeed
-      #   if: steps.unit_tests_results.outputs.unit_tests_results != 'success' && steps.unit-tests.outcome != 'success'
-      #   uses: actions/github-script@v5
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     script: |
-      #       github.rest.issues.createComment({
-      #         issue_number: context.issue.number,
-      #         owner: context.repo.owner,
-      #         repo: context.repo.repo,
-      #         body: 'Unit tests completed unsuccessfully. However, unit tests are inconsistent on the CI so please verify locally with `yarn test:jest`.'
-      #       })
 
       - name: Run integration tests
         if: steps.integration_tests_results.outputs.integration_tests_results != 'success'
@@ -190,7 +176,7 @@ jobs:
       # github virtual env is the latest chrome
       - name: Setup chromedriver
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'
-        run: yarn add --dev chromedriver@100.0.0
+        run: yarn add --dev chromedriver@102.0.0
 
       - name: Run bootstrap
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'


### PR DESCRIPTION
### Description
GitHub env runs on Chrome 102. This is done to get the CI
working again on 1.x however there is a follow-up issue here:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1746

However, there's an issue with Node existing on an a user that
the GitHub CI doesn't have permissions too.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 