### PR TITLE
[MD] skip data source view when pick default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [Vis Builder] Fixes visualization shift when editing agg ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))
 * [Vis Builder] Renames "Histogram" to "Bar" in vis type picker ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))
 * [MD] Add data source param to low-level search call in Discover ([#2431](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2431))
+* [Multi DataSource] Skip data source view in index pattern step when pick default ([#2574](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2574))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/components/header/header.tsx
@@ -103,14 +103,14 @@ export const Header: React.FC<HeaderProps> = ({
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiForm isInvalid={isInputInvalid}>
-            {dataSourceEnabled
+            {dataSourceEnabled && dataSourceRef?.title
               ? renderDataSourceAndIndexPatternInput(
                   isInputInvalid,
                   errors,
                   characterList,
                   query,
                   onQueryChanged,
-                  dataSourceRef!
+                  dataSourceRef.title
                 )
               : renderIndexPatternInput(
                   isInputInvalid,
@@ -216,7 +216,7 @@ const renderDataSourceAndIndexPatternInput = (
   characterList: string,
   query: string,
   onQueryChanged: (e: React.ChangeEvent<HTMLInputElement>) => void,
-  dataSourceRef: DataSourceRef
+  dataSourceTitle: string
 ) => {
   return (
     <EuiFlexGroup gutterSize="none">
@@ -239,7 +239,7 @@ const renderDataSourceAndIndexPatternInput = (
                 defaultMessage: 'Data source name',
               }
             )}
-            value={dataSourceRef!.title}
+            value={dataSourceTitle}
             isInvalid={isInputInvalid}
             disabled={true}
             data-test-subj="createIndexPatternDataSourceName"


### PR DESCRIPTION
Signed-off-by: Kristen Tian <tyarong@amazon.com>

### Description
Skip data source view when pick default - When OSD enable data source feature, user can still choose to use default cluster, in this case, index pattern creation should render with previous experience for this phase.
 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 