### PR TITLE
[D&D] Fix duplicate title warning

### DIFF
--- a/src/plugins/wizard/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/wizard/public/application/utils/get_top_nav_config.tsx
@@ -91,6 +91,7 @@ export const getTopNavConfig = (
           if (!savedWizardVis) {
             return;
           }
+          const currentTitle = savedWizardVis.title;
           savedWizardVis.visualizationState = JSON.stringify(visualizationState);
           savedWizardVis.styleState = JSON.stringify(styleState);
           savedWizardVis.title = newTitle;
@@ -126,11 +127,13 @@ export const getTopNavConfig = (
                   pathname: `${EDIT_PATH}/${id}`,
                 });
               }
-
-              return { id };
+            } else {
+              // reset title if save not successful
+              savedWizardVis.title = currentTitle;
             }
 
-            throw new Error('Saved but no id returned');
+            // Even if id='', which it will be for a duplicate title warning, we still want to return it, to avoid closing the modal
+            return { id };
           } catch (error: any) {
             // eslint-disable-next-line no-console
             console.error(error);
@@ -145,6 +148,9 @@ export const getTopNavConfig = (
               text: error.message,
               'data-test-subj': 'saveVisualizationError',
             });
+
+            // reset title if save not successful
+            savedWizardVis.title = currentTitle;
             return { error };
           }
         };


### PR DESCRIPTION
### Description

Fixes behavior when saving a wizard visualization with a duplicate title. Note that this now matches the (somewhat surprising) behavior as visualizations, where you can override the warning by clicking save a second time after you get the warning in the modal.

![dnd-duplicate-name](https://user-images.githubusercontent.com/1679762/180927637-58bbb45a-0776-4c45-9853-10f506f20cd1.gif)

 
### Issues Resolved

fixes #1918
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 