### PR TITLE
[Backport 2.x] Add @manasvinibs as maintainer (#3006) along with resolving conflict with main branch

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,5 +13,14 @@
 | Ashwin P Chandran | [ashwin-pc](https://github.com/ashwin-pc) | Amazon |
 | Josh Romero | [joshuarrrr](https://github.com/joshuarrrr) | Amazon |
 | Yan Zeng | [zengyan-amazon](https://github.com/zengyan-amazon) | Amazon |
+| Kristen Tian | [kristenTian](https://github.com/kristenTian) | Amazon |
+| Zhongnan Su | [zhongnansu](https://github.com/zhongnansu) | Amazon |
+| Manasvini B Suryanarayana | [manasvinibs](https://github.com/manasvinibs) | Amazon |
+
+## Emeritus
+
+| Maintainer | GitHub ID | Affiliation |
+| --------------- | --------- | ----------- |
+| Tommy Markley | [tmarkley](https://github.com/tmarkley) | Amazon | 
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Basic data points
[OSD] 16 submitted PRs (https://github.com/opensearch-project/OpenSearch-Dashboards/pulls/manasvinibs) [OSD] 74 reviewed PRs (https://github.com/opensearch-project/OpenSearch-Dashboards/issues?q=reviewed-by%3Amanasvinibs) [OSD] 28 issues involved (https://github.com/opensearch-project/OpenSearch-Dashboards/issues?page=1&q=involves%3Amanasvinibs+is%3Aissue)

Highlight
Mana is assisting with extensions project which will be the next evolution of extending core functionality from OpenSearch Dashboards Mana implemented https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2734 which allows for a huge quality of life for local development for external plugin developers to utilize snapshots with a single CLI command compared to before when they would had to pull down OpenSearch build, install their plugin on OpenSearch, and ensure the proper configurations. This has caused historically problems when plugin teams do development and miss some steps per their onboard documentation/PR suggestion and get different results than expected. Mana has assisted reviewing PRs providing great insight on BWC tests, BWC in general, and the release process. Mana has added documentation from insight she has gained within the informal dev doc repo https://cptnb.github.io/opensearch-dashboards-dev-docs/ ensuring the spread of knowledge.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
(cherry picked from commit 9d62439fafb96f2c9aac8f24a0b8c359e873cf83)

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 