### PR TITLE
[CVE] Bump loader-utils to 2.0.4 to fix CVE-2022-37599 and CVE-2022-37603

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [CVE-2021-24033] Remove storybook package to fix CVE-2021-42740 and CVE-2021-24033 ([#2660](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2660))
 * [CVE-2021-42740] Remove storybook package to fix CVE-2021-42740 and CVE-2021-24033 ([#2660](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2660))
 * [CVE-2022-37601] Bump loader-utils to 2.0.3 ([#2707](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2707))
+* [CVE-2022-37599] Bump loader-utils to 2.0.4 ([#2995](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2995))
+* [CVE-2022-37603] Bump loader-utils to 2.0.4 ([#2995](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2995))
 
 ### 📈 Features/Enhancements
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "**/istanbul-instrumenter-loader/schema-utils": "^1.0.0",
     "**/json-schema": "^0.4.0",
     "**/kind-of": ">=6.0.3",
-    "**/loader-utils": "^2.0.3",
+    "**/loader-utils": "^2.0.4",
     "**/lodash": "^4.17.21",
     "**/merge": "^2.1.1",
     "**/minimist": "^1.2.5",

--- a/packages/osd-optimizer/package.json
+++ b/packages/osd-optimizer/package.json
@@ -50,7 +50,7 @@
     "babel-loader": "^8.0.6",
     "css-loader": "^3.4.2",
     "file-loader": "^4.2.0",
-    "loader-utils": "^1.2.3",
+    "loader-utils": "^2.0.4",
     "postcss-loader": "^3.0.0",
     "raw-loader": "^3.1.0",
     "sass-loader": "^8.0.2",

--- a/packages/osd-ui-shared-deps/package.json
+++ b/packages/osd-ui-shared-deps/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "css-loader": "^3.4.2",
     "del": "^6.1.1",
-    "loader-utils": "^1.2.3",
+    "loader-utils": "^2.0.4",
     "val-loader": "^2.1.2",
     "webpack": "^4.41.5"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13859,10 +13859,10 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^2.0.0, loader-utils@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.3.tgz#d4b15b8504c63d1fc3f2ade52d41bc8459d6ede1"
-  integrity sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==
+loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^2.0.0, loader-utils@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"


### PR DESCRIPTION
Signed-off-by: Zilong Xia <zilongx@amazon.com>

### Description
* Resolved [CVE-2022-37599] (https://github.com/advisories/GHSA-hhq3-ff78-jv3g) and [CVE-2022-37603](https://github.com/advisories/GHSA-3rfm-jhwj-7488) in `1.x` branch
* Manually backport CVE fix from this PR (https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2892) to catch the v1.3.7 release train
* A similar PR before to bump `loader-utils` to `2.0.3` (https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2689) for reference
 
### Issues Resolved
Resolved https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2560
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 