### PR TITLE
Make tests covering plugin installation on cluster snapshots work across platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multi DataSource] Add unit test coverage for Update Data source management stack ([#2567](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2567))
 - [BWC Tests] Add BWC tests for 2.5.0 ([#2890](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2890))
 - Fix incorrect validation of time values in JUnit Reporter ([#2965](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2965))
+- Make tests covering plugin installation on cluster snapshots work across platforms ([#2994](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2994))
 
 ## [2.x]
 

--- a/packages/osd-opensearch/src/integration_tests/cluster.test.js
+++ b/packages/osd-opensearch/src/integration_tests/cluster.test.js
@@ -293,14 +293,17 @@ describe('#start(installPath)', () => {
 });
 
 describe('#installOpenSearchPlugins()', () => {
+  const pluginHelperCLI =
+    process.platform === 'win32' ? './bin/opensearch-plugin.bat' : './bin/opensearch-plugin';
+
   it('install array of plugins on cluster snapshot', async () => {
     const cluster = new Cluster({ log });
     await cluster.installOpenSearchPlugins('foo', ['foo1', 'foo2']);
     expect(execa).toHaveBeenCalledTimes(2);
-    expect(execa).toHaveBeenCalledWith('./bin/opensearch-plugin', ['install', '--batch', 'foo1'], {
+    expect(execa).toHaveBeenCalledWith(pluginHelperCLI, ['install', '--batch', 'foo1'], {
       cwd: 'foo',
     });
-    expect(execa).toHaveBeenCalledWith('./bin/opensearch-plugin', ['install', '--batch', 'foo2'], {
+    expect(execa).toHaveBeenCalledWith(pluginHelperCLI, ['install', '--batch', 'foo2'], {
       cwd: 'foo',
     });
   });
@@ -308,7 +311,7 @@ describe('#installOpenSearchPlugins()', () => {
     const cluster = new Cluster({ log });
     await cluster.installOpenSearchPlugins('foo', 'foo1');
     expect(execa).toHaveBeenCalledTimes(1);
-    expect(execa).toHaveBeenCalledWith('./bin/opensearch-plugin', ['install', '--batch', 'foo1'], {
+    expect(execa).toHaveBeenCalledWith(pluginHelperCLI, ['install', '--batch', 'foo1'], {
       cwd: 'foo',
     });
   });


### PR DESCRIPTION
Signed-off-by: Miki <amoo_miki@yahoo.com>

### Description
Tests introduced in #2734 don't pass on Windows due to expecting the non-Windows CLI execution.
 
### Check List
- [ ] All tests pass
  - [X] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 