### PR TITLE
Edit wizard directly on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Add updated_at column to objects' tables ([#1218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1218)) 
 * [Viz Builder] State validation before dispatching and loading ([#2351](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2351))
 * [Viz Builder] Create a new wizard directly on a dashboard ([#2384](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2384))
+* [Viz Builder] Edit wizard directly on dashboard ([#2508](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2508))
 
 ### 🐛 Bug Fixes
 


### PR DESCRIPTION
### Description
Edit wizard directly on dashboard following the steps:
1. choose a dashboard
2. click `Edit` button on the top nav bar of the dashboard
3. select the setting button on the top right of a wizard on that dashboard
4. click edit wizard

<img width="1707" alt="Screen Shot 2022-10-05 at 10 49 47 AM" src="https://user-images.githubusercontent.com/43937633/194127649-4ecb0caf-dcb7-4543-bfcf-e64369e168b3.png">

When finish editing wizard, there are some different options for saving that wizard, this PR ensures the below five different flows for editing wizard all work as expected:
1. `Save and return` button on top nav bar --> will save the original wizard and return back to the dashboard without displaying an additional save modal
2. `Save as` button on top nav bar --> will open a save modal
   * `save as new wizard` toggle on + `add to dashboard after saving` toggle on + Save and return button
   * `save as new wizard` toggle on + `add to dashboard after saving` toggle off + Save button
   * `save as new wizard` toggle off + `return to dashboard after saving` toggle on + Save and return button
   * `save as new wizard` toggle off + `return to dashboard after saving` toggle off + Save button
 
![Screen Shot 2022-10-05 at 10 58 12 AM](https://user-images.githubusercontent.com/43937633/194129211-ec915555-2849-490b-96ee-67b59608acea.png)

![Screen Shot 2022-10-05 at 10 57 32 AM](https://user-images.githubusercontent.com/43937633/194129070-1a522e9e-7081-4534-9b78-1781b5fd1f5f.png)

![Screen Shot 2022-10-05 at 10 57 20 AM](https://user-images.githubusercontent.com/43937633/194129048-15cd6b1c-a5bd-4a5a-afff-7e77de57c6dd.png)

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2382
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 