### PR TITLE
Fix CVE-2022-0686, add resolution for url-parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "**/tar": "^6.1.11",
     "**/trim": "^0.0.3",
     "**/trim-newlines": "^3.0.1",
-    "**/typescript": "4.0.2"
+    "**/typescript": "4.0.2",
+    "**/url-parse": "^1.5.8"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -24032,10 +24032,10 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3, url-parse@^1.4.7, url-parse@^1.5.1:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.3.tgz#71c1303d38fb6639ade183c2992c8cc0686df862"
-  integrity sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==
+url-parse@^1.4.3, url-parse@^1.4.7, url-parse@^1.5.1, url-parse@^1.5.8:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
Signed-off-by: Su <szhongna@amazon.com>

### Description
```
opensearch-dashboards@1.4.0 /Users/szhongna/Projects/OpenSearch-Dashboards
└─┬ @elastic/eui@29.3.2
  └── url-parse@1.5.10 
```
 
### Issues Resolved
CVE-2022-0686
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 