### PR TITLE
[Table Visualization][BUG] partical rows shows metrics for all columns

### DIFF
--- a/src/plugins/vis_type_table/public/to_ast.ts
+++ b/src/plugins/vis_type_table/public/to_ast.ts
@@ -21,10 +21,15 @@ export const toExpressionAst = (vis: Vis, params: any) => {
   );
 
   const schemas = getVisSchemas(vis, params);
+  // manul slice to remove duplicate metrics
+  const metrics =
+    schemas.bucket && vis.params.showPartialRows && !vis.params.showMetricsAtAllLevels
+      ? schemas.metric.slice(-1 * (schemas.metric.length / schemas.bucket.length))
+      : schemas.metric;
 
   const tableData = {
     title: vis.title,
-    metrics: schemas.metric,
+    metrics,
     buckets: schemas.bucket || [],
     splitRow: schemas.split_row,
     splitColumn: schemas.split_column,


### PR DESCRIPTION
### Description
Currently, when we enable Show partial rows in the Options panel, we see metrics been added to every column even though Show metrics for every bucket/level is not enabled.

Metrics are added and returned when we enable the partial rows. This PR fixed the bug by slice the returned data to allow only the last set of metrices.

### Partially resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2579#issuecomment-1287435381

 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 