### PR TITLE
Removes Add Integration button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multi DataSource] Apply get indices error handling in step index pattern ([#2652](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2652))
 - [Vis Builder] Last Updated Timestamp for visbuilder savedobject is getting Generated ([#2628](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2628))
 - Removed Leftover X Pack references ([#2638](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2638)) 
+- Removes Add Integration button ([#2723](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2723))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/__snapshots__/empty_state.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/__snapshots__/empty_state.test.tsx.snap
@@ -35,33 +35,6 @@ exports[`EmptyState should render normally 1`] = `
             className="inpEmptyState__card"
             description={
               <FormattedMessage
-                defaultMessage="Add data from a variety of sources."
-                id="indexPatternManagement.createIndexPattern.emptyState.integrationCardDescription"
-                values={Object {}}
-              />
-            }
-            icon={
-              <EuiIcon
-                color="subdued"
-                size="xl"
-                type="database"
-              />
-            }
-            onClick={[Function]}
-            title={
-              <FormattedMessage
-                defaultMessage="Add integration"
-                id="indexPatternManagement.createIndexPattern.emptyState.integrationCardTitle"
-                values={Object {}}
-              />
-            }
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCard
-            className="inpEmptyState__card"
-            description={
-              <FormattedMessage
                 defaultMessage="Load a data set and a OpenSearch Dashboards dashboard."
                 id="indexPatternManagement.createIndexPattern.emptyState.sampleDataCardDescription"
                 values={Object {}}

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/empty_state.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/empty_state/empty_state.tsx
@@ -151,6 +151,7 @@ export const EmptyState = ({
         <EuiSpacer size="m" />
         <EuiPageContentBody>
           <EuiFlexGrid className="inpEmptyState__cardGrid" columns={3} responsive={true}>
+            {/* TODO: [UNCOMMENTME] Once we have long-term fix for https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2684
             <EuiFlexItem>
               <EuiCard
                 className="inpEmptyState__card"
@@ -169,7 +170,7 @@ export const EmptyState = ({
                   />
                 }
               />
-            </EuiFlexItem>
+            </EuiFlexItem> */}
             {getMlCardState() !== MlCardState.HIDDEN ? mlCard : <></>}
             <EuiFlexItem>
               <EuiCard


### PR DESCRIPTION
Signed-off-by: Bandini Bhopi <bandinib@amazon.com>

### Description
`Add Integration` and `Add sample data` both take the user to the add sample data page. This PR removes `Add Integration` button until we have long term fix for Integration workflow.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2684

### Screenshots

**Before:**

<img width="780" alt="Before" src="https://user-images.githubusercontent.com/63824432/199367841-f8db9e76-8724-4fc4-adae-9125f2ac673c.png">

**After fix:**
![After](https://user-images.githubusercontent.com/63824432/199368049-472f9291-c1b5-4253-902d-80ee6135018a.png)

 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 