### PR TITLE
[1.x] bump chromedriver to 106 to fix function test fail issue

### DIFF
--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -176,7 +176,7 @@ jobs:
       # github virtual env is the latest chrome
       - name: Setup chromedriver
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'
-        run: yarn add --dev chromedriver@104.0.0
+        run: yarn add --dev chromedriver@106.0.0
 
       - name: Run bootstrap
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 🔩 Tests
 
+* bump chromedriver to 106 to fix function test fail issue ([#2514](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2514))
+
 ## [1.x]
 ### 💥 Breaking Changes
 


### PR DESCRIPTION
### Description
Current browser version is 106 whereas chromedriver is 104. This PR bump the version to solve the mismatch.

 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 