### PR TITLE
[Table Visualization][BUG] remove local column width state

### DIFF
--- a/src/plugins/vis_type_table/public/types.ts
+++ b/src/plugins/vis_type_table/public/types.ts
@@ -48,7 +48,7 @@ export interface TableVisConfig extends TableVisParams {
 }
 
 export interface TableVisParams {
-  perPage: number;
+  perPage: number | '';
   showPartialRows: boolean;
   showMetricsAtAllLevels: boolean;
   showTotal: boolean;

--- a/src/plugins/vis_type_table/public/utils/use_pagination.ts
+++ b/src/plugins/vis_type_table/public/utils/use_pagination.ts
@@ -6,10 +6,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { TableVisConfig } from '../types';
 
-export const usePagination = (visConfig: TableVisConfig, nrow: number) => {
+export const usePagination = (visConfig: TableVisConfig, nRow: number) => {
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: visConfig.perPage,
+    pageSize: visConfig.perPage || 0,
   });
   const onChangeItemsPerPage = useCallback(
     (pageSize) => setPagination((p) => ({ ...p, pageSize, pageIndex: 0 })),
@@ -20,12 +20,13 @@ export const usePagination = (visConfig: TableVisConfig, nrow: number) => {
   ]);
 
   useEffect(() => {
-    const maxiPageIndex = Math.ceil(nrow / visConfig.perPage) - 1;
+    const perPage = visConfig.perPage || 0;
+    const maxiPageIndex = Math.ceil(nRow / perPage) - 1;
     setPagination((p) => ({
       pageIndex: p.pageIndex > maxiPageIndex ? maxiPageIndex : p.pageIndex,
-      pageSize: visConfig.perPage,
+      pageSize: perPage,
     }));
-  }, [nrow, visConfig.perPage]);
+  }, [nRow, visConfig.perPage]);
 
   return useMemo(
     () => ({


### PR DESCRIPTION
### Description
* remove local col width state to allow split tables to fetch updated col width state
* fix type errors in usePagination

### Partially resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2579#issuecomment-1281078065

Now col width state is sharing to all split tables in row/col
<img width="1096" alt="Screen Shot 2022-10-15 at 00 02 51" src="https://user-images.githubusercontent.com/79961084/196227285-81c8549e-35a0-43ff-a701-25968ec11bb9.png">
