### PR TITLE
fix d3-color and potential security issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Bump moment-timezone from 0.5.34 to 0.5.37 ([#2361](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2361))
 * [CVE-2022-33987] Upgrade geckodriver to 3.0.2 ([#2166](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2166))
 * Bumps percy-agent to use non-beta version ([#2415](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2415))
+* Resolve sub-dependent d3-color version and potential security issue ([#2454](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2454))
 
 ### 📈 Features/Enhancements
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "**/ansi-regex": "^5.0.1",
     "**/async": "^3.2.3",
     "**/axios": "^0.27.2",
+    "**/d3-color": "^3.1.0",
     "**/glob-parent": "^6.0.0",
     "**/hoist-non-react-statics": "^3.3.2",
     "**/json-schema": "^0.4.0",

--- a/src/dev/jest/config.js
+++ b/src/dev/jest/config.js
@@ -91,7 +91,7 @@ export default {
     '^.+\\.html?$': 'jest-raw-loader',
   },
   transformIgnorePatterns: [
-    // ignore all node_modules except monaco-editor which requires babel transforms to handle dynamic import()
+    // ignore all node_modules except those which require babel transforms to handle dynamic import()
     // since ESM modules are not natively supported in Jest yet (https://github.com/facebook/jest/issues/4842)
     '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|weak-lru-cache|ordered-binary|d3-color))[/\\\\].+\\.js$',
     'packages/osd-pm/dist/index.js',

--- a/src/dev/jest/config.js
+++ b/src/dev/jest/config.js
@@ -93,7 +93,7 @@ export default {
   transformIgnorePatterns: [
     // ignore all node_modules except monaco-editor which requires babel transforms to handle dynamic import()
     // since ESM modules are not natively supported in Jest yet (https://github.com/facebook/jest/issues/4842)
-    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|weak-lru-cache|ordered-binary))[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|weak-lru-cache|ordered-binary|d3-color))[/\\\\].+\\.js$',
     'packages/osd-pm/dist/index.js',
   ],
   snapshotSerializers: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6633,12 +6633,7 @@ d3-collection@1, d3-collection@^1.0.7:
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
 
-d3-color@1, d3-color@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
-  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
-
-"d3-color@1 - 3", d3-color@^3.0.1:
+d3-color@1, "d3-color@1 - 3", d3-color@^1.4.0, d3-color@^3.0.1, d3-color@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==


### PR DESCRIPTION
### Description
Addresses potential ReDoS issue from d3-color version < 3.1.0

d3-color is used as a sub-dependency of elastic/chart package. since there is no function change form 1.4 to 3.1.0, we could add resolution in package.json to overwrite the version.
```
yarn why d3-color
yarn why v1.22.19
[1/4] Why do we have the module "d3-color"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~4.5.2"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "d3-color@1.4.1"
info Has been hoisted to "d3-color"
info Reasons this module exists
   - "workspace-aggregator-26115f01-dd15-42ff-8fa9-cd8d075aae02" depends on it
   - Hoisted from "_project_#@elastic#charts#d3-color"
   - Hoisted from "_project_#@elastic#charts#d3-interpolate#d3-color"
   - Hoisted from "_project_#@elastic#charts#d3-scale#d3-color"
   - Hoisted from "_project_#@elastic#charts#d3-scale#d3-interpolate#d3-color"
```
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 