### PR TITLE
Fixes issue on saving custom vector map options as part of visualization

### DIFF
--- a/src/plugins/maps_legacy/public/common/types/region_map_types.ts
+++ b/src/plugins/maps_legacy/public/common/types/region_map_types.ts
@@ -41,6 +41,8 @@ export interface RegionMapVisParams {
   outlineWeight: number | '';
   isDisplayWarning: boolean;
   showAllShapes: boolean;
+  selectedCustomLayer?: VectorLayer;
+  selectedCustomJoinField?: FileLayerField;
   selectedLayer?: VectorLayer;
   selectedJoinField?: FileLayerField;
   wms: WMSOptions;

--- a/src/plugins/region_map/public/region_map_type.js
+++ b/src/plugins/region_map/public/region_map_type.js
@@ -50,6 +50,7 @@ export function createRegionMapTypeDefinition(dependencies) {
 
   const services = getServices(http);
   const visualization = createRegionMapVisualization(dependencies);
+
   const diffArray = (arr1, arr2) => {
     return arr1.concat(arr2).filter((item) => !arr1.includes(item) || !arr2.includes(item));
   };
@@ -201,9 +202,10 @@ provided base maps, or add your own. Darker colors represent higher values.',
       const customIndices = await getCustomIndices();
 
       let selectedLayer = vectorLayers[0];
-      let selectedCustomLayer = customVectorLayers[0];
       let selectedJoinField = selectedLayer ? selectedLayer.fields[0] : null;
-      const selectedCustomJoinField = selectedCustomLayer ? selectedCustomLayer.fields[0] : null;
+
+      let selectedCustomLayer = customVectorLayers[0];
+      let selectedCustomJoinField = selectedCustomLayer ? selectedCustomLayer.fields[0] : null;
 
       if (regionmapsConfig.includeOpenSearchMapsService) {
         const layers = await serviceSettings.getFileLayers();
@@ -241,11 +243,9 @@ provided base maps, or add your own. Darker colors represent higher values.',
         ];
 
         [selectedLayer] = vis.type.editorConfig.collections.vectorLayers;
-        [selectedCustomLayer] = vis.type.editorConfig.collections.customVectorLayers;
-        vis.params.selectedCustomLayer = selectedCustomLayer;
-        vis.params.selectedCustomJoinField = selectedCustomJoinField;
-
         selectedJoinField = selectedLayer ? selectedLayer.fields[0] : null;
+        [selectedCustomLayer] = vis.type.editorConfig.collections.customVectorLayers;
+        selectedCustomJoinField = selectedCustomLayer ? selectedCustomLayer.fields[0] : null;
 
         if (selectedLayer && !vis.params.selectedLayer && selectedLayer.isEMS) {
           vis.params.emsHotLink = await serviceSettings.getEMSHotLink(selectedLayer);
@@ -255,6 +255,11 @@ provided base maps, or add your own. Darker colors represent higher values.',
       if (!vis.params.selectedLayer) {
         vis.params.selectedLayer = selectedLayer;
         vis.params.selectedJoinField = selectedJoinField;
+      }
+
+      if (!vis.params.selectedCustomLayer) {
+        vis.params.selectedCustomLayer = selectedCustomLayer;
+        vis.params.selectedCustomJoinField = selectedCustomJoinField;
       }
 
       vis.params.layerChosenByUser = vis.params.layerChosenByUser

--- a/src/plugins/region_map/public/region_map_visualization.js
+++ b/src/plugins/region_map/public/region_map_visualization.js
@@ -37,7 +37,7 @@ import {
 import { truncatedColorMaps } from '../../charts/public';
 import { tooltipFormatter } from './tooltip_formatter';
 import { mapTooltipProvider, ORIGIN, lazyLoadMapsLegacyModules } from '../../maps_legacy/public';
-import { DEFAULT_MAP_CHOICE } from '../common';
+import { DEFAULT_MAP_CHOICE, CUSTOM_MAP_CHOICE } from '../common';
 
 export function createRegionMapVisualization({
   http,
@@ -86,7 +86,7 @@ export function createRegionMapVisualization({
       let selectedLayer;
       if (DEFAULT_MAP_CHOICE === this._params.layerChosenByUser) {
         selectedLayer = await this._loadConfig(this._params.selectedLayer);
-        this._params.selectedJoinField = selectedLayer.fields[0];
+        this._params.selectedJoinField = selectedLayer?.fields[0];
       } else {
         selectedLayer = this._params.selectedCustomLayer;
         this._params.selectedJoinField = this._params.selectedCustomJoinField;
@@ -156,12 +156,15 @@ export function createRegionMapVisualization({
     async _updateParams() {
       await super._updateParams();
       let selectedLayer;
-      if (DEFAULT_MAP_CHOICE === this._params.layerChosenByUser) {
+      if (DEFAULT_MAP_CHOICE === this._params.layerChosenByUser && this._params.selectedLayer) {
         selectedLayer = await this._loadConfig(this._params.selectedLayer);
-        this._params.selectedJoinField = selectedLayer.fields[0];
-      } else {
+        this._params.selectedJoinField = selectedLayer?.fields[0];
+      } else if (
+        CUSTOM_MAP_CHOICE === this._params.layerChosenByUser &&
+        this._params.selectedCustomLayer
+      ) {
         selectedLayer = this._params.selectedCustomLayer;
-        this._params.selectedJoinField = this._params.selectedCustomJoinField;
+        this._params.selectedJoinField = this._params?.selectedCustomJoinField;
       }
 
       if (!this._params.selectedJoinField && selectedLayer) {


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description
Modifies region map rendering logic to show saved visualizations correctly.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [x] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 