### PR TITLE
[CI] Clean up for BWC tests & run only on PRs for backports

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -3,10 +3,10 @@
 
 name: Build and test
 
-# trigger on every commit push and PR for all branches except feature branches
+# trigger on every commit push and PR for all branches except feature branches and pushes for backport branches
 on:
   push:
-    branches: [ '**', '!feature/**' ]
+    branches: [ '**', '!feature/**', '!backport/**' ]
   pull_request:
     branches: [ '**', '!feature/**' ]
 
@@ -221,6 +221,10 @@ jobs:
       - name: Skipping tests
         if: steps.verify-opensearch-exists.outputs.version-exists != 'true'
         run: echo Tests were skipped because an OpenSearch release build does not exist for this version yet!
+
+      - name: Setting environment variable to run tests for ${{ matrix.version }}
+        if: steps.verify-opensearch-exists.outputs.version-exists == 'true'
+        run: echo "BWC_VERSIONS=${{ matrix.version }}" >> $GITHUB_ENV
     
       - name: Download OpenSearch Dashboards
         uses: actions/download-artifact@v3
@@ -234,3 +238,12 @@ jobs:
         if: steps.verify-opensearch-exists.outputs.version-exists == 'true'
         run: |
           ./bwctest.sh -s false -o ${{ env.OPENSEARCH_URL }} -d ${{ steps.download.outputs.download-path }}/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+      
+      - uses: actions/upload-artifact@v3
+        if: ${{ failure() && steps.verify-opensearch-exists.outputs.version-exists == 'true' }}
+        with:
+          name: ${{ matrix.version }}-test-failures
+          path: |
+            ./artifacts/bwc_tmp/test/cypress/videos/without-security/*
+            ./artifacts/bwc_tmp/test/cypress/screenshots/without-security/*
+          retention-days: 1

--- a/cypress/integration/with-security/check_filter_and_query.js
+++ b/cypress/integration/with-security/check_filter_and_query.js
@@ -12,6 +12,8 @@ import {
 const miscUtils = new MiscUtils(cy);
 const commonUI = new CommonUI(cy);
 const loginPage = new LoginPage(cy);
+const startDate = 'Nov 1, 2016 @ 00:00:00.000';
+const endDate = `Dec 31, ${new Date().getFullYear()} @ 00:00:00.000`;
 
 describe('check dashboards filter and query', () => {
   beforeEach(() => {
@@ -66,7 +68,7 @@ describe('check dashboards filter and query', () => {
         .find('[class="osdSavedQueryListItem__labelText"]')
         .should('have.text', 'test-query')
         .click();
-      commonUI.setDateRange('Dec 1, 2021 @ 00:00:00.000', 'Jan 1, 2021 @ 00:00:00.000');
+      commonUI.setDateRange(endDate, startDate);
 
       //[Logs] vistor chart should show osx 100%
       cy.get('[data-title="[Logs] Visitors by OS"]')

--- a/cypress/integration/without-security/check_filter_and_query.js
+++ b/cypress/integration/without-security/check_filter_and_query.js
@@ -10,6 +10,8 @@ import {
 
 const miscUtils = new MiscUtils(cy);
 const commonUI = new CommonUI(cy);
+const startDate = 'Nov 1, 2016 @ 00:00:00.000';
+const endDate = `Dec 31, ${new Date().getFullYear()} @ 00:00:00.000`;
 
 describe('check dashboards filter and query', () => {
   beforeEach(() => {
@@ -56,7 +58,7 @@ describe('check dashboards filter and query', () => {
         .find('[class="osdSavedQueryListItem__labelText"]')
         .should('have.text', 'test-query')
         .click();
-      commonUI.setDateRange('Dec 1, 2021 @ 00:00:00.000', 'Jan 1, 2021 @ 00:00:00.000');
+      commonUI.setDateRange(endDate, startDate);
 
       //[Logs] vistor chart should show osx 100%
       cy.get('[data-title="[Logs] Visitors by OS"]')


### PR DESCRIPTION
### Description

Backport PRs will also run actions for pushs and PRs which is just
unneeded double work everytime. So this prevents that.

Also, BWC will run a complete array for every job in the matrix.
Now we set the environment variable to prevents the running of
the default versions.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 