### PR TITLE
[Vis Builder] Removed Hard Coded Strings and Used i18n to transalte

### DIFF
--- a/src/plugins/vis_builder/public/application/components/data_tab/dropbox.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/dropbox.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { i18n } from '@osd/i18n';
 import {
   EuiButtonIcon,
   EuiDragDropContext,
@@ -127,7 +128,11 @@ const DropboxComponent = ({
               } ${canDrop ? 'canDrop' : ''}`}
               {...(isValidDropTarget && dropProps)}
             >
-              <EuiText size="s">Click or drop to add</EuiText>
+              <EuiText size="s">
+                {i18n.translate('visBuilder.dropbox.addField.title', {
+                  defaultMessage: 'Click or drop to add',
+                })}
+              </EuiText>
               <EuiButtonIcon
                 iconType="plusInCircle"
                 aria-label="clear-field"

--- a/src/plugins/vis_builder/public/application/components/workspace.tsx
+++ b/src/plugins/vis_builder/public/application/components/workspace.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { i18n } from '@osd/i18n';
 import { EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiPanel } from '@elastic/eui';
 import React, { FC, useState, useMemo, useEffect, useLayoutEffect } from 'react';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
@@ -89,10 +90,21 @@ export const Workspace: FC = ({ children }) => {
         ) : (
           <EuiFlexItem className="vbWorkspace__empty" data-test-subj="emptyWorkspace">
             <EuiEmptyPrompt
-              title={<h2>Add a field to start</h2>}
+              title={
+                <h2>
+                  {i18n.translate('visBuilder.workSpace.empty.title', {
+                    defaultMessage: 'Add a field to start',
+                  })}
+                </h2>
+              }
               body={
                 <>
-                  <p>Drag a field to the configuration panel to generate a visualization.</p>
+                  <p>
+                    {i18n.translate('visBuilder.workSpace.empty.description', {
+                      defaultMessage:
+                        'Drag a field to the configuration panel to generate a visualization.',
+                    })}
+                  </p>
                   <div className="vbWorkspace__container">
                     <EuiIcon className="vbWorkspace__fieldSvg" type={fields_bg} size="original" />
                     <EuiIcon


### PR DESCRIPTION
Signed-off-by: AbhishekReddy1127 <nallamsa@amazon.com>

### Description
Removed hard coded strings from the Vis builder and used i18n to translate them.
 
### Issues Resolved
Partially resolves #958 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 