### PR TITLE
[D&D] Basic saving, loading, and updating

### DIFF
--- a/src/plugins/saved_objects_management/README.md
+++ b/src/plugins/saved_objects_management/README.md
@@ -7,7 +7,7 @@ From the primary UI page, this plugin allows you to:
 2. Import/export saved objects
 3. Inspect/edit raw saved object values without validation
 
-For 3., this plugin can also be used to provide a route/page for editing, such as `/app/management/opensearch-dashboards/objects/savedVisualizations/{visualizationId}`, although plugins are alos free to provide or host alternate routes for this purpose (see index patterns, for instance, which provide their own integration and UI via the `management` plugin directly).
+For 3., this plugin can also be used to provide a route/page for editing, such as `/app/management/opensearch-dashboards/objects/savedVisualizations/{visualizationId}`, although plugins are also free to provide or host alternate routes for this purpose (see index patterns, for instance, which provide their own integration and UI via the `management` plugin directly).
 ## Making a new saved object type manageable
 
 1. Create a new `SavedObjectsType` or add the `management` property to an existing one. (See `SavedObjectsTypeManagementDefinition` for explanation of its properties: https://github.com/opensearch-project/OpenSearch-Dashboards/blob/e1380f14deb98cc7cce55c3b82c2d501826a78c3/src/core/server/saved_objects/types.ts#L247-L285)

--- a/src/plugins/wizard/common/index.ts
+++ b/src/plugins/wizard/common/index.ts
@@ -6,5 +6,6 @@
 export const PLUGIN_ID = 'wizard';
 export const PLUGIN_NAME = 'Wizard';
 export const VISUALIZE_ID = 'visualize';
+export const EDIT_PATH = '/edit';
 
 export { WizardSavedObjectAttributes, WIZARD_SAVED_OBJECT } from './wizard_saved_object_attributes';

--- a/src/plugins/wizard/common/wizard_saved_object_attributes.ts
+++ b/src/plugins/wizard/common/wizard_saved_object_attributes.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SavedObjectAttributes } from 'opensearch-dashboards/public';
+import { SavedObjectAttributes } from '../../../core/types';
 
 export const WIZARD_SAVED_OBJECT = 'wizard';
 

--- a/src/plugins/wizard/common/wizard_saved_object_attributes.ts
+++ b/src/plugins/wizard/common/wizard_saved_object_attributes.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { integer } from '@opensearch-project/opensearch/api/types';
 import { SavedObjectAttributes } from '../../../core/types';
 
 export const WIZARD_SAVED_OBJECT = 'wizard';
@@ -10,5 +11,7 @@ export const WIZARD_SAVED_OBJECT = 'wizard';
 export interface WizardSavedObjectAttributes extends SavedObjectAttributes {
   title: string;
   description?: string;
-  state: string;
+  visualizationState?: string;
+  styleState?: string;
+  version: integer;
 }

--- a/src/plugins/wizard/public/application/app.tsx
+++ b/src/plugins/wizard/public/application/app.tsx
@@ -4,7 +4,6 @@
  */
 
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { I18nProvider } from '@osd/i18n/react';
 import { EuiPage } from '@elastic/eui';
 import { SideNav } from './components/side_nav';
@@ -13,24 +12,14 @@ import { Workspace } from './components/workspace';
 
 import './app.scss';
 import { TopNav } from './components/top_nav';
