### PR TITLE
Support legacy client for data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # CHANGELOG
-
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-
 ### 💥 Breaking Changes
 
 ### Deprecations
@@ -12,13 +10,13 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 📈 Features/Enhancements
 
-- [MD] Support legacy client for data source ([#2204](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2204))
+* [MD] Support legacy client for data source ([#2204](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2204))
 
 ### 🐛 Bug Fixes
 
 ### 🚞 Infrastructure
 
-- Add CHANGELOG.md and related workflows ([#2414](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2414))
+* Add CHANGELOG.md and related workflows ([#2414](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2414))
 
 ### 📝 Documentation
 
@@ -29,48 +27,48 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### 🔩 Tests
 
 ## [2.x]
-
 ### 💥 Breaking Changes
 
 ### Deprecations
 
 ### 🛡 Security
 
-- Use a forced CSP-compliant interpreter with Vega visualizations ([#2352](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2352))
-- Bump moment-timezone from 0.5.34 to 0.5.37 ([#2361](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2361))
-- [CVE-2022-33987] Upgrade geckodriver to 3.0.2 ([#2166](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2166))
+* Use a forced CSP-compliant interpreter with Vega visualizations ([#2352](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2352))
+* Bump moment-timezone from 0.5.34 to 0.5.37 ([#2361](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2361))
+* [CVE-2022-33987] Upgrade geckodriver to 3.0.2 ([#2166](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2166)) 
 
 ### 📈 Features/Enhancements
 
-- Add updated_at column to objects' tables ([#1218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1218))
+* Add updated_at column to objects' tables ([#1218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1218)) 
 
 ### 🐛 Bug Fixes
 
-- [Viz Builder] Fixes time series for new chart types ([#2309](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2309))
-- [Viz Builder] Add index pattern info when loading embeddable ([#2363](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2363))
-- Fixes management app breadcrumb error ([#2344](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2344))
+* [Viz Builder] Fixes time series for new chart types ([#2309](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2309))
+* [Viz Builder] Add index pattern info when loading embeddable ([#2363](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2363))
+* Fixes management app breadcrumb error ([#2344](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2344))
 
 ### 🚞 Infrastructure
 
-- Add path ignore for markdown files for CI ([#2312](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2312))
-- Updating WS scans to ignore BWC artifacts in `cypress` ([#2408](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2408))
+* Add path ignore for markdown files for CI ([#2312](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2312))
+* Updating WS scans to ignore BWC artifacts in `cypress` ([#2408](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2408))
+
 
 ### 📝 Documentation
 
-- README.md for saving index pattern relationship ([#2276](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2276))
-- Remove extra typo from README. ([#2403](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2403))
+* README.md for saving index pattern relationship ([#2276](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2276))
+* Remove extra typo from README. ([#2403](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2403))
 
 ### 🛠 Maintenance
 
-- Increment from 2.3 to 2.4. ([#2295](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2295))
-- Adding @zengyan-amazon as maintainer ([#2419](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2419))
-- Updating @tmarkley to Emeritus status. ([#2423](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2423))
+* Increment from 2.3 to 2.4. ([#2295](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2295))
+* Adding @zengyan-amazon as maintainer ([#2419](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2419))
+* Updating @tmarkley to Emeritus status. ([#2423](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2423))
 
 ### 🪛 Refactoring
 
 ### 🔩 Tests
 
-- Update caniuse to fix failed integration tests ([#2322](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2322))
+* Update caniuse to fix failed integration tests ([#2322](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2322))
 
-[unreleased]: https://github.com/opensearch-project/OpenSearch-Dashboards/compare/2.3.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/OpenSearch-Dashboards/compare/2.3.0...HEAD
 [2.x]: https://github.com/opensearch-project/OpenSearch-Dashboards/compare/2.3.0...2.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # CHANGELOG
+
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
 ### 💥 Breaking Changes
 
 ### Deprecations
@@ -10,11 +12,13 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 📈 Features/Enhancements
 
+- [MD] Support legacy client for data source ([#2204](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2204))
+
 ### 🐛 Bug Fixes
 
 ### 🚞 Infrastructure
 
-* Add CHANGELOG.md and related workflows ([#2414](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2414))
+- Add CHANGELOG.md and related workflows ([#2414](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2414))
 
 ### 📝 Documentation
 
@@ -25,48 +29,48 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### 🔩 Tests
 
 ## [2.x]
+
 ### 💥 Breaking Changes
 
 ### Deprecations
 
 ### 🛡 Security
 
-* Use a forced CSP-compliant interpreter with Vega visualizations ([#2352](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2352))
-* Bump moment-timezone from 0.5.34 to 0.5.37 ([#2361](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2361))
-* [CVE-2022-33987] Upgrade geckodriver to 3.0.2 ([#2166](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2166)) 
+- Use a forced CSP-compliant interpreter with Vega visualizations ([#2352](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2352))
+- Bump moment-timezone from 0.5.34 to 0.5.37 ([#2361](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2361))
+- [CVE-2022-33987] Upgrade geckodriver to 3.0.2 ([#2166](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2166))
 
 ### 📈 Features/Enhancements
 
-* Add updated_at column to objects' tables ([#1218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1218)) 
+- Add updated_at column to objects' tables ([#1218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1218))
 
 ### 🐛 Bug Fixes
 
-* [Viz Builder] Fixes time series for new chart types ([#2309](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2309))
-* [Viz Builder] Add index pattern info when loading embeddable ([#2363](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2363))
-* Fixes management app breadcrumb error ([#2344](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2344))
+- [Viz Builder] Fixes time series for new chart types ([#2309](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2309))
+- [Viz Builder] Add index pattern info when loading embeddable ([#2363](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2363))
+- Fixes management app breadcrumb error ([#2344](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2344))
 
 ### 🚞 Infrastructure
 
-* Add path ignore for markdown files for CI ([#2312](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2312))
-* Updating WS scans to ignore BWC artifacts in `cypress` ([#2408](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2408))
-
+- Add path ignore for markdown files for CI ([#2312](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2312))
+- Updating WS scans to ignore BWC artifacts in `cypress` ([#2408](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2408))
 
 ### 📝 Documentation
 
-* README.md for saving index pattern relationship ([#2276](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2276))
-* Remove extra typo from README. ([#2403](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2403))
+- README.md for saving index pattern relationship ([#2276](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2276))
+- Remove extra typo from README. ([#2403](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2403))
 
 ### 🛠 Maintenance
 
-* Increment from 2.3 to 2.4. ([#2295](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2295))
-* Adding @zengyan-amazon as maintainer ([#2419](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2419))
-* Updating @tmarkley to Emeritus status. ([#2423](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2423))
+- Increment from 2.3 to 2.4. ([#2295](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2295))
+- Adding @zengyan-amazon as maintainer ([#2419](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2419))
+- Updating @tmarkley to Emeritus status. ([#2423](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2423))
 
 ### 🪛 Refactoring
 
 ### 🔩 Tests
 
-* Update caniuse to fix failed integration tests ([#2322](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2322))
+- Update caniuse to fix failed integration tests ([#2322](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2322))
 
-[Unreleased]: https://github.com/opensearch-project/OpenSearch-Dashboards/compare/2.3.0...HEAD
+[unreleased]: https://github.com/opensearch-project/OpenSearch-Dashboards/compare/2.3.0...HEAD
 [2.x]: https://github.com/opensearch-project/OpenSearch-Dashboards/compare/2.3.0...2.x

--- a/src/core/server/http/router/router.ts
+++ b/src/core/server/http/router/router.ts
@@ -306,7 +306,6 @@ export class Router implements IRouter {
           opensearchDashboardsResponseFactory.badRequest({ body: e.message })
         );
       }
-      // TODO: add legacy data source client config error handling
 
       return hapiResponseAdapter.toInternalError();
     }

--- a/src/core/server/opensearch/legacy/cluster_client.ts
+++ b/src/core/server/opensearch/legacy/cluster_client.ts
@@ -65,7 +65,7 @@ const noop = () => undefined;
  * OpenSearch JS client.
  * @param options Options that affect the way we call the API and process the result.
  */
-export const callAPI = async (
+const callAPI = async (
   client: Client,
   endpoint: string,
   clientParams: Record<string, any> = {},

--- a/src/core/server/opensearch/legacy/cluster_client.ts
+++ b/src/core/server/opensearch/legacy/cluster_client.ts
@@ -65,7 +65,7 @@ const noop = () => undefined;
  * OpenSearch JS client.
  * @param options Options that affect the way we call the API and process the result.
  */
-const callAPI = async (
+export const callAPI = async (
   client: Client,
   endpoint: string,
   clientParams: Record<string, any> = {},

--- a/src/plugins/data/server/index_patterns/fetcher/index_patterns_fetcher.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/index_patterns_fetcher.ts
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import { LegacyAPICaller, OpenSearchClient } from 'opensearch-dashboards/server';
+import { LegacyAPICaller } from 'opensearch-dashboards/server';
 
 import { getFieldCapabilities, resolveTimePattern, createNoMatchingIndicesError } from './lib';
 
@@ -48,9 +48,9 @@ interface FieldSubType {
 }
 
 export class IndexPatternsFetcher {
-  private _callDataCluster: LegacyAPICaller | OpenSearchClient;
+  private _callDataCluster: LegacyAPICaller;
 
-  constructor(callDataCluster: LegacyAPICaller | OpenSearchClient) {
+  constructor(callDataCluster: LegacyAPICaller) {
     this._callDataCluster = callDataCluster;
   }
 

--- a/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/field_capabilities.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/field_capabilities/field_capabilities.ts
@@ -30,7 +30,7 @@
 
 import { defaults, keyBy, sortBy } from 'lodash';
 
-import { LegacyAPICaller, OpenSearchClient } from 'opensearch-dashboards/server';
+import { LegacyAPICaller } from 'opensearch-dashboards/server';
 import { callFieldCapsApi } from '../opensearch_api';
 import { FieldCapsResponse, readFieldCapsResponse } from './field_caps_response';
 import { mergeOverrides } from './overrides';
@@ -47,7 +47,7 @@ import { FieldDescriptor } from '../../index_patterns_fetcher';
  *  @return {Promise<Array<FieldDescriptor>>}
  */
 export async function getFieldCapabilities(
-  callCluster: LegacyAPICaller | OpenSearchClient,
+  callCluster: LegacyAPICaller,
   indices: string | string[] = [],
   metaFields: string[] = [],
   fieldCapsOptions?: { allowNoIndices: boolean }

--- a/src/plugins/data/server/index_patterns/fetcher/lib/opensearch_api.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/opensearch_api.ts
@@ -57,23 +57,10 @@ export interface IndexAliasResponse {
  *  @return {Promise<IndexAliasResponse>}
  */
 export async function callIndexAliasApi(
-  callCluster: LegacyAPICaller | OpenSearchClient,
+  callCluster: LegacyAPICaller,
   indices: string[] | string
 ): Promise<IndicesAliasResponse> {
   try {
-    // This approach of identify between OpenSearchClient vs LegacyAPICaller
-    // will be deprecated after support data client with legacy client
-    // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2133
-    if ('transport' in callCluster) {
-      return (
-        await callCluster.indices.getAlias({
-          index: indices,
-          ignore_unavailable: true,
-          allow_no_indices: true,
-        })
-      ).body as IndicesAliasResponse;
-    }
-
     return (await callCluster('indices.getAlias', {
       index: indices,
       ignoreUnavailable: true,
@@ -97,25 +84,11 @@ export async function callIndexAliasApi(
  *  @return {Promise<FieldCapsResponse>}
  */
 export async function callFieldCapsApi(
-  callCluster: LegacyAPICaller | OpenSearchClient,
+  callCluster: LegacyAPICaller,
   indices: string[] | string,
   fieldCapsOptions: { allowNoIndices: boolean } = { allowNoIndices: false }
 ) {
   try {
-    // This approach of identify between OpenSearchClient vs LegacyAPICaller
-    // will be deprecated after support data client with legacy client
-    // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2133
-    if ('transport' in callCluster) {
-      return (
-        await callCluster.fieldCaps({
-          index: indices,
-          fields: '*',
-          ignore_unavailable: true,
-          allow_no_indices: fieldCapsOptions.allowNoIndices,
-        })
-      ).body as FieldCapsResponse;
-    }
-
     return (await callCluster('fieldCaps', {
       index: indices,
       fields: '*',

--- a/src/plugins/data/server/index_patterns/fetcher/lib/resolve_time_pattern.ts
+++ b/src/plugins/data/server/index_patterns/fetcher/lib/resolve_time_pattern.ts
@@ -47,10 +47,7 @@ import { callIndexAliasApi, IndicesAliasResponse } from './opensearch_api';
  *                            and the indices that actually match the time
  *                            pattern (matches);
  */
-export async function resolveTimePattern(
-  callCluster: LegacyAPICaller | OpenSearchClient,
-  timePattern: string
-) {
+export async function resolveTimePattern(callCluster: LegacyAPICaller, timePattern: string) {
   const aliases = await callIndexAliasApi(callCluster, timePatternToWildcard(timePattern));
 
   const allIndexDetails = chain<IndicesAliasResponse>(aliases)

--- a/src/plugins/data/server/index_patterns/routes.ts
+++ b/src/plugins/data/server/index_patterns/routes.ts
@@ -29,7 +29,11 @@
  */
 
 import { schema } from '@osd/config-schema';
-import { HttpServiceSetup, RequestHandlerContext } from 'opensearch-dashboards/server';
+import {
+  HttpServiceSetup,
+  LegacyAPICaller,
+  RequestHandlerContext,
+} from 'opensearch-dashboards/server';
 import { IndexPatternsFetcher } from './fetcher';
 
 export function registerRoutes(http: HttpServiceSetup) {
@@ -151,11 +155,12 @@ export function registerRoutes(http: HttpServiceSetup) {
   );
 }
 
-const decideClient = async (context: RequestHandlerContext, request: any) => {
+const decideClient = async (
+  context: RequestHandlerContext,
+  request: any
+): Promise<LegacyAPICaller> => {
   const dataSourceId = request.query.data_source;
-  if (dataSourceId) {
-    return await context.dataSource.opensearch.getClient(dataSourceId);
-  }
-
-  return context.core.opensearch.legacy.client.callAsCurrentUser;
+  return dataSourceId
+    ? (context.dataSource.opensearch.legacy.getClient(dataSourceId).callAPI as LegacyAPICaller)
+    : context.core.opensearch.legacy.client.callAsCurrentUser;
 };

--- a/src/plugins/data_source/server/client/configure_client.ts
+++ b/src/plugins/data_source/server/client/configure_client.ts
@@ -75,12 +75,18 @@ const getQueryClient = async (
   dataSource: SavedObject<DataSourceAttributes>,
   cryptographyClient: CryptographyClient
 ): Promise<Client> => {
-  if (AuthType.NoAuth === dataSource.attributes.auth.type) {
-    return rootClient.child();
-  } else {
-    const credential = await getCredential(dataSource, cryptographyClient);
+  const authType = dataSource.attributes.auth.type;
 
-    return getBasicAuthClient(rootClient, credential);
+  switch (authType) {
+    case AuthType.NoAuth:
+      return rootClient.child();
+
+    case AuthType.UsernamePasswordType:
+      const credential = await getCredential(dataSource, cryptographyClient);
+      return getBasicAuthClient(rootClient, credential);
+
+    default:
+      throw Error(`${authType} is not a supported auth type for data source`);
   }
 };
 

--- a/src/plugins/data_source/server/client/index.ts
+++ b/src/plugins/data_source/server/client/index.ts
@@ -3,5 +3,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OpenSearchClientPool } from './client_pool';
-export { configureClient } from './configure_client';
+export { OpenSearchClientPool, OpenSearchClientPoolSetup } from './client_pool';
+export { configureClient, getDataSource, getCredential } from './configure_client';

--- a/src/plugins/data_source/server/data_source_service.test.ts
+++ b/src/plugins/data_source/server/data_source_service.test.ts
@@ -33,6 +33,7 @@ describe('Data Source Service', () => {
     test('exposes proper contract', async () => {
       const setup = await service.setup(config);
       expect(setup).toHaveProperty('getDataSourceClient');
+      expect(setup).toHaveProperty('getDataSourceLegacyClient');
     });
   });
 });

--- a/src/plugins/data_source/server/data_source_service.ts
+++ b/src/plugins/data_source/server/data_source_service.ts
@@ -23,7 +23,7 @@ export interface DataSourceServiceSetup {
       endpoint: string,
       clientParams?: Record<string, any>,
       options?: LegacyCallAPIOptions
-    ) => Promise<any>;
+    ) => Promise<unknown>;
   };
 }
 export class DataSourceService {

--- a/src/plugins/data_source/server/data_source_service.ts
+++ b/src/plugins/data_source/server/data_source_service.ts
@@ -5,47 +5,66 @@
 
 import {
   Auditor,
+  LegacyCallAPIOptions,
   Logger,
   OpenSearchClient,
-  SavedObjectsClientContract,
 } from '../../../../src/core/server';
 import { DataSourcePluginConfigType } from '../config';
 import { configureClient, OpenSearchClientPool } from './client';
-import { CryptographyClient } from './cryptography';
+import { configureLegacyClient } from './legacy';
+import { DataSourceClientParams } from './types';
 export interface DataSourceServiceSetup {
-  getDataSourceClient: (
-    dataSourceId: string,
-    // this saved objects client is used to fetch data source on behalf of users, caller should pass scoped saved objects client
-    savedObjects: SavedObjectsClientContract,
-    cryptographyClient: CryptographyClient
-  ) => Promise<OpenSearchClient>;
+  getDataSourceClient: (params: DataSourceClientParams) => Promise<OpenSearchClient>;
+
+  getDataSourceLegacyClient: (
+    params: DataSourceClientParams
+  ) => {
+    callAPI: (
+      endpoint: string,
+      clientParams?: Record<string, any>,
+      options?: LegacyCallAPIOptions
+    ) => Promise<any>;
+  };
 }
 export class DataSourceService {
   private readonly openSearchClientPool: OpenSearchClientPool;
+  private readonly legacyClientPool: OpenSearchClientPool;
+  private readonly legacyLogger: Logger;
 
   constructor(private logger: Logger) {
+    this.legacyLogger = logger.get('legacy');
     this.openSearchClientPool = new OpenSearchClientPool(logger);
+    this.legacyClientPool = new OpenSearchClientPool(this.legacyLogger);
   }
 
-  async setup(config: DataSourcePluginConfigType) {
-    const openSearchClientPoolSetup = await this.openSearchClientPool.setup(config);
+  async setup(config: DataSourcePluginConfigType): Promise<DataSourceServiceSetup> {
+    const opensearchClientPoolSetup = await this.openSearchClientPool.setup(config);
+    const legacyClientPoolSetup = await this.legacyClientPool.setup(config);
 
-    const getDataSourceClient = (
-      dataSourceId: string,
-      savedObjects: SavedObjectsClientContract,
-      cryptographyClient: CryptographyClient
+    const getDataSourceClient = async (
+      params: DataSourceClientParams
     ): Promise<OpenSearchClient> => {
-      return configureClient(
-        dataSourceId,
-        savedObjects,
-        cryptographyClient,
-        openSearchClientPoolSetup,
-        config,
-        this.logger
-      );
+      return configureClient(params, opensearchClientPoolSetup, config, this.logger);
     };
 
-    return { getDataSourceClient };
+    const getDataSourceLegacyClient = (params: DataSourceClientParams) => {
+      return {
+        callAPI: (
+          endpoint: string,
+          clientParams?: Record<string, any>,
+          options?: LegacyCallAPIOptions
+        ) =>
+          configureLegacyClient(
+            params,
+            { endpoint, clientParams, options },
+            legacyClientPoolSetup,
+            config,
+            this.legacyLogger
+          ),
+      };
+    };
+
+    return { getDataSourceClient, getDataSourceLegacyClient };
   }
 
   start() {}

--- a/src/plugins/data_source/server/legacy/client_config.test.ts
+++ b/src/plugins/data_source/server/legacy/client_config.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { DataSourcePluginConfigType } from '../../config';
+import { parseClientOptions } from './client_config';
+
+const TEST_DATA_SOURCE_ENDPOINT = 'http://datasource.com';
+
+const config = {
+  enabled: true,
+  clientPool: {
+    size: 5,
+  },
+} as DataSourcePluginConfigType;
+
+describe('parseClientOptions', () => {
+  test('include the ssl client configs as defaults', () => {
+    expect(parseClientOptions(config, TEST_DATA_SOURCE_ENDPOINT)).toEqual(
+      expect.objectContaining({
+        host: TEST_DATA_SOURCE_ENDPOINT,
+        ssl: {
+          rejectUnauthorized: true,
+        },
+      })
+    );
+  });
+});

--- a/src/plugins/data_source/server/legacy/client_config.ts
+++ b/src/plugins/data_source/server/legacy/client_config.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ConfigOptions } from 'elasticsearch';
+import { DataSourcePluginConfigType } from '../../config';
+
+/**
+ * Parse the client options from given data source config and endpoint
+ *
+ * @param config The config to generate the client options from.
+ * @param endpoint endpoint url of data source
+ */
+export function parseClientOptions(
+  // TODO: will use client configs, that comes from a merge result of user config and default legacy client config,
+  config: DataSourcePluginConfigType,
+  endpoint: string
+): ConfigOptions {
+  const configOptions: ConfigOptions = {
+    host: endpoint,
+    ssl: {
+      rejectUnauthorized: true,
+    },
+  };
+
+  return configOptions;
+}

--- a/src/plugins/data_source/server/legacy/configure_legacy_client.test.mocks.ts
+++ b/src/plugins/data_source/server/legacy/configure_legacy_client.test.mocks.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const ClientMock = jest.fn();
+jest.doMock('elasticsearch', () => {
+  const actual = jest.requireActual('elasticsearch');
+  return {
+    ...actual,
+    Client: ClientMock,
+  };
+});
+
+export const parseClientOptionsMock = jest.fn();
+jest.doMock('./client_config', () => ({
+  parseClientOptions: parseClientOptionsMock,
+}));

--- a/src/plugins/data_source/server/legacy/configure_legacy_client.test.ts
+++ b/src/plugins/data_source/server/legacy/configure_legacy_client.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsClientContract } from '../../../../core/server';
+import { loggingSystemMock, savedObjectsClientMock } from '../../../../core/server/mocks';
+import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../common';
+import { AuthType, DataSourceAttributes } from '../../common/data_sources';
+import { DataSourcePluginConfigType } from '../../config';
+import { CryptographyClient } from '../cryptography';
+import { DataSourceClientParams, LegacyClientCallAPIParams } from '../types';
+import { OpenSearchClientPoolSetup } from '../client';
+import { ConfigOptions } from 'elasticsearch';
+import { ClientMock, parseClientOptionsMock } from './configure_legacy_client.test.mocks';
+import { configureLegacyClient } from './configure_legacy_client';
+
+const DATA_SOURCE_ID = 'a54b76ec86771ee865a0f74a305dfff8';
+const cryptographyClient = new CryptographyClient('test', 'test', new Array(32).fill(0));
+
+// TODO: improve UT
+describe('configureLegacyClient', () => {
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let config: DataSourcePluginConfigType;
+  let savedObjectsMock: jest.Mocked<SavedObjectsClientContract>;
+  let clientPoolSetup: OpenSearchClientPoolSetup;
+  let configOptions: ConfigOptions;
+  let dataSourceAttr: DataSourceAttributes;
+
+  let mockOpenSearchClientInstance: {
+    close: jest.Mock;
+    ping: jest.Mock;
+  };
+  let dataSourceClientParams: DataSourceClientParams;
+  let callApiParams: LegacyClientCallAPIParams;
+  let decodeAndDecryptSpy: jest.SpyInstance<Promise<string>, [encrypted: string]>;
+
+  const mockResponse = { data: 'ping' };
+
+  beforeEach(() => {
+    mockOpenSearchClientInstance = {
+      close: jest.fn(),
+      ping: jest.fn(),
+    };
+    logger = loggingSystemMock.createLogger();
+    savedObjectsMock = savedObjectsClientMock.create();
+    config = {
+      enabled: true,
+      clientPool: {
+        size: 5,
+      },
+    } as DataSourcePluginConfigType;
+
+    configOptions = {
+      host: 'http://localhost',
+      ssl: {
+        rejectUnauthorized: true,
+      },
+    } as ConfigOptions;
+
+    dataSourceAttr = {
+      title: 'title',
+      endpoint: 'http://localhost',
+      auth: {
+        type: AuthType.UsernamePasswordType,
+        credentials: {
+          username: 'username',
+          password: 'password',
+        },
+      },
+    } as DataSourceAttributes;
+
+    clientPoolSetup = {
+      getClientFromPool: jest.fn(),
+      addClientToPool: jest.fn(),
+    };
+
+    callApiParams = {
+      endpoint: 'ping',
+    };
+
+    savedObjectsMock.get.mockResolvedValueOnce({
+      id: DATA_SOURCE_ID,
+      type: DATA_SOURCE_SAVED_OBJECT_TYPE,
+      attributes: dataSourceAttr,
+      references: [],
+    });
+
+    dataSourceClientParams = {
+      dataSourceId: DATA_SOURCE_ID,
+      savedObjects: savedObjectsMock,
+      cryptographyClient,
+    };
+
+    ClientMock.mockImplementation(() => mockOpenSearchClientInstance);
+
+    mockOpenSearchClientInstance.ping.mockImplementation(function mockCall(this: any) {
+      return Promise.resolve({
+        context: this,
+        response: mockResponse,
+      });
+    });
+
+    decodeAndDecryptSpy = jest
+      .spyOn(cryptographyClient, 'decodeAndDecrypt')
+      .mockResolvedValue('password');
+  });
+
+  afterEach(() => {
+    ClientMock.mockReset();
+    jest.resetAllMocks();
+  });
+
+  test('configure client with auth.type == no_auth, will call new Client() to create client', async () => {
+    savedObjectsMock.get.mockReset().mockResolvedValueOnce({
+      id: DATA_SOURCE_ID,
+      type: DATA_SOURCE_SAVED_OBJECT_TYPE,
+      attributes: {
+        ...dataSourceAttr,
+        auth: {
+          type: AuthType.NoAuth,
+        },
+      },
+      references: [],
+    });
+
+    parseClientOptionsMock.mockReturnValue(configOptions);
+
+    await configureLegacyClient(
+      dataSourceClientParams,
+      callApiParams,
+      clientPoolSetup,
+      config,
+      logger
+    );
+
+    expect(parseClientOptionsMock).toHaveBeenCalled();
+    expect(ClientMock).toHaveBeenCalledTimes(1);
+    expect(ClientMock).toHaveBeenCalledWith(configOptions);
+    expect(savedObjectsMock.get).toHaveBeenCalledTimes(1);
+  });
+
+  test('configure client with auth.type == no_auth, will first call decrypt()', async () => {
+    const mockResult = await configureLegacyClient(
+      dataSourceClientParams,
+      callApiParams,
+      clientPoolSetup,
+      config,
+      logger
+    );
+
+    expect(ClientMock).toHaveBeenCalledTimes(1);
+    expect(savedObjectsMock.get).toHaveBeenCalledTimes(1);
+    expect(decodeAndDecryptSpy).toHaveBeenCalledTimes(1);
+    expect(mockResult).toBeDefined();
+  });
+
+  test('correctly called with endpoint and params', async () => {
+    const mockParams = { param: 'ping' };
+    const mockResult = await configureLegacyClient(
+      dataSourceClientParams,
+      { ...callApiParams, clientParams: mockParams },
+      clientPoolSetup,
+      config,
+      logger
+    );
+
+    expect(mockResult.response).toBe(mockResponse);
+    expect(mockResult.context).toBe(mockOpenSearchClientInstance);
+    expect(mockOpenSearchClientInstance.ping).toHaveBeenCalledTimes(1);
+    expect(mockOpenSearchClientInstance.ping).toHaveBeenLastCalledWith(mockParams);
+  });
+});

--- a/src/plugins/data_source/server/legacy/index.ts
+++ b/src/plugins/data_source/server/legacy/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { configureLegacyClient } from './configure_legacy_client';

--- a/src/plugins/data_source/server/lib/error.ts
+++ b/src/plugins/data_source/server/lib/error.ts
@@ -14,8 +14,8 @@ export class DataSourceConfigError extends OsdError {
       ? error.output.payload.message
       : error.message;
     super(messagePrefix + messageContent);
-    // Cast all 5xx error returned by saveObjectClient to 500, 400 for both savedObject client
-    // 4xx errors, and other errors
+    // Cast all 5xx error returned by saveObjectClient to 500.
+    // Case both savedObject client 4xx errors, and other errors to 400
     this.statusCode = SavedObjectsErrorHelpers.isOpenSearchUnavailableError(error) ? 500 : 400;
   }
 }

--- a/src/plugins/data_source/server/lib/error.ts
+++ b/src/plugins/data_source/server/lib/error.ts
@@ -15,7 +15,7 @@ export class DataSourceConfigError extends OsdError {
       : error.message;
     super(messagePrefix + messageContent);
     // Cast all 5xx error returned by saveObjectClient to 500.
-    // Case both savedObject client 4xx errors, and other errors to 400
+    // Cast both savedObject client 4xx errors, and other errors to 400
     this.statusCode = SavedObjectsErrorHelpers.isOpenSearchUnavailableError(error) ? 500 : 400;
   }
 }

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -131,11 +131,20 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
             const auditor = auditTrailPromise.then((auditTrail) => auditTrail.asScoped(req));
             this.logAuditMessage(auditor, dataSourceId, req);
 
-            return dataSourceService.getDataSourceClient(
+            return dataSourceService.getDataSourceClient({
               dataSourceId,
-              context.core.savedObjects.client,
-              cryptographyClient
-            );
+              savedObjects: context.core.savedObjects.client,
+              cryptographyClient,
+            });
+          },
+          legacy: {
+            getClient: (dataSourceId: string) => {
+              return dataSourceService.getDataSourceLegacyClient({
+                dataSourceId,
+                savedObjects: context.core.savedObjects.client,
+                cryptographyClient,
+              });
+            },
           },
         },
       };

--- a/src/plugins/data_source/server/types.ts
+++ b/src/plugins/data_source/server/types.ts
@@ -3,11 +3,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenSearchClient } from 'src/core/server';
+import {
+  LegacyCallAPIOptions,
+  OpenSearchClient,
+  SavedObjectsClientContract,
+} from 'src/core/server';
+import { CryptographyClient } from './cryptography';
+
+export interface LegacyClientCallAPIParams {
+  endpoint: string;
+  clientParams?: Record<string, any>;
+  options?: LegacyCallAPIOptions;
+}
+
+export interface DataSourceClientParams {
+  dataSourceId: string;
+  // this saved objects client is used to fetch data source on behalf of users, caller should pass scoped saved objects client
+  savedObjects: SavedObjectsClientContract;
+  cryptographyClient: CryptographyClient;
+}
 
 export interface DataSourcePluginRequestContext {
   opensearch: {
     getClient: (dataSourceId: string) => Promise<OpenSearchClient>;
+    legacy: {
+      getClient: (
+        dataSourceId: string
+      ) => {
+        callAPI: (
+          endpoint: string,
+          clientParams: Record<string, any>,
+          options?: LegacyCallAPIOptions
+        ) => Promise<any>;
+      };
+    };
   };
 }
 declare module 'src/core/server' {

--- a/src/plugins/data_source/server/types.ts
+++ b/src/plugins/data_source/server/types.ts
@@ -34,7 +34,7 @@ export interface DataSourcePluginRequestContext {
           endpoint: string,
           clientParams: Record<string, any>,
           options?: LegacyCallAPIOptions
-        ) => Promise<any>;
+        ) => Promise<unknown>;
       };
     };
   };

--- a/src/plugins/index_pattern_management/server/routes/resolve_index.ts
+++ b/src/plugins/index_pattern_management/server/routes/resolve_index.ts
@@ -29,7 +29,7 @@
  */
 
 import { schema } from '@osd/config-schema';
-import { IRouter } from 'src/core/server';
+import { IRouter, LegacyAPICaller } from 'src/core/server';
 
 export function registerResolveIndexRoute(router: IRouter): void {
   router.get(
@@ -59,25 +59,16 @@ export function registerResolveIndexRoute(router: IRouter): void {
         : null;
 
       const dataSourceId = req.query.data_source;
-      if (dataSourceId) {
-        const result = await (
-          await context.dataSource.opensearch.getClient(dataSourceId)
-        ).indices.resolveIndex({
-          name: encodeURIComponent(req.params.query),
-          expand_wildcards: req.query.expand_wildcards,
-        });
-        return res.ok({ body: result.body });
-      }
+      const caller = dataSourceId
+        ? context.dataSource.opensearch.legacy.getClient(dataSourceId).callAPI
+        : context.core.opensearch.legacy.client.callAsCurrentUser;
 
-      const result = await context.core.opensearch.legacy.client.callAsCurrentUser(
-        'transport.request',
-        {
-          method: 'GET',
-          path: `/_resolve/index/${encodeURIComponent(req.params.query)}${
-            queryString ? '?' + new URLSearchParams(queryString).toString() : ''
-          }`,
-        }
-      );
+      const result = await caller('transport.request', {
+        method: 'GET',
+        path: `/_resolve/index/${encodeURIComponent(req.params.query)}${
+          queryString ? '?' + new URLSearchParams(queryString).toString() : ''
+        }`,
+      });
       return res.ok({ body: result });
     }
   );


### PR DESCRIPTION
Signed-off-by: Su <szhongna@amazon.com>

### Description
Legacy clients are using `elasticsearch.js` 
new clients are using `openearch.js`
```
Usage:
data_source.context.legacy.getClient(datasourceId).callAPI("ping", {params: something}, {options: something})
```

- Add support for data source legacy client
  - launch another pool within the `data-source service` setup stage, specifically for legacy clients
  - returns a function interface `LegacyAPICaller` as required by elasticsearch.js clients
- Refactor index pattern related logic to use `data_source.legacy.getClient`
- Added UT
 
### Issues Resolved
#2133 
#2386 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 