### PR TITLE
[MD] Instantiate credential management plugin code structure

### DIFF
--- a/src/plugins/credential_management/.eslintrc.js
+++ b/src/plugins/credential_management/.eslintrc.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * For new files created by OpenSearch Contributors
+ */
+ const OSD_NEW_HEADER = `
+ /*
+  * Copyright OpenSearch Contributors
+  * SPDX-License-Identifier: Apache-2.0
+  */
+ `;
+
+module.exports = {
+  root: true,
+  extends: ['@elastic/eslint-config-kibana', 'plugin:@elastic/eui/recommended'],
+  rules: {
+    '@osd/eslint/require-license-header': [
+      'error',
+      {
+        licenses: [OSD_NEW_HEADER],
+      },
+    ],
+  },
+};

--- a/src/plugins/credential_management/.i18nrc.json
+++ b/src/plugins/credential_management/.i18nrc.json
@@ -1,0 +1,7 @@
+{
+  "prefix": "credentialManagement",
+  "paths": {
+    "credentialManagement": "."
+  },
+  "translations": ["translations/ja-JP.json"]
+}

--- a/src/plugins/credential_management/README.md
+++ b/src/plugins/credential_management/README.md
@@ -1,0 +1,11 @@
+# credentialManagement
+
+A OpenSearch Dashboards plugin
+
+---
+
+## Development
+
+See the [OpenSearch Dashboards contributing
+guide](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/CONTRIBUTING.md) for instructions
+setting up your development environment.

--- a/src/plugins/credential_management/common/index.ts
+++ b/src/plugins/credential_management/common/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const PLUGIN_ID = 'credentialManagement';
+export const PLUGIN_NAME = 'credentialManagement';

--- a/src/plugins/credential_management/opensearch_dashboards.json
+++ b/src/plugins/credential_management/opensearch_dashboards.json
@@ -1,0 +1,9 @@
+{
+  "id": "credentialManagement",
+  "version": "1.0.0",
+  "opensearchDashboardsVersion": "opensearchDashboards",
+  "server": true,
+  "ui": true,
+  "requiredPlugins": ["navigation"],
+  "optionalPlugins": []
+}

--- a/src/plugins/credential_management/public/application.tsx
+++ b/src/plugins/credential_management/public/application.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { AppMountParameters, CoreStart } from '../../../core/public';
+import { AppPluginStartDependencies } from './types';
+import { CredentialManagementApp } from './components/app';
+
+export const renderApp = (
+  { notifications, http }: CoreStart,
+  { navigation }: AppPluginStartDependencies,
+  { appBasePath, element }: AppMountParameters
+) => {
+  ReactDOM.render(
+    <CredentialManagementApp
+      basename={appBasePath}
+      notifications={notifications}
+      http={http}
+      navigation={navigation}
+    />,
+    element
+  );
+
+  return () => ReactDOM.unmountComponentAtNode(element);
+};

