### PR TITLE
[BUG] Fixing some of the broken links in core plugin API documentations

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -4,11 +4,11 @@ Core is a set of systems (frontend, backend etc.) that OpenSearch Dashboards and
 
 ## Plugin development
 Core Plugin API Documentation:
- - [Core Public API](/docs/development/core/public/opensearch-dashboards-plugin-core-public.md)
- - [Core Server API](/docs/development/core/server/opensearch-dashboards-plugin-core-server.md)
+ - [Core Public API](../core/public/public.api.md)
+ - [Core Server API](../core/server/server.api.md)
  - [Conventions for Plugins](./CONVENTIONS.md)
  - [Testing OpenSearch Dashboards Plugins](./TESTING.md)
- - [OpenSearch Dashboards Platform Plugin API](./docs/developer/architecture/kibana-platform-plugin-api.asciidoc )
+ - [OpenSearch Dashboards Platform Plugin API](./PRINCIPLES.md)
  
 Internal Documentation:
  - [Saved Objects Migrations](./server/saved_objects/migrations/README.md)


### PR DESCRIPTION
Signed-off-by: Manasvini B Suryanarayana <manasvis@amazon.com>

### Description
 Fixing some of the broken links in core plugin API documentations
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1895
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff 