### PR TITLE
[UX] Restyle global breadcrumbs

### DIFF
--- a/src/core/public/_variables.scss
+++ b/src/core/public/_variables.scss
@@ -1,6 +1,6 @@
 @import "@elastic/eui/src/global_styling/variables/header";
 
 $osdHeaderOffset: $euiHeaderHeightCompensation;
-$osdPacificSky: #b9d9eb;
-$osdSanFranciscoFog: #d9e1e2;
-$osdMidnightSky: #002a3a;
+$osdHeaderBreadcrumbBlueBackground: #b9d9eb;
+$osdHeaderBreadcrumbGrayBackground: #d9e1e2;
+$osdHeaderBreadcrumbCollapsedLink: #002a3a;

--- a/src/core/public/_variables.scss
+++ b/src/core/public/_variables.scss
@@ -3,4 +3,4 @@
 $osdHeaderOffset: $euiHeaderHeightCompensation;
 $osdPacificSky: #b9d9eb;
 $osdSanFranciscoFog: #d9e1e2;
-$osdDarkCyanBlue: #003b5c;
+$osdMidnightSky: #002a3a;

--- a/src/core/public/_variables.scss
+++ b/src/core/public/_variables.scss
@@ -1,3 +1,6 @@
 @import "@elastic/eui/src/global_styling/variables/header";
 
 $osdHeaderOffset: $euiHeaderHeightCompensation;
+$osdPacificSky: #b9d9eb;
+$osdSanFranciscoFog: #d9e1e2;
+$osdDarkCyanBlue: #003b5c;

