### PR TITLE
[D&D] Add wizard saved objects to vis list

### DIFF
--- a/src/plugins/visualizations/public/vis_types/vis_type_alias_registry.ts
+++ b/src/plugins/visualizations/public/vis_types/vis_type_alias_registry.ts
@@ -28,6 +28,7 @@
  * under the License.
  */
 
+import { SavedObjectAttributes } from 'opensearch-dashboards/public';
 import { TriggerContextMapping } from '../../../ui_actions/public';
 
 export interface VisualizationListItem {
@@ -51,7 +52,7 @@ export interface VisualizationsAppExtension {
   toListItem: (savedObject: {
     id: string;
     type: string;
-    attributes: object;
+    attributes: SavedObjectAttributes;
   }) => VisualizationListItem;
 }
 

--- a/src/plugins/wizard/public/plugin.ts
+++ b/src/plugins/wizard/public/plugin.ts
@@ -21,7 +21,7 @@ import {
 } from './types';
 import { WizardEmbeddableFactoryDefinition, WIZARD_EMBEDDABLE } from './embeddable';
 import wizardIcon from './assets/wizard_icon.svg';
-import { PLUGIN_ID, PLUGIN_NAME } from '../common';
+import { EDIT_PATH, PLUGIN_ID, PLUGIN_NAME, WIZARD_SAVED_OBJECT } from '../common';
 import { TypeService } from './services/type_service';
 import { getPreloadedStore } from './application/utils/state_management';
 import { setAggService, setIndexPatterns } from './plugin_services';
@@ -119,6 +119,22 @@ export class WizardPlugin
       stage: 'experimental',
       aliasApp: PLUGIN_ID,
       aliasPath: '#/',
+      appExtensions: {
+        visualizations: {
+          docTypes: [PLUGIN_ID],
+          toListItem: ({ id, attributes }) => ({
+            description: attributes?.description,
+            editApp: PLUGIN_ID,
+            editUrl: `${EDIT_PATH}/${encodeURIComponent(id)}`,
+            icon: wizardIcon,
+            id,
+            savedObjectType: WIZARD_SAVED_OBJECT,
+            stage: 'experimental',
+            title: attributes?.title,
+            typeTitle: PLUGIN_NAME,
+          }),
+        },
+      },
     });
 
     return {


### PR DESCRIPTION
via appExtensions of alias registration


Signed-off-by: Josh Romero <rmerqg@amazon.com>

### Description

Updates alias registration with necessary `appExtensions`
<img width="1642" alt="Screen Shot 2022-07-21 at 5 59 41 PM" src="https://user-images.githubusercontent.com/1679762/180340360-9f5b70ec-ede9-4695-b1cb-b312fc622928.png">

 
### Issues Resolved

fixes #1887
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 