### PR TITLE
[D&D] Add a flag in the YAML config to enable and disable the D&D plugin

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -184,3 +184,7 @@
 # Set the value of this setting to false to suppress search usage telemetry
 # for reducing the load of OpenSearch cluster.
 # data.search.usageTelemetry.enabled: false
+
+# Set the value of this setting to true to start exploring wizard
+# functionality in Visualization.
+# wizard.enabled: true

--- a/src/plugins/wizard/config.ts
+++ b/src/plugins/wizard/config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema, TypeOf } from '@osd/config-schema';
+
+export const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: true }),
+});
+
+export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/src/plugins/wizard/public/plugin.ts
+++ b/src/plugins/wizard/public/plugin.ts
@@ -26,13 +26,14 @@ import { getPreloadedStore } from './application/utils/state_management';
 import { setAggService, setIndexPatterns } from './plugin_services';
 import { createSavedWizardLoader } from './saved_visualizations';
 import { registerDefaultTypes } from './visualizations';
+import { ConfigSchema } from '../config';
 
 export class WizardPlugin
   implements
     Plugin<WizardSetup, WizardStart, WizardPluginSetupDependencies, WizardPluginStartDependencies> {
   private typeService = new TypeService();
 
-  constructor(public initializerContext: PluginInitializerContext) {}
+  constructor(public initializerContext: PluginInitializerContext<ConfigSchema>) {}
 
   public setup(
     core: CoreSetup<WizardPluginStartDependencies, WizardStart>,

--- a/src/plugins/wizard/server/index.ts
+++ b/src/plugins/wizard/server/index.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PluginInitializerContext } from '../../../core/server';
+import { PluginConfigDescriptor, PluginInitializerContext } from '../../../core/server';
+import { ConfigSchema, configSchema } from '../config';
 import { WizardPlugin } from './plugin';
 
 // This exports static code and TypeScript types,
@@ -14,3 +15,10 @@ export function plugin(initializerContext: PluginInitializerContext) {
 }
 
 export { WizardPluginSetup, WizardPluginStart } from './types';
+
+export const config: PluginConfigDescriptor<ConfigSchema> = {
+  exposeToBrowser: {
+    enabled: true,
+  },
+  schema: configSchema,
+};


### PR DESCRIPTION
Signed-off-by: Manasvini B Suryanarayana <manasvis@amazon.com>

### Description
As part of this https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1708 this PR is adding a flag in the YAML config to enable and disable the D&D plugin.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1877
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [x] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff 