### PR TITLE
Add index pattern info when loading embeddable

### DIFF
--- a/src/plugins/wizard/common/wizard_saved_object_attributes.ts
+++ b/src/plugins/wizard/common/wizard_saved_object_attributes.ts
@@ -13,4 +13,7 @@ export interface WizardSavedObjectAttributes extends SavedObjectAttributes {
   visualizationState?: string;
   styleState?: string;
   version: number;
+  searchSourceFields?: {
+    index?: string;
+  };
 }

--- a/src/plugins/wizard/public/embeddable/wizard_embeddable.tsx
+++ b/src/plugins/wizard/public/embeddable/wizard_embeddable.tsx
@@ -116,8 +116,15 @@ export class WizardEmbeddable extends Embeddable<SavedObjectEmbeddableInput, Wiz
       return;
     }
     const { visualization, style } = this.serializedState;
+
+    const vizStateWithoutIndex = JSON.parse(visualization);
+    const visualizationState = {
+      searchField: vizStateWithoutIndex.searchField,
+      activeVisualization: vizStateWithoutIndex.activeVisualization,
+      indexPattern: this.savedWizard?.searchSourceFields?.index,
+    };
     const rootState = {
-      visualization: JSON.parse(visualization),
+      visualization: visualizationState,
       style: JSON.parse(style),
     };
     const visualizationName = rootState.visualization?.activeVisualization?.name ?? '';


### PR DESCRIPTION
### Description
Since index pattern is not included in the visualization state anymore, need to add the index pattern information so the embeddable can be loaded correctly.

Signed-off-by: abbyhu2000 <abigailhu2000@gmail.com>
 
### Issues Resolved
resolves #2363
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 