### PR TITLE
add path ignore for markdown files

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -7,8 +7,12 @@ name: Build and test
 on:
   push:
     branches: [ '**', '!feature/**', '!backport/**' ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ '**', '!feature/**' ]
+    paths-ignore:
+      - '**/*.md'
 
 env:
   TEST_BROWSER_HEADLESS: 1


### PR DESCRIPTION
Signed-off-by: abbyhu2000 <abigailhu2000@gmail.com>

### Description
To save resources and job runners, some PRs do not need to run the full test suite. For PRs and pushes with markdown changes only, the build and test workflow will be skipped. (Linter test should be okay to skipped since it will automatically run with every commit). For PRs and pushes with markdown changes along with other changes, the build and test workflow will not be skipped. 
 
### Issues Resolved
resolves #1214 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 