### PR TITLE
Fixes maps wms zoom limitation

### DIFF
--- a/src/plugins/maps_legacy/public/map/base_maps_visualization.js
+++ b/src/plugins/maps_legacy/public/map/base_maps_visualization.js
@@ -164,7 +164,8 @@ export function BaseMapsVisualizationProvider() {
 
       try {
         if (this._wmsConfigured()) {
-          if (WMS_MINZOOM > this._opensearchDashboardsMap.getMaxZoomLevel()) {
+          const currentMaxZoomLevel = this._opensearchDashboardsMap.getMaxZoomLevel();
+          if (WMS_MINZOOM < currentMaxZoomLevel || WMS_MAXZOOM > currentMaxZoomLevel) {
             this._opensearchDashboardsMap.setMinZoom(WMS_MINZOOM);
             this._opensearchDashboardsMap.setMaxZoom(WMS_MAXZOOM);
           }


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
When using WMS to customize base tile maps in region map or coordinate maps, user aren’t able to get into higher zoom levels than opensearch maps service default maximum zoom level.

By this PR fixed, the WMS max zoom value can be reached to 22 which is originally deigned [here](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/9678a4bed88361574dc75f872c31d68834986562/src/plugins/maps_legacy/public/map/base_maps_visualization.js#L39)
 
### Issues Resolved
https://github.com/opensearch-project/maps/issues/19
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
    - [X] `yarn test:jest`
    - [X] `yarn test:jest_integration`
    - [X] `yarn test:ftr`
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff 