### PR TITLE
[MD] Add delete an existing credential page button

### DIFF
--- a/src/plugins/credential_management/public/components/create_credential_wizard/create_credential_wizard.tsx
+++ b/src/plugins/credential_management/public/components/create_credential_wizard/create_credential_wizard.tsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
-
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import {
   EuiHorizontalRule,

--- a/src/plugins/credential_management/public/components/text_content/text_content.ts
+++ b/src/plugins/credential_management/public/components/text_content/text_content.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+
+export const deleteCredentialDescribeMsg = i18n.translate(
+  'credentialManagement.textContent.deleteCredentialDescribeMsg',
+  {
+    defaultMessage:
+      'This will also delete their credential materials. All data sources using this credential will be invalid for access, and they must choose new credentials.',
+  }
+);
+
+export const deleteCredentialConfirmMsg = i18n.translate(
+  'credentialManagement.textContent.deleteCredentialConfirmMsg',
+  {
+    defaultMessage: 'To confirm deletion, click delete button.',
+  }
+);
+
+export const deleteCredentialWarnMsg = i18n.translate(
+  'credentialManagement.textContent.deleteCredentialWarnMsg',
+  {
+    defaultMessage: 'Note: this action is irrevocable!',
+  }
+);
+
+export const deleteButtonOnConfirmText = i18n.translate(
+  'credentialManagement.textContent.deleteButtonOnConfirmText',
+  {
+    defaultMessage: 'Delete credential permanently?',
+  }
+);
+
+export const deleteCredentialButtonDescription = i18n.translate(
+  'credentialManagement.textContent.deleteCredentialButtonDescription',
+  {
+    defaultMessage: 'Remove this credential',
+  }
+);
+
+export const cancelButtonOnDeleteCancelText = i18n.translate(
+  'credentialManagement.textContent.cancelButtonOnDeleteCancelText',
+  {
+    defaultMessage: 'Cancel',
+  }
+);
+
+export const confirmButtonOnDeleteComfirmText = i18n.translate(
+  'credentialManagement.textContent.confirmButtonOnDeleteComfirmText',
+  {
+    defaultMessage: 'Delete',
+  }
+);


### PR DESCRIPTION
### Description
Adding a button which can delete an existing credential page. 
Resolved issue #2027 

 
The listing page of credential management: 
<img width="1427" alt="Screen Shot 2022-08-03 at 1 50 46 PM" src="https://user-images.githubusercontent.com/109543558/182709263-39491d51-0130-452f-81e6-cf1f58e9c00b.png">

The detail page of one credential:
<img width="1223" alt="Screen Shot 2022-08-03 at 1 49 16 PM" src="https://user-images.githubusercontent.com/109543558/182709381-137439c5-62b5-4b26-be3d-2e8cd74b6f96.png">

The pop up window when click the delete button:
<img width="1221" alt="Screen Shot 2022-08-03 at 1 49 34 PM" src="https://user-images.githubusercontent.com/109543558/182709475-e600a4df-a311-4510-a00f-ab4a9bdfcb60.png">

The listing page after deleting the credential:
<img width="1222" alt="Screen Shot 2022-08-03 at 1 49 42 PM" src="https://user-images.githubusercontent.com/109543558/182709612-7e1232a1-8ed3-4d76-b4cf-f72a204c6347.png">

