### PR TITLE
[UX] Change timeline icon

### DIFF
--- a/src/plugins/vis_type_timeline/public/timeline_vis_type.tsx
+++ b/src/plugins/vis_type_timeline/public/timeline_vis_type.tsx
@@ -51,7 +51,7 @@ export function getTimelineVisDefinition(dependencies: TimelineVisDependencies) 
   return {
     name: TIMELINE_VIS_NAME,
     title: 'Timeline',
-    icon: 'visTimelion',
+    icon: 'timeline',
     description: i18n.translate('timeline.timelineDescription', {
       defaultMessage: 'Build time-series using functional expressions',
     }),

--- a/src/plugins/visualizations/public/wizard/type_selection/type_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/type_selection/type_selection.tsx
@@ -275,7 +275,7 @@ class TypeSelection extends React.Component<TypeSelectionProps, TypeSelectionSta
         {...stage}
       >
         <VisTypeIcon
-          icon={visType.type.icon === 'visTimeline' ? 'visTimelion' : visType.type.icon}
+          icon={visType.type.icon}
           image={'image' in visType.type ? visType.type.image : undefined}
         />
       </EuiKeyPadMenuItem>


### PR DESCRIPTION
Signed-off-by: Bandini Bhopi <bandinib@amazon.com>

### Description
Changed Timeline Viz icon on the visualization type selection screen.

### SC
<img width="827" alt="Screen Shot 2022-08-17 at 1 57 06 PM" src="https://user-images.githubusercontent.com/63824432/185241771-e55e9801-a93d-49e7-b5ec-b15497713df7.png">

 
### Issues Resolved
#2155 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 