### PR TITLE
[Vis Builder] Rename wizard to visBuilder in i18n id and formatted message id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [Vis Builder] Change classname prefix wiz to vb ([#2581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2581/files))
 * [Vis Builder] Change wizard to vis_builder in file names and paths ([#2587](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2587))
 * [Multi DataSource] Address UX comments on Data source list and create page ([#2625](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2625))
+* [Vis Builder] Rename wizard to visBuilder in i18n id and formatted message id ([#2635](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2635))
 
 ### 🐛 Bug Fixes
 * [Vis Builder] Fixes auto bounds for timeseries bar chart visualization ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))

--- a/src/plugins/vis_builder/public/application/components/data_source_select.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_source_select.tsx
@@ -39,7 +39,7 @@ export const DataSourceSelect = () => {
           dispatch(setIndexPattern(foundOption.id));
         }
       }}
-      prepend={i18n.translate('wizard.nav.dataSource.selector.title', {
+      prepend={i18n.translate('visBuilder.nav.dataSource.selector.title', {
         defaultMessage: 'Data Source',
       })}
       error={error}

--- a/src/plugins/vis_builder/public/application/components/data_tab/field_search.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/field_search.tsx
@@ -21,7 +21,7 @@ export interface Props {
  * Additionally there's a button displayed that allows the user to show/hide more filter fields
  */
 export function FieldSearch({ value }: Props) {
-  const searchPlaceholder = i18n.translate('wizard.fieldChooser.searchPlaceHolder', {
+  const searchPlaceholder = i18n.translate('visBuilder.fieldChooser.searchPlaceHolder', {
     defaultMessage: 'Search field names',
   });
 

--- a/src/plugins/vis_builder/public/application/components/experimental_info.tsx
+++ b/src/plugins/vis_builder/public/application/components/experimental_info.tsx
@@ -14,13 +14,13 @@ export const InfoComponent = () => {
       className="hide-for-sharing"
       data-test-subj="experimentalVisInfo"
       size="s"
-      title={i18n.translate('wizard.experimentalInfoTitle', {
+      title={i18n.translate('visBuilder.experimentalInfoTitle', {
         defaultMessage: 'This editor is experimental and should not be used in production',
       })}
       iconType="beaker"
     >
       <FormattedMessage
-        id="wizard.experimentalInfoText"
+        id="visBuilder.experimentalInfoText"
         defaultMessage="We want to hear from you about how we can improve your experience. Leave feedback in {githubLink}."
         values={{
           githubLink: (

--- a/src/plugins/vis_builder/public/application/components/right_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/right_nav.tsx
@@ -53,13 +53,13 @@ export const RightNav = () => {
       </div>
       {newVisType && (
         <EuiConfirmModal
-          title={i18n.translate('wizard.rightNav.changeVisType.modalTitle', {
+          title={i18n.translate('visBuilder.rightNav.changeVisType.modalTitle', {
             defaultMessage: 'Change visualization type',
           })}
-          confirmButtonText={i18n.translate('wizard.rightNav.changeVisType.confirmText', {
+          confirmButtonText={i18n.translate('visBuilder.rightNav.changeVisType.confirmText', {
             defaultMessage: 'Change type',
           })}
-          cancelButtonText={i18n.translate('wizard.rightNav.changeVisType.cancelText', {
+          cancelButtonText={i18n.translate('visBuilder.rightNav.changeVisType.cancelText', {
             defaultMessage: 'Cancel',
           })}
           onCancel={() => setNewVisType(undefined)}
@@ -78,7 +78,7 @@ export const RightNav = () => {
         >
           <p>
             <FormattedMessage
-              id="wizard.rightNav.changeVisType.modalDescription"
+              id="visBuilder.rightNav.changeVisType.modalDescription"
               defaultMessage="Changing the visualization type will reset all field selections. Do you want to continue?"
             />
           </p>

--- a/src/plugins/vis_builder/public/application/utils/breadcrumbs.ts
+++ b/src/plugins/vis_builder/public/application/utils/breadcrumbs.ts
@@ -6,14 +6,14 @@
 import { i18n } from '@osd/i18n';
 import { VISUALIZE_ID } from '../../../common';
 
-const defaultEditText = i18n.translate('wizard.editor.defaultEditBreadcrumbText', {
+const defaultEditText = i18n.translate('visBuilder.editor.defaultEditBreadcrumbText', {
   defaultMessage: 'Edit',
 });
 
 export function getVisualizeLandingBreadcrumbs(navigateToApp) {
   return [
     {
-      text: i18n.translate('wizard.listing.breadcrumb', {
+      text: i18n.translate('visBuilder.listing.breadcrumb', {
         defaultMessage: 'Visualize',
       }),
       onClick: () => navigateToApp(VISUALIZE_ID),
@@ -25,7 +25,7 @@ export function getCreateBreadcrumbs(navigateToApp) {
   return [
     ...getVisualizeLandingBreadcrumbs(navigateToApp),
     {
-      text: i18n.translate('wizard.editor.createBreadcrumb', {
+      text: i18n.translate('visBuilder.editor.createBreadcrumb', {
         defaultMessage: 'Create',
       }),
     },

--- a/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
@@ -69,16 +69,16 @@ export const getTopNavConfig = (
       id: 'save',
       iconType: savedWizardVis?.id && originatingApp ? undefined : ('save' as const),
       emphasize: savedWizardVis && !savedWizardVis.id,
-      description: i18n.translate('wizard.topNavMenu.saveVisualizationButtonAriaLabel', {
+      description: i18n.translate('visBuilder.topNavMenu.saveVisualizationButtonAriaLabel', {
         defaultMessage: 'Save Visualization',
       }),
       className: savedWizardVis?.id && originatingApp ? 'saveAsButton' : '',
       label:
         savedWizardVis?.id && originatingApp
-          ? i18n.translate('wizard.topNavMenu.saveVisualizationAsButtonLabel', {
+          ? i18n.translate('visBuilder.topNavMenu.saveVisualizationAsButtonLabel', {
               defaultMessage: 'save as',
             })
-          : i18n.translate('wizard.topNavMenu.saveVisualizationButtonLabel', {
+          : i18n.translate('visBuilder.topNavMenu.saveVisualizationButtonLabel', {
               defaultMessage: 'save',
             }),
       testId: 'wizardSaveButton',
@@ -115,7 +115,7 @@ export const getTopNavConfig = (
             emphasize: true,
             iconType: 'checkInCircleFilled' as const,
             description: i18n.translate(
-              'wizard.topNavMenu.saveAndReturnVisualizationButtonAriaLabel',
+              'visBuilder.topNavMenu.saveAndReturnVisualizationButtonAriaLabel',
               {
                 defaultMessage: 'Finish editing wizard and return to the last app',
               }
@@ -193,7 +193,7 @@ export const getOnSave = (
 
       if (id) {
         toastNotifications.addSuccess({
-          title: i18n.translate('wizard.topNavMenu.saveVisualization.successNotificationText', {
+          title: i18n.translate('visBuilder.topNavMenu.saveVisualization.successNotificationText', {
             defaultMessage: `Saved '{visTitle}'`,
             values: {
               visTitle: savedWizardVis.title,
@@ -236,7 +236,7 @@ export const getOnSave = (
       console.error(error);
 
       toastNotifications.addDanger({
-        title: i18n.translate('wizard.topNavMenu.saveVisualization.failureNotificationText', {
+        title: i18n.translate('visBuilder.topNavMenu.saveVisualization.failureNotificationText', {
           defaultMessage: `Error on saving '{visTitle}'`,
           values: {
             visTitle: newTitle,

--- a/src/plugins/vis_builder/public/application/utils/use/use_can_save.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_can_save.ts
@@ -22,7 +22,7 @@ export const useCanSave = () => {
 // TODO: Need to finalize the error messages
 const getErrorMsg = (isEmpty, hasNoChange, hasDraftAgg) => {
   const i18nTranslate = (key: string, defaultMessage: string) =>
-    i18n.translate(`wizard.saveVisualizationTooltip.${key}`, {
+    i18n.translate(`visBuilder.saveVisualizationTooltip.${key}`, {
       defaultMessage,
     });
 

--- a/src/plugins/vis_builder/public/embeddable/disabled_visualization.tsx
+++ b/src/plugins/vis_builder/public/embeddable/disabled_visualization.tsx
@@ -15,14 +15,14 @@ export function DisabledVisualization({ title }: { title: string }) {
       <EuiIcon type="beaker" size="xl" />
       <div>
         <FormattedMessage
-          id="wizard.disabledVisualizationTitle"
+          id="visBuilder.disabledVisualizationTitle"
           defaultMessage="{title} is an experimental visualization."
           values={{ title: <em className="visDisabledLabVisualization__title">{title}</em> }}
         />
       </div>
       <div>
         <FormattedMessage
-          id="wizard.disabledVisualizationMessage"
+          id="visBuilder.disabledVisualizationMessage"
           defaultMessage="Please turn on lab-mode in the advanced settings to see these visualizations."
         />
       </div>

--- a/src/plugins/vis_builder/public/embeddable/vis_builder_embeddable_factory.tsx
+++ b/src/plugins/vis_builder/public/embeddable/vis_builder_embeddable_factory.tsx
@@ -106,7 +106,7 @@ export class WizardEmbeddableFactoryDefinition
   }
 
   public getDisplayName() {
-    return i18n.translate('wizard.displayName', {
+    return i18n.translate('visBuilder.displayName', {
       defaultMessage: PLUGIN_ID,
     });
   }

--- a/src/plugins/vis_builder/public/plugin.ts
+++ b/src/plugins/vis_builder/public/plugin.ts
@@ -110,8 +110,8 @@ export class WizardPlugin
     visualizations.registerAlias({
       name: PLUGIN_ID,
       title: PLUGIN_NAME,
-      description: i18n.translate('wizard.visPicker.description', {
-        defaultMessage: 'Create visualizations using the new Drag & Drop experience',
+      description: i18n.translate('visBuilder.visPicker.description', {
+        defaultMessage: 'Create visualizations using the new Visualization Builder',
       }),
       icon: wizardIconSecondaryFill,
       stage: 'experimental',


### PR DESCRIPTION
Signed-off-by: abbyhu2000 <abigailhu2000@gmail.com>

### Description
Rename wizard to visBuilder in i18n id and formatted message id
 
### Issues Resolved
resolves part of #1706 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 