### PR TITLE
adding relation between credential selection and no auth checkbox

### DIFF
--- a/src/plugins/data_source_management/public/components/create_edit_data_source_wizard/create_edit_data_source_wizard.tsx
+++ b/src/plugins/data_source_management/public/components/create_edit_data_source_wizard/create_edit_data_source_wizard.tsx
@@ -211,6 +211,20 @@ export class CreateEditDataSourceWizard extends React.Component<
     });
   };
 
+  onChangeNoAuth = () => {
+    this.setState(
+      {
+        noAuthentication: !this.state.noAuthentication,
+      },
+      () => {
+        /* When credential is already selected and user checks the noAuth checkbox, reset previously selected credential*/
+        if (this.state.noAuthentication && this.state.selectedCredentials.length) {
+          this.setState({ selectedCredentials: [] });
+        }
+      }
+    );
+  };
+
   onClickCreateNewDataSource = () => {
     if (this.isFormValid()) {
       const formValues: DataSourceEditPageItem = {
@@ -231,6 +245,10 @@ export class CreateEditDataSourceWizard extends React.Component<
 
   onSelectExistingCredentials = (options: CredentialsComboBoxItem[]) => {
     this.setState({ selectedCredentials: options }, () => {
+      /* When noAuth checkbox is checked and user selects credentials, un-check the noAuth checkbox*/
+      if (options.length && this.state.noAuthentication) {
+        this.onChangeNoAuth();
+      }
       if (this.state.formErrorsByField.credential.length) {
         this.isFormValid();
       }
@@ -435,11 +453,7 @@ export class CreateEditDataSourceWizard extends React.Component<
             id="noAuthentication"
             label="Continue without authentication"
             checked={this.state.noAuthentication}
-            onChange={(e) => {
-              this.setState({
-                noAuthentication: !this.state.noAuthentication,
-              });
-            }}
+            onChange={this.onChangeNoAuth}
             compressed
           />
 


### PR DESCRIPTION
Signed-off-by: mpabba3003 <amazonmanideep@gmail.com>

### Description
- Adding relation between Credential selection & NoAuth checkbox (User can select only one of them)
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2021

### Screenshots
https://user-images.githubusercontent.com/109986843/185689558-e28b5756-4870-4bc8-9010-5deecc9e3d08.mov
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 