### PR TITLE
[BUG] show region blocked warning config not respected

### DIFF
--- a/src/plugins/maps_legacy/public/map/base_maps_visualization.js
+++ b/src/plugins/maps_legacy/public/map/base_maps_visualization.js
@@ -205,12 +205,13 @@ export function BaseMapsVisualizationProvider() {
         isDarkMode
       );
       const showZoomMessage = serviceSettings.shouldShowZoomMessage(tmsLayer);
+      const showRegionBlockedWarning = serviceSettings.shouldShowRegionBlockedWarning();
       const options = { ...tmsLayer };
       delete options.id;
       delete options.subdomains;
       this._opensearchDashboardsMap.setBaseLayer({
         baseLayerType: 'tms',
-        options: { ...options, showZoomMessage, ...meta },
+        options: { ...options, showZoomMessage, showRegionBlockedWarning, ...meta },
       });
     }
 

--- a/src/plugins/maps_legacy/public/map/service_settings.js
+++ b/src/plugins/maps_legacy/public/map/service_settings.js
@@ -58,6 +58,7 @@ export class ServiceSettings {
     this._hasTmsConfigured = typeof tilemapsConfig.url === 'string' && tilemapsConfig.url !== '';
 
     this._showZoomMessage = true;
+    this._showRegionBlockedWarning = this._mapConfig.showRegionBlockedWarning;
     this._emsClient = null;
     this._opensearchMapsClient = new OpenSearchMapsClient({
       language: i18n.getLocale(),
@@ -86,6 +87,10 @@ export class ServiceSettings {
       attribution: _.escape(markdownIt.render(this._tilemapsConfig.options.attribution || '')),
       url: this._tilemapsConfig.url,
     });
+  }
+
+  shouldShowRegionBlockedWarning() {
+    return this._showRegionBlockedWarning;
   }
 
   shouldShowZoomMessage({ origin }) {

--- a/src/plugins/vis_type_vega/public/services.ts
+++ b/src/plugins/vis_type_vega/public/services.ts
@@ -57,3 +57,4 @@ export const [getMapsLegacyConfig, setMapsLegacyConfig] = createGetterSetter<Map
 
 export const getEnableExternalUrls = () => getInjectedVars().enableExternalUrls;
 export const getEmsTileLayerId = () => getMapsLegacyConfig().emsTileLayerId;
+export const getShowRegionBlockedWarning = () => getMapsLegacyConfig().showRegionBlockedWarning;

--- a/src/plugins/vis_type_vega/public/vega_view/vega_map_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_map_view.js
@@ -32,7 +32,7 @@ import { i18n } from '@osd/i18n';
 import { vega } from '../lib/vega';
 import { VegaBaseView } from './vega_base_view';
 import { VegaMapLayer } from './vega_map_layer';
-import { getEmsTileLayerId, getUISettings } from '../services';
+import { getEmsTileLayerId, getShowRegionBlockedWarning, getUISettings } from '../services';
 import { lazyLoadMapsLegacyModules } from '../../../maps_legacy/public';
 
 export class VegaMapView extends VegaBaseView {
@@ -58,7 +58,7 @@ export class VegaMapView extends VegaBaseView {
       baseMapOpts = {
         ...baseMapOpts,
         ...(await this._serviceSettings.getAttributesForTMSLayer(baseMapOpts, true, isDarkMode)),
-        showRegionBlockedWarning: this._serviceSettings._mapConfig.showRegionBlockedWarning,
+        showRegionBlockedWarning: getShowRegionBlockedWarning(),
       };
       if (!baseMapOpts) {
         this.onWarn(


### PR DESCRIPTION
### Description
The configuration wasn't passed down to the options that was
expecting it to be available for the plugin to run the conditional
logic.

Value was undefined for region map. Also, cleaned up the vega map
view code.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2041
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 