### PR TITLE
[BUG] Telemetry plugin cluster info rename error

### DIFF
--- a/src/plugins/telemetry/server/telemetry_collection/get_cluster_info.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_cluster_info.ts
@@ -53,7 +53,7 @@ export interface OpenSearchClusterInfo {
  *
  * @param {function} opensearchClient The asInternalUser handler (exposed for testing)
  */
-export async function getClusterInfo(opensearchClient: OpenSearchClusterInfo) {
-  const { body } = await opensearchClient.info<OpenSearchClusterInfo>();
+export async function getClusterInfo(opensearchClient: OpenSearchClient) {
+  const { body } = await opensearchClient.info<OpenSearchClient>();
   return body;
 }


### PR DESCRIPTION
### Description
Introduced when renaming, I accidentally typed the param
incorrectly.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 