### PR TITLE
[Backport 1.x][BUG]fix suggestion list cutoff issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### 📈 Features/Enhancements
 
 ### 🐛 Bug Fixes
+* [BUG] Fix suggestion list cutoff issue ([#2607](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2607))
 
 ### 🚞 Infrastructure
 
@@ -46,7 +47,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 🛠 Maintenance
 
-* [Version] Increment to 1.4 ([#1341](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1341)) 
+* [Version] Increment to 1.4 ([#1341](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1341))
 
 ### 🪛 Refactoring
 

--- a/src/plugins/data/public/ui/typeahead/_suggestion.scss
+++ b/src/plugins/data/public/ui/typeahead/_suggestion.scss
@@ -141,7 +141,7 @@ $osdTypeaheadTypes: (
   flex-grow: 0; /* 2 */
   flex-basis: auto; /* 2 */
   font-family: $euiCodeFontFamily;
-  width: 250px;
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   padding: $euiSizeXS $euiSizeS;


### PR DESCRIPTION
In this PR, we fixed the suggestion list cutoff in an easy way. We remove width 250px and add block display to allow browser to select a width and add ellipsis at the bottom.

However, we might have longer input that can't fit into the search. When we truncate the search, the elements look the same which might be still an issue for customer usage. We definitely need more feedbacks on the cutoff behavior.

Issue resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2555

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2607
 
### Check List
- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 