### PR TITLE
[Table Visualization] format table cell and restore showTotal feature

### DIFF
--- a/src/plugins/vis_type_table/public/types.ts
+++ b/src/plugins/vis_type_table/public/types.ts
@@ -58,7 +58,7 @@ export interface TableVisParams {
 export interface FormattedColumn {
   id: string;
   title: string;
-  formatter: IFieldFormat | undefined;
+  formatter: IFieldFormat;
   filterable: boolean;
   formattedTotal?: string | number;
   sumTotal?: number;

--- a/src/plugins/vis_type_table/public/utils/convert_to_formatted_data.ts
+++ b/src/plugins/vis_type_table/public/utils/convert_to_formatted_data.ts
@@ -80,6 +80,7 @@ export interface FormattedDataProps {
   formattedRows: OpenSearchDashboardsDatatableRow[];
   formattedColumns: FormattedColumn[];
 }
+
 export const convertToFormattedData = (
   table: Table,
   visConfig: TableVisConfig
@@ -95,7 +96,9 @@ export const convertToFormattedData = (
       const dimension =
         isBucket || isSplitColumn || metrics.find((metric) => metric.accessor === i);
 
-      const formatter = dimension ? getFormatService().deserialize(dimension.format) : undefined;
+      if (!dimension) return undefined;
+
+      const formatter = getFormatService().deserialize(dimension.format);
 
       const formattedColumn: FormattedColumn = {
         id: col.id,
@@ -157,7 +160,7 @@ export const convertToFormattedData = (
 
       return formattedColumn;
     })
-    .filter((column) => column);
+    .filter((column): column is FormattedColumn => !!column);
 
   if (visConfig.percentageCol) {
     const insertAtIndex = formattedColumns.findIndex(
@@ -165,7 +168,7 @@ export const convertToFormattedData = (
     );
 
     // column to show percentage for was removed
-    if (insertAtIndex < 0) return;
+    if (insertAtIndex < 0) return { formattedRows, formattedColumns };
 
     const { cols, rows } = addPercentageCol(
       formattedColumns,


### PR DESCRIPTION
### Description
* format table cell to show formatted Date and percent
* restore showTotal feature: it allows table vis to show total, avg, min, max and count statics on count
* fix some type errors
 
### Partically resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2379
 
<img width="1147" alt="Screen Shot 2022-10-12 at 15 58 40" src="https://user-images.githubusercontent.com/79961084/195465020-48222578-99f5-4d1a-a6c8-f0cdf041bc6e.png">

<img width="1141" alt="Screen Shot 2022-10-12 at 16 15 45" src="https://user-images.githubusercontent.com/79961084/195465035-060ba332-59c1-4e70-a79e-e24fb160eedc.png">
