### PR TITLE
[MD] Display error toast for create index pattern with data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * [MD] Support legacy client for data source ([#2204](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2204))
 * [Plugin Helpers] Facilitate version changes ([#2398](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2398))
+* [MD] Display error toast for create index pattern with data source ([#2506](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2506))
 
 ### 🐛 Bug Fixes
 * [Vis Builder] Fixes auto bounds for timeseries bar chart visualization ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
@@ -134,6 +134,7 @@ export class CreateIndexPatternWizard extends Component<
             id: errorMsg.props.id,
             color: 'warning',
             iconType: 'alert',
+            text: errors.body.message,
           },
         ]),
       }));

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_indices.test.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_indices.test.ts
@@ -119,7 +119,7 @@ describe('getIndices', () => {
     expect(result[1].name).toBe('foo');
   });
 
-  it('should make two calls in cross cluser case', async () => {
+  it('should make two calls in cross cluster case', async () => {
     http.get.mockResolvedValue(successfulResolveResponse);
     const result = await getIndices({
       http,
@@ -201,9 +201,23 @@ describe('getIndices', () => {
         getIndexTags,
         pattern: 'opensearch-dashboards',
         searchClient,
-        dataSourceId,
       });
       expect(result.length).toBe(0);
+    });
+
+    it('should throw error with data source use case', async () => {
+      http.get.mockImplementationOnce(() => {
+        throw new Error('Test error');
+      });
+      expect(
+        getIndices({
+          http,
+          getIndexTags,
+          pattern: 'opensearch-dashboards',
+          searchClient,
+          dataSourceId,
+        })
+      ).rejects.toThrowError();
     });
   });
 });

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_indices.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/lib/get_indices.ts
@@ -199,7 +199,14 @@ export async function getIndices({
     pattern,
     showAllIndices,
     dataSourceId,
-  }).catch(() => []);
+  }).catch((error) => {
+    // swallow the errors to be backwards compatible with non-data-source use case
+    if (dataSourceId) {
+      throw error;
+    } else {
+      return [];
+    }
+  });
   requests.push(promiseResolve);
 
   if (isCCS) {


### PR DESCRIPTION
Signed-off-by: Su <szhongna@amazon.com>

### Description
Display error toast for create index pattern with data source.
Make use of the existing toast component instead of swallowing error, we generate the pop-up for data source use case in index pattern
<img width="1229" alt="image" src="https://user-images.githubusercontent.com/32652829/193956387-def78d6e-dc1b-4ca5-9a57-e2e03fff3592.png">

 
### Issues Resolved
 https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2285
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 