### PR TITLE
[Vis Builder] Cancel flow when user create viz builder from dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [Multi DataSource] Make text content dynamically translated & update unit tests ([#2570](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2570))
 * [Vis Builder] Change classname prefix wiz to vb ([#2581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2581/files))
 * [Vis Builder] Change wizard to vis_builder in file names and paths ([#2587](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2587))
+* [Vis Builder] Cancel flow when user create viz builder from dashboard ([#2627](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2627))
 
 ### 🐛 Bug Fixes
 * [Vis Builder] Fixes auto bounds for timeseries bar chart visualization ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))

--- a/src/plugins/vis_builder/public/application/utils/get_top_nav_config.test.tsx
+++ b/src/plugins/vis_builder/public/application/utils/get_top_nav_config.test.tsx
@@ -21,6 +21,7 @@ describe('getOnSave', () => {
     newDescription: string;
     returnToOrigin: boolean;
   };
+  let setSaveSuccess: any;
 
   beforeEach(() => {
     savedWizardVis = {
@@ -38,6 +39,7 @@ describe('getOnSave', () => {
     visualizationIdFromUrl = '';
     dispatch = jest.fn();
     mockServices = createWizardServicesMock();
+    setSaveSuccess = jest.fn();
 
     onSaveProps = {
       newTitle: 'new title',
@@ -56,7 +58,8 @@ describe('getOnSave', () => {
       originatingApp,
       visualizationIdFromUrl,
       dispatch,
-      mockServices
+      mockServices,
+      setSaveSuccess
     );
     const onSaveResult = await onSave(onSaveProps);
 
@@ -69,7 +72,8 @@ describe('getOnSave', () => {
       originatingApp,
       visualizationIdFromUrl,
       dispatch,
-      mockServices
+      mockServices,
+      setSaveSuccess
     );
     const onSaveReturn = await onSave(onSaveProps);
     expect(savedWizardVis).toMatchInlineSnapshot(`
@@ -112,7 +116,8 @@ describe('getOnSave', () => {
       originatingApp,
       visualizationIdFromUrl,
       dispatch,
-      mockServices
+      mockServices,
+      setSaveSuccess
     );
     const onSaveResult = await onSave(onSaveProps);
     expect(savedWizardVis.title).toBe('save wizard wiz title');
@@ -130,7 +135,8 @@ describe('getOnSave', () => {
       originatingApp,
       visualizationIdFromUrl,
       dispatch,
-      mockServices
+      mockServices,
+      setSaveSuccess
     );
     const onSaveResult = await onSave(onSaveProps);
     expect(onSaveResult?.id).toBe('2');
@@ -147,7 +153,8 @@ describe('getOnSave', () => {
       originatingApp,
       visualizationIdFromUrl,
       dispatch,
-      mockServices
+      mockServices,
+      setSaveSuccess
     );
     const onSaveResult = await onSave(onSaveProps);
     expect(onSaveResult?.id).toBe('1');

--- a/src/plugins/vis_builder/public/plugin.ts
+++ b/src/plugins/vis_builder/public/plugin.ts
@@ -89,6 +89,7 @@ export class WizardPlugin
           savedWizardLoader: selfStart.savedWizardLoader,
           embeddable: pluginsStart.embeddable,
           scopedHistory: params.history,
+          onAppLeave: params.onAppLeave,
         };
 
         // Instantiate the store

--- a/src/plugins/vis_builder/public/types.ts
+++ b/src/plugins/vis_builder/public/types.ts
@@ -45,6 +45,7 @@ export interface WizardServices extends CoreStart {
   history: History;
   embeddable: EmbeddableStart;
   scopedHistory: ScopedHistory;
+  onAppLeave: AppMountParameters['onAppLeave'];
 }
 
 export interface ISavedVis {


### PR DESCRIPTION
Signed-off-by: abbyhu2000 <abigailhu2000@gmail.com>

### Description
When user creates a vis builder visualization from a dashboard, there should be a cancel button on the top nav next to the save buttons. User should be prompted to see a cancel confirmation window when they click cancel button, and the changes will be discarded and not saved.
 
### Issues Resolved
resolves #2382 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 