--- a/src/plugins/credential_management/public/components/app.tsx
+++ b/src/plugins/credential_management/public/components/app.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { i18n } from '@osd/i18n';
+import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+
+import {
+  EuiButton,
+  EuiHorizontalRule,
+  EuiPage,
+  EuiPageBody,
+  EuiPageContent,
+  EuiPageContentBody,
+  EuiPageContentHeader,
+  EuiPageHeader,
+  EuiTitle,
+  EuiText,
+} from '@elastic/eui';
+
+import { CoreStart } from '../../../../core/public';
+import { NavigationPublicPluginStart } from '../../../navigation/public';
+
+import { PLUGIN_ID, PLUGIN_NAME } from '../../common';
+
+interface CredentialManagementAppDeps {
+  basename: string;
+  notifications: CoreStart['notifications'];
+  http: CoreStart['http'];
+  navigation: NavigationPublicPluginStart;
+}
+
+export const CredentialManagementApp = ({
+  basename,
+  notifications,
+  http,
+  navigation,
+}: CredentialManagementAppDeps) => {
+  // Use React hooks to manage state.
+  const [timestamp, setTimestamp] = useState<string | undefined>();
+
+  const onClickHandler = () => {
+    // Use the core http service to make a response to the server API.
+    http.get('/api/credential_management/example').then((res) => {
+      setTimestamp(res.time);
+      // Use the core notifications service to display a success message.
+      notifications.toasts.addSuccess(
+        i18n.translate('credentialManagement.dataUpdated', {
+          defaultMessage: 'Data updated',
+        })
+      );
+    });
+  };
+
+  // Render the application DOM.
+  // Note that `navigation.ui.TopNavMenu` is a stateful component exported on the `navigation` plugin's start contract.
+  return (
+    <Router basename={basename}>
+      <I18nProvider>
+        <>
+          <navigation.ui.TopNavMenu
+            appName={PLUGIN_ID}
+            showSearchBar={true}
+            useDefaultBehaviors={true}
+          />
+          <EuiPage restrictWidth="1000px">
+            <EuiPageBody component="main">
+              <EuiPageHeader>
+                <EuiTitle size="l">
+                  <h1>
+                    <FormattedMessage
+                      id="credentialManagement.helloWorldText"
+                      defaultMessage="{name}"
+                      values={{ name: PLUGIN_NAME }}
+                    />
+                  </h1>
+                </EuiTitle>
+              </EuiPageHeader>
+              <EuiPageContent>
+                <EuiPageContentHeader>
+                  <EuiTitle>
+                    <h2>
+                      <FormattedMessage
+                        id="credentialManagement.congratulationsTitle"
+                        defaultMessage="Congratulations, you have successfully created a new OpenSearch Dashboards Plugin!"
+                      />
+                    </h2>
+                  </EuiTitle>
+                </EuiPageContentHeader>
+                <EuiPageContentBody>
+                  <EuiText>
+                    <p>
+                      <FormattedMessage
+                        id="credentialManagement.content"
+                        defaultMessage="Look through the generated code and check out the plugin development documentation."
+                      />
+                    </p>
+                    <EuiHorizontalRule />
+                    <p>
+                      <FormattedMessage
+                        id="credentialManagement.timestampText"
+                        defaultMessage="Last timestamp: {time}"
+                        values={{ time: timestamp ? timestamp : 'Unknown' }}
+                      />
+                    </p>
+                    <EuiButton type="primary" size="s" onClick={onClickHandler}>
+                      <FormattedMessage
+                        id="credentialManagement.buttonText"
+                        defaultMessage="Get data"
+                      />
+                    </EuiButton>
+                  </EuiText>
+                </EuiPageContentBody>
+              </EuiPageContent>
+            </EuiPageBody>
+          </EuiPage>
+        </>
+      </I18nProvider>
+    </Router>
+  );
+};

--- a/src/plugins/credential_management/public/index.scss
+++ b/src/plugins/credential_management/public/index.scss
@@ -1,0 +1,1 @@
+/* stylelint-disable no-empty-source */

--- a/src/plugins/credential_management/public/index.ts
+++ b/src/plugins/credential_management/public/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import './index.scss';
+
+import { CredentialManagementPlugin } from './plugin';
+
+// This exports static code and TypeScript types,
+// as well as, OpenSearch Dashboards Platform `plugin()` initializer.
+export function plugin() {
+  return new CredentialManagementPlugin();
+}
+export { CredentialManagementPluginSetup, CredentialManagementPluginStart } from './types';

