### PR TITLE
[MD][CM]credential listing page

### DIFF
--- a/src/plugins/credential_management/public/components/create_credential_wizard/create_credential_wizard.tsx
+++ b/src/plugins/credential_management/public/components/create_credential_wizard/create_credential_wizard.tsx
@@ -19,6 +19,8 @@ import {
   EuiButton,
   EuiPageContent,
   EuiFieldPassword,
+  EuiLoadingSpinner,
+  EuiOverlayMask,
 } from '@elastic/eui';
 import { DocLinksStart } from 'src/core/public';
 import { Credential } from '../../../../data_source/public';
@@ -36,6 +38,7 @@ interface CreateCredentialWizardState {
   dual: boolean;
   toasts: EuiGlobalToastListToast[];
   docLinks: DocLinksStart;
+  isLoading: boolean;
 }
 
 export class CreateCredentialWizard extends React.Component<
@@ -57,6 +60,7 @@ export class CreateCredentialWizard extends React.Component<
       dual: true,
       toasts: [],
       docLinks: context.services.docLinks,
+      isLoading: false,
     };
   }
 
@@ -159,8 +163,12 @@ export class CreateCredentialWizard extends React.Component<
 
   render() {
     const content = this.renderContent();
-
-    return (
+    const { isLoading } = this.state;
+    return isLoading ? (
+      <EuiOverlayMask>
+        <EuiLoadingSpinner size="xl" />
+      </EuiOverlayMask>
+    ) : (
       <>
         {content}
         <EuiGlobalToastList
@@ -176,8 +184,8 @@ export class CreateCredentialWizard extends React.Component<
 
   createCredential = async () => {
     const { savedObjects } = this.context.services;
+    this.setState({ isLoading: true });
     try {
-      // TODO: Add rendering spanner https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2050
       await savedObjects.client.create('credential', {
         title: this.state.credentialName,
         credentialMaterials: {
@@ -207,6 +215,7 @@ export class CreateCredentialWizard extends React.Component<
         ]),
       }));
     }
+    this.setState({ isLoading: false });
   };
 }
 

--- a/src/plugins/credential_management/public/components/edit_credential/edit_credential.tsx
+++ b/src/plugins/credential_management/public/components/edit_credential/edit_credential.tsx
@@ -23,6 +23,8 @@ import {
   EuiToolTip,
   EuiButtonIcon,
   EuiConfirmModal,
+  EuiLoadingSpinner,
+  EuiOverlayMask,
 } from '@elastic/eui';
 import { DocLinksStart } from 'src/core/public';
 import { Credential } from '../../../../data_source/public';
@@ -43,6 +45,7 @@ interface EditCredentialState {
   toasts: EuiGlobalToastListToast[];
   docLinks: DocLinksStart;
   isVisible: boolean;
+  isLoading: boolean;
 }
 
 export interface EditCredentialProps extends RouteComponentProps {
@@ -69,11 +72,13 @@ export class EditCredentialComponent extends React.Component<
       toasts: [],
       docLinks: context.services.docLinks,
       isVisible: false,
+      isLoading: false,
     };
   }
 
   confirmDelete = async () => {
     const { savedObjects } = this.context.services;
+    this.setState({ isLoading: true });
     try {
       await savedObjects.client.delete('credential', this.props.credential.id);
       this.props.history.push('');
@@ -95,6 +100,7 @@ export class EditCredentialComponent extends React.Component<
         ]),
       }));
     }
+    this.setState({ isLoading: false });
   };
 
   delelteButtonRender() {
@@ -138,7 +144,7 @@ export class EditCredentialComponent extends React.Component<
       </>
     );
   }
-  // TODO: Add rendering spanner https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2050
+
   renderContent() {
     const options = [
       {
@@ -164,6 +170,7 @@ export class EditCredentialComponent extends React.Component<
               />
             </EuiFormRow>
           </EuiDescribedFormGroup>
+
           <EuiDescribedFormGroup
             title={<h3>Credential Type</h3>}
             description={
@@ -228,8 +235,12 @@ export class EditCredentialComponent extends React.Component<
 
   render() {
     const content = this.renderContent();
-
-    return (
+    const { isLoading } = this.state;
+    return isLoading ? (
+      <EuiOverlayMask>
+        <EuiLoadingSpinner size="xl" />
+      </EuiOverlayMask>
+    ) : (
       <>
         {content}
         <EuiGlobalToastList
@@ -249,6 +260,7 @@ export class EditCredentialComponent extends React.Component<
 
   updateCredential = async () => {
     const { savedObjects } = this.context.services;
+    this.setState({ isLoading: true });
     try {
       await savedObjects.client.update('credential', this.props.credential.id, {
         title: this.state.credentialName,
@@ -279,6 +291,7 @@ export class EditCredentialComponent extends React.Component<
         ]),
       }));
     }
+    this.setState({ isLoading: false });
   };
 }
 

--- a/src/plugins/credential_management/public/components/utils.ts
+++ b/src/plugins/credential_management/public/components/utils.ts
@@ -45,8 +45,9 @@ export async function deleteCredentials(
   savedObjectsClient: SavedObjectsClientContract,
   selectedCredentials: CredentialsTableItem[]
 ) {
-  // TODO: Refactor with nonblocking IO
-  for (const credential of selectedCredentials) {
-    await savedObjectsClient.delete('credential', credential.id);
-  }
+  await Promise.all(
+    selectedCredentials.map(async (selectedCredential) => {
+      await savedObjectsClient.delete('credential', selectedCredential.id);
+    })
+  );
 }


### PR DESCRIPTION
Signed-off-by: Yibo Wang <yibow@amazon.com>

### Description
Optimization for credential listing page

- [x] Delete button layout and text cases (Singular VS Plural)
- [x] Confirmation pops up after delete button clicking. Notes: need to confirm the confirmation box content
- [x] Localization for delete button pops up Note: will do after confirming the confirmation box content
- [x] Spinning in progress page
- [x] Delete method with non-blocking IO

1. Current listing page with modified layout of delete button
<img width="1799" alt="Screen Shot 2022-08-15 at 9 30 27 AM" src="https://user-images.githubusercontent.com/109543558/184677831-14c8b333-3fd6-4aa0-8419-ad31292c4d73.png">

2. Solved text cases(singular vs plural)
<img width="1771" alt="Screen Shot 2022-08-15 at 9 30 36 AM" src="https://user-images.githubusercontent.com/109543558/184677947-9602152e-3899-416b-9460-27a66e983f59.png">
<img width="1739" alt="Screen Shot 2022-08-15 at 9 30 44 AM" src="https://user-images.githubusercontent.com/109543558/184677968-f1032a57-0459-4ce9-bb43-a4b082880328.png">

3. Spinning in progress page when doing an action (eg. delete, update)
<img width="1913" alt="Screen Shot 2022-08-15 at 9 37 27 AM" src="https://user-images.githubusercontent.com/109543558/184678143-d0bf8c75-ed34-4602-bfb7-c7301d061407.png">

4. Confirmation pops up after delete button clicking. (Need to confirm the content in the confirmation box)
<img width="800" alt="Screen Shot 2022-08-11 at 1 24 46 PM" src="https://user-images.githubusercontent.com/109543558/184678417-48110747-b22b-4ae9-9244-564d2c5e1482.png">

 
### Issues Resolved
#2055
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 