### PR TITLE
fix(D&D): fixes reloading app

### DIFF
--- a/src/plugins/wizard/public/plugin.ts
+++ b/src/plugins/wizard/public/plugin.ts
@@ -25,6 +25,7 @@ import { TypeService } from './services/type_service';
 import { getPreloadedStore } from './application/utils/state_management';
 import { setAggService, setIndexPatterns } from './plugin_services';
 import { createSavedWizardLoader } from './saved_visualizations';
+import { registerDefaultTypes } from './visualizations';
 
 export class WizardPlugin
   implements
@@ -38,6 +39,8 @@ export class WizardPlugin
     { visualizations }: WizardPluginSetupDependencies
   ) {
     const typeService = this.typeService;
+    registerDefaultTypes(typeService.setup());
+
     // Register the plugin to core
     core.application.register({
       id: 'wizard',
@@ -63,8 +66,6 @@ export class WizardPlugin
         setIndexPatterns(data.indexPatterns);
 
         // Register Default Visualizations
-        const { registerDefaultTypes } = await import('./visualizations');
-        registerDefaultTypes(typeService.setup(), pluginsStart);
 
         const services: WizardServices = {
           ...coreStart,

--- a/src/plugins/wizard/public/visualizations/index.ts
+++ b/src/plugins/wizard/public/visualizations/index.ts
@@ -5,12 +5,8 @@
 
 import type { TypeServiceSetup } from '../services/type_service';
 import { createMetricConfig } from './metric';
-import { WizardPluginStartDependencies } from '../types';
 
-export function registerDefaultTypes(
-  typeServiceSetup: TypeServiceSetup,
-  pluginsStart: WizardPluginStartDependencies
-) {
+export function registerDefaultTypes(typeServiceSetup: TypeServiceSetup) {
   const visualizationTypes = [createMetricConfig];
 
   visualizationTypes.forEach((createTypeConfig) => {


### PR DESCRIPTION
Signed-off-by: Ashwin Pc <ashwinpc@amazon.com>

### Description
When navigating in and out of the app, the app is mounted multiple times. This causes the viz types to be registered multiple times causing an error that crashes it. This fix moves the registration out to the setup phase allowing the registration to happen only once.
 
### Issues Resolved
-
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 