### PR TITLE
[VisBuilder] [BUG] fix empty workspace animation does not work in firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multi DataSource] Update default audit log path ([#2793](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2793))
 - [Table Visualization] Fix first column sort issue ([#2828](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2828))
 - Temporary workaround for task-kill exceptions on Windows when it is passed a pid for a process that is already dead ([#2842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2842))
+- [Vis Builder] Fix empty workspace animation does not work in firefox ([#2853](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2853))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/vis_builder/public/application/components/workspace.scss
+++ b/src/plugins/vis_builder/public/application/components/workspace.scss
@@ -30,6 +30,7 @@ $keyframe-multiplier: 1 / $animation-multiplier;
     animation: vbDragAnimation #{$total-duartion}s ease-in-out infinite forwards;
     position: absolute;
     top: 34.5%;
+    width: 50% !important;
   }
 }
 

--- a/src/plugins/vis_builder/public/application/components/workspace.tsx
+++ b/src/plugins/vis_builder/public/application/components/workspace.tsx
@@ -93,14 +93,14 @@ export const Workspace: FC = ({ children }) => {
               body={
                 <>
                   <p>Drag a field to the configuration panel to generate a visualization.</p>
-                  <span className="vbWorkspace__container">
+                  <div className="vbWorkspace__container">
                     <EuiIcon className="vbWorkspace__fieldSvg" type={fields_bg} size="original" />
                     <EuiIcon
                       className="vbWorkspace__handFieldSvg"
                       type={hand_field}
                       size="original"
                     />
-                  </span>
+                  </div>
                 </>
               }
             />


### PR DESCRIPTION
Signed-off-by: raintygao <tygao@amazon.com>

### Description
The visbuilder animation in firefox does not work. 
This PR fixed the bug by modifying the dom structure and adding css attributes.  Since `osd-ui-shared` will provide `width: 100%` style by default with a higher priority, `!important` is added to ensure that it meets expectations.

Normal condition:
![image](https://user-images.githubusercontent.com/42465692/201029840-ec8ffbf2-3f88-4c5a-a0ff-eddee2a6ac9b.png)

Error condition
![image](https://user-images.githubusercontent.com/42465692/201030098-af3e02e4-aea9-486a-a04e-c96f0744eecf.png)

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2443
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 