### PR TITLE
[cve] add vega-interpreter

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "tslib": "^2.0.0",
     "type-detect": "^4.0.8",
     "uuid": "3.3.2",
+    "vega-interpreter": "^1.0.4",
     "whatwg-fetch": "^3.0.0",
     "yauzl": "^2.10.0"
   },

--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -184,6 +184,7 @@ export class VegaBaseView {
     const config = {
       // eslint-disable-next-line import/namespace
       logLevel: vega.Warn, // note: eslint has a false positive here
+      expr: vega.expressionInterpreter,
       renderer: this._parser.renderer,
     };
 

--- a/src/plugins/vis_type_vega/public/vega_view/vega_map_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_map_view.js
@@ -138,7 +138,7 @@ export class VegaMapView extends VegaBaseView {
     }
 
     const vegaMapLayer = new VegaMapLayer(
-      this._parser.spec,
+      (this._parser.spec, null, { ast: true }),
       {
         vega,
         bindingsContainer: this._$controls.get(0),

--- a/src/plugins/vis_type_vega/public/vega_view/vega_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_view.js
@@ -36,7 +36,10 @@ export class VegaView extends VegaBaseView {
     // In some cases, Vega may be initialized twice... TBD
     if (!this._$container) return;
 
-    const view = new vega.View(vega.parse(this._parser.spec), this._vegaViewConfig);
+    const view = new vega.View(
+      vega.parse(this._parser.spec, null, { ast: true }),
+      this._vegaViewConfig
+    );
 
     view.warn = this.onWarn.bind(this);
     view.error = this.onError.bind(this);

--- a/yarn.lock
+++ b/yarn.lock
@@ -17988,6 +17988,11 @@ vega-hierarchy@~4.1.0:
     vega-dataflow "^5.7.3"
     vega-util "^1.15.2"
 
+vega-interpreter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/vega-interpreter/-/vega-interpreter-1.0.4.tgz#291ebf85bc2d1c3550a3da22ff75b3ba0d326a39"
+  integrity sha512-6tpYIa/pJz0cZo5fSxDSkZkAA51pID2LjOtQkOQvbzn+sJiCaWKPFhur8MBqbcmYZ9bnap1OYNwlrvpd2qBLvg==
+
 vega-label@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/vega-label/-/vega-label-1.2.0.tgz#bcb2659aec54f890f9debab3e41ab87a58292dce"


### PR DESCRIPTION
### Description
From vega-interpreter:
By default, the Vega parser performs code generation for parsed Vega expressions, and the Vega runtime then uses the Function constructor to create JavaScript functions from the generated code. Although the Vega parser includes its own security checks, the runtime generation of functions from source code nevertheless violates security policies designed to prevent cross-site scripting.

vega-interpreter is intro in vega 5.13 to validate the expression and fix the above issue.

There are two components being affected: VegaView and VegaMapView. Both of them extend VegaBaseView. VegaBaseView is calling createViewConfig to create a config and vega.expressionInterpreter will check and varify the expression.

There is a performance issue. According to vega-interpreter, it, on average, will slow the performance for 10%. But we don't have a metric to valuate that for now. From the sanity test I did, I don't see big performance diff.

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 