### PR TITLE
Bump chrome driver version in PR check workflow

### DIFF
--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -176,7 +176,7 @@ jobs:
       # github virtual env is the latest chrome
       - name: Setup chromedriver
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'
-        run: yarn add --dev chromedriver@102.0.0
+        run: yarn add --dev chromedriver@104.0.0
 
       - name: Run bootstrap
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'


### PR DESCRIPTION
Signed-off-by: Su <szhongna@amazon.com>

### Description
Bump chrome driver version to 1.4
 
### Issues Resolved
```
│ warn Failure while creating webdriver instance
     │ warn { SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 102
     │      Current browser version is 104.0.5112.79 with binary path /usr/bin/google-chrome
     │          at Object.throwDecodedError (/home/runner/work/OpenSearch-Dashboards/OpenSearch-Dashboards/node_modules/selenium-webdriver/lib/error.js:550:15)
     │          at parseHttpResponse (/home/runner/work/OpenSearch-Dashboards/OpenSearch-Dashboards/node_modules/selenium-webdriver/lib/http.js:565:13)
     │          at Executor.execute (/home/runner/work/OpenSearch-Dashboards/OpenSearch-Dashboards/node_modules/selenium-webdriver/lib/http.js:491:26)
     │          at process._tickCallback (internal/process/next_tick.js:68:7)
     │        name: 'SessionNotCreatedError',
```
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
    - [x] `yarn test:jest`
    - [x] `yarn test:jest_integration`
    - [x] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 