### PR TITLE
[CVE] Bump follow-redirects to 1.15.2 to fix CVE-2022-0155 and CVE-20…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 🛡 Security
 * [CVE-2022-0144] Bump shelljs from 0.8.4 to 0.8.5 ([#2511](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2511))
+* [CVE-2022-0155] Bump follow-redirects to 1.15.2 [#2653](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2653))
+* [CVE-2022-0536] Bump follow-redirects to 1.15.2 [#2653](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2653))
 
 ### 📈 Features/Enhancements
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "**/ansi-regex": "^5.0.1",
     "**/axios": "^0.21.4",
     "**/ejs": "^3.1.6",
+    "**/follow-redirects": "^1.15.2",
     "**/front-matter": "^4.0.2",
     "**/glob-parent": "^6.0.0",
     "**/hoist-non-react-statics": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11322,15 +11322,10 @@ focus-trap@^2.0.1:
   dependencies:
     tabbable "^1.0.3"
 
-follow-redirects@1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.12.1.tgz#de54a6205311b93d60398ebc01cf7015682312b6"
-  integrity sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==
-
-follow-redirects@^1.0.0, follow-redirects@^1.14.0:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.3.tgz#6ada78118d8d24caee595595accdc0ac6abd022e"
-  integrity sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==
+follow-redirects@1.12.1, follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 font-awesome@4.7.0:
   version "4.7.0"


### PR DESCRIPTION
Signed-off-by: Zilong Xia <zilongx@amazon.com>

### Description
* Resolves [CVE-2022-0155](https://github.com/advisories/GHSA-74fj-2j2h-c42q) and [CVE-2022-0536](https://github.com/advisories/GHSA-pw2r-vq6v-hr8c) by bumping `follow-redirects` up to 1.15.2
* There are no breaking changes introduced in by checking detailed change history of [follow-redirects](https://github.com/follow-redirects/follow-redirects/commits/main)
* This PR is to backport similar updates in `2.0.0` (https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1113) to `1.x`
 
### Issues Resolved
Resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1133
Resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1238
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 