### PR TITLE
 [Visualizations] Adds visConfig.title and uiState to build pipeline function

### DIFF
--- a/src/plugins/visualizations/public/legacy/build_pipeline.ts
+++ b/src/plugins/visualizations/public/legacy/build_pipeline.ts
@@ -445,8 +445,10 @@ export const buildPipeline = async (vis: Vis, params: BuildPipelineParams) => {
     } else {
       const visConfig = { ...vis.params };
       visConfig.dimensions = schemas;
+      visConfig.title = title;
       pipeline += `visualization type='${vis.type.name}'
     ${prepareJson('visConfig', visConfig)}
+    ${prepareJson('uiState', uiState)}
     metricsAtAllLevels=${vis.isHierarchical()}
     partialRows=${vis.params.showPartialRows || false} `;
       if (indexPattern) {


### PR DESCRIPTION
In pipeline building, this PR adds `visConfig.title` and `uiState` properties for "visualization" function.

This aims 2 goals:
-    To be consistent with pipelines built with "buildPipelineVisFunction".
-    To provide "title" and "uiState" informations for visualizations.

This is currently a missing information for community plugins.