--- a/src/plugins/credential_management/public/plugin.ts
+++ b/src/plugins/credential_management/public/plugin.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import { AppMountParameters, CoreSetup, CoreStart, Plugin } from '../../../core/public';
+import {
+  CredentialManagementPluginSetup,
+  CredentialManagementPluginStart,
+  AppPluginStartDependencies,
+} from './types';
+import { PLUGIN_NAME } from '../common';
+
+export class CredentialManagementPlugin
+  implements Plugin<CredentialManagementPluginSetup, CredentialManagementPluginStart> {
+  public setup(core: CoreSetup): CredentialManagementPluginSetup {
+    // Register an application into the side navigation menu
+    core.application.register({
+      id: 'credentialManagement',
+      title: PLUGIN_NAME,
+      async mount(params: AppMountParameters) {
+        // Load application bundle
+        const { renderApp } = await import('./application');
+        // Get start services as specified in opensearch_dashboards.json
+        const [coreStart, depsStart] = await core.getStartServices();
+        // Render the application
+        return renderApp(coreStart, depsStart as AppPluginStartDependencies, params);
+      },
+    });
+
+    // Return methods that should be available to other plugins
+    return {
+      getGreeting() {
+        return i18n.translate('credentialManagement.greetingText', {
+          defaultMessage: 'Hello from {name}!',
+          values: {
+            name: PLUGIN_NAME,
+          },
+        });
+      },
+    };
+  }
+
+  public start(core: CoreStart): CredentialManagementPluginStart {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/src/plugins/credential_management/public/types.ts
+++ b/src/plugins/credential_management/public/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NavigationPublicPluginStart } from '../../navigation/public';
+
+export interface CredentialManagementPluginSetup {
+  getGreeting: () => string;
+}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CredentialManagementPluginStart {}
+
+export interface AppPluginStartDependencies {
+  navigation: NavigationPublicPluginStart;
+}

--- a/src/plugins/credential_management/server/index.ts
+++ b/src/plugins/credential_management/server/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PluginInitializerContext } from '../../../core/server';
+import { CredentialManagementPlugin } from './plugin';
+
+// This exports static code and TypeScript types,
+// as well as, OpenSearch Dashboards Platform `plugin()` initializer.
+
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new CredentialManagementPlugin(initializerContext);
+}
+
+export { CredentialManagementPluginSetup, CredentialManagementPluginStart } from './types';

--- a/src/plugins/credential_management/server/plugin.ts
+++ b/src/plugins/credential_management/server/plugin.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  PluginInitializerContext,
+  CoreSetup,
+  CoreStart,
+  Plugin,
+  Logger,
+} from '../../../core/server';
+
+import { CredentialManagementPluginSetup, CredentialManagementPluginStart } from './types';
+import { defineRoutes } from './routes';
+
+export class CredentialManagementPlugin
+  implements Plugin<CredentialManagementPluginSetup, CredentialManagementPluginStart> {
+  private readonly logger: Logger;
+
+  constructor(initializerContext: PluginInitializerContext) {
+    this.logger = initializerContext.logger.get();
+  }
+
+  public setup(core: CoreSetup) {
+    this.logger.debug('credentialManagement: Setup');
+    const router = core.http.createRouter();
+
+    // Register server side APIs
+    defineRoutes(router);
+
+    return {};
+  }
+
+  public start(core: CoreStart) {
+    this.logger.debug('credentialManagement: Started');
+    return {};
+  }
+
+  public stop() {}
+}

--- a/src/plugins/credential_management/server/routes/index.ts
+++ b/src/plugins/credential_management/server/routes/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IRouter } from '../../../../core/server';
+
+export function defineRoutes(router: IRouter) {
+  router.get(
+    {
+      path: '/api/credential_management/example',
+      validate: false,
+    },
+    async (context, request, response) => {
+      return response.ok({
+        body: {
+          time: new Date().toISOString(),
+        },
+      });
+    }
+  );
+}

--- a/src/plugins/credential_management/server/types.ts
+++ b/src/plugins/credential_management/server/types.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CredentialManagementPluginSetup {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CredentialManagementPluginStart {}


### PR DESCRIPTION
Signed-off-by: Louis Chu [clingzhi@amazon.com](mailto:clingzhi@amazon.com)

### Description
1. Instantiate credential management plugin code structure
2. Adopt New OSD Header

### Context
1. **RFC**: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1388
2. **Epic**: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1733

### Steps
```
% node scripts/generate_plugin credential_management 
? Plugin name (use camelCase) credentialManagement
? Will this plugin be part of the OpenSearch Dashboards repository? Yes
? What type of internal plugin would you like to create OpenSearch Dashboards OSS
? Should an UI plugin be generated? Yes
? Should a server plugin be generated? Yes
 succ 🎉

      Your plugin has been created in src/plugins/credential_management
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 