### PR TITLE
[MD] Wrap datasource errors for route handlers to understand

### DIFF
--- a/src/core/server/http/router/router.ts
+++ b/src/core/server/http/router/router.ts
@@ -300,10 +300,22 @@ export class Router implements IRouter {
       if (LegacyOpenSearchErrorHelpers.isNotAuthorizedError(e)) {
         return e;
       }
+
+      if (isDataSourceConfigError(e)) {
+        return hapiResponseAdapter.handle(
+          opensearchDashboardsResponseFactory.badRequest({ body: e.message })
+        );
+      }
+      // TODO: add legacy data source client config error handling
+
       return hapiResponseAdapter.toInternalError();
     }
   }
 }
+
+const isDataSourceConfigError = (error: any) => {
+  return error.constructor.name === 'DataSourceConfigError' && error.statusCode === 400;
+};
 
 const convertOpenSearchUnauthorized = (
   e: OpenSearchNotAuthorizedError

--- a/src/plugins/data_source/server/data_source_service.ts
+++ b/src/plugins/data_source/server/data_source_service.ts
@@ -30,7 +30,7 @@ export class DataSourceService {
   async setup(config: DataSourcePluginConfigType) {
     const openSearchClientPoolSetup = await this.openSearchClientPool.setup(config);
 
-    const getDataSourceClient = async (
+    const getDataSourceClient = (
       dataSourceId: string,
       savedObjects: SavedObjectsClientContract,
       cryptographyClient: CryptographyClient

--- a/src/plugins/data_source/server/lib/error.test.ts
+++ b/src/plugins/data_source/server/lib/error.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsErrorHelpers } from '../../../../../src/core/server';
+import { DataSourceConfigError } from './error';
+
+describe('DataSourceConfigError', () => {
+  it('create from savedObject bad request error should be 400 error', () => {
+    const error = SavedObjectsErrorHelpers.createBadRequestError('test reason message');
+    expect(new DataSourceConfigError('test prefix: ', error)).toMatchObject({
+      statusCode: 400,
+      message: 'test prefix: test reason message: Bad Request',
+    });
+  });
+
+  it('create from savedObject not found error should be 400 error', () => {
+    const error = SavedObjectsErrorHelpers.decorateNotAuthorizedError(new Error());
+    expect(new DataSourceConfigError('test prefix: ', error)).toHaveProperty('statusCode', 400);
+  });
+
+  it('create from savedObject service unavailable error should be a 500 error', () => {
+    const error = SavedObjectsErrorHelpers.decorateOpenSearchUnavailableError(
+      new Error('test reason message')
+    );
+    expect(new DataSourceConfigError('test prefix: ', error)).toMatchObject({
+      statusCode: 500,
+      message: 'test prefix: test reason message',
+    });
+  });
+
+  it('create from non savedObject error should always be a 400 error', () => {
+    const error = new Error('test reason message');
+    expect(new DataSourceConfigError('test prefix: ', error)).toMatchObject({
+      statusCode: 400,
+      message: 'test prefix: test reason message',
+    });
+  });
+});

--- a/src/plugins/data_source/server/lib/error.ts
+++ b/src/plugins/data_source/server/lib/error.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsErrorHelpers } from '../../../../../src/core/server';
+import { OsdError } from '../../../../../src/plugins/opensearch_dashboards_utils/common';
+
+export class DataSourceConfigError extends OsdError {
+  // must have statusCode to avoid route handler in search.ts to return 500
+  statusCode: number;
+  constructor(messagePrefix: string, error: any) {
+    const messageContent = SavedObjectsErrorHelpers.isSavedObjectsClientError(error)
+      ? error.output.payload.message
+      : error.message;
+    super(messagePrefix + messageContent);
+    // Cast all 5xx error returned by saveObjectClient to 500, 400 for both savedObject client
+    // 4xx errors, and other errors
+    this.statusCode = SavedObjectsErrorHelpers.isOpenSearchUnavailableError(error) ? 500 : 400;
+  }
+}

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OpenSearchClientError } from '@opensearch-project/opensearch/lib/errors';
 import { Observable } from 'rxjs';
 import { first, map } from 'rxjs/operators';
 import {
@@ -129,21 +128,14 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
       return {
         opensearch: {
           getClient: (dataSourceId: string) => {
-            try {
-              const auditor = auditTrailPromise.then((auditTrail) => auditTrail.asScoped(req));
-              this.logAuditMessage(auditor, dataSourceId, req);
+            const auditor = auditTrailPromise.then((auditTrail) => auditTrail.asScoped(req));
+            this.logAuditMessage(auditor, dataSourceId, req);
 
-              return dataSourceService.getDataSourceClient(
-                dataSourceId,
-                context.core.savedObjects.client,
-                cryptographyClient
-              );
-            } catch (error: any) {
-              logger.error(
-                `Fail to get data source client for dataSourceId: [${dataSourceId}]. Detail: ${error.messages}`
-              );
-              throw new OpenSearchClientError(error.message);
-            }
+            return dataSourceService.getDataSourceClient(
+              dataSourceId,
+              context.core.savedObjects.client,
+              cryptographyClient
+            );
           },
         },
       };


### PR DESCRIPTION
Signed-off-by: Su <szhongna@amazon.com>

### Description
- remove useless and redundant try catch
- create `DataSourceConfigError`, which cast all 4xx to 400 and all 5xx to 400, and assign a 400 for non savedObjectClient error
- Refactor `router.ts` to conditionally deal with 400 DataSourceClientError
- TODO： 
  - [ ] UI side pop-ups, alarm messages.

<img width="1887" alt="image" src="https://user-images.githubusercontent.com/32652829/187778465-d134693b-f97b-481c-b934-bc8ac70f0c92.png">
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/32652829/187778572-59165580-c4c0-47a6-abde-a9c72d59c037.png">
<img width="1415" alt="image" src="https://user-images.githubusercontent.com/32652829/187778747-f5e24f77-2217-46cd-af52-0418ebc35a95.png">

 
### Issues Resolved
#2210 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 