### PR TITLE
Adding @abbyhu2000 as a Dashboards co-maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,5 +12,6 @@
 | Miki Barahmand | [AMoo-Miki](https://github.com/AMoo-Miki) | Amazon |
 | Ashwin P Chandran | [ashwin-pc](https://github.com/ashwin-pc) | Amazon |
 | Josh Romero | [joshuarrrr](https://github.com/joshuarrrr) | Amazon |
+| Abby Hu | [abbyhu2000](https://github.com/abbyhu2000) | Amazon |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Signed-off-by: Ashwin P Chandran <ashwinpc@amazon.com>

### Description
I nominated Abby Hu (@abbyhu2000) to be a co-maintainer for OpenSearch Dashboards through our [nomination process](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md#nomination). The maintainers have agreed, and Abby has kindly accepted.

Abby has made multiple contributions to OpenSearch Dashboards, the most notable of which is [Custom Branding (#826)](https://github.com/opensearch-project/OpenSearch-Dashboards/commit/9037b61e9d4da3c44f0ba0fab8f803db5873ef89) along with many other bug fixes and changes, including some of her recent contributions to VisBuilder. ([Commits](https://github.com/opensearch-project/OpenSearch-Dashboards/commits?author=abbyhu2000))
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 