### PR TITLE
Temporarily prevents `task-kill` exceptions on Windows when it is passed a `pid` for a process that is already dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Change geckodriver version to make consistency ([#2772](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2772))
 - [Multi DataSource] Update default audit log path ([#2793](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2793))
 - [Table Visualization] Fix first column sort issue ([#2828](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2828))
+- Temporary workaround for task-kill exceptions on Windows when it is passed a pid for a process that is already dead ([#2842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2842))
 
 ### 🚞 Infrastructure
 


### PR DESCRIPTION
OSD uses `tree-kill` [[npm](https://www.npmjs.com/package/tree-kill)], a library that terminates a process and all of its children, for stopping processes started using `Cluster`. This library behaves differently on different platforms. If the `pid` it is asked to terminate is not running:

* on darwin and linux, it silently returns without throwing and exception
* on win32 in produces an exception

As a result, calling cluster.stop() on an already terminated cluster will throw and exception on Windows but will silently continue on other operating systems.

Ref: #2811

Signed-off-by: Miki <amoo_miki@yahoo.com>
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 