--- a/src/core/public/chrome/public/assets/round_filter.svg
+++ b/src/core/public/chrome/public/assets/round_filter.svg
@@ -1,0 +1,8 @@
+<svg style="visibility: hidden; position: absolute;" width="0" height="0" xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <defs>
+        <filter id="round"><feGaussianBlur in="SourceGraphic" stdDeviation="2"/>    
+            <feColorMatrix in="blur" mode="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 19 -9" result="goo" />
+            <feComposite in="SourceGraphic" in2="goo" operator="atop"/>
+        </filter>
+    </defs>
+</svg>

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -3595,7 +3595,7 @@ exports[`Header handles visibility and lock changes 1`] = `
               breadcrumbs={
                 Array [
                   Object {
-                    "data-background": "osdHeaderBreadcrumbs first last",
+                    "className": "osdBreadcrumbs first last",
                     "data-test-subj": "breadcrumb first last",
                     "text": "test",
                   },
@@ -3609,7 +3609,7 @@ exports[`Header handles visibility and lock changes 1`] = `
                 breadcrumbs={
                   Array [
                     Object {
-                      "data-background": "osdHeaderBreadcrumbs first last",
+                      "className": "osdBreadcrumbs first last",
                       "data-test-subj": "breadcrumb first last",
                       "text": "test",
                     },
@@ -3628,8 +3628,7 @@ exports[`Header handles visibility and lock changes 1`] = `
                   <EuiInnerText>
                     <span
                       aria-current="page"
-                      className="euiBreadcrumb euiBreadcrumb--last"
-                      data-background="osdHeaderBreadcrumbs first last"
+                      className="euiBreadcrumb osdBreadcrumbs first last euiBreadcrumb--last"
                       data-test-subj="breadcrumb first last"
                       title="test"
                     >
@@ -8828,7 +8827,7 @@ exports[`Header renders condensed header 1`] = `
               breadcrumbs={
                 Array [
                   Object {
-                    "data-background": "osdHeaderBreadcrumbs first last",
+                    "className": "osdBreadcrumbs first last",
                     "data-test-subj": "breadcrumb first",
                     "text": "test",
                   },
@@ -8842,7 +8841,7 @@ exports[`Header renders condensed header 1`] = `
                 breadcrumbs={
                   Array [
                     Object {
-                      "data-background": "osdHeaderBreadcrumbs first last",
+                      "className": "osdBreadcrumbs first last",
                       "data-test-subj": "breadcrumb first",
                       "text": "test",
                     },
@@ -8861,8 +8860,7 @@ exports[`Header renders condensed header 1`] = `
                   <EuiInnerText>
                     <span
                       aria-current="page"
-                      className="euiBreadcrumb euiBreadcrumb--last"
-                      data-background="osdHeaderBreadcrumbs first last"
+                      className="euiBreadcrumb osdBreadcrumbs first last euiBreadcrumb--last"
                       data-test-subj="breadcrumb first"
                       title="test"
                     >

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -3595,7 +3595,7 @@ exports[`Header handles visibility and lock changes 1`] = `
               breadcrumbs={
                 Array [
                   Object {
-                    "className": "osdBreadcrumbs first last",
+                    "className": "osdBreadcrumbs",
                     "data-test-subj": "breadcrumb first last",
                     "text": "test",
                   },
@@ -3609,7 +3609,7 @@ exports[`Header handles visibility and lock changes 1`] = `
                 breadcrumbs={
                   Array [
                     Object {
-                      "className": "osdBreadcrumbs first last",
+                      "className": "osdBreadcrumbs",
                       "data-test-subj": "breadcrumb first last",
                       "text": "test",
                     },
@@ -3628,7 +3628,7 @@ exports[`Header handles visibility and lock changes 1`] = `
                   <EuiInnerText>
                     <span
                       aria-current="page"
-                      className="euiBreadcrumb osdBreadcrumbs first last euiBreadcrumb--last"
+                      className="euiBreadcrumb osdBreadcrumbs euiBreadcrumb--last"
                       data-test-subj="breadcrumb first last"
                       title="test"
                     >
@@ -8827,7 +8827,7 @@ exports[`Header renders condensed header 1`] = `
               breadcrumbs={
                 Array [
                   Object {
-                    "className": "osdBreadcrumbs first last",
+                    "className": "osdBreadcrumbs",
                     "data-test-subj": "breadcrumb first",
                     "text": "test",
                   },
@@ -8841,7 +8841,7 @@ exports[`Header renders condensed header 1`] = `
                 breadcrumbs={
                   Array [
                     Object {
-                      "className": "osdBreadcrumbs first last",
+                      "className": "osdBreadcrumbs",
                       "data-test-subj": "breadcrumb first",
                       "text": "test",
                     },
@@ -8860,7 +8860,7 @@ exports[`Header renders condensed header 1`] = `
                   <EuiInnerText>
                     <span
                       aria-current="page"
-                      className="euiBreadcrumb osdBreadcrumbs first last euiBreadcrumb--last"
+                      className="euiBreadcrumb osdBreadcrumbs euiBreadcrumb--last"
                       data-test-subj="breadcrumb first"
                       title="test"
                     >

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -3595,11 +3595,13 @@ exports[`Header handles visibility and lock changes 1`] = `
               breadcrumbs={
                 Array [
                   Object {
+                    "data-background": "osdHeaderBreadcrumbs first last",
                     "data-test-subj": "breadcrumb first last",
                     "text": "test",
                   },
                 ]
               }
+              className="osdHeaderBreadcrumbs"
               data-test-subj="breadcrumbs"
               max={10}
             >
@@ -3607,25 +3609,27 @@ exports[`Header handles visibility and lock changes 1`] = `
                 breadcrumbs={
                   Array [
                     Object {
+                      "data-background": "osdHeaderBreadcrumbs first last",
                       "data-test-subj": "breadcrumb first last",
                       "text": "test",
                     },
                   ]
                 }
-                className="euiHeaderBreadcrumbs"
+                className="euiHeaderBreadcrumbs osdHeaderBreadcrumbs"
                 data-test-subj="breadcrumbs"
                 max={10}
                 truncate={true}
               >
                 <nav
                   aria-label="breadcrumb"
-                  className="euiBreadcrumbs euiHeaderBreadcrumbs euiBreadcrumbs--truncate"
+                  className="euiBreadcrumbs euiHeaderBreadcrumbs osdHeaderBreadcrumbs euiBreadcrumbs--truncate"
                   data-test-subj="breadcrumbs"
                 >
                   <EuiInnerText>
                     <span
                       aria-current="page"
                       className="euiBreadcrumb euiBreadcrumb--last"
+                      data-background="osdHeaderBreadcrumbs first last"
                       data-test-subj="breadcrumb first last"
                       title="test"
                     >
@@ -8824,11 +8828,13 @@ exports[`Header renders condensed header 1`] = `
               breadcrumbs={
                 Array [
                   Object {
+                    "data-background": "osdHeaderBreadcrumbs first last",
                     "data-test-subj": "breadcrumb first",
                     "text": "test",
                   },
                 ]
               }
+              className="osdHeaderBreadcrumbs"
               data-test-subj="breadcrumbs"
               max={10}
             >
@@ -8836,25 +8842,27 @@ exports[`Header renders condensed header 1`] = `
                 breadcrumbs={
                   Array [
                     Object {
+                      "data-background": "osdHeaderBreadcrumbs first last",
                       "data-test-subj": "breadcrumb first",
                       "text": "test",
                     },
                   ]
                 }
-                className="euiHeaderBreadcrumbs"
+                className="euiHeaderBreadcrumbs osdHeaderBreadcrumbs"
                 data-test-subj="breadcrumbs"
                 max={10}
                 truncate={true}
               >
                 <nav
                   aria-label="breadcrumb"
-                  className="euiBreadcrumbs euiHeaderBreadcrumbs euiBreadcrumbs--truncate"
+                  className="euiBreadcrumbs euiHeaderBreadcrumbs osdHeaderBreadcrumbs euiBreadcrumbs--truncate"
                   data-test-subj="breadcrumbs"
                 >
                   <EuiInnerText>
                     <span
                       aria-current="page"
                       className="euiBreadcrumb euiBreadcrumb--last"
+                      data-background="osdHeaderBreadcrumbs first last"
                       data-test-subj="breadcrumb first"
                       title="test"
                     >

--- a/src/core/public/chrome/ui/header/__snapshots__/header_breadcrumbs.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header_breadcrumbs.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HeaderBreadcrumbs renders updates to the breadcrumbs$ observable 1`] = `
 <span
   aria-current="page"
-  className="euiBreadcrumb osdBreadcrumbs first last euiBreadcrumb--last"
+  className="euiBreadcrumb osdBreadcrumbs euiBreadcrumb--last"
   data-test-subj="breadcrumb first last"
   title="First"
 >
@@ -15,7 +15,7 @@ exports[`HeaderBreadcrumbs renders updates to the breadcrumbs$ observable 2`] = 
 Array [
   <span
     aria-current="false"
-    className="euiBreadcrumb osdBreadcrumbs first"
+    className="euiBreadcrumb osdBreadcrumbs"
     data-test-subj="breadcrumb first"
     title="First"
   >
@@ -23,7 +23,7 @@ Array [
   </span>,
   <span
     aria-current="page"
-    className="euiBreadcrumb osdBreadcrumbs last euiBreadcrumb--last"
+    className="euiBreadcrumb osdBreadcrumbs euiBreadcrumb--last"
     data-test-subj="breadcrumb last"
     title="Second"
   >

--- a/src/core/public/chrome/ui/header/__snapshots__/header_breadcrumbs.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header_breadcrumbs.test.tsx.snap
@@ -3,8 +3,7 @@
 exports[`HeaderBreadcrumbs renders updates to the breadcrumbs$ observable 1`] = `
 <span
   aria-current="page"
-  className="euiBreadcrumb euiBreadcrumb--last"
-  data-background="osdHeaderBreadcrumbs first last"
+  className="euiBreadcrumb osdBreadcrumbs first last euiBreadcrumb--last"
   data-test-subj="breadcrumb first last"
   title="First"
 >
@@ -16,8 +15,7 @@ exports[`HeaderBreadcrumbs renders updates to the breadcrumbs$ observable 2`] = 
 Array [
   <span
     aria-current="false"
-    className="euiBreadcrumb"
-    data-background="osdHeaderBreadcrumbs first"
+    className="euiBreadcrumb osdBreadcrumbs first"
     data-test-subj="breadcrumb first"
     title="First"
   >
@@ -25,8 +23,7 @@ Array [
   </span>,
   <span
     aria-current="page"
-    className="euiBreadcrumb euiBreadcrumb--last"
-    data-background="osdHeaderBreadcrumbs last"
+    className="euiBreadcrumb osdBreadcrumbs last euiBreadcrumb--last"
     data-test-subj="breadcrumb last"
     title="Second"
   >

--- a/src/core/public/chrome/ui/header/__snapshots__/header_breadcrumbs.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header_breadcrumbs.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`HeaderBreadcrumbs renders updates to the breadcrumbs$ observable 1`] = 
 <span
   aria-current="page"
   className="euiBreadcrumb euiBreadcrumb--last"
+  data-background="osdHeaderBreadcrumbs first last"
   data-test-subj="breadcrumb first last"
   title="First"
 >
@@ -16,6 +17,7 @@ Array [
   <span
     aria-current="false"
     className="euiBreadcrumb"
+    data-background="osdHeaderBreadcrumbs first"
     data-test-subj="breadcrumb first"
     title="First"
   >
@@ -24,6 +26,7 @@ Array [
   <span
     aria-current="page"
     className="euiBreadcrumb euiBreadcrumb--last"
+    data-background="osdHeaderBreadcrumbs last"
     data-test-subj="breadcrumb last"
     title="Second"
   >

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.scss
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.scss
@@ -1,52 +1,39 @@
 @import "../../../../public/variables";
 
-@mixin background($color,$shape) {
-  background-color: #{$color};
-  clip-path: $shape;
-  padding: $euiSizeXS - 2.5 $euiSizeL - $euiSizeXS;
-}
+$firstBreadcrumbPolygon: polygon(
+  0% 0%,
+  100% 0%,
+  calc(100% - #{$euiSizeS}) 100%,
+  0% 100%
+);
+$breadcrumbPolygon: polygon(
+  $euiSizeS 0%,
+  100% 0%,
+  calc(100% - #{$euiSizeS}) 100%,
+  0% 100%
+);
 
 .osdHeaderBreadcrumbs {
+  /*
+  filter defines a custom filter effect by grouping atomic filter primitives!
+  here we are using Gaussian filter with stdDeviation for applying
+  border-radius on clipped background.
+  */
+
   filter: url("../../public/assets/round_filter.svg#round");
 
-  .osdBreadcrumbs.first {
-    @include background($osdHeaderBreadcrumbGrayBackground,
-    polygon(
-      0% 0%,
-      100% 0%,
-      calc(100% - #{$euiSizeS}) 100%,
-      0% 100%
-    ));
-  }
+  .osdBreadcrumbs {
+    clip-path: $breadcrumbPolygon;
+    background-color: $osdHeaderBreadcrumbGrayBackground;
+    padding: $euiSizeXS - 2.5 $euiSizeL - $euiSizeXS;
 
-  .osdBreadcrumbs.middle {
-    @include background($osdHeaderBreadcrumbGrayBackground,
-    polygon(
-      $euiSizeS 0%,
-      100% 0%,
-      calc(100% - #{$euiSizeS}) 100%,
-      0% 100%
-    ));
-  }
+    &:first-child {
+      clip-path: $firstBreadcrumbPolygon;
+    }
 
-  .osdBreadcrumbs.last {
-    @include background($osdHeaderBreadcrumbBlueBackground,
-    polygon(
-      $euiSizeS 0%,
-      100% 0%,
-      calc(100% - #{$euiSizeS}) 100%,
-      0% 100%
-    ));
-  }
-
-  .osdBreadcrumbs.first.last {
-    @include background($osdHeaderBreadcrumbBlueBackground,
-    polygon(
-      0% 0%,
-      100% 0%,
-      calc(100% - #{$euiSizeS}) 100%,
-      0% 100%
-    ));
+    &:last-child {
+      background-color: $osdHeaderBreadcrumbBlueBackground;
+    }
   }
 
   .euiBreadcrumbSeparator {
@@ -62,7 +49,7 @@
     padding: 0 $euiSizeS;
   }
 
-  .euiBreadcrumb:not(.euiBreadcrumb--last) {
+  .euiBreadcrumb:not(.euiBreadcrumb:last-child) {
     margin-right: 0;
   }
 }

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.scss
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.scss
@@ -10,7 +10,7 @@
   filter: url("../../public/assets/round_filter.svg#round");
 
   .osdBreadcrumbs.first {
-    @include background($osdSanFranciscoFog,
+    @include background($osdHeaderBreadcrumbGrayBackground,
     polygon(
       0% 0%,
       100% 0%,
@@ -20,17 +20,17 @@
   }
 
   .osdBreadcrumbs.middle {
-    @include background($osdSanFranciscoFog,
+    @include background($osdHeaderBreadcrumbGrayBackground,
     polygon(
       $euiSizeS 0%,
       100% 0%,
-      calc(100% - #{$euiSizeS})  100%,
+      calc(100% - #{$euiSizeS}) 100%,
       0% 100%
     ));
   }
 
   .osdBreadcrumbs.last {
-    @include background($osdPacificSky,
+    @include background($osdHeaderBreadcrumbBlueBackground,
     polygon(
       $euiSizeS 0%,
       100% 0%,
@@ -40,11 +40,11 @@
   }
 
   .osdBreadcrumbs.first.last {
-    @include background($osdPacificSky,
+    @include background($osdHeaderBreadcrumbBlueBackground,
     polygon(
       0% 0%,
       100% 0%,
-      calc(100% - #{$euiSizeS})100%,
+      calc(100% - #{$euiSizeS}) 100%,
       0% 100%
     ));
   }
@@ -54,7 +54,7 @@
   }
 
   .euiBreadcrumb__collapsedLink {
-    color: $osdMidnightSky;
+    color: $osdHeaderBreadcrumbCollapsedLink;
     background: $euiColorEmptyShade;
   }
 

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.scss
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.scss
@@ -4,27 +4,49 @@
   background-color: #{$color};
   clip-path: $shape;
   padding: $euiSizeXS - 2.5 $euiSizeL - $euiSizeXS;
-  border-radius: $euiSizeXS - 2;
 }
 
 .osdHeaderBreadcrumbs {
-  [data-background="osdHeaderBreadcrumbs first"] {
-    @include backround($osdSanFranciscoFog, polygon(0% 0%,100% 0%,calc(100% - #{
-      $euiSizeS + 2}) 100%,0% 100%));
-  }
+  filter: url("../../public/assets/round_filter.svg#round");
 
-  [data-background="osdHeaderBreadcrumbs middle"] {
+  .osdBreadcrumbs.first {
     @include backround($osdSanFranciscoFog,
-    polygon($euiSizeS + 2 0%,100% 0%,calc(100% - #{$euiSizeS + 2})  100%,0% 100%));
+    polygon(
+      0% 0%,
+      100% 0%,
+      calc(100% - #{$euiSizeS}) 100%,
+      0% 100%
+    ));
   }
 
-  [data-background="osdHeaderBreadcrumbs last"] {
-    @include backround($osdPacificSky,polygon(
-      $euiSizeS + 2 0%, 100% 0%, calc(100% - #{$euiSizeS + 2}) 100%, 0% 100%));
+  .osdBreadcrumbs.middle {
+    @include backround($osdSanFranciscoFog,
+    polygon(
+      $euiSizeS 0%,
+      100% 0%,
+      calc(100% - #{$euiSizeS})  100%,
+      0% 100%
+    ));
   }
 
-  [data-background="osdHeaderBreadcrumbs first last"] {
-    @include backround($osdPacificSky,polygon(0% 0%,100% 0%,calc(100% - #{$euiSizeS + 2}) 100%,0% 100%));
+  .osdBreadcrumbs.last {
+    @include backround($osdPacificSky,
+    polygon(
+      $euiSizeS 0%,
+      100% 0%,
+      calc(100% - #{$euiSizeS}) 100%,
+      0% 100%
+    ));
+  }
+
+  .osdBreadcrumbs.first.last {
+    @include backround($osdPacificSky,
+    polygon(
+      0% 0%,
+      100% 0%,
+      calc(100% - #{$euiSizeS})100%,
+      0% 100%
+    ));
   }
 
   .euiBreadcrumbSeparator {
@@ -36,7 +58,8 @@
   }
 
   .euiBreadcrumb__collapsedLink {
-    color: $osdDarkCyanBlue;
+    color: $osdMidnightSky;
+    background: $euiColorEmptyShade;
   }
 
   .euiPopover__anchor {

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.scss
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.scss
@@ -1,6 +1,6 @@
 @import "../../../../public/variables";
 
-@mixin backround($color,$shape) {
+@mixin background($color,$shape) {
   background-color: #{$color};
   clip-path: $shape;
   padding: $euiSizeXS - 2.5 $euiSizeL - $euiSizeXS;
@@ -10,7 +10,7 @@
   filter: url("../../public/assets/round_filter.svg#round");
 
   .osdBreadcrumbs.first {
-    @include backround($osdSanFranciscoFog,
+    @include background($osdSanFranciscoFog,
     polygon(
       0% 0%,
       100% 0%,
@@ -20,7 +20,7 @@
   }
 
   .osdBreadcrumbs.middle {
-    @include backround($osdSanFranciscoFog,
+    @include background($osdSanFranciscoFog,
     polygon(
       $euiSizeS 0%,
       100% 0%,
@@ -30,7 +30,7 @@
   }
 
   .osdBreadcrumbs.last {
-    @include backround($osdPacificSky,
+    @include background($osdPacificSky,
     polygon(
       $euiSizeS 0%,
       100% 0%,
@@ -40,7 +40,7 @@
   }
 
   .osdBreadcrumbs.first.last {
-    @include backround($osdPacificSky,
+    @include background($osdPacificSky,
     polygon(
       0% 0%,
       100% 0%,

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.scss
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.scss
@@ -1,0 +1,49 @@
+@import "../../../../public/variables";
+
+@mixin backround($color,$shape) {
+  background-color: #{$color};
+  clip-path: $shape;
+  padding: $euiSizeXS - 2.5 $euiSizeL - $euiSizeXS;
+  border-radius: $euiSizeXS - 2;
+}
+
+.osdHeaderBreadcrumbs {
+  [data-background="osdHeaderBreadcrumbs first"] {
+    @include backround($osdSanFranciscoFog, polygon(0% 0%,100% 0%,calc(100% - #{
+      $euiSizeS + 2}) 100%,0% 100%));
+  }
+
+  [data-background="osdHeaderBreadcrumbs middle"] {
+    @include backround($osdSanFranciscoFog,
+    polygon($euiSizeS + 2 0%,100% 0%,calc(100% - #{$euiSizeS + 2})  100%,0% 100%));
+  }
+
+  [data-background="osdHeaderBreadcrumbs last"] {
+    @include backround($osdPacificSky,polygon(
+      $euiSizeS + 2 0%, 100% 0%, calc(100% - #{$euiSizeS + 2}) 100%, 0% 100%));
+  }
+
+  [data-background="osdHeaderBreadcrumbs first last"] {
+    @include backround($osdPacificSky,polygon(0% 0%,100% 0%,calc(100% - #{$euiSizeS + 2}) 100%,0% 100%));
+  }
+
+  .euiBreadcrumbSeparator {
+    display: none;
+  }
+
+  .euiBreadcrumb:not(.euiBreadcrumb--collapsed) {
+    max-width: 170px;
+  }
+
+  .euiBreadcrumb__collapsedLink {
+    color: $osdDarkCyanBlue;
+  }
+
+  .euiPopover__anchor {
+    padding: 0 $euiSizeS;
+  }
+
+  .euiBreadcrumb:not(.euiBreadcrumb--last) {
+    margin-right: 0;
+  }
+}

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.scss
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.scss
@@ -53,10 +53,6 @@
     display: none;
   }
 
-  .euiBreadcrumb:not(.euiBreadcrumb--collapsed) {
-    max-width: 170px;
-  }
-
   .euiBreadcrumb__collapsedLink {
     color: $osdMidnightSky;
     background: $euiColorEmptyShade;

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -51,8 +51,6 @@ export function HeaderBreadcrumbs({ appTitle$, breadcrumbs$ }: Props) {
     crumbs = [{ text: appTitle }];
   }
 
-  const crumbsLength = crumbs.length;
-
   crumbs = crumbs.map((breadcrumb, i) => ({
     ...breadcrumb,
     'data-test-subj': classNames(
@@ -61,12 +59,7 @@ export function HeaderBreadcrumbs({ appTitle$, breadcrumbs$ }: Props) {
       i === 0 && 'first',
       i === breadcrumbs.length - 1 && 'last'
     ),
-    className: classNames(
-      'osdBreadcrumbs',
-      i === 0 && 'first',
-      i > 0 && i < crumbsLength - 1 && 'middle',
-      i === crumbsLength - 1 && 'last'
-    ),
+    className: classNames('osdBreadcrumbs'),
   }));
 
   return (

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -50,9 +50,9 @@ export function HeaderBreadcrumbs({ appTitle$, breadcrumbs$ }: Props) {
   if (breadcrumbs.length === 0 && appTitle) {
     crumbs = [{ text: appTitle }];
   }
-  
+
   const crumbsLength = crumbs.length;
-  
+
   crumbs = crumbs.map((breadcrumb, i) => ({
     ...breadcrumb,
     'data-test-subj': classNames(

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -50,7 +50,9 @@ export function HeaderBreadcrumbs({ appTitle$, breadcrumbs$ }: Props) {
   if (breadcrumbs.length === 0 && appTitle) {
     crumbs = [{ text: appTitle }];
   }
-
+  
+  const crumbsLength = crumbs.length;
+  
   crumbs = crumbs.map((breadcrumb, i) => ({
     ...breadcrumb,
     'data-test-subj': classNames(
@@ -62,8 +64,8 @@ export function HeaderBreadcrumbs({ appTitle$, breadcrumbs$ }: Props) {
     className: classNames(
       'osdBreadcrumbs',
       i === 0 && 'first',
-      i > 0 && i < crumbs.length - 1 && 'middle',
-      i === crumbs.length - 1 && 'last'
+      i > 0 && i < crumbsLength - 1 && 'middle',
+      i === crumbsLength - 1 && 'last'
     ),
   }));
 

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -59,8 +59,8 @@ export function HeaderBreadcrumbs({ appTitle$, breadcrumbs$ }: Props) {
       i === 0 && 'first',
       i === breadcrumbs.length - 1 && 'last'
     ),
-    'data-background': classNames(
-      'osdHeaderBreadcrumbs',
+    className: classNames(
+      'osdBreadcrumbs',
       i === 0 && 'first',
       i > 0 && i < crumbs.length - 1 && 'middle',
       i === crumbs.length - 1 && 'last'

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -35,6 +35,8 @@ import useObservable from 'react-use/lib/useObservable';
 import { Observable } from 'rxjs';
 import { ChromeBreadcrumb } from '../../chrome_service';
 
+import './header_breadcrumbs.scss';
+
 interface Props {
   appTitle$: Observable<string>;
   breadcrumbs$: Observable<ChromeBreadcrumb[]>;
@@ -57,7 +59,20 @@ export function HeaderBreadcrumbs({ appTitle$, breadcrumbs$ }: Props) {
       i === 0 && 'first',
       i === breadcrumbs.length - 1 && 'last'
     ),
+    'data-background': classNames(
+      'osdHeaderBreadcrumbs',
+      i === 0 && 'first',
+      i > 0 && i < crumbs.length - 1 && 'middle',
+      i === crumbs.length - 1 && 'last'
+    ),
   }));
 
-  return <EuiHeaderBreadcrumbs breadcrumbs={crumbs} max={10} data-test-subj="breadcrumbs" />;
+  return (
+    <EuiHeaderBreadcrumbs
+      breadcrumbs={crumbs}
+      max={2}
+      data-test-subj="breadcrumbs"
+      className="osdHeaderBreadcrumbs"
+    />
+  );
 }

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -70,7 +70,7 @@ export function HeaderBreadcrumbs({ appTitle$, breadcrumbs$ }: Props) {
   return (
     <EuiHeaderBreadcrumbs
       breadcrumbs={crumbs}
-      max={2}
+      max={10}
       data-test-subj="breadcrumbs"
       className="osdHeaderBreadcrumbs"
     />


### PR DESCRIPTION
Signed-off-by: kaddy645 <xdeskart@amazon.com>

### Description
We'd like to enhance the breadcrumb component in the global header to be more useful and integrated into the overall look and feel

### SC

<img width="963" alt="Screen Shot 2022-07-27 at 9 25 31 AM" src="https://user-images.githubusercontent.com/32860683/181342737-4ad87393-8ca7-4f29-b89a-725bfd55e279.png">


### Issues Resolved
[Issue-1858](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1858)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 