### PR TITLE
Enable compressed header by default

### DIFF
--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -112,7 +112,7 @@ export function Header({
   const toggleCollapsibleNavRef = createRef<HTMLButtonElement & { euiAnimate: () => void }>();
   const navId = htmlIdGenerator()();
   const className = classnames('hide-for-sharing', 'headerGlobalNav');
-  const { useExpandedHeader = true, darkMode } = branding;
+  const { useExpandedHeader = false, darkMode } = branding;
 
   return (
     <>

--- a/src/core/public/chrome/ui/header/home_icon.tsx
+++ b/src/core/public/chrome/ui/header/home_icon.tsx
@@ -21,7 +21,7 @@ export const HomeIcon = ({
   assetFolderUrl = '',
   mark,
   applicationTitle = 'opensearch dashboards',
-  useExpandedHeader = true,
+  useExpandedHeader = false,
 }: ChromeBranding) => {
   const { defaultUrl: markUrl, darkModeUrl: darkMarkUrl } = mark ?? {};
 

--- a/src/core/public/core_system.ts
+++ b/src/core/public/core_system.ts
@@ -260,7 +260,7 @@ export class CoreSystem {
 
       await this.plugins.start(core);
 
-      const { useExpandedHeader = true } = injectedMetadata.getBranding() ?? {};
+      const { useExpandedHeader = false } = injectedMetadata.getBranding() ?? {};
 
       // ensure the rootDomElement is empty
       this.rootDomElement.textContent = '';

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -82,7 +82,7 @@ export const config = {
         defaultValue: '',
       }),
       useExpandedHeader: schema.boolean({
-        defaultValue: true,
+        defaultValue: false,
       }),
     }),
   }),

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -270,7 +270,7 @@ export class RenderingService {
       : DEFAULT_TITLE;
 
     // use expanded menu by default unless explicitly set to false
-    const { useExpandedHeader = true } = branding;
+    const { useExpandedHeader = false } = branding;
 
     const brandingAssignment: BrandingAssignment = {
       logoDefault,


### PR DESCRIPTION
Signed-off-by: Ashwin P Chandran <ashwinpc@amazon.com>

### Description
Enables the compressed header by default
 
### Issues Resolved
#1834
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 