### PR TITLE
[MD]Enable datasource link in saveObjectManagement

### DIFF
--- a/src/plugins/data_source/server/saved_objects/data_source.ts
+++ b/src/plugins/data_source/server/saved_objects/data_source.ts
@@ -16,7 +16,15 @@ export const dataSource: SavedObjectsType = {
     getTitle(obj) {
       return obj.attributes.title;
     },
-    // todo: update getEditUrl & getInAppUrl after #2021
+    getEditUrl(obj) {
+      return `/management/opensearch-dashboards/dataSources/${encodeURIComponent(obj.id)}`;
+    },
+    getInAppUrl(obj) {
+      return {
+        path: `/app/management/opensearch-dashboards/dataSources/${encodeURIComponent(obj.id)}`,
+        uiCapabilitiesPath: 'management.opensearchDashboards.dataSources',
+      };
+    },
   },
   mappings: {
     dynamic: false,

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_data_source/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_data_source/components/header/header.tsx
@@ -10,7 +10,6 @@ import {
   EuiSpacer,
   EuiText,
   EuiFlexItem,
-  EuiFormRow,
   EuiButton,
   EuiFlexGroup,
   EuiSwitch,

--- a/src/plugins/management/server/capabilities_provider.ts
+++ b/src/plugins/management/server/capabilities_provider.ts
@@ -38,6 +38,7 @@ export const capabilitiesProvider = () => ({
       settings: true,
       indexPatterns: true,
       objects: true,
+      dataSources: true,
     },
   },
 });


### PR DESCRIPTION
Signed-off-by: Kristen Tian <tyarong@amazon.com>

### Description
Enable datasource link in saveObjectManagement.

 -- Now can click and open the edit page of data source in save object management page.
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 