### PR TITLE
Increment from 2.3 to 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dashboarding"
   ],
   "private": true,
-  "version": "2.3.0",
+  "version": "2.4.0",
   "branch": "main",
   "types": "./opensearch_dashboards.d.ts",
   "tsdocMetadata": "./build/tsdoc-metadata.json",


### PR DESCRIPTION
Signed-off-by: Louis Chu <clingzhi@amazon.com>

### Description
Increment the version on the parent branch (2.x) to the next development iteration (2.4) after 2.3 branch cut.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2293
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 