### PR TITLE
[Tests] update tests to reflect max zoom level for maps

### DIFF
--- a/test/functional/apps/visualize/_tile_map.js
+++ b/test/functional/apps/visualize/_tile_map.js
@@ -259,7 +259,7 @@ export default function ({ getService, getPageObjects }) {
         zoomWarningEnabled = await testSubjects.exists('zoomWarningEnabled');
         log.debug(`Zoom warning enabled: ${zoomWarningEnabled}`);
 
-        const zoomLevel = 9;
+        const zoomLevel = 13;
         for (let i = 0; i < zoomLevel; i++) {
           await PageObjects.tileMap.clickMapZoomIn();
         }
@@ -276,7 +276,7 @@ export default function ({ getService, getPageObjects }) {
         }
       });
 
-      it('should show warning at zoom 10', async () => {
+      it('should show warning at zoom 14', async () => {
         await testSubjects.existOrFail('maxZoomWarning');
       });
 


### PR DESCRIPTION
### Description
Maps zoom level were updated to be 14 as noted here:
https://github.com/opensearch-project/maps/issues/4#issuecomment-1162013693

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 