### PR TITLE
Add @manasvinibs as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,7 @@
 | Yan Zeng | [zengyan-amazon](https://github.com/zengyan-amazon) | Amazon |
 | Kristen Tian | [kristenTian](https://github.com/kristenTian) | Amazon |
 | Zhongnan Su | [zhongnansu](https://github.com/zhongnansu) | Amazon |
+| Manasvini B Suryanarayana | [manasvinibs](https://github.com/manasvinibs) | Amazon |
 
 ## Emeritus
 


### PR DESCRIPTION
## Basic data points
* [OSD] 16 submitted PRs (https://github.com/opensearch-project/OpenSearch-Dashboards/pulls/manasvinibs)
* [OSD] 74 reviewed PRs (https://github.com/opensearch-project/OpenSearch-Dashboards/issues?q=reviewed-by%3Amanasvinibs)
* [OSD] 28 issues involved (https://github.com/opensearch-project/OpenSearch-Dashboards/issues?page=1&q=involves%3Amanasvinibs+is%3Aissue)

## Highlight
* Mana is assisting with extensions project which will be the next evolution of extending core functionality from OpenSearch Dashboards 
* Mana implemented https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2734 which allows for a huge quality of life for local development for external plugin developers to utilize snapshots with a single CLI command compared to before when they would had to pull down OpenSearch build, install their plugin on OpenSearch, and ensure the proper configurations. This has caused historically problems when plugin teams do development and miss some steps per their onboard documentation/PR suggestion and get different results than expected. 
* Mana has assisted reviewing PRs providing great insight on BWC tests, BWC in general, and the release process. 
* Mana has added documentation from insight she has gained within the informal dev doc repo https://cptnb.github.io/opensearch-dashboards-dev-docs/ ensuring the spread of knowledge.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>