### PR TITLE
Add null auth header to child client spawn

### DIFF
--- a/src/plugins/data_source/server/client/configure_client.ts
+++ b/src/plugins/data_source/server/client/configure_client.ts
@@ -141,5 +141,9 @@ const getBasicAuthClient = (
       username,
       password,
     },
+    // Child client doesn't allow auth option, adding null auth header to bypass,
+    // so logic in child() can rebuild the auth header based on the auth input.
+    // See https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2182 for details
+    headers: { authorization: null },
   });
 };


### PR DESCRIPTION
Signed-off-by: Su <szhongna@amazon.com>

### Description
Add null auth header to child client spawn. See issue below for more details  and discussion
 
### Issues Resolved
#2182 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 