### PR TITLE
Refactor to add config test client

### DIFF
--- a/src/plugins/data_source/server/client/client_pool.ts
+++ b/src/plugins/data_source/server/client/client_pool.ts
@@ -29,7 +29,7 @@ export class OpenSearchClientPool {
 
   constructor(private logger: Logger) {}
 
-  public async setup(config: DataSourcePluginConfigType): Promise<OpenSearchClientPoolSetup> {
+  public setup(config: DataSourcePluginConfigType): OpenSearchClientPoolSetup {
     const logger = this.logger;
     const { size } = config.clientPool;
 

--- a/src/plugins/data_source/server/data_source_service.ts
+++ b/src/plugins/data_source/server/data_source_service.ts
@@ -3,16 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  Auditor,
-  LegacyCallAPIOptions,
-  Logger,
-  OpenSearchClient,
-} from '../../../../src/core/server';
+import { LegacyCallAPIOptions, Logger, OpenSearchClient } from '../../../../src/core/server';
 import { DataSourcePluginConfigType } from '../config';
 import { configureClient, OpenSearchClientPool } from './client';
 import { configureLegacyClient } from './legacy';
 import { DataSourceClientParams } from './types';
+import { DataSourceAttributes } from '../common/data_sources';
+import { configureTestClient } from './client/configure_client';
 export interface DataSourceServiceSetup {
   getDataSourceClient: (params: DataSourceClientParams) => Promise<OpenSearchClient>;
 
@@ -25,6 +22,8 @@ export interface DataSourceServiceSetup {
       options?: LegacyCallAPIOptions
     ) => Promise<unknown>;
   };
+
+  getTestingClient: (dataSource: DataSourceAttributes) => Promise<OpenSearchClient>;
 }
 export class DataSourceService {
   private readonly openSearchClientPool: OpenSearchClientPool;
@@ -47,6 +46,10 @@ export class DataSourceService {
       return configureClient(params, opensearchClientPoolSetup, config, this.logger);
     };
 
+    const getTestingClient = (dataSource: DataSourceAttributes): Promise<OpenSearchClient> => {
+      return configureTestClient(dataSource, opensearchClientPoolSetup, config, this.logger);
+    };
+
     const getDataSourceLegacyClient = (params: DataSourceClientParams) => {
       return {
         callAPI: (
@@ -64,7 +67,7 @@ export class DataSourceService {
       };
     };
 
-    return { getDataSourceClient, getDataSourceLegacyClient };
+    return { getDataSourceClient, getDataSourceLegacyClient, getTestingClient };
   }
 
   start() {}

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -29,6 +29,7 @@ import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../common';
 // eslint-disable-next-line @osd/eslint/no-restricted-paths
 import { ensureRawRequest } from '../../../../src/core/server/http/router';
 import { createDataSourceError } from './lib/error';
+
 export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourcePluginStart> {
   private readonly logger: Logger;
   private readonly cryptographyService: CryptographyService;
@@ -102,6 +103,9 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
         auditTrailPromise
       )
     );
+
+    const router = core.http.createRouter();
+    registerTestConnectionRoute(router, dataSourceService);
 
     return {
       createDataSourceError: (e: any) => createDataSourceError(e),


### PR DESCRIPTION
Signed-off-by: Kristen Tian <tyarong@amazon.com>

### Description
Sub task of test connection meta issue -  Refactor to support config test/validation client

With this change, then route.ts should be able to:

`const dataSourceClient: OpenSearchClient = await dataSourceService.getTestingClient(req.body);`

 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 