-import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
-import { WizardServices } from '../types';
-import { useSavedWizardVisInstance } from './utils/use/use_saved_wizard_vis';
 
 export const WizardApp = () => {
-  const { id: visualizationIdFromUrl } = useParams<{ id: string }>();
-
-  const { services } = useOpenSearchDashboards<WizardServices>();
-
-  const savedWizardVisInstance = useSavedWizardVisInstance(services, visualizationIdFromUrl);
-  const savedWizardViz = savedWizardVisInstance?.savedWizardVis;
-
   // Render the application DOM.
   return (
     <I18nProvider>
       <DragDropProvider>
         <EuiPage className="wizLayout">
-          <TopNav savedWizardViz={savedWizardViz} />
+          <TopNav />
           <SideNav />
           <Workspace />
         </EuiPage>

--- a/src/plugins/wizard/public/application/app.tsx
+++ b/src/plugins/wizard/public/application/app.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import { I18nProvider } from '@osd/i18n/react';
 import { EuiPage } from '@elastic/eui';
 import { SideNav } from './components/side_nav';
@@ -12,14 +13,24 @@ import { Workspace } from './components/workspace';
 
 import './app.scss';
 import { TopNav } from './components/top_nav';
+import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
+import { WizardServices } from '../types';
+import { useSavedWizardVisInstance } from './utils/use/use_saved_wizard_vis';
 
 export const WizardApp = () => {
+  const { id: visualizationIdFromUrl } = useParams<{ id: string }>();
+
+  const { services } = useOpenSearchDashboards<WizardServices>();
+
+  const savedWizardVisInstance = useSavedWizardVisInstance(services, visualizationIdFromUrl);
+  const savedWizardViz = savedWizardVisInstance?.savedWizardVis;
+
   // Render the application DOM.
   return (
     <I18nProvider>
       <DragDropProvider>
         <EuiPage className="wizLayout">
-          <TopNav />
+          <TopNav savedWizardViz={savedWizardViz} />
           <SideNav />
           <Workspace />
         </EuiPage>

--- a/src/plugins/wizard/public/application/components/top_nav.tsx
+++ b/src/plugins/wizard/public/application/components/top_nav.tsx
@@ -3,23 +3,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { i18n } from '@osd/i18n';
-import React, { useMemo, useEffect } from 'react';
-import { PLUGIN_ID, VISUALIZE_ID } from '../../../common';
+import React, { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { PLUGIN_ID } from '../../../common';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
-import { getTopNavconfig } from '../utils/get_top_nav_config';
+import { getTopNavConfig } from '../utils/get_top_nav_config';
 import { WizardServices } from '../../types';
 
 import './top_nav.scss';
 import { useIndexPattern } from '../utils/use';
 import { useTypedSelector } from '../utils/state_management';
-import { SavedObject } from '../../../../saved_objects/public';
+import { useSavedWizardVis } from '../utils/use/use_saved_wizard_vis';
 
-export const TopNav = ({ savedWizardViz }: { savedWizardViz?: SavedObject }) => {
+export const TopNav = () => {
+  // id will only be set for the edit route
+  const { id: visualizationIdFromUrl } = useParams<{ id: string }>();
   const { services } = useOpenSearchDashboards<WizardServices>();
   const {
     setHeaderActionMenu,
-    chrome,
     navigation: {
       ui: { TopNavMenu },
     },
@@ -29,34 +30,27 @@ export const TopNav = ({ savedWizardViz }: { savedWizardViz?: SavedObject }) => 
     (state) => !!state.visualization.activeVisualization?.draftAgg
   );
 
+  const savedWizardVis = useSavedWizardVis(services, visualizationIdFromUrl);
+
   const config = useMemo(() => {
-    const visInstance = {
-      ...savedWizardViz,
-      state: JSON.stringify(rootState),
-    };
-    return getTopNavconfig({ visInstance, hasUnappliedChanges }, services);
-  }, [hasUnappliedChanges, rootState, savedWizardViz, services]);
+    if (savedWizardVis === undefined) {
+      return;
+    }
+    const { visualization: visualizationState, style: styleState } = rootState;
+
+    return getTopNavConfig(
+      {
+        visualizationIdFromUrl,
+        savedWizardVis,
+        visualizationState,
+        styleState,
+        hasUnappliedChanges,
+      },
+      services
+    );
+  }, [hasUnappliedChanges, rootState, savedWizardVis, services, visualizationIdFromUrl]);
 
   const indexPattern = useIndexPattern();
-
-  useEffect(() => {
-    const visualizeHref = window.location.href.split(`${PLUGIN_ID}#/`)[0] + `${VISUALIZE_ID}#/`;
-    chrome.setBreadcrumbs([
-      {
-        text: i18n.translate('visualize.listing.breadcrumb', {
-          defaultMessage: 'Visualize',
-        }),
-        href: visualizeHref,
-      },
-      {
-        text: i18n.translate('wizard.nav.breadcrumb.create', {
-          defaultMessage: 'Create',
-        }),
-      },
-    ]);
-    // we want to run this hook exactly once, which you do by an empty dep array
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <div className="wizTopNav">

--- a/src/plugins/wizard/public/application/components/top_nav.tsx
+++ b/src/plugins/wizard/public/application/components/top_nav.tsx
@@ -12,8 +12,10 @@ import { WizardServices } from '../../types';
 
 import './top_nav.scss';
 import { useIndexPattern } from '../utils/use';
+import { useTypedSelector } from '../utils/state_management';
+import { SavedObject } from '../../../../saved_objects/public';
 
-export const TopNav = () => {
+export const TopNav = ({ savedWizardViz }: { savedWizardViz?: SavedObject }) => {
   const { services } = useOpenSearchDashboards<WizardServices>();
   const {
     setHeaderActionMenu,
@@ -22,8 +24,19 @@ export const TopNav = () => {
       ui: { TopNavMenu },
     },
   } = services;
+  const rootState = useTypedSelector((state) => state);
+  const hasUnappliedChanges = useTypedSelector(
+    (state) => !!state.visualization.activeVisualization?.draftAgg
+  );
 
-  const config = useMemo(() => getTopNavconfig(services), [services]);
+  const config = useMemo(() => {
+    const visInstance = {
+      ...savedWizardViz,
+      state: JSON.stringify(rootState),
+    };
+    return getTopNavconfig({ visInstance, hasUnappliedChanges }, services);
+  }, [hasUnappliedChanges, rootState, savedWizardViz, services]);
+
   const indexPattern = useIndexPattern();
 
   useEffect(() => {

--- a/src/plugins/wizard/public/application/index.tsx
+++ b/src/plugins/wizard/public/application/index.tsx
@@ -5,25 +5,30 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { Router, Route, Switch } from 'react-router-dom';
 import { Provider as ReduxProvider } from 'react-redux';
 import { Store } from 'redux';
 import { AppMountParameters } from '../../../../core/public';
 import { WizardServices } from '../types';
 import { WizardApp } from './app';
 import { OpenSearchDashboardsContextProvider } from '../../../opensearch_dashboards_react/public';
+import { EDIT_PATH } from '../../common';
 
 export const renderApp = (
-  { appBasePath, element }: AppMountParameters,
+  { element, history }: AppMountParameters,
   services: WizardServices,
   store: Store
 ) => {
   ReactDOM.render(
-    <Router basename={appBasePath}>
+    <Router history={history}>
       <OpenSearchDashboardsContextProvider services={services}>
         <ReduxProvider store={store}>
           <services.i18n.Context>
-            <WizardApp />
+            <Switch>
+              <Route path={[`${EDIT_PATH}/:id`, '/']} exact={false}>
+                <WizardApp />
+              </Route>
+            </Switch>
           </services.i18n.Context>
         </ReduxProvider>
       </OpenSearchDashboardsContextProvider>

--- a/src/plugins/wizard/public/application/utils/breadcrumbs.ts
+++ b/src/plugins/wizard/public/application/utils/breadcrumbs.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import { VISUALIZE_ID } from '../../../common';
+
+const defaultEditText = i18n.translate('wizard.editor.defaultEditBreadcrumbText', {
+  defaultMessage: 'Edit',
+});
+
+export function getVisualizeLandingBreadcrumbs(navigateToApp) {
+  return [
+    {
+      text: i18n.translate('wizard.listing.breadcrumb', {
+        defaultMessage: 'Visualize',
+      }),
+      onClick: () => navigateToApp(VISUALIZE_ID),
+    },
+  ];
+}
+
+export function getCreateBreadcrumbs(navigateToApp) {
+  return [
+    ...getVisualizeLandingBreadcrumbs(navigateToApp),
+    {
+      text: i18n.translate('wizard.editor.createBreadcrumb', {
+        defaultMessage: 'Create',
+      }),
+    },
+  ];
+}
+
+export function getEditBreadcrumbs(text: string = defaultEditText, navigateToApp) {
+  return [
+    ...getVisualizeLandingBreadcrumbs(navigateToApp),
+    {
+      text,
+    },
+  ];
+}

--- a/src/plugins/wizard/public/application/utils/get_saved_wizard_vis.ts
+++ b/src/plugins/wizard/public/application/utils/get_saved_wizard_vis.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WizardServices } from '../..';
+
+export const getSavedWizardVis = async (services: WizardServices, wizardVisId?: string) => {
+  const { savedWizardLoader } = services;
+  if (!savedWizardLoader) {
+    return {};
+  }
+  const savedWizardVis = await savedWizardLoader.get(wizardVisId);
+
+  return savedWizardVis;
+};

--- a/src/plugins/wizard/public/application/utils/state_management/store.ts
+++ b/src/plugins/wizard/public/application/utils/state_management/store.ts
@@ -30,3 +30,6 @@ export const getPreloadedStore = async (services: WizardServices) => {
 export type RootState = ReturnType<typeof rootReducer>;
 type Store = ReturnType<typeof configurePreloadedStore>;
 export type AppDispatch = Store['dispatch'];
+
+export { setState as setStyleState } from './style_slice';
+export { setState as setVisualizationState } from './visualization_slice';

--- a/src/plugins/wizard/public/application/utils/state_management/store.ts
+++ b/src/plugins/wizard/public/application/utils/state_management/store.ts
@@ -31,5 +31,5 @@ export type RootState = ReturnType<typeof rootReducer>;
 type Store = ReturnType<typeof configurePreloadedStore>;
 export type AppDispatch = Store['dispatch'];
 
-export { setState as setStyleState } from './style_slice';
-export { setState as setVisualizationState } from './visualization_slice';
+export { setState as setStyleState, StyleState } from './style_slice';
+export { setState as setVisualizationState, VisualizationState } from './visualization_slice';

--- a/src/plugins/wizard/public/application/utils/state_management/style_slice.ts
+++ b/src/plugins/wizard/public/application/utils/state_management/style_slice.ts
@@ -6,7 +6,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { WizardServices } from '../../../types';
 
-type StyleState<T = any> = T;
+export type StyleState<T = any> = T;
 
 const initialState = {} as StyleState;
 

--- a/src/plugins/wizard/public/application/utils/state_management/visualization_slice.ts
+++ b/src/plugins/wizard/public/application/utils/state_management/visualization_slice.ts
@@ -7,7 +7,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { CreateAggConfigParams } from '../../../../../data/common';
 import { WizardServices } from '../../../types';
 
-interface VisualizationState {
+export interface VisualizationState {
   indexPattern?: string;
   searchField: string;
   activeVisualization?: {

--- a/src/plugins/wizard/public/application/utils/state_management/visualization_slice.ts
+++ b/src/plugins/wizard/public/application/utils/state_management/visualization_slice.ts
@@ -105,6 +105,9 @@ export const slice = createSlice({
     updateAggConfigParams: (state, action: PayloadAction<CreateAggConfigParams[]>) => {
       state.activeVisualization!.aggConfigParams = action.payload;
     },
+    setState: (_state, action: PayloadAction<VisualizationState>) => {
+      return action.payload;
+    },
   },
 });
 
@@ -117,4 +120,5 @@ export const {
   updateAggConfigParams,
   saveAgg,
   reorderAgg,
+  setState,
 } = slice.actions;

--- a/src/plugins/wizard/public/application/utils/use/use_saved_wizard_vis.ts
+++ b/src/plugins/wizard/public/application/utils/use/use_saved_wizard_vis.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// import { i18n } from '@osd/i18n';
+import { useEffect, useState } from 'react';
+import { SavedObject } from '../../../../../saved_objects/public';
+// import { redirectWhenMissing } from '../../../../../opensearch_dashboards_utils/public';
+// import { EDIT_PATH } from '../../../../common';
+import { WizardServices } from '../../../types';
+import { MetricOptionsDefaults } from '../../../visualizations/metric/metric_viz_type';
+import { getSavedWizardVis } from '../get_saved_wizard_vis';
+import { useTypedDispatch, setStyleState, setVisualizationState } from '../state_management';
+
+export const useSavedWizardVisInstance = (
+  services: WizardServices,
+  visualizationIdFromUrl: string | undefined
+) => {
+  const [state, setState] = useState<{
+    savedWizardVis?: SavedObject;
+  }>({});
+  const dispatch = useTypedDispatch();
+
+  useEffect(() => {
+    const {
+      // application: { navigateToApp },
+      chrome,
+      // history,
+      // http: { basePath },
+      // setActiveUrl,
+      // toastNotifications,
+    } = services;
+    // TODO: remove "instance" from naming
+    const getSavedWizardVisInstance = async () => {
+      try {
+        const savedWizardVis = await getSavedWizardVis(services, visualizationIdFromUrl);
+
+        if (savedWizardVis.id) {
+          // TODO: update breadcrumbs
+          // chrome.setBreadcrumbs(getEditBreadcrumbs(savedWizardVis.title));
+          chrome.docTitle.change(savedWizardVis.title);
+        } else {
+          // chrome.setBreadcrumbs(getCreateBreadcrumbs());
+        }
+
+        dispatch(setStyleState<MetricOptionsDefaults>(JSON.parse(savedWizardVis.state).style));
+        dispatch(setVisualizationState(JSON.parse(savedWizardVis.state).visualization));
+        setState({ savedWizardVis });
+      } catch (error) {
+        // TODO: implement error handling
+        // const managementRedirectTarget = {
+        //   app: 'management',
+        //   path: `opensearch-dashboards/objects/savedVisualizations/${visualizationIdFromUrl}`,
+        // };
+        //
+        // try {
+        //   redirectWhenMissing({
+        //     history,
+        //     navigateToApp,
+        //     toastNotifications,
+        //     basePath,
+        //     mapping: managementRedirectTarget,
+        //     onBeforeRedirect() {
+        //       setActiveUrl(EDIT_PATH);
+        //     },
+        //   })(error);
+        // } catch (e) {
+        //   toastNotifications.addWarning({
+        //     title: i18n.translate('visualize.createVisualization.failedToLoadErrorMessage', {
+        //       defaultMessage: 'Failed to load the visualization',
+        //     }),
+        //     text: e.message,
+        //   });
+        //   history.replace(EDIT_PATH);
+        // }
+      }
+    };
+
+    getSavedWizardVisInstance();
+  }, [dispatch, services, visualizationIdFromUrl]);
+
+  return state;
+};

--- a/src/plugins/wizard/public/plugin.test.ts
+++ b/src/plugins/wizard/public/plugin.test.ts
@@ -9,6 +9,7 @@ import { dataPluginMock } from '../../../plugins/data/public/mocks';
 import { embeddablePluginMock } from '../../../plugins/embeddable/public/mocks';
 import { navigationPluginMock } from '../../../plugins/navigation/public/mocks';
 import { visualizationsPluginMock } from '../../../plugins/visualizations/public/mocks';
+import { PLUGIN_ID, PLUGIN_NAME } from '../common';
 import { WizardPlugin } from './plugin';
 
 describe('WizardPlugin', () => {
@@ -34,8 +35,8 @@ describe('WizardPlugin', () => {
       expect(setupDeps.visualizations.registerAlias).toHaveBeenCalledWith(
         // TODO: Update this once the properties are final
         expect.objectContaining({
-          name: 'wizard',
-          title: 'Wizard',
+          name: PLUGIN_ID,
+          title: PLUGIN_NAME,
           aliasPath: '#/',
         })
       );

--- a/src/plugins/wizard/public/plugin.test.ts
+++ b/src/plugins/wizard/public/plugin.test.ts
@@ -14,7 +14,7 @@ import { WizardPlugin } from './plugin';
 
 describe('WizardPlugin', () => {
   describe('setup', () => {
-    it('initializes the plugin correctly and registers it as an alias vizualization', () => {
+    it('initializes the plugin correctly and registers it as an alias visualization', () => {
       const plugin = new WizardPlugin(coreMock.createPluginInitializerContext());
       const pluginStartContract = {
         data: dataPluginMock.createStartContract(),

--- a/src/plugins/wizard/public/plugin.ts
+++ b/src/plugins/wizard/public/plugin.ts
@@ -20,7 +20,7 @@ import {
   WizardStart,
 } from './types';
 import wizardIcon from './assets/wizard_icon.svg';
-import { PLUGIN_NAME } from '../common';
+import { PLUGIN_ID, PLUGIN_NAME } from '../common';
 import { TypeService } from './services/type_service';
 import { getPreloadedStore } from './application/utils/state_management';
 import { setAggService, setIndexPatterns } from './plugin_services';
@@ -35,7 +35,7 @@ export class WizardPlugin
   constructor(public initializerContext: PluginInitializerContext) {}
 
   public setup(
-    core: CoreSetup<WizardPluginStartDependencies>,
+    core: CoreSetup<WizardPluginStartDependencies, WizardStart>,
     { visualizations }: WizardPluginSetupDependencies
   ) {
     const typeService = this.typeService;
@@ -43,7 +43,7 @@ export class WizardPlugin
 
     // Register the plugin to core
     core.application.register({
-      id: 'wizard',
+      id: PLUGIN_ID,
       title: PLUGIN_NAME,
       navLinkStatus: AppNavLinkStatus.hidden,
       async mount(params: AppMountParameters) {
@@ -51,7 +51,8 @@ export class WizardPlugin
         const { renderApp } = await import('./application');
 
         // Get start services as specified in opensearch_dashboards.json
-        const [coreStart, pluginsStart] = await core.getStartServices();
+        const startServices = core.getStartServices();
+        const [coreStart, pluginsStart, selfStart] = await startServices;
         const { data, savedObjects, navigation, expressions } = pluginsStart;
 
         // make sure the index pattern list is up to date
@@ -76,6 +77,7 @@ export class WizardPlugin
           expressions,
           setHeaderActionMenu: params.setHeaderActionMenu,
           types: typeService.start(),
+          savedWizardLoader: selfStart.savedWizardLoader,
         };
 
         // Instantiate the store
@@ -88,15 +90,15 @@ export class WizardPlugin
 
     // Register the plugin as an alias to create visualization
     visualizations.registerAlias({
-      name: 'wizard',
-      title: 'Wizard',
+      name: PLUGIN_ID,
+      title: PLUGIN_NAME,
       description: i18n.translate('wizard.vizPicker.description', {
         defaultMessage: 'TODO...',
       }),
       // TODO: Replace with actual icon once available
       icon: wizardIcon,
       stage: 'beta',
-      aliasApp: 'wizard',
+      aliasApp: PLUGIN_ID,
       aliasPath: '#/',
     });
 

--- a/src/plugins/wizard/public/plugin.ts
+++ b/src/plugins/wizard/public/plugin.ts
@@ -51,8 +51,7 @@ export class WizardPlugin
         const { renderApp } = await import('./application');
 
         // Get start services as specified in opensearch_dashboards.json
-        const startServices = core.getStartServices();
-        const [coreStart, pluginsStart, selfStart] = await startServices;
+        const [coreStart, pluginsStart, selfStart] = await core.getStartServices();
         const { data, savedObjects, navigation, expressions } = pluginsStart;
 
         // make sure the index pattern list is up to date
@@ -75,6 +74,7 @@ export class WizardPlugin
           savedObjectsPublic: savedObjects,
           navigation,
           expressions,
+          history: params.history,
           setHeaderActionMenu: params.setHeaderActionMenu,
           types: typeService.start(),
           savedWizardLoader: selfStart.savedWizardLoader,
@@ -92,7 +92,7 @@ export class WizardPlugin
     visualizations.registerAlias({
       name: PLUGIN_ID,
       title: PLUGIN_NAME,
-      description: i18n.translate('wizard.vizPicker.description', {
+      description: i18n.translate('wizard.visPicker.description', {
         defaultMessage: 'TODO...',
       }),
       // TODO: Replace with actual icon once available

--- a/src/plugins/wizard/public/saved_visualizations/_saved_vis.ts
+++ b/src/plugins/wizard/public/saved_visualizations/_saved_vis.ts
@@ -19,8 +19,8 @@ export function createSavedWizardVisClass(services: SavedObjectOpenSearchDashboa
     public static mapping = {
       title: 'text',
       description: 'text',
-      state: 'text',
-      //   savedSearchId: 'keyword',
+      visualizationState: 'text',
+      styleState: 'text',
       version: 'integer',
     };
 
@@ -40,8 +40,8 @@ export function createSavedWizardVisClass(services: SavedObjectOpenSearchDashboa
         defaults: {
           title: '',
           description: '',
-          state: '{}',
-          //   savedSearchId,
+          visualizationState: '{}',
+          styleState: '{}',
           version: 1,
         },
       });

--- a/src/plugins/wizard/public/saved_visualizations/_saved_vis.ts
+++ b/src/plugins/wizard/public/saved_visualizations/_saved_vis.ts
@@ -7,12 +7,13 @@ import {
   createSavedObjectClass,
   SavedObjectOpenSearchDashboardsServices,
 } from '../../../saved_objects/public';
+import { EDIT_PATH, PLUGIN_ID, WIZARD_SAVED_OBJECT } from '../../common';
 
 export function createSavedWizardVisClass(services: SavedObjectOpenSearchDashboardsServices) {
   const SavedObjectClass = createSavedObjectClass(services);
 
   class SavedWizardVis extends SavedObjectClass {
-    public static type = 'wizard';
+    public static type = WIZARD_SAVED_OBJECT;
 
     // if type:wizard has no mapping, we push this mapping into OpenSearch
     public static mapping = {
@@ -20,7 +21,7 @@ export function createSavedWizardVisClass(services: SavedObjectOpenSearchDashboa
       description: 'text',
       state: 'text',
       //   savedSearchId: 'keyword',
-      //   version: 'integer',
+      version: 'integer',
     };
 
     // Order these fields to the top, the rest are alphabetical
@@ -41,11 +42,11 @@ export function createSavedWizardVisClass(services: SavedObjectOpenSearchDashboa
           description: '',
           state: '{}',
           //   savedSearchId,
-          //   version: 1,
+          version: 1,
         },
       });
       this.showInRecentlyAccessed = true;
-      this.getFullPath = () => `/app/wizard#/edit/${this.id}`;
+      this.getFullPath = () => `/app/${PLUGIN_ID}${EDIT_PATH}/${this.id}`;
     }
   }
 

--- a/src/plugins/wizard/public/types.ts
+++ b/src/plugins/wizard/public/types.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SavedObjectsStart } from '../../saved_objects/public';
+import { History } from 'history';
+import { SavedObject, SavedObjectsStart } from '../../saved_objects/public';
 import { EmbeddableSetup } from '../../embeddable/public';
 import { DashboardStart } from '../../dashboard/public';
 import { VisualizationsSetup } from '../../visualizations/public';
@@ -40,4 +41,16 @@ export interface WizardServices extends CoreStart {
   data: DataPublicPluginStart;
   types: TypeServiceStart;
   expressions: ExpressionsStart;
+  history: History;
 }
+
+export interface ISavedVis {
+  id?: string;
+  title: string;
+  description?: string;
+  visualizationState?: string;
+  styleState?: string;
+  version?: number;
+}
+
+export interface WizardVisSavedObject extends SavedObject, ISavedVis {}

--- a/src/plugins/wizard/public/types.ts
+++ b/src/plugins/wizard/public/types.ts
@@ -33,6 +33,7 @@ export interface WizardPluginStartDependencies {
 
 export interface WizardServices extends CoreStart {
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
+  savedWizardLoader: WizardStart['savedWizardLoader'];
   toastNotifications: ToastsStart;
   savedObjectsPublic: SavedObjectsStart;
   navigation: NavigationPublicPluginStart;

--- a/src/plugins/wizard/server/saved_objects/wizard_app.ts
+++ b/src/plugins/wizard/server/saved_objects/wizard_app.ts
@@ -38,8 +38,11 @@ export const wizardSavedObjectType: SavedObjectsType = {
       description: {
         type: 'text',
       },
-      //   TODO: Determine what needs to be pulled out of state and added directly into the mapping
-      state: {
+      visualizationState: {
+        type: 'text',
+        index: false,
+      },
+      styleState: {
         type: 'text',
         index: false,
       },

--- a/src/plugins/wizard/server/saved_objects/wizard_app.ts
+++ b/src/plugins/wizard/server/saved_objects/wizard_app.ts
@@ -4,7 +4,12 @@
  */
 
 import { SavedObject, SavedObjectsType } from '../../../../core/server';
-import { WizardSavedObjectAttributes, WIZARD_SAVED_OBJECT } from '../../common';
+import {
+  EDIT_PATH,
+  PLUGIN_ID,
+  WizardSavedObjectAttributes,
+  WIZARD_SAVED_OBJECT,
+} from '../../common';
 
 export const wizardSavedObjectType: SavedObjectsType = {
   name: WIZARD_SAVED_OBJECT,
@@ -19,7 +24,7 @@ export const wizardSavedObjectType: SavedObjectsType = {
       `/management/opensearch-dashboards/objects/savedWizard/${encodeURIComponent(id)}`,
     getInAppUrl({ id }: SavedObject) {
       return {
-        path: `/app/wizard#/edit/${encodeURIComponent(id)}`,
+        path: `/app/${PLUGIN_ID}${EDIT_PATH}/${encodeURIComponent(id)}`,
         uiCapabilitiesPath: 'wizard.show',
       };
     },
@@ -38,6 +43,7 @@ export const wizardSavedObjectType: SavedObjectsType = {
         type: 'text',
         index: false,
       },
+      version: { type: 'integer' },
     },
   },
 };


### PR DESCRIPTION
### Description

- Allows saving new d&d visualizations (both visualization and styling)
- Saved visualizations can be loaded using a new `/edit/:id` route
- Saved visualizations can be updated (edited and re-saved)
- Initial handling of editor state and "savability", although more work needed.
 
### Issues Resolved

- Fixes #1867
- Fixes  #1868

 
### Check List
- [x] Commits are signed per the DCO using --signoff 