### PR TITLE
Trim trailing slashes before checking no-restricted-path rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BWC Tests] Add BWC tests for 2.5.0 ([#2890](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2890))
 - Fix incorrect validation of time values in JUnit Reporter ([#2965](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2965))
 - Make tests covering plugin installation on cluster snapshots work across platforms ([#2994](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2994))
+- Correct the linting logic for `no-restricted-path` to ignore trailing slashes ([#3020](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3020))
 
 ## [2.x]
 

--- a/packages/osd-eslint-plugin-eslint/rules/no_restricted_paths.js
+++ b/packages/osd-eslint-plugin-eslint/rules/no_restricted_paths.js
@@ -58,7 +58,7 @@ function traverseToTopFolder(src, pattern) {
     const srcIdx = src.lastIndexOf(path.sep);
     src = src.slice(0, srcIdx);
   }
-  return src.replace(/\\/g, '/');
+  return src.replace(/\\/g, '/').replace(/\/$/, '');
 }
 
 function isSameFolderOrDescendent(src, imported, pattern) {

--- a/packages/osd-eslint-plugin-eslint/rules/no_restricted_paths.test.js
+++ b/packages/osd-eslint-plugin-eslint/rules/no_restricted_paths.test.js
@@ -97,6 +97,22 @@ ruleTester.run('@osd/eslint/no-restricted-paths', rule, {
         },
       ],
     },
+    {
+      code: 'import b from "testfiles/no_restricted_paths/server/deep/deeper/e.js"',
+      filename: path.join(__dirname, 'testfiles/no_restricted_paths/server/deep/d.js'),
+      options: [
+        {
+          basePath: __dirname,
+          zones: [
+            {
+              target: 'testfiles/**/server/**/*',
+              from: 'testfiles/**/server/**/*',
+              allowSameFolder: true,
+            },
+          ],
+        },
+      ],
+    },
 
     // irrelevant function calls
     {


### PR DESCRIPTION
Signed-off-by: Miki <amoo_miki@yahoo.com>

### Description
`no-restricted-paths` compares source files and import statements, and their membership in restricted zones. However, when `allowSameFolder` is true, it failed to remove a trailing slash before validation which results in a false-positive.
 
### Check List
- [ ] All tests pass
  - [X] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 