### PR TITLE
[MD] Fix view single document issue by updating low-level search call param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [Vis Builder] Fixes auto bounds for timeseries bar chart visualization ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))
 * [Vis Builder] Fixes visualization shift when editing agg ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))
 * [Vis Builder] Renames "Histogram" to "Bar" in vis type picker ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))
+* [MD] Add data source param to low-level search call in Discover ([#2431](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2431))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/discover/public/application/components/doc/use_opensearch_doc_search.ts
+++ b/src/plugins/discover/public/application/components/doc/use_opensearch_doc_search.ts
@@ -82,6 +82,7 @@ export function useOpenSearchDocSearch({
 
         const { rawResponse } = await getServices()
           .data.search.search({
+            dataSourceId: indexPatternEntity.dataSourceRef?.id,
             params: {
               index,
               body: buildSearchBody(id, indexPatternEntity),


### PR DESCRIPTION
Signed-off-by: Su <szhongna@amazon.com>

### Description
Add datasource param to low-level search call in Discover, that fixes the rendering issue of single document, while searching against data source
 
### Issues Resolved
Part of #2400, issue reported by @abbyhu2000  
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 