### PR TITLE
[BUG] Plugin helpers fix related to fs promises module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 🐛 Bug Fixes
 
+* Plugin helpers fix related to fs promises module ([#2486](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2486))
+
 ### 🚞 Infrastructure
 
 ### 📝 Documentation

--- a/packages/osd-plugin-helpers/src/tasks/update_versions.ts
+++ b/packages/osd-plugin-helpers/src/tasks/update_versions.ts
@@ -4,10 +4,12 @@
  */
 
 // @ts-ignore
-import { readFile, writeFile } from 'fs/promises';
+import { promises } from 'fs';
 import path from 'path';
 import { createFailError } from '@osd/dev-utils';
 import { FileUpdateContext, ObjectUpdateContext, VersionContext } from '../contexts';
+
+const { readFile, writeFile } = promises;
 
 export async function updateVersions({
   log,


### PR DESCRIPTION
### Description
In Node v10, there was no dedicated module for fs/promises. Causing the plugin helpers to fail while building out plugins.

Solved by importing promises from fs then using the desired methods.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2485
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 