### PR TITLE
[VizBuilder] Create a new wizard directly on a dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * Add updated_at column to objects' tables ([#1218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1218)) 
 * [Viz Builder] State validation before dispatching and loading ([#2351](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2351))
+* [Viz Builder] Create a new wizard directly on a dashboard ([#2384](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2384))
 
 ### 🐛 Bug Fixes
 

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -232,3 +232,4 @@
 #data_source.encryption.wrappingKeyName: 'changeme'
 #data_source.encryption.wrappingKeyNamespace: 'changeme'
 #data_source.encryption.wrappingKey: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -232,4 +232,3 @@
 #data_source.encryption.wrappingKeyName: 'changeme'
 #data_source.encryption.wrappingKeyNamespace: 'changeme'
 #data_source.encryption.wrappingKey: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-

--- a/src/plugins/wizard/public/application/components/top_nav.tsx
+++ b/src/plugins/wizard/public/application/components/top_nav.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useUnmount } from 'react-use';
 import { PLUGIN_ID } from '../../../common';
@@ -40,6 +40,9 @@ export const TopNav = () => {
 
     return getTopNavConfig(
       {
+        originatingApp,
+        setOriginatingApp,
+        stateTransfer,
         visualizationIdFromUrl,
         savedWizardVis: saveStateToSavedObject(savedWizardVis, rootState, indexPattern),
         saveDisabledReason,
@@ -56,6 +59,7 @@ export const TopNav = () => {
     dispatch,
     services,
   ]);
+
 
   // reset validity before component destroyed
   useUnmount(() => {

--- a/src/plugins/wizard/public/application/components/top_nav.tsx
+++ b/src/plugins/wizard/public/application/components/top_nav.tsx
@@ -53,7 +53,15 @@ export const TopNav = () => {
     };
 
     setConfig(getConfig());
-  }, [rootState, savedWizardVis, services, visualizationIdFromUrl, saveDisabledReason, dispatch, indexPattern]);
+  }, [
+    rootState,
+    savedWizardVis,
+    services,
+    visualizationIdFromUrl,
+    saveDisabledReason,
+    dispatch,
+    indexPattern,
+  ]);
 
   // reset validity before component destroyed
   useUnmount(() => {

--- a/src/plugins/wizard/public/application/components/top_nav.tsx
+++ b/src/plugins/wizard/public/application/components/top_nav.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useUnmount } from 'react-use';
 import { PLUGIN_ID } from '../../../common';
@@ -17,6 +17,7 @@ import { useTypedSelector, useTypedDispatch } from '../utils/state_management';
 import { setEditorState } from '../utils/state_management/metadata_slice';
 import { useCanSave } from '../utils/use/use_can_save';
 import { saveStateToSavedObject } from '../../saved_visualizations/transforms';
+import { TopNavMenuData } from '../../../../navigation/public';
 
 export const TopNav = () => {
   // id will only be set for the edit route
@@ -34,32 +35,25 @@ export const TopNav = () => {
   const saveDisabledReason = useCanSave();
   const savedWizardVis = useSavedWizardVis(visualizationIdFromUrl);
   const { selected: indexPattern } = useIndexPatterns();
+  const [config, setConfig] = useState<TopNavMenuData[] | undefined>();
 
-  const config = useMemo(() => {
-    if (!savedWizardVis || !indexPattern) return;
+  useEffect(() => {
+    const getConfig = () => {
+      if (!savedWizardVis || !indexPattern) return;
 
-    return getTopNavConfig(
-      {
-        originatingApp,
-        setOriginatingApp,
-        stateTransfer,
-        visualizationIdFromUrl,
-        savedWizardVis: saveStateToSavedObject(savedWizardVis, rootState, indexPattern),
-        saveDisabledReason,
-        dispatch,
-      },
-      services
-    );
-  }, [
-    savedWizardVis,
-    visualizationIdFromUrl,
-    rootState,
-    indexPattern,
-    saveDisabledReason,
-    dispatch,
-    services,
-  ]);
+      return getTopNavConfig(
+        {
+          visualizationIdFromUrl,
+          savedWizardVis: saveStateToSavedObject(savedWizardVis, rootState, indexPattern),
+          saveDisabledReason,
+          dispatch,
+        },
+        services
+      );
+    };
 
+    setConfig(getConfig());
+  }, [rootState, savedWizardVis, services, visualizationIdFromUrl, saveDisabledReason, dispatch, indexPattern]);
 
   // reset validity before component destroyed
   useUnmount(() => {

--- a/src/plugins/wizard/public/application/utils/get_top_nav_config.test.tsx
+++ b/src/plugins/wizard/public/application/utils/get_top_nav_config.test.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WizardServices } from '../../types';
+import { getOnSave } from './get_top_nav_config';
+import { createWizardServicesMock } from './mocks';
+
+describe('getOnSave', () => {
+  let savedWizardVis: any;
+  let originatingApp: string | undefined;
+  let visualizationIdFromUrl: string;
+  let dispatch: any;
+  let mockServices: jest.Mocked<WizardServices>;
+  let onSaveProps: {
+    newTitle: string;
+    newCopyOnSave: boolean;
+    isTitleDuplicateConfirmed: boolean;
+    onTitleDuplicate: any;
+    newDescription: string;
+    returnToOrigin: boolean;
+  };
+
+  beforeEach(() => {
+    savedWizardVis = {
+      id: '1',
+      title: 'save wizard wiz title',
+      description: '',
+      visualizationState: '',
+      styleState: '',
+      version: 0,
+      copyOnSave: true,
+      searchSourceFields: {},
+      save: jest.fn().mockReturnValue('1'),
+    };
+    originatingApp = '';
+    visualizationIdFromUrl = '';
+    dispatch = jest.fn();
+    mockServices = createWizardServicesMock();
+
+    onSaveProps = {
+      newTitle: 'new title',
+      newCopyOnSave: false,
+      isTitleDuplicateConfirmed: false,
+      onTitleDuplicate: jest.fn(),
+      newDescription: 'new description',
+      returnToOrigin: true,
+    };
+  });
+
+  test('return undefined when savedWizardVis is null', async () => {
+    savedWizardVis = null;
+    const onSave = getOnSave(
+      savedWizardVis,
+      originatingApp,
+      visualizationIdFromUrl,
+      dispatch,
+      mockServices
+    );
+    const onSaveResult = await onSave(onSaveProps);
+
+    expect(onSaveResult).toBeUndefined();
+  });
+
+  test('savedWizardVis get saved correctly', async () => {
+    const onSave = getOnSave(
+      savedWizardVis,
+      originatingApp,
+      visualizationIdFromUrl,
+      dispatch,
+      mockServices
+    );
+    const onSaveReturn = await onSave(onSaveProps);
+    expect(savedWizardVis).toMatchInlineSnapshot(`
+      Object {
+        "copyOnSave": false,
+        "description": "new description",
+        "id": "1",
+        "save": [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {
+                "confirmOverwrite": false,
+                "isTitleDuplicateConfirmed": false,
+                "onTitleDuplicate": [MockFunction],
+                "returnToOrigin": true,
+              },
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": "1",
+            },
+          ],
+        },
+        "searchSourceFields": Object {},
+        "styleState": "",
+        "title": "new title",
+        "version": 0,
+        "visualizationState": "",
+      }
+    `);
+    expect(onSaveReturn?.id).toBe('1');
+  });
+
+  test('savedWizardVis does not change title with a null id', async () => {
+    savedWizardVis.save = jest.fn().mockReturnValue(null);
+    const onSave = getOnSave(
+      savedWizardVis,
+      originatingApp,
+      visualizationIdFromUrl,
+      dispatch,
+      mockServices
+    );
+    const onSaveResult = await onSave(onSaveProps);
+    expect(savedWizardVis.title).toBe('save wizard wiz title');
+    expect(onSaveResult?.id).toBeNull();
+  });
+
+  test('create a new wizard from dashboard', async () => {
+    savedWizardVis.id = null;
+    savedWizardVis.save = jest.fn().mockReturnValue('2');
+    originatingApp = 'dashboard';
+    onSaveProps.returnToOrigin = true;
+
+    const onSave = getOnSave(
+      savedWizardVis,
+      originatingApp,
+      visualizationIdFromUrl,
+      dispatch,
+      mockServices
+    );
+    const onSaveResult = await onSave(onSaveProps);
+    expect(onSaveResult?.id).toBe('2');
+    expect(dispatch).toBeCalledTimes(0);
+  });
+
+  test('edit an exising wizard from dashboard', async () => {
+    savedWizardVis.copyOnSave = false;
+    originatingApp = 'dashboard';
+    onSaveProps.returnToOrigin = true;
+    const onSave = getOnSave(
+      savedWizardVis,
+      originatingApp,
+      visualizationIdFromUrl,
+      dispatch,
+      mockServices
+    );
+    const onSaveResult = await onSave(onSaveProps);
+    expect(onSaveResult?.id).toBe('1');
+    expect(mockServices.application.navigateToApp).toBeCalledTimes(1);
+  });
+});

--- a/src/plugins/wizard/public/application/utils/get_top_nav_config.test.tsx
+++ b/src/plugins/wizard/public/application/utils/get_top_nav_config.test.tsx
@@ -120,7 +120,7 @@ describe('getOnSave', () => {
   });
 
   test('create a new wizard from dashboard', async () => {
-    savedWizardVis.id = null;
+    savedWizardVis.id = undefined;
     savedWizardVis.save = jest.fn().mockReturnValue('2');
     originatingApp = 'dashboard';
     onSaveProps.returnToOrigin = true;
@@ -139,6 +139,7 @@ describe('getOnSave', () => {
 
   test('edit an exising wizard from dashboard', async () => {
     savedWizardVis.copyOnSave = false;
+    onSaveProps.newDescription = 'new description after editing';
     originatingApp = 'dashboard';
     onSaveProps.returnToOrigin = true;
     const onSave = getOnSave(
@@ -151,5 +152,6 @@ describe('getOnSave', () => {
     const onSaveResult = await onSave(onSaveProps);
     expect(onSaveResult?.id).toBe('1');
     expect(mockServices.application.navigateToApp).toBeCalledTimes(1);
+    expect(savedWizardVis.description).toBe('new description after editing');
   });
 });

--- a/src/plugins/wizard/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/wizard/public/application/utils/get_top_nav_config.tsx
@@ -41,21 +41,22 @@ import { WizardVisSavedObject } from '../../types';
 import { AppDispatch } from './state_management';
 import { EDIT_PATH } from '../../../common';
 import { setEditorState } from './state_management/metadata_slice';
-import { EmbeddableStateTransfer } from '../../../../embeddable/public';
 interface TopNavConfigParams {
   visualizationIdFromUrl: string;
   savedWizardVis: WizardVisSavedObject;
   saveDisabledReason?: string;
   dispatch: AppDispatch;
-  originatingApp?: string;
-  setOriginatingApp?: (originatingApp: string | undefined) => void;
-  stateTransfer: EmbeddableStateTransfer;
 }
 
 export const getTopNavConfig = (
   { visualizationIdFromUrl, savedWizardVis, saveDisabledReason, dispatch }: TopNavConfigParams,
-  { history, toastNotifications, i18n: { Context: I18nContext } }: WizardServices
+  { application, history, toastNotifications, i18n: { Context: I18nContext }, embeddable, scopedHistory }: WizardServices
 ) => {
+  const { originatingApp: originatingApp } = embeddable
+      .getStateTransfer(scopedHistory)
+      .getIncomingEditorState({ keysToRemoveAfterFetch: ['id', 'input'] }) || {};
+  const stateTransfer = embeddable.getStateTransfer();
+
   const topNavConfig: TopNavMenuData[] = [
     {
       id: 'save',
@@ -118,14 +119,15 @@ export const getTopNavConfig = (
                   stateTransfer.navigateToWithEmbeddablePackage(originatingApp, {
                     state: { type: 'wizard', input: { savedObjectId: id } },
                   });
+                  return {id};
                 } else {
                   // edit an existing wizard from the dashboard
                   application.navigateToApp(originatingApp);
                 }
               } else {
                 // create wizard from creating visualization page, not related to any dashboard
-                if (setOriginatingApp && originatingApp && newlyCreated) {
-                  setOriginatingApp(undefined);
+                if ( originatingApp && newlyCreated) {
+                  //setOriginatingApp(undefined);
                 }
               }
 

--- a/src/plugins/wizard/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/wizard/public/application/utils/get_top_nav_config.tsx
@@ -58,7 +58,7 @@ export const getTopNavConfig = (
     scopedHistory,
   } = services;
 
-  const { originatingApp: originatingApp } =
+  const { originatingApp } =
     embeddable
       .getStateTransfer(scopedHistory)
       .getIncomingEditorState({ keysToRemoveAfterFetch: ['id', 'input'] }) || {};
@@ -126,7 +126,7 @@ export const getOnSave = (
     if (!savedWizardVis) {
       return;
     }
-    const newlyCreated = !Boolean(savedWizardVis.id) || savedWizardVis.copyOnSave;
+    const newlyCreated = !savedWizardVis.id || savedWizardVis.copyOnSave;
     const currentTitle = savedWizardVis.title;
     savedWizardVis.title = newTitle;
     savedWizardVis.description = newDescription;
@@ -152,15 +152,15 @@ export const getOnSave = (
         });
 
         if (originatingApp && returnToOrigin) {
-          // create or edit wizard directly from a dashboard
+          // create or edit wizard directly from another app, such as `dashboard`
           if (newlyCreated && stateTransfer) {
-            // create and add a new wizard to the dashboard
+            // create new embeddable to transfer to originatingApp
             stateTransfer.navigateToWithEmbeddablePackage(originatingApp, {
               state: { type: 'wizard', input: { savedObjectId: id } },
             });
             return { id };
           } else {
-            // edit an existing wizard from the dashboard
+            // update an existing wizard from another app
             application.navigateToApp(originatingApp);
           }
         }

--- a/src/plugins/wizard/public/application/utils/mocks.ts
+++ b/src/plugins/wizard/public/application/utils/mocks.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ScopedHistory } from '../../../../../core/public';
+import { coreMock, scopedHistoryMock } from '../../../../../core/public/mocks';
+import { dataPluginMock } from '../../../../data/public/mocks';
+import { embeddablePluginMock } from '../../../../embeddable/public/mocks';
+import { expressionsPluginMock } from '../../../../expressions/public/mocks';
+import { navigationPluginMock } from '../../../../navigation/public/mocks';
+import { WizardServices } from '../../types';
+
+export const createWizardServicesMock = () => {
+  const coreStartMock = coreMock.createStart();
+  const toastNotifications = coreStartMock.notifications.toasts;
+  const applicationMock = coreStartMock.application;
+  const i18nContextMock = coreStartMock.i18n.Context;
+  const indexPatternMock = dataPluginMock.createStartContract().indexPatterns;
+  const embeddableMock = embeddablePluginMock.createStartContract();
+  const scopedhistoryMock = (scopedHistoryMock.create() as unknown) as ScopedHistory;
+  const navigationMock = navigationPluginMock.createStartContract();
+  const expressionMock = expressionsPluginMock.createStartContract();
+
+  const wizardServicesMock = {
+    ...coreStartMock,
+    navigation: navigationMock,
+    expression: expressionMock,
+    savedWizardLoader: {
+      get: jest.fn(),
+    } as any,
+    setHeaderActionMenu: () => {},
+    applicationMock,
+    history: {
+      push: jest.fn(),
+      location: { pathname: '' },
+    },
+    toastNotifications,
+    i18n: i18nContextMock,
+    data: indexPatternMock,
+    embeddable: embeddableMock,
+    scopedHistory: scopedhistoryMock,
+  };
+
+  return (wizardServicesMock as unknown) as jest.Mocked<WizardServices>;
+};

--- a/src/plugins/wizard/public/application/utils/mocks.ts
+++ b/src/plugins/wizard/public/application/utils/mocks.ts
@@ -18,7 +18,6 @@ export const createWizardServicesMock = () => {
   const i18nContextMock = coreStartMock.i18n.Context;
   const indexPatternMock = dataPluginMock.createStartContract().indexPatterns;
   const embeddableMock = embeddablePluginMock.createStartContract();
-  const scopedhistoryMock = (scopedHistoryMock.create() as unknown) as ScopedHistory;
   const navigationMock = navigationPluginMock.createStartContract();
   const expressionMock = expressionsPluginMock.createStartContract();
 
@@ -39,7 +38,7 @@ export const createWizardServicesMock = () => {
     i18n: i18nContextMock,
     data: indexPatternMock,
     embeddable: embeddableMock,
-    scopedHistory: scopedhistoryMock,
+    scopedHistory: (scopedHistoryMock.create() as unknown) as ScopedHistory,
   };
 
   return (wizardServicesMock as unknown) as jest.Mocked<WizardServices>;

--- a/src/plugins/wizard/public/plugin.ts
+++ b/src/plugins/wizard/public/plugin.ts
@@ -87,6 +87,8 @@ export class WizardPlugin
           setHeaderActionMenu: params.setHeaderActionMenu,
           types: typeService.start(),
           savedWizardLoader: selfStart.savedWizardLoader,
+          embeddable: pluginsStart.embeddable,
+          scopedHistory: params.history,
         };
 
         // Instantiate the store

--- a/src/plugins/wizard/public/types.ts
+++ b/src/plugins/wizard/public/types.ts
@@ -13,7 +13,7 @@ import { NavigationPublicPluginStart } from '../../navigation/public';
 import { DataPublicPluginStart } from '../../data/public';
 import { TypeServiceSetup, TypeServiceStart } from './services/type_service';
 import { SavedObjectLoader } from '../../saved_objects/public';
-import { AppMountParameters, CoreStart, ToastsStart } from '../../../core/public';
+import { AppMountParameters, CoreStart, ToastsStart, ScopedHistory } from '../../../core/public';
 
 export type WizardSetup = TypeServiceSetup;
 export interface WizardStart extends TypeServiceStart {
@@ -43,6 +43,8 @@ export interface WizardServices extends CoreStart {
   types: TypeServiceStart;
   expressions: ExpressionsStart;
   history: History;
+  embeddable: EmbeddableStart;
+  scopedHistory: ScopedHistory;
 }
 
 export interface ISavedVis {


### PR DESCRIPTION
### Description
After selecting a dashboard, create a new wizard directly from the dashboard and have the option to add to that dashboard.

Signed-off-by: abbyhu2000 <abigailhu2000@gmail.com>
 
### Issues Resolved
resolves #2381 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 