### PR TITLE
Adding @zengyan-amazon as a Dashboards co-maintainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### 🛠 Maintenance
 
 * Increment from 2.3 to 2.4. ([#2295](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2295))
+* Adding @zengyan-amazon as maintainer.
 
 ### 🪛 Refactoring
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,5 +13,6 @@
 | Ashwin P Chandran | [ashwin-pc](https://github.com/ashwin-pc) | Amazon |
 | Josh Romero | [joshuarrrr](https://github.com/joshuarrrr) | Amazon |
 | Abby Hu | [abbyhu2000](https://github.com/abbyhu2000) | Amazon |
+| Yan Zeng | [zengyan-amazon](https://github.com/zengyan-amazon) | Amazon |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Signed-off-by: Neumann <neumanns@amazon.com>

### Description
Adding Yan Zeng as Maintainer

 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 