### PR TITLE
Add empty data source plugin

### DIFF
--- a/src/plugins/data_source/README.md
+++ b/src/plugins/data_source/README.md
@@ -1,0 +1,13 @@
+# data_source
+
+A OpenSearch Dashboards plugin
+
+This plugin introduce OpenSearch data source into OpenSearch Dashboards, and provides related functions to connect to OpenSearch data sources.
+
+---
+
+## Development
+
+See the [OpenSearch Dashboards contributing
+guide](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/CONTRIBUTING.md) for instructions
+setting up your development environment.

--- a/src/plugins/data_source/common/index.ts
+++ b/src/plugins/data_source/common/index.ts
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 export const PLUGIN_ID = 'dataSource';

--- a/src/plugins/data_source/common/index.ts
+++ b/src/plugins/data_source/common/index.ts
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+export const PLUGIN_ID = 'dataSource';
+export const PLUGIN_NAME = 'data_source';

--- a/src/plugins/data_source/opensearch_dashboards.json
+++ b/src/plugins/data_source/opensearch_dashboards.json
@@ -1,0 +1,9 @@
+{
+  "id": "dataSource",
+  "version": "opensearchDashboards",
+  "opensearchDashboardsVersion": "opensearchDashboards",
+  "server": true,
+  "ui": false,
+  "requiredPlugins": [],
+  "optionalPlugins": []
+}

--- a/src/plugins/data_source/server/index.ts
+++ b/src/plugins/data_source/server/index.ts
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import { schema, TypeOf } from '@osd/config-schema';

--- a/src/plugins/data_source/server/index.ts
+++ b/src/plugins/data_source/server/index.ts
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { schema, TypeOf } from 'packages/osd-config-schema/target/types';
+import { PluginConfigDescriptor, PluginInitializerContext } from '../../../core/server';
+import { DataSourcePlugin } from './plugin';
+
+export const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: false }),
+});
+
+export type DataSourcePluginConfigType = TypeOf<typeof configSchema>;
+
+export const config: PluginConfigDescriptor<DataSourcePluginConfigType> = {
+  schema: configSchema,
+};
+
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new DataSourcePlugin(initializerContext);
+}
+
+export { DataSourcePluginSetup, DataSourcePluginStart } from './types';

--- a/src/plugins/data_source/server/index.ts
+++ b/src/plugins/data_source/server/index.ts
@@ -9,8 +9,8 @@
  * GitHub history for details.
  */
 
-import { schema, TypeOf } from 'packages/osd-config-schema/target/types';
-import { PluginConfigDescriptor, PluginInitializerContext } from '../../../core/server';
+import { schema, TypeOf } from '@osd/config-schema';
+import { PluginConfigDescriptor, PluginInitializerContext } from 'src/core/server';
 import { DataSourcePlugin } from './plugin';
 
 export const configSchema = schema.object({

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import { PluginInitializerContext, CoreSetup, CoreStart, Plugin, Logger } from 'src/core/server';

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import {
+  PluginInitializerContext,
+  CoreSetup,
+  CoreStart,
+  Plugin,
+  Logger,
+} from '../../../core/server';
+
+import { DataSourcePluginSetup, DataSourcePluginStart } from './types';
+
+export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourcePluginStart> {
+  private readonly logger: Logger;
+
+  constructor(initializerContext: PluginInitializerContext) {
+    this.logger = initializerContext.logger.get();
+  }
+
+  public setup(core: CoreSetup) {
+    this.logger.debug('data_source: Setup');
+
+    return {};
+  }
+
+  public start(core: CoreStart) {
+    this.logger.debug('data_source: Started');
+    return {};
+  }
+
+  public stop() {}
+}

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -9,13 +9,7 @@
  * GitHub history for details.
  */
 
-import {
-  PluginInitializerContext,
-  CoreSetup,
-  CoreStart,
-  Plugin,
-  Logger,
-} from '../../../core/server';
+import { PluginInitializerContext, CoreSetup, CoreStart, Plugin, Logger } from 'src/core/server';
 
 import { DataSourcePluginSetup, DataSourcePluginStart } from './types';
 

--- a/src/plugins/data_source/server/types.ts
+++ b/src/plugins/data_source/server/types.ts
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/plugins/data_source/server/types.ts
+++ b/src/plugins/data_source/server/types.ts
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DataSourcePluginSetup {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DataSourcePluginStart {}


### PR DESCRIPTION
### Description
This PR adds an empty dataSource plugin, for future data source saved objects type and related function implementation

Signed-off-by: Yan Zeng <zengyan@amazon.com>
 
### Issues Resolved
part of #1971 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 