### PR TITLE
[MD][IP]Tweak fetch data back to original

### DIFF
--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
@@ -164,7 +164,7 @@ export class CreateIndexPatternWizard extends Component<
     );
 
     // query local and remote indices, updating state independently
-    const queryLocalAndRemotePromise = ensureMinimumTime(
+    ensureMinimumTime(
       this.catchAndWarn(
         getIndices({ http, getIndexTags, pattern: '*', searchClient, dataSourceId }),
 
@@ -175,7 +175,7 @@ export class CreateIndexPatternWizard extends Component<
       this.setState({ allIndices, isInitiallyLoadingIndices: false })
     );
 
-    const queryWithFallbackPromise = this.catchAndWarn(
+    this.catchAndWarn(
       // if we get an error from remote cluster query, supply fallback value that allows user entry.
       // ['a'] is fallback value
       getIndices({ http, getIndexTags, pattern: '*:*', searchClient, dataSourceId }),
@@ -185,8 +185,6 @@ export class CreateIndexPatternWizard extends Component<
     ).then((remoteIndices: string[] | MatchedItem[]) =>
       this.setState({ remoteClustersExist: !!remoteIndices.length })
     );
-
-    await Promise.all([queryLocalAndRemotePromise, queryWithFallbackPromise]);
   };
 
   createIndexPattern = async (timeFieldName: string | undefined, indexPatternId: string) => {
@@ -244,7 +242,7 @@ export class CreateIndexPatternWizard extends Component<
 
   goToNextFromDataSource = (dataSourceRef: DataSourceRef) => {
     this.setState({ isInitiallyLoadingIndices: true, dataSourceRef }, async () => {
-      await this.fetchData();
+      this.fetchData();
       this.goToNextStep();
     });
   };


### PR DESCRIPTION
Signed-off-by: Kristen Tian <tyarong@amazon.com>

### Description
Tweak fetch data back to original pattern - as it is not a good practice to have sideEffect in the legacy lifecycle  UNSAFE_componentWillMount

Related PR: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2146/files#diff-fe9f5fddd56a46e7e832e116eaef58350d813a4847106dbacfadc7046025fbed
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 