### PR TITLE
[DeAngular][visualization][vislib] remove angular from vislib

### DIFF
--- a/src/plugins/vis_type_vislib/public/vislib/lib/binder.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/binder.ts
@@ -30,7 +30,6 @@
 
 import d3 from 'd3';
 import $ from 'jquery';
-import { IScope } from 'angular';
 
 export interface Emitter {
   on: (...args: any[]) => void;
@@ -41,13 +40,6 @@ export interface Emitter {
 
 export class Binder {
   private disposal: Array<() => void> = [];
-
-  constructor($scope: IScope) {
-    // support auto-binding to $scope objects
-    if ($scope) {
-      $scope.$on('$destroy', () => this.destroy());
-    }
-  }
 
   public on(emitter: Emitter, ...args: any[]) {
     const on = emitter.on || emitter.addListener;


### PR DESCRIPTION
### Description
* remove angular import and $scope from Binder class since there is
no usage in the code

### Issue resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2137
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 