### PR TITLE
Apply get indice error handling in step index pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [Multi DataSource] Address UX comments on Edit Data source page ([#2629](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2629))
 * [BUG] Fix suggestion list cutoff issue ([#2607](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2607))
 * [Multi DataSource] Address UX comments on index pattern management stack ([#2611](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2611))
+* [Multi DataSource] Apply get indices error handling in step index pattern ([#2652](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2652))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/__snapshots__/create_index_pattern_wizard.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/__snapshots__/create_index_pattern_wizard.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`CreateIndexPatternWizard renders index pattern step when there are indi
           },
         ]
       }
+      catchAndWarn={[Function]}
       goToNextStep={[Function]}
       goToPreviousStep={[Function]}
       indexPatternCreationType={
@@ -90,6 +91,7 @@ exports[`CreateIndexPatternWizard renders the empty state when there are no indi
     <EuiHorizontalRule />
     <StepIndexPattern
       allIndices={Array []}
+      catchAndWarn={[Function]}
       goToNextStep={[Function]}
       goToPreviousStep={[Function]}
       indexPatternCreationType={
@@ -191,6 +193,7 @@ exports[`CreateIndexPatternWizard renders when there are no indices but there ar
     <EuiHorizontalRule />
     <StepIndexPattern
       allIndices={Array []}
+      catchAndWarn={[Function]}
       goToNextStep={[Function]}
       goToPreviousStep={[Function]}
       indexPatternCreationType={
@@ -248,6 +251,7 @@ exports[`CreateIndexPatternWizard shows system indices even if there are no othe
           },
         ]
       }
+      catchAndWarn={[Function]}
       goToNextStep={[Function]}
       goToPreviousStep={[Function]}
       indexPatternCreationType={

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/step_index_pattern.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_index_pattern/step_index_pattern.test.tsx
@@ -62,6 +62,7 @@ const allIndices = [
 ];
 
 const goToNextStep = () => {};
+const catchAndWarn = jest.fn(async (asyncFn) => await asyncFn);
 
 const mockContext = mockManagementPlugin.createIndexPatternManagmentContext();
 
@@ -94,6 +95,7 @@ describe('StepIndexPattern', () => {
         goToNextStep,
         indexPatternCreationType: mockIndexPatternCreationType,
         initialQuery: 'opensearch-dashboards',
+        catchAndWarn,
       },
       mockContext
     );
@@ -116,6 +118,7 @@ describe('StepIndexPattern', () => {
         isIncludingSystemIndices: false,
         goToNextStep,
         indexPatternCreationType: mockIndexPatternCreationType,
+        catchAndWarn,
       },
       mockContext
     );
@@ -139,6 +142,7 @@ describe('StepIndexPattern', () => {
         isIncludingSystemIndices: false,
         goToNextStep,
         indexPatternCreationType: mockIndexPatternCreationType,
+        catchAndWarn,
       },
       mockContext
     );
@@ -163,6 +167,7 @@ describe('StepIndexPattern', () => {
         isIncludingSystemIndices: false,
         goToNextStep,
         indexPatternCreationType: mockIndexPatternCreationType,
+        catchAndWarn,
       },
       mockContext
     );
@@ -179,6 +184,7 @@ describe('StepIndexPattern', () => {
         isIncludingSystemIndices: false,
         goToNextStep,
         indexPatternCreationType: mockIndexPatternCreationType,
+        catchAndWarn,
       },
       mockContext
     );
@@ -194,6 +200,7 @@ describe('StepIndexPattern', () => {
         isIncludingSystemIndices: false,
         goToNextStep,
         indexPatternCreationType: mockIndexPatternCreationType,
+        catchAndWarn,
       },
       mockContext
     );

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
@@ -317,6 +317,7 @@ export class CreateIndexPatternWizard extends Component<
             }
             dataSourceRef={dataSourceRef}
             stepInfo={stepInfo}
+            catchAndWarn={this.catchAndWarn}
           />
         </EuiPageContent>
       );


### PR DESCRIPTION
Error handling only happens before loading the indices to step index pattern but not within. Therefore pass the error handling inside the step as well to render error state.

Signed-off-by: Kristen Tian <tyarong@amazon.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2598
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 