### PR TITLE
[MD] onboard TSVB to support multiple data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [Multi DataSource] Add data source config to opensearch-dashboards-docker ([#2557](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2557))
 * [Multi DataSource] Make text content dynamically translated & update unit tests ([#2570](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2570))
 * [Vis Builder] Change classname prefix wiz to vb ([#2581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2581/files))
+* [Multi DataSource] Onboard TSVB to support multiple data source ([#2572](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2572))
 
 ### 🐛 Bug Fixes
 * [Vis Builder] Fixes auto bounds for timeseries bar chart visualization ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))

--- a/src/plugins/data/server/index.ts
+++ b/src/plugins/data/server/index.ts
@@ -145,6 +145,7 @@ export {
   FieldDescriptor as IndexPatternFieldDescriptor,
   shouldReadFieldFromDocValues, // used only in logstash_fields fixture
   FieldDescriptor,
+  decideLegacyClient,
 } from './index_patterns';
 
 export {

--- a/src/plugins/data/server/index_patterns/routes.ts
+++ b/src/plugins/data/server/index_patterns/routes.ts
@@ -29,12 +29,9 @@
  */
 
 import { schema } from '@osd/config-schema';
-import {
-  HttpServiceSetup,
-  LegacyAPICaller,
-  RequestHandlerContext,
-} from 'opensearch-dashboards/server';
+import { HttpServiceSetup, RequestHandlerContext } from 'opensearch-dashboards/server';
 import { IndexPatternsFetcher } from './fetcher';
+import { decideLegacyClient } from './utils';
 
 export function registerRoutes(http: HttpServiceSetup) {
   const parseMetaFields = (metaFields: string | string[]) => {
@@ -62,7 +59,7 @@ export function registerRoutes(http: HttpServiceSetup) {
       },
     },
     async (context, request, response) => {
-      const callAsCurrentUser = await decideClient(context, request);
+      const callAsCurrentUser = await decideLegacyClient(context, request);
       const indexPatterns = new IndexPatternsFetcher(callAsCurrentUser);
       const { pattern, meta_fields: metaFields } = request.query;
 
@@ -122,7 +119,7 @@ export function registerRoutes(http: HttpServiceSetup) {
       },
     },
     async (context: RequestHandlerContext, request: any, response: any) => {
-      const callAsCurrentUser = await decideClient(context, request);
+      const callAsCurrentUser = await decideLegacyClient(context, request);
 
       const indexPatterns = new IndexPatternsFetcher(callAsCurrentUser);
       const { pattern, interval, look_back: lookBack, meta_fields: metaFields } = request.query;
@@ -154,13 +151,3 @@ export function registerRoutes(http: HttpServiceSetup) {
     }
   );
 }
-
-const decideClient = async (
-  context: RequestHandlerContext,
-  request: any
-): Promise<LegacyAPICaller> => {
-  const dataSourceId = request.query.data_source;
-  return dataSourceId
-    ? (context.dataSource.opensearch.legacy.getClient(dataSourceId).callAPI as LegacyAPICaller)
-    : context.core.opensearch.legacy.client.callAsCurrentUser;
-};

--- a/src/plugins/data/server/index_patterns/utils.ts
+++ b/src/plugins/data/server/index_patterns/utils.ts
@@ -28,7 +28,11 @@
  * under the License.
  */
 
-import { SavedObjectsClientContract } from 'opensearch-dashboards/server';
+import {
+  SavedObjectsClientContract,
+  LegacyAPICaller,
+  RequestHandlerContext,
+} from 'opensearch-dashboards/server';
 import { IFieldType, IndexPatternAttributes, SavedObject } from '../../common';
 
 export const getFieldByName = (
@@ -55,4 +59,14 @@ export const findIndexPatternById = async (
   if (savedObjectsResponse.total > 0) {
     return savedObjectsResponse.saved_objects[0];
   }
+};
+
+export const decideLegacyClient = async (
+  context: RequestHandlerContext,
+  request: any
+): Promise<LegacyAPICaller> => {
+  const dataSourceId = request?.query?.data_source;
+  return dataSourceId
+    ? (context.dataSource.opensearch.legacy.getClient(dataSourceId).callAPI as LegacyAPICaller)
+    : context.core.opensearch.legacy.client.callAsCurrentUser;
 };

--- a/src/plugins/vis_type_timeseries/opensearch_dashboards.json
+++ b/src/plugins/vis_type_timeseries/opensearch_dashboards.json
@@ -5,6 +5,6 @@
   "server": true,
   "ui": true,
   "requiredPlugins": ["charts", "data", "expressions", "visualizations"],
-  "optionalPlugins": ["usageCollection"],
+  "optionalPlugins": ["usageCollection", "dataSource"],
   "requiredBundles": ["opensearchDashboardsUtils", "opensearchDashboardsReact"]
 }

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/abstract_search_strategy.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/abstract_search_strategy.test.js
@@ -66,7 +66,7 @@ describe('AbstractSearchStrategy', () => {
   });
 
   test('should return response', async () => {
-    const searches = [{ body: 'body', index: 'index' }];
+    const searches = [{ body: 'body', index: 'index', dataSourceId: 'dataSourceId' }];
     const searchFn = jest.fn().mockReturnValue(Promise.resolve({}));
 
     const responses = await abstractSearchStrategy.search(
@@ -101,6 +101,7 @@ describe('AbstractSearchStrategy', () => {
           index: 'index',
         },
         indexType: undefined,
+        dataSourceId: 'dataSourceId',
       },
       {
         strategy: 'opensearch',

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/abstract_search_strategy.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/abstract_search_strategy.ts
@@ -69,7 +69,7 @@ export class AbstractSearchStrategy {
   async search(req: ReqFacade, bodies: any[], options = {}) {
     const [, deps] = await req.framework.core.getStartServices();
     const requests: any[] = [];
-    bodies.forEach((body) => {
+    bodies.forEach(({ dataSourceId, ...body }) => {
       requests.push(
         deps.data.search.search(
           req.requestContext,
@@ -79,6 +79,7 @@ export class AbstractSearchStrategy {
               ...this.additionalParams,
             },
             indexType: this.indexType,
+            dataSourceId,
           },
           {
             ...options,

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/annotations/get_request_params.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/annotations/get_request_params.js
@@ -41,7 +41,10 @@ export async function getAnnotationRequestParams(
 ) {
   const opensearchShardTimeout = await getOpenSearchShardTimeout(req);
   const indexPattern = annotation.index_pattern;
-  const { indexPatternObject, indexPatternString } = await getIndexPatternObject(req, indexPattern);
+  const { indexPatternObject, indexPatternString, dataSourceId } = await getIndexPatternObject(
+    req,
+    indexPattern
+  );
   const request = buildAnnotationRequest(
     req,
     panel,
@@ -57,5 +60,6 @@ export async function getAnnotationRequestParams(
       ...request,
       timeout: opensearchShardTimeout > 0 ? `${opensearchShardTimeout}ms` : undefined,
     },
+    dataSourceId,
   };
 }

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_table_data.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_table_data.js
@@ -43,7 +43,7 @@ export async function getTableData(req, panel) {
     capabilities,
   } = await req.framework.searchStrategyRegistry.getViableStrategy(req, panelIndexPattern);
   const opensearchQueryConfig = await getOpenSearchQueryConfig(req);
-  const { indexPatternObject } = await getIndexPatternObject(req, panelIndexPattern);
+  const { indexPatternObject, dataSourceId } = await getIndexPatternObject(req, panelIndexPattern);
 
   const meta = {
     type: panel.type,
@@ -62,6 +62,7 @@ export async function getTableData(req, panel) {
       {
         body,
         index: panelIndexPattern,
+        dataSourceId,
       },
     ]);
 

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_index_pattern.d.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_index_pattern.d.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReqFacade } from '../../search_strategies/strategies/abstract_search_strategy';
+
+export function getIndexPatternObject(
+  requestContext: ReqFacade,
+  indexPattern: string
+): Promise<{
+  indexPatternObject: any;
+  indexPatternString: string;
+  dataSourceId?: string;
+}>;

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_index_pattern.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_index_pattern.js
@@ -54,17 +54,24 @@ export async function getIndexPatternObject(req, indexPatternString) {
     )
     .map((indexPattern) => {
       const { title, fields, timeFieldName } = indexPattern.attributes;
+      const dataSourceId =
+        indexPattern.references?.[0]?.type === 'data-source'
+          ? indexPattern.references[0].id
+          : undefined;
+
       return {
         title,
         timeFieldName,
         fields: JSON.parse(fields),
+        dataSourceId,
       };
     });
 
   const indexPatternObject = indexPatterns.length === 1 ? indexPatterns[0] : null;
-
+  const dataSourceId = indexPatternObject?.dataSourceId;
   return {
     indexPatternObject,
     indexPatternString: indexPatternString || get(indexPatternObject, 'title', ''),
+    dataSourceId,
   };
 }

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/series/get_request_params.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/series/get_request_params.js
@@ -41,7 +41,10 @@ export async function getSeriesRequestParams(
 ) {
   const indexPattern =
     (series.override_index_pattern && series.series_index_pattern) || panel.index_pattern;
-  const { indexPatternObject, indexPatternString } = await getIndexPatternObject(req, indexPattern);
+  const { indexPatternObject, indexPatternString, dataSourceId } = await getIndexPatternObject(
+    req,
+    indexPattern
+  );
   const request = buildRequestBody(
     req,
     panel,
@@ -58,5 +61,6 @@ export async function getSeriesRequestParams(
       ...request,
       timeout: opensearchShardTimeout > 0 ? `${opensearchShardTimeout}ms` : undefined,
     },
+    dataSourceId,
   };
 }


### PR DESCRIPTION
Signed-off-by: Su <szhongna@amazon.com>

### Description
### [require UX/UI changes to go along]

[MD] onboard TSVB to support multiple data source
Unlike other vis types, TSVB has its own backend. From the expressions TSVB generated, it doesn't go through `opensearchaggs` to create the searchSource obj, and call high level search API. Instead, they retrieve the index pattern, build the OpenSearch query from their plugin and directly query OpenSearch in 2 ways.
1. by calling the data plugin *low level* search API, to get actual data
2. directly use `legacyOpenSearchClient` to query OS to get runtime fields  and fields capabilities. 

This PR targets to refactor above 2 flows by integrating with datasource params. That also requires adding `MD` as an optional plugin of TSVB

See issue below for more details
 
### Issues Resolved
#2153
part of #1990 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 