### PR TITLE
[Build] Update folder timestamps after copying files into them using `scanCopy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Temporary workaround for task-kill exceptions on Windows when it is passed a pid for a process that is already dead ([#2842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2842))
 - [Vis Builder] Fix empty workspace animation does not work in firefox ([#2853](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2853))
 - Bumped `del` version to fix MacOS race condition ([#2847](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2873))
+- [Build] Fixed "Last Access Time" not being set by `scanCopy` on Windows ([#2964](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2964))
 
 ### 🚞 Infrastructure
 

--- a/src/dev/build/lib/scan_copy.ts
+++ b/src/dev/build/lib/scan_copy.ts
@@ -107,12 +107,12 @@ export async function scanCopy(options: Options) {
       await copyFileAsync(record.absolute, record.absoluteDest, Fs.constants.COPYFILE_EXCL);
     }
 
-    if (time) {
-      await utimesAsync(record.absoluteDest, time, time);
-    }
-
     if (record.isDirectory) {
       await copyChildren(record);
+    }
+
+    if (time) {
+      await utimesAsync(record.absoluteDest, time, time);
     }
   };
 


### PR DESCRIPTION
Signed-off-by: Miki <amoo_miki@yahoo.com>

### Description
Fixes folder timestamps being updated before copying files into them.

When updating the timestamps were requested, `scanCopy` first set the times and then copied content into the destination folder. On certain platforms, copying files into a folder updates its "Last Access Time" and that overwrites the just set timestamps. This PR, makes sure the timestamps are set only after copying the content. 
 
### Check List
- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 