### PR TITLE
[Vis Builder] Rename wizard to visBuilder in class name, type name and function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [Vis Builder] Change wizard to vis_builder in file names and paths ([#2587](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2587))
 * [Multi DataSource] Address UX comments on Data source list and create page ([#2625](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2625))
 * [Vis Builder] Rename wizard to visBuilder in i18n id and formatted message id ([#2635](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2635))
+* [Vis Builder] Rename wizard to visBuilder in class name, type name and function name ([#2639](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2639))
 
 ### 🐛 Bug Fixes
 * [Vis Builder] Fixes auto bounds for timeseries bar chart visualization ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))

--- a/src/plugins/vis_builder/common/index.ts
+++ b/src/plugins/vis_builder/common/index.ts
@@ -9,6 +9,6 @@ export const VISUALIZE_ID = 'visualize';
 export const EDIT_PATH = '/edit';
 
 export {
-  WizardSavedObjectAttributes,
-  WIZARD_SAVED_OBJECT,
+  VisBuilderSavedObjectAttributes,
+  VISBUILDER_SAVED_OBJECT,
 } from './vis_builder_saved_object_attributes';

--- a/src/plugins/vis_builder/common/vis_builder_saved_object_attributes.ts
+++ b/src/plugins/vis_builder/common/vis_builder_saved_object_attributes.ts
@@ -5,9 +5,9 @@
 
 import { SavedObjectAttributes } from '../../../core/types';
 
-export const WIZARD_SAVED_OBJECT = 'wizard';
+export const VISBUILDER_SAVED_OBJECT = 'wizard';
 
-export interface WizardSavedObjectAttributes extends SavedObjectAttributes {
+export interface VisBuilderSavedObjectAttributes extends SavedObjectAttributes {
   title: string;
   description?: string;
   visualizationState?: string;

--- a/src/plugins/vis_builder/public/application/app.tsx
+++ b/src/plugins/vis_builder/public/application/app.tsx
@@ -13,7 +13,7 @@ import { Workspace } from './components/workspace';
 import './app.scss';
 import { RightNav } from './components/right_nav';
 
-export const WizardApp = () => {
+export const VisBuilderApp = () => {
   // Render the application DOM.
   return (
     <I18nProvider>

--- a/src/plugins/vis_builder/public/application/components/data_tab/field_search.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/field_search.tsx
@@ -17,7 +17,7 @@ export interface Props {
 }
 
 /**
- * Component is Wizard's side bar to  search of available fields
+ * Component is VisBuilder's side bar to  search of available fields
  * Additionally there's a button displayed that allows the user to show/hide more filter fields
  */
 export function FieldSearch({ value }: Props) {

--- a/src/plugins/vis_builder/public/application/components/data_tab/secondary_panel.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/secondary_panel.tsx
@@ -11,7 +11,7 @@ import { DefaultEditorAggParams } from '../../../../../vis_default_editor/public
 import { Title } from './title';
 import { useIndexPatterns, useVisualizationType } from '../../utils/use';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
-import { WizardServices } from '../../../types';
+import { VisBuilderServices } from '../../../types';
 import { AggParam, IAggType, IFieldParamType } from '../../../../../data/public';
 import { saveDraftAgg, editDraftAgg } from '../../utils/state_management/visualization_slice';
 import { setValidity } from '../../utils/state_management/metadata_slice';
@@ -33,7 +33,7 @@ export function SecondaryPanel() {
         search: { aggs: aggService },
       },
     },
-  } = useOpenSearchDashboards<WizardServices>();
+  } = useOpenSearchDashboards<VisBuilderServices>();
   const schemas = vizType.ui.containerConfig.data.schemas.all;
 
   const aggConfigs = useMemo(() => {

--- a/src/plugins/vis_builder/public/application/components/data_tab/use/use_dropbox.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/use/use_dropbox.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../../utils/state_management/visualization_slice';
 import { useIndexPatterns } from '../../../utils/use/use_index_pattern';
 import { useOpenSearchDashboards } from '../../../../../../opensearch_dashboards_react/public';
-import { WizardServices } from '../../../../types';
+import { VisBuilderServices } from '../../../../types';
 
 const filterByName = propFilter('name');
 const filterByType = propFilter('type');
@@ -38,7 +38,7 @@ export const useDropbox = (props: UseDropboxProps): DropboxProps => {
         search: { aggs: aggService },
       },
     },
-  } = useOpenSearchDashboards<WizardServices>();
+  } = useOpenSearchDashboards<VisBuilderServices>();
   const aggConfigParams = useTypedSelector(
     (state) => state.visualization.activeVisualization?.aggConfigParams
   );

--- a/src/plugins/vis_builder/public/application/components/right_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/right_nav.tsx
@@ -16,14 +16,14 @@ import { FormattedMessage } from '@osd/i18n/react';
 import { useVisualizationType } from '../utils/use';
 import './side_nav.scss';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
-import { WizardServices } from '../../types';
+import { VisBuilderServices } from '../../types';
 import { setActiveVisualization, useTypedDispatch } from '../utils/state_management';
 
 export const RightNav = () => {
   const [newVisType, setNewVisType] = useState<string>();
   const {
     services: { types },
-  } = useOpenSearchDashboards<WizardServices>();
+  } = useOpenSearchDashboards<VisBuilderServices>();
   const { ui, name: activeVisName } = useVisualizationType();
   const dispatch = useTypedDispatch();
   const StyleSection = ui.containerConfig.style.render;

--- a/src/plugins/vis_builder/public/application/components/top_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/top_nav.tsx
@@ -9,10 +9,10 @@ import { useUnmount } from 'react-use';
 import { PLUGIN_ID } from '../../../common';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { getTopNavConfig } from '../utils/get_top_nav_config';
-import { WizardServices } from '../../types';
+import { VisBuilderServices } from '../../types';
 
 import './top_nav.scss';
-import { useIndexPatterns, useSavedWizardVis } from '../utils/use';
+import { useIndexPatterns, useSavedVisBuilderVis } from '../utils/use';
 import { useTypedSelector, useTypedDispatch } from '../utils/state_management';
 import { setEditorState } from '../utils/state_management/metadata_slice';
 import { useCanSave } from '../utils/use/use_can_save';
@@ -22,7 +22,7 @@ import { TopNavMenuData } from '../../../../navigation/public';
 export const TopNav = () => {
   // id will only be set for the edit route
   const { id: visualizationIdFromUrl } = useParams<{ id: string }>();
-  const { services } = useOpenSearchDashboards<WizardServices>();
+  const { services } = useOpenSearchDashboards<VisBuilderServices>();
   const {
     setHeaderActionMenu,
     navigation: {
@@ -33,18 +33,18 @@ export const TopNav = () => {
   const dispatch = useTypedDispatch();
 
   const saveDisabledReason = useCanSave();
-  const savedWizardVis = useSavedWizardVis(visualizationIdFromUrl);
+  const savedVisBuilderVis = useSavedVisBuilderVis(visualizationIdFromUrl);
   const { selected: indexPattern } = useIndexPatterns();
   const [config, setConfig] = useState<TopNavMenuData[] | undefined>();
 
   useEffect(() => {
     const getConfig = () => {
-      if (!savedWizardVis || !indexPattern) return;
+      if (!savedVisBuilderVis || !indexPattern) return;
 
       return getTopNavConfig(
         {
           visualizationIdFromUrl,
-          savedWizardVis: saveStateToSavedObject(savedWizardVis, rootState, indexPattern),
+          savedVisBuilderVis: saveStateToSavedObject(savedVisBuilderVis, rootState, indexPattern),
           saveDisabledReason,
           dispatch,
         },
@@ -55,7 +55,7 @@ export const TopNav = () => {
     setConfig(getConfig());
   }, [
     rootState,
-    savedWizardVis,
+    savedVisBuilderVis,
     services,
     visualizationIdFromUrl,
     saveDisabledReason,

--- a/src/plugins/vis_builder/public/application/components/workspace.tsx
+++ b/src/plugins/vis_builder/public/application/components/workspace.tsx
@@ -7,7 +7,7 @@ import { EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiPanel } from '@e
 import React, { FC, useState, useMemo, useEffect, useLayoutEffect } from 'react';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { IExpressionLoaderParams } from '../../../../expressions/public';
-import { WizardServices } from '../../types';
+import { VisBuilderServices } from '../../types';
 import { validateSchemaState } from '../utils/validate_schema_state';
 import { useTypedSelector } from '../utils/state_management';
 import { useVisualizationType } from '../utils/use';
@@ -26,7 +26,7 @@ export const Workspace: FC = ({ children }) => {
       notifications: { toasts },
       data,
     },
-  } = useOpenSearchDashboards<WizardServices>();
+  } = useOpenSearchDashboards<VisBuilderServices>();
   const { toExpression, ui } = useVisualizationType();
   const [expression, setExpression] = useState<string>();
   const [searchContext, setSearchContext] = useState<IExpressionLoaderParams['searchContext']>({

--- a/src/plugins/vis_builder/public/application/index.tsx
+++ b/src/plugins/vis_builder/public/application/index.tsx
@@ -9,14 +9,14 @@ import { Router, Route, Switch } from 'react-router-dom';
 import { Provider as ReduxProvider } from 'react-redux';
 import { Store } from 'redux';
 import { AppMountParameters } from '../../../../core/public';
-import { WizardServices } from '../types';
-import { WizardApp } from './app';
+import { VisBuilderServices } from '../types';
+import { VisBuilderApp } from './app';
 import { OpenSearchDashboardsContextProvider } from '../../../opensearch_dashboards_react/public';
 import { EDIT_PATH } from '../../common';
 
 export const renderApp = (
   { element, history }: AppMountParameters,
-  services: WizardServices,
+  services: VisBuilderServices,
   store: Store
 ) => {
   ReactDOM.render(
@@ -26,7 +26,7 @@ export const renderApp = (
           <services.i18n.Context>
             <Switch>
               <Route path={[`${EDIT_PATH}/:id`, '/']} exact={false}>
-                <WizardApp />
+                <VisBuilderApp />
               </Route>
             </Switch>
           </services.i18n.Context>

--- a/src/plugins/vis_builder/public/application/utils/get_saved_vis_builder_vis.ts
+++ b/src/plugins/vis_builder/public/application/utils/get_saved_vis_builder_vis.ts
@@ -3,14 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { WizardServices } from '../..';
+import { VisBuilderServices } from '../..';
 
-export const getSavedWizardVis = async (services: WizardServices, wizardVisId?: string) => {
-  const { savedWizardLoader } = services;
-  if (!savedWizardLoader) {
+export const getSavedVisBuilderVis = async (
+  services: VisBuilderServices,
+  visBuilderVisId?: string
+) => {
+  const { savedVisBuilderLoader } = services;
+  if (!savedVisBuilderLoader) {
     return {};
   }
-  const savedWizardVis = await savedWizardLoader.get(wizardVisId);
+  const savedVisBuilderVis = await savedVisBuilderLoader.get(visBuilderVisId);
 
-  return savedWizardVis;
+  return savedVisBuilderVis;
 };

--- a/src/plugins/vis_builder/public/application/utils/get_top_nav_config.test.tsx
+++ b/src/plugins/vis_builder/public/application/utils/get_top_nav_config.test.tsx
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { WizardServices } from '../../types';
+import { VisBuilderServices } from '../../types';
 import { getOnSave } from './get_top_nav_config';
-import { createWizardServicesMock } from './mocks';
+import { createVisBuilderServicesMock } from './mocks';
 
 describe('getOnSave', () => {
-  let savedWizardVis: any;
+  let savedVisBuilderVis: any;
   let originatingApp: string | undefined;
   let visualizationIdFromUrl: string;
   let dispatch: any;
-  let mockServices: jest.Mocked<WizardServices>;
+  let mockServices: jest.Mocked<VisBuilderServices>;
   let onSaveProps: {
     newTitle: string;
     newCopyOnSave: boolean;
@@ -23,9 +23,9 @@ describe('getOnSave', () => {
   };
 
   beforeEach(() => {
-    savedWizardVis = {
+    savedVisBuilderVis = {
       id: '1',
-      title: 'save wizard wiz title',
+      title: 'save visBuilder wiz title',
       description: '',
       visualizationState: '',
       styleState: '',
@@ -37,7 +37,7 @@ describe('getOnSave', () => {
     originatingApp = '';
     visualizationIdFromUrl = '';
     dispatch = jest.fn();
-    mockServices = createWizardServicesMock();
+    mockServices = createVisBuilderServicesMock();
 
     onSaveProps = {
       newTitle: 'new title',
@@ -49,10 +49,10 @@ describe('getOnSave', () => {
     };
   });
 
-  test('return undefined when savedWizardVis is null', async () => {
-    savedWizardVis = null;
+  test('return undefined when savedVisBuilderVis is null', async () => {
+    savedVisBuilderVis = null;
     const onSave = getOnSave(
-      savedWizardVis,
+      savedVisBuilderVis,
       originatingApp,
       visualizationIdFromUrl,
       dispatch,
@@ -63,16 +63,16 @@ describe('getOnSave', () => {
     expect(onSaveResult).toBeUndefined();
   });
 
-  test('savedWizardVis get saved correctly', async () => {
+  test('savedVisBuilderVis get saved correctly', async () => {
     const onSave = getOnSave(
-      savedWizardVis,
+      savedVisBuilderVis,
       originatingApp,
       visualizationIdFromUrl,
       dispatch,
       mockServices
     );
     const onSaveReturn = await onSave(onSaveProps);
-    expect(savedWizardVis).toMatchInlineSnapshot(`
+    expect(savedVisBuilderVis).toMatchInlineSnapshot(`
       Object {
         "copyOnSave": false,
         "description": "new description",
@@ -105,28 +105,28 @@ describe('getOnSave', () => {
     expect(onSaveReturn?.id).toBe('1');
   });
 
-  test('savedWizardVis does not change title with a null id', async () => {
-    savedWizardVis.save = jest.fn().mockReturnValue(null);
+  test('savedVisBuilderVis does not change title with a null id', async () => {
+    savedVisBuilderVis.save = jest.fn().mockReturnValue(null);
     const onSave = getOnSave(
-      savedWizardVis,
+      savedVisBuilderVis,
       originatingApp,
       visualizationIdFromUrl,
       dispatch,
       mockServices
     );
     const onSaveResult = await onSave(onSaveProps);
-    expect(savedWizardVis.title).toBe('save wizard wiz title');
+    expect(savedVisBuilderVis.title).toBe('save visBuilder wiz title');
     expect(onSaveResult?.id).toBeNull();
   });
 
-  test('create a new wizard from dashboard', async () => {
-    savedWizardVis.id = undefined;
-    savedWizardVis.save = jest.fn().mockReturnValue('2');
+  test('create a new visBuilder from dashboard', async () => {
+    savedVisBuilderVis.id = undefined;
+    savedVisBuilderVis.save = jest.fn().mockReturnValue('2');
     originatingApp = 'dashboard';
     onSaveProps.returnToOrigin = true;
 
     const onSave = getOnSave(
-      savedWizardVis,
+      savedVisBuilderVis,
       originatingApp,
       visualizationIdFromUrl,
       dispatch,
@@ -137,13 +137,13 @@ describe('getOnSave', () => {
     expect(dispatch).toBeCalledTimes(0);
   });
 
-  test('edit an exising wizard from dashboard', async () => {
-    savedWizardVis.copyOnSave = false;
+  test('edit an exising visBuilder from dashboard', async () => {
+    savedVisBuilderVis.copyOnSave = false;
     onSaveProps.newDescription = 'new description after editing';
     originatingApp = 'dashboard';
     onSaveProps.returnToOrigin = true;
     const onSave = getOnSave(
-      savedWizardVis,
+      savedVisBuilderVis,
       originatingApp,
       visualizationIdFromUrl,
       dispatch,
@@ -152,6 +152,6 @@ describe('getOnSave', () => {
     const onSaveResult = await onSave(onSaveProps);
     expect(onSaveResult?.id).toBe('1');
     expect(mockServices.application.navigateToApp).toBeCalledTimes(1);
-    expect(savedWizardVis.description).toBe('new description after editing');
+    expect(savedVisBuilderVis.description).toBe('new description after editing');
   });
 });

--- a/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
@@ -36,21 +36,21 @@ import {
   SavedObjectSaveOpts,
   showSaveModal,
 } from '../../../../saved_objects/public';
-import { WizardServices } from '../..';
-import { WizardVisSavedObject } from '../../types';
+import { VisBuilderServices } from '../..';
+import { VisBuilderVisSavedObject } from '../../types';
 import { AppDispatch } from './state_management';
 import { EDIT_PATH } from '../../../common';
 import { setEditorState } from './state_management/metadata_slice';
 export interface TopNavConfigParams {
   visualizationIdFromUrl: string;
-  savedWizardVis: WizardVisSavedObject;
+  savedVisBuilderVis: VisBuilderVisSavedObject;
   saveDisabledReason?: string;
   dispatch: AppDispatch;
 }
 
 export const getTopNavConfig = (
-  { visualizationIdFromUrl, savedWizardVis, saveDisabledReason, dispatch }: TopNavConfigParams,
-  services: WizardServices
+  { visualizationIdFromUrl, savedVisBuilderVis, saveDisabledReason, dispatch }: TopNavConfigParams,
+  services: VisBuilderServices
 ) => {
   const {
     i18n: { Context: I18nContext },
@@ -67,14 +67,14 @@ export const getTopNavConfig = (
   const topNavConfig: TopNavMenuData[] = [
     {
       id: 'save',
-      iconType: savedWizardVis?.id && originatingApp ? undefined : ('save' as const),
-      emphasize: savedWizardVis && !savedWizardVis.id,
+      iconType: savedVisBuilderVis?.id && originatingApp ? undefined : ('save' as const),
+      emphasize: savedVisBuilderVis && !savedVisBuilderVis.id,
       description: i18n.translate('visBuilder.topNavMenu.saveVisualizationButtonAriaLabel', {
         defaultMessage: 'Save Visualization',
       }),
-      className: savedWizardVis?.id && originatingApp ? 'saveAsButton' : '',
+      className: savedVisBuilderVis?.id && originatingApp ? 'saveAsButton' : '',
       label:
-        savedWizardVis?.id && originatingApp
+        savedVisBuilderVis?.id && originatingApp
           ? i18n.translate('visBuilder.topNavMenu.saveVisualizationAsButtonLabel', {
               defaultMessage: 'save as',
             })
@@ -87,9 +87,9 @@ export const getTopNavConfig = (
       run: (_anchorElement) => {
         const saveModal = (
           <SavedObjectSaveModalOrigin
-            documentInfo={savedWizardVis}
+            documentInfo={savedVisBuilderVis}
             onSave={getOnSave(
-              savedWizardVis,
+              savedVisBuilderVis,
               originatingApp,
               visualizationIdFromUrl,
               dispatch,
@@ -105,7 +105,7 @@ export const getTopNavConfig = (
         showSaveModal(saveModal, I18nContext);
       },
     },
-    ...(originatingApp && ((savedWizardVis && savedWizardVis.id) || embeddableId)
+    ...(originatingApp && ((savedVisBuilderVis && savedVisBuilderVis.id) || embeddableId)
       ? [
           {
             id: 'saveAndReturn',
@@ -117,7 +117,7 @@ export const getTopNavConfig = (
             description: i18n.translate(
               'visBuilder.topNavMenu.saveAndReturnVisualizationButtonAriaLabel',
               {
-                defaultMessage: 'Finish editing wizard and return to the last app',
+                defaultMessage: 'Finish editing visBuilder and return to the last app',
               }
             ),
             testId: 'wizardsaveAndReturnButton',
@@ -125,15 +125,15 @@ export const getTopNavConfig = (
             tooltip: saveDisabledReason,
             run: async () => {
               const saveOptions = {
-                newTitle: savedWizardVis.title,
+                newTitle: savedVisBuilderVis.title,
                 newCopyOnSave: false,
                 isTitleDuplicateConfirmed: false,
-                newDescription: savedWizardVis.description,
+                newDescription: savedVisBuilderVis.description,
                 returnToOrigin: true,
               };
 
               const onSave = getOnSave(
-                savedWizardVis,
+                savedVisBuilderVis,
                 originatingApp,
                 visualizationIdFromUrl,
                 dispatch,
@@ -151,7 +151,7 @@ export const getTopNavConfig = (
 };
 
 export const getOnSave = (
-  savedWizardVis,
+  savedVisBuilderVis,
   originatingApp,
   visualizationIdFromUrl,
   dispatch,
@@ -173,18 +173,18 @@ export const getOnSave = (
     const { embeddable, toastNotifications, application, history } = services;
     const stateTransfer = embeddable.getStateTransfer();
 
-    if (!savedWizardVis) {
+    if (!savedVisBuilderVis) {
       return;
     }
 
-    const currentTitle = savedWizardVis.title;
-    savedWizardVis.title = newTitle;
-    savedWizardVis.description = newDescription;
-    savedWizardVis.copyOnSave = newCopyOnSave;
-    const newlyCreated = !savedWizardVis.id || savedWizardVis.copyOnSave;
+    const currentTitle = savedVisBuilderVis.title;
+    savedVisBuilderVis.title = newTitle;
+    savedVisBuilderVis.description = newDescription;
+    savedVisBuilderVis.copyOnSave = newCopyOnSave;
+    const newlyCreated = !savedVisBuilderVis.id || savedVisBuilderVis.copyOnSave;
 
     try {
-      const id = await savedWizardVis.save({
+      const id = await savedVisBuilderVis.save({
         confirmOverwrite: false,
         isTitleDuplicateConfirmed,
         onTitleDuplicate,
@@ -196,14 +196,14 @@ export const getOnSave = (
           title: i18n.translate('visBuilder.topNavMenu.saveVisualization.successNotificationText', {
             defaultMessage: `Saved '{visTitle}'`,
             values: {
-              visTitle: savedWizardVis.title,
+              visTitle: savedVisBuilderVis.title,
             },
           }),
           'data-test-subj': 'saveVisualizationSuccess',
         });
 
         if (originatingApp && returnToOrigin) {
-          // create or edit wizard directly from another app, such as `dashboard`
+          // create or edit visBuilder directly from another app, such as `dashboard`
           if (newlyCreated && stateTransfer) {
             // create new embeddable to transfer to originatingApp
             stateTransfer.navigateToWithEmbeddablePackage(originatingApp, {
@@ -211,7 +211,7 @@ export const getOnSave = (
             });
             return { id };
           } else {
-            // update an existing wizard from another app
+            // update an existing visBuilder from another app
             application.navigateToApp(originatingApp);
           }
         }
@@ -226,7 +226,7 @@ export const getOnSave = (
         dispatch(setEditorState({ state: 'clean' }));
       } else {
         // reset title if save not successful
-        savedWizardVis.title = currentTitle;
+        savedVisBuilderVis.title = currentTitle;
       }
 
       // Even if id='', which it will be for a duplicate title warning, we still want to return it, to avoid closing the modal
@@ -247,7 +247,7 @@ export const getOnSave = (
       });
 
       // reset title if save not successful
-      savedWizardVis.title = currentTitle;
+      savedVisBuilderVis.title = currentTitle;
       return { error };
     }
   };

--- a/src/plugins/vis_builder/public/application/utils/mocks.ts
+++ b/src/plugins/vis_builder/public/application/utils/mocks.ts
@@ -9,9 +9,9 @@ import { dataPluginMock } from '../../../../data/public/mocks';
 import { embeddablePluginMock } from '../../../../embeddable/public/mocks';
 import { expressionsPluginMock } from '../../../../expressions/public/mocks';
 import { navigationPluginMock } from '../../../../navigation/public/mocks';
-import { WizardServices } from '../../types';
+import { VisBuilderServices } from '../../types';
 
-export const createWizardServicesMock = () => {
+export const createVisBuilderServicesMock = () => {
   const coreStartMock = coreMock.createStart();
   const toastNotifications = coreStartMock.notifications.toasts;
   const applicationMock = coreStartMock.application;
@@ -21,11 +21,11 @@ export const createWizardServicesMock = () => {
   const navigationMock = navigationPluginMock.createStartContract();
   const expressionMock = expressionsPluginMock.createStartContract();
 
-  const wizardServicesMock = {
+  const visBuilderServicesMock = {
     ...coreStartMock,
     navigation: navigationMock,
     expression: expressionMock,
-    savedWizardLoader: {
+    savedVisBuilderLoader: {
       get: jest.fn(),
     } as any,
     setHeaderActionMenu: () => {},
@@ -41,5 +41,5 @@ export const createWizardServicesMock = () => {
     scopedHistory: (scopedHistoryMock.create() as unknown) as ScopedHistory,
   };
 
-  return (wizardServicesMock as unknown) as jest.Mocked<WizardServices>;
+  return (visBuilderServicesMock as unknown) as jest.Mocked<VisBuilderServices>;
 };

--- a/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
@@ -4,10 +4,10 @@
  */
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { WizardServices } from '../../../types';
+import { VisBuilderServices } from '../../../types';
 
 /*
- * Initial state: default state when opening wizard plugin
+ * Initial state: default state when opening visBuilder plugin
  * Clean state: when viz finished loading and ready to be edited
  * Dirty state: when there are changes applied to the viz after it finished loading
  */
@@ -33,7 +33,7 @@ const initialState: MetadataState = {
 export const getPreloadedState = async ({
   types,
   data,
-}: WizardServices): Promise<MetadataState> => {
+}: VisBuilderServices): Promise<MetadataState> => {
   const preloadedState = { ...initialState };
 
   return preloadedState;

--- a/src/plugins/vis_builder/public/application/utils/state_management/preload.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/preload.ts
@@ -4,14 +4,14 @@
  */
 
 import { PreloadedState } from '@reduxjs/toolkit';
-import { WizardServices } from '../../..';
+import { VisBuilderServices } from '../../..';
 import { getPreloadedState as getPreloadedStyleState } from './style_slice';
 import { getPreloadedState as getPreloadedVisualizationState } from './visualization_slice';
 import { getPreloadedState as getPreloadedMetadataState } from './metadata_slice';
 import { RootState } from './store';
 
 export const getPreloadedState = async (
-  services: WizardServices
+  services: VisBuilderServices
 ): Promise<PreloadedState<RootState>> => {
   const styleState = await getPreloadedStyleState(services);
   const visualizationState = await getPreloadedVisualizationState(services);

--- a/src/plugins/vis_builder/public/application/utils/state_management/store.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/store.ts
@@ -7,7 +7,7 @@ import { combineReducers, configureStore, PreloadedState } from '@reduxjs/toolki
 import { reducer as styleReducer } from './style_slice';
 import { reducer as visualizationReducer } from './visualization_slice';
 import { reducer as metadataReducer } from './metadata_slice';
-import { WizardServices } from '../../..';
+import { VisBuilderServices } from '../../..';
 import { getPreloadedState } from './preload';
 import { setEditorState } from './metadata_slice';
 
@@ -24,7 +24,7 @@ export const configurePreloadedStore = (preloadedState: PreloadedState<RootState
   });
 };
 
-export const getPreloadedStore = async (services: WizardServices) => {
+export const getPreloadedStore = async (services: VisBuilderServices) => {
   const preloadedState = await getPreloadedState(services);
   const store = configurePreloadedStore(preloadedState);
 

--- a/src/plugins/vis_builder/public/application/utils/state_management/style_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/style_slice.ts
@@ -4,14 +4,17 @@
  */
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { WizardServices } from '../../../types';
+import { VisBuilderServices } from '../../../types';
 import { setActiveVisualization } from './shared_actions';
 
 export type StyleState<T = any> = T;
 
 const initialState = {} as StyleState;
 
-export const getPreloadedState = async ({ types, data }: WizardServices): Promise<StyleState> => {
+export const getPreloadedState = async ({
+  types,
+  data,
+}: VisBuilderServices): Promise<StyleState> => {
   let preloadedState = initialState;
 
   const defaultVisualization = types.all()[0];

--- a/src/plugins/vis_builder/public/application/utils/state_management/visualization_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/visualization_slice.ts
@@ -5,7 +5,7 @@
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { CreateAggConfigParams } from '../../../../../data/common';
-import { WizardServices } from '../../../types';
+import { VisBuilderServices } from '../../../types';
 import { setActiveVisualization } from './shared_actions';
 
 export interface VisualizationState {
@@ -25,7 +25,7 @@ const initialState: VisualizationState = {
 export const getPreloadedState = async ({
   types,
   data,
-}: WizardServices): Promise<VisualizationState> => {
+}: VisBuilderServices): Promise<VisualizationState> => {
   const preloadedState = { ...initialState };
 
   const defaultVisualization = types.all()[0];

--- a/src/plugins/vis_builder/public/application/utils/use/index.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/index.ts
@@ -5,4 +5,4 @@
 
 export { useVisualizationType } from './use_visualization_type';
 export { useIndexPatterns } from './use_index_pattern';
-export { useSavedWizardVis } from './use_saved_vis_builder_vis';
+export { useSavedVisBuilderVis } from './use_saved_vis_builder_vis';

--- a/src/plugins/vis_builder/public/application/utils/use/use_index_pattern.tsx
+++ b/src/plugins/vis_builder/public/application/utils/use/use_index_pattern.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useState } from 'react';
 import { IndexPattern } from '../../../../../data/public';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
-import { WizardServices } from '../../../types';
+import { VisBuilderServices } from '../../../types';
 import { useTypedSelector } from '../state_management';
 
 export const useIndexPatterns = () => {
@@ -15,7 +15,7 @@ export const useIndexPatterns = () => {
   const [error, setError] = useState<Error | undefined>(undefined);
   const {
     services: { data },
-  } = useOpenSearchDashboards<WizardServices>();
+  } = useOpenSearchDashboards<VisBuilderServices>();
 
   let foundSelected: IndexPattern | undefined;
   if (!loading && !error) {

--- a/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
@@ -12,10 +12,10 @@ import {
   SavedObjectNotFound,
 } from '../../../../../opensearch_dashboards_utils/public';
 import { EDIT_PATH, PLUGIN_ID } from '../../../../common';
-import { WizardServices } from '../../../types';
+import { VisBuilderServices } from '../../../types';
 import { MetricOptionsDefaults } from '../../../visualizations/metric/metric_viz_type';
 import { getCreateBreadcrumbs, getEditBreadcrumbs } from '../breadcrumbs';
-import { getSavedWizardVis } from '../get_saved_vis_builder_vis';
+import { getSavedVisBuilderVis } from '../get_saved_vis_builder_vis';
 import {
   useTypedDispatch,
   setStyleState,
@@ -24,12 +24,12 @@ import {
 } from '../state_management';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { setEditorState } from '../state_management/metadata_slice';
-import { validateWizardState } from '../vis_builder_state_validation';
+import { validateVisBuilderState } from '../vis_builder_state_validation';
 
 // This function can be used when instantiating a saved vis or creating a new one
 // using url parameters, embedding and destroying it in DOM
-export const useSavedWizardVis = (visualizationIdFromUrl: string | undefined) => {
-  const { services } = useOpenSearchDashboards<WizardServices>();
+export const useSavedVisBuilderVis = (visualizationIdFromUrl: string | undefined) => {
+  const { services } = useOpenSearchDashboards<VisBuilderServices>();
   const [savedVisState, setSavedVisState] = useState<SavedObject | undefined>(undefined);
   const dispatch = useTypedDispatch();
 
@@ -49,27 +49,30 @@ export const useSavedWizardVis = (visualizationIdFromUrl: string | undefined) =>
         text: message,
       });
     };
-    const loadSavedWizardVis = async () => {
+    const loadSavedVisBuilderVis = async () => {
       try {
-        const savedWizardVis = await getSavedWizardVis(services, visualizationIdFromUrl);
+        const savedVisBuilderVis = await getSavedVisBuilderVis(services, visualizationIdFromUrl);
 
-        if (savedWizardVis.id) {
-          chrome.setBreadcrumbs(getEditBreadcrumbs(savedWizardVis.title, navigateToApp));
-          chrome.docTitle.change(savedWizardVis.title);
+        if (savedVisBuilderVis.id) {
+          chrome.setBreadcrumbs(getEditBreadcrumbs(savedVisBuilderVis.title, navigateToApp));
+          chrome.docTitle.change(savedVisBuilderVis.title);
         } else {
           chrome.setBreadcrumbs(getCreateBreadcrumbs(navigateToApp));
         }
 
-        if (savedWizardVis.styleState !== '{}' && savedWizardVis.visualizationState !== '{}') {
-          const styleState = JSON.parse(savedWizardVis.styleState);
-          const vizStateWithoutIndex = JSON.parse(savedWizardVis.visualizationState);
+        if (
+          savedVisBuilderVis.styleState !== '{}' &&
+          savedVisBuilderVis.visualizationState !== '{}'
+        ) {
+          const styleState = JSON.parse(savedVisBuilderVis.styleState);
+          const vizStateWithoutIndex = JSON.parse(savedVisBuilderVis.visualizationState);
           const visualizationState: VisualizationState = {
             searchField: vizStateWithoutIndex.searchField,
             activeVisualization: vizStateWithoutIndex.activeVisualization,
-            indexPattern: savedWizardVis.searchSourceFields.index,
+            indexPattern: savedVisBuilderVis.searchSourceFields.index,
           };
 
-          const validateResult = validateWizardState({ styleState, visualizationState });
+          const validateResult = validateVisBuilderState({ styleState, visualizationState });
           if (!validateResult.valid) {
             const err = validateResult.errors;
             if (err) {
@@ -82,7 +85,7 @@ export const useSavedWizardVis = (visualizationIdFromUrl: string | undefined) =>
           dispatch(setVisualizationState(visualizationState));
         }
 
-        setSavedVisState(savedWizardVis);
+        setSavedVisState(savedVisBuilderVis);
         dispatch(setEditorState({ state: 'clean' }));
       } catch (error) {
         const managementRedirectTarget = {
@@ -113,7 +116,7 @@ export const useSavedWizardVis = (visualizationIdFromUrl: string | undefined) =>
       }
     };
 
-    loadSavedWizardVis();
+    loadSavedVisBuilderVis();
   }, [dispatch, services, visualizationIdFromUrl]);
 
   return savedVisState;

--- a/src/plugins/vis_builder/public/application/utils/use/use_visualization_type.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_visualization_type.ts
@@ -5,14 +5,14 @@
 
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { VisualizationType } from '../../../services/type_service/visualization_type';
-import { WizardServices } from '../../../types';
+import { VisBuilderServices } from '../../../types';
 import { useTypedSelector } from '../state_management';
 
 export const useVisualizationType = (): VisualizationType => {
   const { activeVisualization } = useTypedSelector((state) => state.visualization);
   const {
     services: { types },
-  } = useOpenSearchDashboards<WizardServices>();
+  } = useOpenSearchDashboards<VisBuilderServices>();
 
   const visualizationType = types.get(activeVisualization?.name ?? '');
 

--- a/src/plugins/vis_builder/public/application/utils/vis_builder_state_validation.test.ts
+++ b/src/plugins/vis_builder/public/application/utils/vis_builder_state_validation.test.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { validateWizardState } from './vis_builder_state_validation';
+import { validateVisBuilderState } from './vis_builder_state_validation';
 
-describe('wizard state validation', () => {
+describe('visBuilder state validation', () => {
   const validStyleState = {
     addLegend: true,
     addTooltip: true,
@@ -21,8 +21,8 @@ describe('wizard state validation', () => {
     searchField: '',
   };
   describe('correct return when validation suceeds', () => {
-    test('with correct wizard state', () => {
-      const validationResult = validateWizardState({
+    test('with correct visBuilder state', () => {
+      const validationResult = validateVisBuilderState({
         styleState: validStyleState,
         visualizationState: validVisualizationState,
       });
@@ -32,7 +32,7 @@ describe('wizard state validation', () => {
   });
   describe('correct return with errors when validation fails', () => {
     test('with non object type styleStyle', () => {
-      const validationResult = validateWizardState({
+      const validationResult = validateVisBuilderState({
         styleState: [],
         visualizationState: validVisualizationState,
       });

--- a/src/plugins/vis_builder/public/application/utils/vis_builder_state_validation.ts
+++ b/src/plugins/vis_builder/public/application/utils/vis_builder_state_validation.ts
@@ -4,16 +4,16 @@
  */
 
 import Ajv from 'ajv';
-import wizardStateSchema from './schema.json';
+import visBuilderStateSchema from './schema.json';
 
 const ajv = new Ajv();
-const validateState = ajv.compile(wizardStateSchema);
+const validateState = ajv.compile(visBuilderStateSchema);
 
-export const validateWizardState = (wizardState) => {
-  const isWizardStateValid = validateState(wizardState);
+export const validateVisBuilderState = (visBuilderState) => {
+  const isVisBuilderStateValid = validateState(visBuilderState);
 
   return {
-    valid: isWizardStateValid,
+    valid: isVisBuilderStateValid,
     errors: validateState.errors,
   };
 };

--- a/src/plugins/vis_builder/public/embeddable/disabled_embeddable.tsx
+++ b/src/plugins/vis_builder/public/embeddable/disabled_embeddable.tsx
@@ -8,13 +8,13 @@ import ReactDOM from 'react-dom';
 import { Embeddable, EmbeddableOutput } from '../../../embeddable/public';
 
 import { DisabledVisualization } from './disabled_visualization';
-import { WizardInput, WIZARD_EMBEDDABLE } from './vis_builder_embeddable';
+import { VisBuilderInput, VISBUILDER_EMBEDDABLE } from './vis_builder_embeddable';
 
-export class DisabledEmbeddable extends Embeddable<WizardInput, EmbeddableOutput> {
+export class DisabledEmbeddable extends Embeddable<VisBuilderInput, EmbeddableOutput> {
   private domNode?: HTMLElement;
-  public readonly type = WIZARD_EMBEDDABLE;
+  public readonly type = VISBUILDER_EMBEDDABLE;
 
-  constructor(private readonly title: string, initialInput: WizardInput) {
+  constructor(private readonly title: string, initialInput: VisBuilderInput) {
     super(initialInput, { title });
   }
 

--- a/src/plugins/vis_builder/public/embeddable/vis_builder_component.tsx
+++ b/src/plugins/vis_builder/public/embeddable/vis_builder_component.tsx
@@ -6,16 +6,16 @@
 import React from 'react';
 
 import { SavedObjectEmbeddableInput, withEmbeddableSubscription } from '../../../embeddable/public';
-import { WizardEmbeddable, WizardOutput } from './vis_builder_embeddable';
+import { VisBuilderEmbeddable, VisBuilderOutput } from './vis_builder_embeddable';
 import { getReactExpressionRenderer } from '../plugin_services';
 
 interface Props {
-  embeddable: WizardEmbeddable;
+  embeddable: VisBuilderEmbeddable;
   input: SavedObjectEmbeddableInput;
-  output: WizardOutput;
+  output: VisBuilderOutput;
 }
 
-function WizardEmbeddableComponentInner({ embeddable, input: {}, output: { error } }: Props) {
+function VisBuilderEmbeddableComponentInner({ embeddable, input: {}, output: { error } }: Props) {
   const { expression } = embeddable;
   const ReactExpressionRenderer = getReactExpressionRenderer();
 
@@ -31,8 +31,8 @@ function WizardEmbeddableComponentInner({ embeddable, input: {}, output: { error
   );
 }
 
-export const WizardEmbeddableComponent = withEmbeddableSubscription<
+export const VisBuilderEmbeddableComponent = withEmbeddableSubscription<
   SavedObjectEmbeddableInput,
-  WizardOutput,
-  WizardEmbeddable
->(WizardEmbeddableComponentInner);
+  VisBuilderOutput,
+  VisBuilderEmbeddable
+>(VisBuilderEmbeddableComponentInner);

--- a/src/plugins/vis_builder/public/embeddable/vis_builder_embeddable.tsx
+++ b/src/plugins/vis_builder/public/embeddable/vis_builder_embeddable.tsx
@@ -7,7 +7,7 @@ import { cloneDeep, isEqual } from 'lodash';
 import ReactDOM from 'react-dom';
 import { merge, Subscription } from 'rxjs';
 
-import { PLUGIN_ID, WizardSavedObjectAttributes, WIZARD_SAVED_OBJECT } from '../../common';
+import { PLUGIN_ID, VisBuilderSavedObjectAttributes, VISBUILDER_SAVED_OBJECT } from '../../common';
 import {
   Embeddable,
   EmbeddableOutput,
@@ -32,10 +32,10 @@ import { getExpressionLoader, getTypeService } from '../plugin_services';
 import { PersistedState } from '../../../visualizations/public';
 
 // Apparently this needs to match the saved object type for the clone and replace panel actions to work
-export const WIZARD_EMBEDDABLE = WIZARD_SAVED_OBJECT;
+export const VISBUILDER_EMBEDDABLE = VISBUILDER_SAVED_OBJECT;
 
-export interface WizardEmbeddableConfiguration {
-  savedWizard: WizardSavedObjectAttributes;
+export interface VisBuilderEmbeddableConfiguration {
+  savedVisBuilder: VisBuilderSavedObjectAttributes;
   // TODO: add indexPatterns as part of configuration
   // indexPatterns?: IIndexPattern[];
   editPath: string;
@@ -43,18 +43,18 @@ export interface WizardEmbeddableConfiguration {
   editable: boolean;
 }
 
-export interface WizardOutput extends EmbeddableOutput {
+export interface VisBuilderOutput extends EmbeddableOutput {
   /**
-   * Will contain the saved object attributes of the Wizard Saved Object that matches
+   * Will contain the saved object attributes of the VisBuilder Saved Object that matches
    * `input.savedObjectId`. If the id is invalid, this may be undefined.
    */
-  savedWizard?: WizardSavedObjectAttributes;
+  savedVisBuilder?: VisBuilderSavedObjectAttributes;
 }
 
 type ExpressionLoader = InstanceType<ExpressionsStart['ExpressionLoader']>;
 
-export class WizardEmbeddable extends Embeddable<SavedObjectEmbeddableInput, WizardOutput> {
-  public readonly type = WIZARD_EMBEDDABLE;
+export class VisBuilderEmbeddable extends Embeddable<SavedObjectEmbeddableInput, VisBuilderOutput> {
+  public readonly type = VISBUILDER_EMBEDDABLE;
   private handler?: ExpressionLoader;
   private timeRange?: TimeRange;
   private query?: Query;
@@ -64,13 +64,13 @@ export class WizardEmbeddable extends Embeddable<SavedObjectEmbeddableInput, Wiz
   private autoRefreshFetchSubscription: Subscription;
   private subscriptions: Subscription[] = [];
   private node?: HTMLElement;
-  private savedWizard?: WizardSavedObjectAttributes;
+  private savedVisBuilder?: VisBuilderSavedObjectAttributes;
   private serializedState?: { visualization: string; style: string };
   private uiState?: PersistedState;
 
   constructor(
     timefilter: TimefilterContract,
-    { savedWizard, editPath, editUrl, editable }: WizardEmbeddableConfiguration,
+    { savedVisBuilder, editPath, editUrl, editable }: VisBuilderEmbeddableConfiguration,
     initialInput: SavedObjectEmbeddableInput,
     {
       parent,
@@ -81,17 +81,17 @@ export class WizardEmbeddable extends Embeddable<SavedObjectEmbeddableInput, Wiz
     super(
       initialInput,
       {
-        defaultTitle: savedWizard.title,
+        defaultTitle: savedVisBuilder.title,
         editPath,
         editApp: PLUGIN_ID,
         editUrl,
         editable,
-        savedWizard,
+        savedVisBuilder,
       },
       parent
     );
 
-    this.savedWizard = savedWizard;
+    this.savedVisBuilder = savedVisBuilder;
     this.uiState = new PersistedState();
 
     this.autoRefreshFetchSubscription = timefilter
@@ -107,7 +107,7 @@ export class WizardEmbeddable extends Embeddable<SavedObjectEmbeddableInput, Wiz
 
   private getSerializedState = () => {
     const { visualizationState: visualization = '{}', styleState: style = '{}' } =
-      this.savedWizard || {};
+      this.savedVisBuilder || {};
     return {
       visualization,
       style,
@@ -124,7 +124,7 @@ export class WizardEmbeddable extends Embeddable<SavedObjectEmbeddableInput, Wiz
     const visualizationState = {
       searchField: vizStateWithoutIndex.searchField,
       activeVisualization: vizStateWithoutIndex.activeVisualization,
-      indexPattern: this.savedWizard?.searchSourceFields?.index,
+      indexPattern: this.savedVisBuilder?.searchSourceFields?.index,
     };
     const rootState = {
       visualization: visualizationState,
@@ -162,7 +162,7 @@ export class WizardEmbeddable extends Embeddable<SavedObjectEmbeddableInput, Wiz
 
   // Needed to add informational tooltip
   public getDescription() {
-    return this.savedWizard?.description;
+    return this.savedVisBuilder?.description;
   }
 
   public render(node: HTMLElement) {
@@ -192,8 +192,8 @@ export class WizardEmbeddable extends Embeddable<SavedObjectEmbeddableInput, Wiz
       },
     });
 
-    if (this.savedWizard?.description) {
-      div.setAttribute('data-description', this.savedWizard.description);
+    if (this.savedVisBuilder?.description) {
+      div.setAttribute('data-description', this.savedVisBuilder.description);
     }
 
     div.setAttribute('data-test-subj', 'wizardLoader');
@@ -295,7 +295,7 @@ export class WizardEmbeddable extends Embeddable<SavedObjectEmbeddableInput, Wiz
     this.updateOutput({ loading: false, error });
   };
 
-  // TODO: we may eventually need to add support for visualizations that use triggers like filter or brush, but current wizard vis types don't support triggers
+  // TODO: we may eventually need to add support for visualizations that use triggers like filter or brush, but current VisBuilder vis types don't support triggers
   // public supportedTriggers(): TriggerId[] {
   //   return this.visType.getSupportedTriggers?.() ?? [];
   // }

--- a/src/plugins/vis_builder/public/embeddable/vis_builder_embeddable_factory.tsx
+++ b/src/plugins/vis_builder/public/embeddable/vis_builder_embeddable_factory.tsx
@@ -17,44 +17,53 @@ import {
   EDIT_PATH,
   PLUGIN_ID,
   PLUGIN_NAME,
-  WizardSavedObjectAttributes,
-  WIZARD_SAVED_OBJECT,
+  VisBuilderSavedObjectAttributes,
+  VISBUILDER_SAVED_OBJECT,
 } from '../../common';
 import { DisabledEmbeddable } from './disabled_embeddable';
-import { WizardEmbeddable, WizardOutput, WIZARD_EMBEDDABLE } from './vis_builder_embeddable';
-import wizardIcon from '../assets/wizard_icon.svg';
-import { getHttp, getSavedWizardLoader, getTimeFilter, getUISettings } from '../plugin_services';
+import {
+  VisBuilderEmbeddable,
+  VisBuilderOutput,
+  VISBUILDER_EMBEDDABLE,
+} from './vis_builder_embeddable';
+import visBuilderIcon from '../assets/wizard_icon.svg';
+import {
+  getHttp,
+  getSavedVisBuilderLoader,
+  getTimeFilter,
+  getUISettings,
+} from '../plugin_services';
 
 // TODO: use or remove?
-export type WizardEmbeddableFactory = EmbeddableFactory<
+export type VisBuilderEmbeddableFactory = EmbeddableFactory<
   SavedObjectEmbeddableInput,
-  WizardOutput | EmbeddableOutput,
-  WizardEmbeddable | DisabledEmbeddable,
-  WizardSavedObjectAttributes
+  VisBuilderOutput | EmbeddableOutput,
+  VisBuilderEmbeddable | DisabledEmbeddable,
+  VisBuilderSavedObjectAttributes
 >;
 
-export class WizardEmbeddableFactoryDefinition
+export class VisBuilderEmbeddableFactoryDefinition
   implements
     EmbeddableFactoryDefinition<
       SavedObjectEmbeddableInput,
-      WizardOutput | EmbeddableOutput,
-      WizardEmbeddable | DisabledEmbeddable,
-      WizardSavedObjectAttributes
+      VisBuilderOutput | EmbeddableOutput,
+      VisBuilderEmbeddable | DisabledEmbeddable,
+      VisBuilderSavedObjectAttributes
     > {
-  public readonly type = WIZARD_EMBEDDABLE;
+  public readonly type = VISBUILDER_EMBEDDABLE;
   public readonly savedObjectMetaData = {
     // TODO: Update to include most vis functionality
     name: PLUGIN_NAME,
     includeFields: ['visualizationState'],
-    type: WIZARD_SAVED_OBJECT,
-    getIconForSavedObject: () => wizardIcon,
+    type: VISBUILDER_SAVED_OBJECT,
+    getIconForSavedObject: () => visBuilderIcon,
   };
 
   // TODO: Would it be better to explicitly declare start service dependencies?
   constructor() {}
 
   public canCreateNew() {
-    // Because wizard creation starts with the visualization modal, no need to have a separate entry for wizard until it's separate
+    // Because VisBuilder creation starts with the visualization modal, no need to have a separate entry for VisBuilder until it's separate
     return false;
   }
 
@@ -68,9 +77,9 @@ export class WizardEmbeddableFactoryDefinition
     savedObjectId: string,
     input: Partial<SavedObjectEmbeddableInput> & { id: string },
     parent?: IContainer
-  ): Promise<WizardEmbeddable | ErrorEmbeddable | DisabledEmbeddable> {
+  ): Promise<VisBuilderEmbeddable | ErrorEmbeddable | DisabledEmbeddable> {
     try {
-      const savedWizard = await getSavedWizardLoader().get(savedObjectId);
+      const savedVisBuilder = await getSavedVisBuilderLoader().get(savedObjectId);
       const editPath = `${EDIT_PATH}/${savedObjectId}`;
       const editUrl = getHttp().basePath.prepend(`/app/${PLUGIN_ID}${editPath}`);
       const isLabsEnabled = getUISettings().get<boolean>(VISUALIZE_ENABLE_LABS_SETTING);
@@ -79,10 +88,10 @@ export class WizardEmbeddableFactoryDefinition
         return new DisabledEmbeddable(PLUGIN_NAME, input);
       }
 
-      return new WizardEmbeddable(
+      return new VisBuilderEmbeddable(
         getTimeFilter(),
         {
-          savedWizard,
+          savedVisBuilder,
           editUrl,
           editPath,
           editable: true,

--- a/src/plugins/vis_builder/public/index.ts
+++ b/src/plugins/vis_builder/public/index.ts
@@ -4,11 +4,11 @@
  */
 
 import { PluginInitializerContext } from '../../../core/public';
-import { WizardPlugin } from './plugin';
+import { VisBuilderPlugin } from './plugin';
 
 // This exports static code and TypeScript types,
 // as well as, OpenSearch Dashboards Platform `plugin()` initializer.
 export function plugin(initializerContext: PluginInitializerContext) {
-  return new WizardPlugin(initializerContext);
+  return new VisBuilderPlugin(initializerContext);
 }
-export { WizardServices, WizardPluginStartDependencies, WizardStart } from './types';
+export { VisBuilderServices, VisBuilderPluginStartDependencies, VisBuilderStart } from './types';

--- a/src/plugins/vis_builder/public/plugin.test.ts
+++ b/src/plugins/vis_builder/public/plugin.test.ts
@@ -10,12 +10,12 @@ import { embeddablePluginMock } from '../../embeddable/public/mocks';
 import { navigationPluginMock } from '../../navigation/public/mocks';
 import { visualizationsPluginMock } from '../../visualizations/public/mocks';
 import { PLUGIN_ID, PLUGIN_NAME } from '../common';
-import { WizardPlugin } from './plugin';
+import { VisBuilderPlugin } from './plugin';
 
-describe('WizardPlugin', () => {
+describe('VisBuilderPlugin', () => {
   describe('setup', () => {
     it('initializes the plugin correctly and registers it as an alias visualization', () => {
-      const plugin = new WizardPlugin(coreMock.createPluginInitializerContext());
+      const plugin = new VisBuilderPlugin(coreMock.createPluginInitializerContext());
       const pluginStartContract = {
         data: dataPluginMock.createStartContract(),
         savedObject: savedObjectsServiceMock.createStartContract(),

--- a/src/plugins/vis_builder/public/plugin.ts
+++ b/src/plugins/vis_builder/public/plugin.ts
@@ -13,43 +13,48 @@ import {
   PluginInitializerContext,
 } from '../../../core/public';
 import {
-  WizardPluginSetupDependencies,
-  WizardPluginStartDependencies,
-  WizardServices,
-  WizardSetup,
-  WizardStart,
+  VisBuilderPluginSetupDependencies,
+  VisBuilderPluginStartDependencies,
+  VisBuilderServices,
+  VisBuilderSetup,
+  VisBuilderStart,
 } from './types';
-import { WizardEmbeddableFactoryDefinition, WIZARD_EMBEDDABLE } from './embeddable';
-import wizardIconSecondaryFill from './assets/wizard_icon_secondary_fill.svg';
-import wizardIcon from './assets/wizard_icon.svg';
-import { EDIT_PATH, PLUGIN_ID, PLUGIN_NAME, WIZARD_SAVED_OBJECT } from '../common';
+import { VisBuilderEmbeddableFactoryDefinition, VISBUILDER_EMBEDDABLE } from './embeddable';
+import visBuilderIconSecondaryFill from './assets/wizard_icon_secondary_fill.svg';
+import visBuilderIcon from './assets/wizard_icon.svg';
+import { EDIT_PATH, PLUGIN_ID, PLUGIN_NAME, VISBUILDER_SAVED_OBJECT } from '../common';
 import { TypeService } from './services/type_service';
 import { getPreloadedStore } from './application/utils/state_management';
 import {
   setSearchService,
   setIndexPatterns,
   setHttp,
-  setSavedWizardLoader,
+  setSavedVisBuilderLoader,
   setExpressionLoader,
   setTimeFilter,
   setUISettings,
   setTypeService,
   setReactExpressionRenderer,
 } from './plugin_services';
-import { createSavedWizardLoader } from './saved_visualizations';
+import { createSavedVisBuilderLoader } from './saved_visualizations';
 import { registerDefaultTypes } from './visualizations';
 import { ConfigSchema } from '../config';
 
-export class WizardPlugin
+export class VisBuilderPlugin
   implements
-    Plugin<WizardSetup, WizardStart, WizardPluginSetupDependencies, WizardPluginStartDependencies> {
+    Plugin<
+      VisBuilderSetup,
+      VisBuilderStart,
+      VisBuilderPluginSetupDependencies,
+      VisBuilderPluginStartDependencies
+    > {
   private typeService = new TypeService();
 
   constructor(public initializerContext: PluginInitializerContext<ConfigSchema>) {}
 
   public setup(
-    core: CoreSetup<WizardPluginStartDependencies, WizardStart>,
-    { embeddable, visualizations }: WizardPluginSetupDependencies
+    core: CoreSetup<VisBuilderPluginStartDependencies, VisBuilderStart>,
+    { embeddable, visualizations }: VisBuilderPluginSetupDependencies
   ) {
     const typeService = this.typeService;
     registerDefaultTypes(typeService.setup());
@@ -76,7 +81,7 @@ export class WizardPlugin
 
         // Register Default Visualizations
 
-        const services: WizardServices = {
+        const services: VisBuilderServices = {
           ...coreStart,
           toastNotifications: coreStart.notifications.toasts,
           data,
@@ -86,7 +91,7 @@ export class WizardPlugin
           history: params.history,
           setHeaderActionMenu: params.setHeaderActionMenu,
           types: typeService.start(),
-          savedWizardLoader: selfStart.savedWizardLoader,
+          savedVisBuilderLoader: selfStart.savedVisBuilderLoader,
           embeddable: pluginsStart.embeddable,
           scopedHistory: params.history,
         };
@@ -102,9 +107,9 @@ export class WizardPlugin
     // Register embeddable
     // TODO: investigate simplification via getter a la visualizations:
     // const start = createStartServicesGetter(core.getStartServices));
-    // const embeddableFactory = new WizardEmbeddableFactoryDefinition({ start });
-    const embeddableFactory = new WizardEmbeddableFactoryDefinition();
-    embeddable.registerEmbeddableFactory(WIZARD_EMBEDDABLE, embeddableFactory);
+    // const embeddableFactory = new VisBuilderEmbeddableFactoryDefinition({ start });
+    const embeddableFactory = new VisBuilderEmbeddableFactoryDefinition();
+    embeddable.registerEmbeddableFactory(VISBUILDER_EMBEDDABLE, embeddableFactory);
 
     // Register the plugin as an alias to create visualization
     visualizations.registerAlias({
@@ -113,7 +118,7 @@ export class WizardPlugin
       description: i18n.translate('visBuilder.visPicker.description', {
         defaultMessage: 'Create visualizations using the new Visualization Builder',
       }),
-      icon: wizardIconSecondaryFill,
+      icon: visBuilderIconSecondaryFill,
       stage: 'experimental',
       aliasApp: PLUGIN_ID,
       aliasPath: '#/',
@@ -124,9 +129,9 @@ export class WizardPlugin
             description: attributes?.description,
             editApp: PLUGIN_ID,
             editUrl: `${EDIT_PATH}/${encodeURIComponent(id)}`,
-            icon: wizardIcon,
+            icon: visBuilderIcon,
             id,
-            savedObjectType: WIZARD_SAVED_OBJECT,
+            savedObjectType: VISBUILDER_SAVED_OBJECT,
             stage: 'experimental',
             title: attributes?.title,
             typeTitle: PLUGIN_NAME,
@@ -140,10 +145,13 @@ export class WizardPlugin
     };
   }
 
-  public start(core: CoreStart, { data, expressions }: WizardPluginStartDependencies): WizardStart {
+  public start(
+    core: CoreStart,
+    { data, expressions }: VisBuilderPluginStartDependencies
+  ): VisBuilderStart {
     const typeService = this.typeService.start();
 
-    const savedWizardLoader = createSavedWizardLoader({
+    const savedVisBuilderLoader = createSavedVisBuilderLoader({
       savedObjectsClient: core.savedObjects.client,
       indexPatterns: data.indexPatterns,
       search: data.search,
@@ -157,14 +165,14 @@ export class WizardPlugin
     setReactExpressionRenderer(expressions.ReactExpressionRenderer);
     setHttp(core.http);
     setIndexPatterns(data.indexPatterns);
-    setSavedWizardLoader(savedWizardLoader);
+    setSavedVisBuilderLoader(savedVisBuilderLoader);
     setTimeFilter(data.query.timefilter.timefilter);
     setTypeService(typeService);
     setUISettings(core.uiSettings);
 
     return {
       ...typeService,
-      savedWizardLoader,
+      savedVisBuilderLoader,
     };
   }
 

--- a/src/plugins/vis_builder/public/plugin_services.ts
+++ b/src/plugins/vis_builder/public/plugin_services.ts
@@ -5,7 +5,7 @@
 
 import { createGetterSetter } from '../../opensearch_dashboards_utils/common';
 import { DataPublicPluginStart, TimefilterContract } from '../../data/public';
-import { SavedWizardLoader } from './saved_visualizations';
+import { SavedVisBuilderLoader } from './saved_visualizations';
 import { HttpStart, IUiSettingsClient } from '../../../core/public';
 import { ExpressionsStart } from '../../expressions/public';
 import { TypeServiceStart } from './services/type_service';
@@ -28,9 +28,9 @@ export const [getIndexPatterns, setIndexPatterns] = createGetterSetter<
   DataPublicPluginStart['indexPatterns']
 >('data.indexPatterns');
 
-export const [getSavedWizardLoader, setSavedWizardLoader] = createGetterSetter<SavedWizardLoader>(
-  'SavedWizardLoader'
-);
+export const [getSavedVisBuilderLoader, setSavedVisBuilderLoader] = createGetterSetter<
+  SavedVisBuilderLoader
+>('SavedVisBuilderLoader');
 
 export const [getTimeFilter, setTimeFilter] = createGetterSetter<TimefilterContract>('TimeFilter');
 

--- a/src/plugins/vis_builder/public/saved_visualizations/_saved_vis.ts
+++ b/src/plugins/vis_builder/public/saved_visualizations/_saved_vis.ts
@@ -7,16 +7,16 @@ import {
   createSavedObjectClass,
   SavedObjectOpenSearchDashboardsServices,
 } from '../../../saved_objects/public';
-import { EDIT_PATH, PLUGIN_ID, WIZARD_SAVED_OBJECT } from '../../common';
+import { EDIT_PATH, PLUGIN_ID, VISBUILDER_SAVED_OBJECT } from '../../common';
 import { injectReferences } from './saved_visualization_references';
 
-export function createSavedWizardVisClass(services: SavedObjectOpenSearchDashboardsServices) {
+export function createSavedVisBuilderVisClass(services: SavedObjectOpenSearchDashboardsServices) {
   const SavedObjectClass = createSavedObjectClass(services);
 
-  class SavedWizardVis extends SavedObjectClass {
-    public static type = WIZARD_SAVED_OBJECT;
+  class SavedVisBuilderVis extends SavedObjectClass {
+    public static type = VISBUILDER_SAVED_OBJECT;
 
-    // if type:wizard has no mapping, we push this mapping into OpenSearch
+    // if type:visBuilder has no mapping, we push this mapping into OpenSearch
     public static mapping = {
       title: 'text',
       description: 'text',
@@ -31,8 +31,8 @@ export function createSavedWizardVisClass(services: SavedObjectOpenSearchDashboa
     // ID is optional, without it one will be generated on save.
     constructor(id: string) {
       super({
-        type: SavedWizardVis.type,
-        mapping: SavedWizardVis.mapping,
+        type: SavedVisBuilderVis.type,
+        mapping: SavedVisBuilderVis.mapping,
         injectReferences,
 
         // if this is null/undefined then the SavedObject will be assigned the defaults
@@ -52,5 +52,5 @@ export function createSavedWizardVisClass(services: SavedObjectOpenSearchDashboa
     }
   }
 
-  return SavedWizardVis;
+  return SavedVisBuilderVis;
 }

--- a/src/plugins/vis_builder/public/saved_visualizations/saved_visualization_references.ts
+++ b/src/plugins/vis_builder/public/saved_visualizations/saved_visualization_references.ts
@@ -4,11 +4,11 @@
  */
 
 import { SavedObjectReference } from '../../../../core/public';
-import { WizardVisSavedObject } from '../types';
+import { VisBuilderVisSavedObject } from '../types';
 import { injectSearchSourceReferences } from '../../../data/public';
 
 export function injectReferences(
-  savedObject: WizardVisSavedObject,
+  savedObject: VisBuilderVisSavedObject,
   references: SavedObjectReference[]
 ) {
   if (savedObject.searchSourceFields) {

--- a/src/plugins/vis_builder/public/saved_visualizations/saved_visualizations.ts
+++ b/src/plugins/vis_builder/public/saved_visualizations/saved_visualizations.ts
@@ -7,12 +7,12 @@ import {
   SavedObjectLoader,
   SavedObjectOpenSearchDashboardsServices,
 } from '../../../saved_objects/public';
-import { createSavedWizardVisClass } from './_saved_vis';
+import { createSavedVisBuilderVisClass } from './_saved_vis';
 
-export type SavedWizardLoader = ReturnType<typeof createSavedWizardLoader>;
-export function createSavedWizardLoader(services: SavedObjectOpenSearchDashboardsServices) {
+export type SavedVisBuilderLoader = ReturnType<typeof createSavedVisBuilderLoader>;
+export function createSavedVisBuilderLoader(services: SavedObjectOpenSearchDashboardsServices) {
   const { savedObjectsClient } = services;
-  const SavedWizardVisClass = createSavedWizardVisClass(services);
+  const SavedVisBuilderVisClass = createSavedVisBuilderVisClass(services);
 
-  return new SavedObjectLoader(SavedWizardVisClass, savedObjectsClient);
+  return new SavedObjectLoader(SavedVisBuilderVisClass, savedObjectsClient);
 }

--- a/src/plugins/vis_builder/public/saved_visualizations/transforms.test.ts
+++ b/src/plugins/vis_builder/public/saved_visualizations/transforms.test.ts
@@ -7,7 +7,7 @@ import { coreMock } from '../../../../core/public/mocks';
 import { getStubIndexPattern } from '../../../data/public/test_utils';
 import { IndexPattern } from '../../../data/public';
 import { RootState } from '../application/utils/state_management';
-import { WizardVisSavedObject } from '../types';
+import { VisBuilderVisSavedObject } from '../types';
 import { saveStateToSavedObject } from './transforms';
 
 const getConfig = (cfg: any) => cfg;
@@ -21,7 +21,7 @@ describe('transforms', () => {
 
     beforeEach(() => {
       TEST_INDEX_PATTERN_ID = 'test-pattern';
-      savedObject = {} as WizardVisSavedObject;
+      savedObject = {} as VisBuilderVisSavedObject;
       rootState = {
         metadata: { editor: { state: 'loading', validity: {} } },
         style: '',

--- a/src/plugins/vis_builder/public/saved_visualizations/transforms.ts
+++ b/src/plugins/vis_builder/public/saved_visualizations/transforms.ts
@@ -6,13 +6,13 @@
 import produce from 'immer';
 import { IndexPattern } from '../../../data/public';
 import { RootState, VisualizationState } from '../application/utils/state_management';
-import { WizardVisSavedObject } from '../types';
+import { VisBuilderVisSavedObject } from '../types';
 
 export const saveStateToSavedObject = (
-  obj: WizardVisSavedObject,
+  obj: VisBuilderVisSavedObject,
   state: RootState,
   indexPattern: IndexPattern
-): WizardVisSavedObject => {
+): VisBuilderVisSavedObject => {
   if (state.visualization.indexPattern !== indexPattern.id)
     throw new Error('indexPattern id should match the value in redux state');
 

--- a/src/plugins/vis_builder/public/types.ts
+++ b/src/plugins/vis_builder/public/types.ts
@@ -15,16 +15,16 @@ import { TypeServiceSetup, TypeServiceStart } from './services/type_service';
 import { SavedObjectLoader } from '../../saved_objects/public';
 import { AppMountParameters, CoreStart, ToastsStart, ScopedHistory } from '../../../core/public';
 
-export type WizardSetup = TypeServiceSetup;
-export interface WizardStart extends TypeServiceStart {
-  savedWizardLoader: SavedObjectLoader;
+export type VisBuilderSetup = TypeServiceSetup;
+export interface VisBuilderStart extends TypeServiceStart {
+  savedVisBuilderLoader: SavedObjectLoader;
 }
 
-export interface WizardPluginSetupDependencies {
+export interface VisBuilderPluginSetupDependencies {
   embeddable: EmbeddableSetup;
   visualizations: VisualizationsSetup;
 }
-export interface WizardPluginStartDependencies {
+export interface VisBuilderPluginStartDependencies {
   embeddable: EmbeddableStart;
   navigation: NavigationPublicPluginStart;
   data: DataPublicPluginStart;
@@ -33,9 +33,9 @@ export interface WizardPluginStartDependencies {
   expressions: ExpressionsStart;
 }
 
-export interface WizardServices extends CoreStart {
+export interface VisBuilderServices extends CoreStart {
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
-  savedWizardLoader: WizardStart['savedWizardLoader'];
+  savedVisBuilderLoader: VisBuilderStart['savedVisBuilderLoader'];
   toastNotifications: ToastsStart;
   savedObjectsPublic: SavedObjectsStart;
   navigation: NavigationPublicPluginStart;
@@ -56,4 +56,4 @@ export interface ISavedVis {
   version?: number;
 }
 
-export interface WizardVisSavedObject extends SavedObject, ISavedVis {}
+export interface VisBuilderVisSavedObject extends SavedObject, ISavedVis {}

--- a/src/plugins/vis_builder/server/index.ts
+++ b/src/plugins/vis_builder/server/index.ts
@@ -5,16 +5,16 @@
 
 import { PluginConfigDescriptor, PluginInitializerContext } from '../../../core/server';
 import { ConfigSchema, configSchema } from '../config';
-import { WizardPlugin } from './plugin';
+import { VisBuilderPlugin } from './plugin';
 
 // This exports static code and TypeScript types,
 // as well as the OpenSearch Dashboards Platform `plugin()` initializer.
 
 export function plugin(initializerContext: PluginInitializerContext) {
-  return new WizardPlugin(initializerContext);
+  return new VisBuilderPlugin(initializerContext);
 }
 
-export { WizardPluginSetup, WizardPluginStart } from './types';
+export { VisBuilderPluginSetup, VisBuilderPluginStart } from './types';
 
 export const config: PluginConfigDescriptor<ConfigSchema> = {
   exposeToBrowser: {

--- a/src/plugins/vis_builder/server/plugin.ts
+++ b/src/plugins/vis_builder/server/plugin.ts
@@ -11,11 +11,11 @@ import {
   Logger,
 } from '../../../core/server';
 
-import { WizardPluginSetup, WizardPluginStart } from './types';
+import { VisBuilderPluginSetup, VisBuilderPluginStart } from './types';
 import { capabilitiesProvider } from './capabilities_provider';
-import { wizardSavedObjectType } from './saved_objects';
+import { visBuilderSavedObjectType } from './saved_objects';
 
-export class WizardPlugin implements Plugin<WizardPluginSetup, WizardPluginStart> {
+export class VisBuilderPlugin implements Plugin<VisBuilderPluginSetup, VisBuilderPluginStart> {
   private readonly logger: Logger;
 
   constructor(initializerContext: PluginInitializerContext) {
@@ -26,7 +26,7 @@ export class WizardPlugin implements Plugin<WizardPluginSetup, WizardPluginStart
     this.logger.debug('wizard: Setup');
 
     // Register saved object types
-    savedObjects.registerType(wizardSavedObjectType);
+    savedObjects.registerType(visBuilderSavedObjectType);
 
     // Register capabilities
     capabilities.registerProvider(capabilitiesProvider);

--- a/src/plugins/vis_builder/server/saved_objects/index.ts
+++ b/src/plugins/vis_builder/server/saved_objects/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { wizardSavedObjectType } from './vis_builder_app';
+export { visBuilderSavedObjectType } from './vis_builder_app';

--- a/src/plugins/vis_builder/server/saved_objects/vis_builder_app.ts
+++ b/src/plugins/vis_builder/server/saved_objects/vis_builder_app.ts
@@ -7,20 +7,20 @@ import { SavedObject, SavedObjectsType } from '../../../../core/server';
 import {
   EDIT_PATH,
   PLUGIN_ID,
-  WizardSavedObjectAttributes,
-  WIZARD_SAVED_OBJECT,
+  VisBuilderSavedObjectAttributes,
+  VISBUILDER_SAVED_OBJECT,
 } from '../../common';
-import { wizardSavedObjectTypeMigrations } from './vis_builder_migration';
+import { visBuilderSavedObjectTypeMigrations } from './vis_builder_migration';
 
-export const wizardSavedObjectType: SavedObjectsType = {
-  name: WIZARD_SAVED_OBJECT,
+export const visBuilderSavedObjectType: SavedObjectsType = {
+  name: VISBUILDER_SAVED_OBJECT,
   hidden: false,
   namespaceType: 'single',
   management: {
     // icon: '', // TODO: Need a custom icon here - unfortunately a custom SVG won't work without changes to the SavedObjectsManagement plugin
     defaultSearchField: 'title',
     importableAndExportable: true,
-    getTitle: ({ attributes: { title } }: SavedObject<WizardSavedObjectAttributes>) => title,
+    getTitle: ({ attributes: { title } }: SavedObject<VisBuilderSavedObjectAttributes>) => title,
     getEditUrl: ({ id }: SavedObject) =>
       `/management/opensearch-dashboards/objects/savedWizard/${encodeURIComponent(id)}`,
     getInAppUrl({ id }: SavedObject) {
@@ -30,7 +30,7 @@ export const wizardSavedObjectType: SavedObjectsType = {
       };
     },
   },
-  migrations: wizardSavedObjectTypeMigrations,
+  migrations: visBuilderSavedObjectTypeMigrations,
   mappings: {
     properties: {
       title: {

--- a/src/plugins/vis_builder/server/saved_objects/vis_builder_migration.test.ts
+++ b/src/plugins/vis_builder/server/saved_objects/vis_builder_migration.test.ts
@@ -4,13 +4,13 @@
  */
 
 import { SavedObjectMigrationFn, SavedObjectMigrationContext } from '../../../../core/server';
-import { wizardSavedObjectTypeMigrations } from './vis_builder_migration';
+import { visBuilderSavedObjectTypeMigrations } from './vis_builder_migration';
 
 const savedObjectMigrationContext = (null as unknown) as SavedObjectMigrationContext;
 
 describe('2.3.0', () => {
   const migrate = (doc: any) =>
-    wizardSavedObjectTypeMigrations['2.3.0'](
+    visBuilderSavedObjectTypeMigrations['2.3.0'](
       doc as Parameters<SavedObjectMigrationFn>[0],
       savedObjectMigrationContext
     );
@@ -67,7 +67,7 @@ describe('2.3.0', () => {
     });
   });
 
-  it('should migrate the old version wizard saved object to new version wizard saved object', () => {
+  it('should migrate the old version visBuilder saved object to new version VisBuilder saved object', () => {
     const migratedDoc = migrate({
       type: 'wizard',
       attributes: {

--- a/src/plugins/vis_builder/server/saved_objects/vis_builder_migration.ts
+++ b/src/plugins/vis_builder/server/saved_objects/vis_builder_migration.ts
@@ -46,6 +46,6 @@ const migrateIndexPattern: SavedObjectMigrationFn<any, any> = (doc) => {
   }
 };
 
-export const wizardSavedObjectTypeMigrations = {
+export const visBuilderSavedObjectTypeMigrations = {
   '2.3.0': flow(migrateIndexPattern),
 };

--- a/src/plugins/vis_builder/server/types.ts
+++ b/src/plugins/vis_builder/server/types.ts
@@ -5,6 +5,6 @@
 
 // We need to export plugin server types, even if empty
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface WizardPluginSetup {}
+export interface VisBuilderPluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface WizardPluginStart {}
+export interface VisBuilderPluginStart {}


### PR DESCRIPTION
Reame wizard to visBuilder

Signed-off-by: abbyhu2000 <abigailhu2000@gmail.com>

### Description
Rename wizard to visBuilder in class name, type name and function name
 
### Issues Resolved
resolves part of #1706 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 