### PR TITLE
[Backport 2.x] Adding @zengyan-amazon as a Dashboards co-maintainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### 🛠 Maintenance
 
 * Increment from 2.3 to 2.4. ([#2295](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2295))
+* Adding @zengyan-amazon as maintainer.
 
 ### 🪛 Refactoring
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,10 +7,11 @@
 | Bishoy Boktor | [boktorbb-amzn](https://github.com/boktorbb-amzn) | Amazon |
 | Mihir Soni | [mihirsoni](https://github.com/mihirsoni) | Amazon |
 | Rocky | [kavilla](https://github.com/kavilla) | Amazon |
-| Sean Neumann | [seanneumann](https://github.com/seanneumann) | Amazon | 
-| Tommy Markley | [tmarkley](https://github.com/tmarkley) | Amazon | 
+| Sean Neumann | [seanneumann](https://github.com/seanneumann) | Amazon |
+| Tommy Markley | [tmarkley](https://github.com/tmarkley) | Amazon |
 | Miki Barahmand | [AMoo-Miki](https://github.com/AMoo-Miki) | Amazon |
 | Ashwin P Chandran | [ashwin-pc](https://github.com/ashwin-pc) | Amazon |
 | Josh Romero | [joshuarrrr](https://github.com/joshuarrrr) | Amazon |
+| Yan Zeng | [zengyan-amazon](https://github.com/zengyan-amazon) | Amazon |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2419
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 