### PR TITLE
[Table Visualization][IMPROVE] remove repeated column from split tables

### DIFF
--- a/src/plugins/vis_type_table/public/utils/convert_to_formatted_data.ts
+++ b/src/plugins/vis_type_table/public/utils/convert_to_formatted_data.ts
@@ -85,16 +85,12 @@ export const convertToFormattedData = (
   table: Table,
   visConfig: TableVisConfig
 ): FormattedDataProps => {
-  const { buckets, metrics, splitColumn } = visConfig;
+  const { buckets, metrics } = visConfig;
   let formattedRows: OpenSearchDashboardsDatatableRow[] = table.rows;
   let formattedColumns: FormattedColumn[] = table.columns
     .map(function (col, i) {
       const isBucket = buckets.find((bucket) => bucket.accessor === i);
-      const isSplitColumn = splitColumn
-        ? splitColumn.find((splitCol) => splitCol.accessor === i)
-        : undefined;
-      const dimension =
-        isBucket || isSplitColumn || metrics.find((metric) => metric.accessor === i);
+      const dimension = isBucket || metrics.find((metric) => metric.accessor === i);
 
       if (!dimension) return undefined;
 


### PR DESCRIPTION
### Description
Currently, when we split table by columns, the split column is shown both in the table title and as a separate column. This is not needed. In this PR, we remove the repeated column in split tables in col.

### Partically resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2579#issuecomment-1281099947

Now if you split a table with city, city will not repeat itself as a separate column:
<img width="1316" alt="Screen Shot 2022-10-16 at 23 40 30" src="https://user-images.githubusercontent.com/79961084/196228315-d95e7316-94f1-43ea-9220-9cb7572bb23d.png">
