### PR TITLE
Fix incorrect validation of time values in JUnit Reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - [Multi DataSource] Add unit test coverage for Update Data source management stack ([#2567](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2567))
 - [BWC Tests] Add BWC tests for 2.5.0 ([#2890](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2890))
+- Fix incorrect validation of time values in JUnit Reporter ([#2965](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2965))
 
 ## [2.x]
 

--- a/src/dev/jest/junit_reporter.js
+++ b/src/dev/jest/junit_reporter.js
@@ -70,8 +70,9 @@ export default class JestJUnitReporter {
       { skipNullAttributes: true }
     );
 
-    const msToIso = (ms) => (ms ? new Date(ms).toISOString().slice(0, -5) : undefined);
-    const msToSec = (ms) => (ms ? (ms / 1000).toFixed(3) : undefined);
+    const isNumeric = (val) => !isNaN(parseFloat(val)) && isFinite(val);
+    const msToIso = (ms) => (isNumeric(ms) ? new Date(ms).toISOString().slice(0, -5) : undefined);
+    const msToSec = (ms) => (isNumeric(ms) ? (ms / 1000).toFixed(3) : undefined);
 
     root.att({
       name: 'jest',


### PR DESCRIPTION
Signed-off-by: Miki <amoo_miki@yahoo.com>

### Description
https://github.com/opensearch-project/OpenSearch-Dashboards/blob/808129bcf077912c2ed4af5aea517c32ec1315a5/src/dev/jest/junit_reporter.js#L73-L74

These two lines, consider `ms = 0` as invalid. If `ms` is `0`, for example when a test takes no time and `0` is passed in, the report doesn't include `time`.
 
 
### Check List
- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 