### PR TITLE
Bumps simple-git from 3.4.0 to 3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Legacy Maps Plugin] Prevent reverse-tabnabbing ([#2540](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2540))
 - Eliminate dependency on `got` versions older than 11.8.5 ([#2801](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2801))
 - [Multi DataSource] Add explicit no spellcheck on password fields ([#2818](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2818))
+- [CVE-2022-25912] Bumps simple-git from 3.4.0 to 3.15.0 ([#3036](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3036))
 
 ### 📈 Features/Enhancements
 

--- a/package.json
+++ b/package.json
@@ -439,7 +439,7 @@
     "reselect": "^4.0.0",
     "resize-observer-polyfill": "^1.5.1",
     "selenium-webdriver": "^4.0.0-alpha.7",
-    "simple-git": "^3.4.0",
+    "simple-git": "^3.15.0",
     "sinon": "^7.4.2",
     "strip-ansi": "^6.0.0",
     "stylelint": "^14.5.2",

--- a/packages/osd-opensearch/package.json
+++ b/packages/osd-opensearch/package.json
@@ -22,7 +22,7 @@
     "getopts": "^2.2.5",
     "glob": "^7.1.7",
     "node-fetch": "^2.6.7",
-    "simple-git": "^3.4.0",
+    "simple-git": "^3.15.0",
     "tar-fs": "^2.1.0",
     "tree-kill": "^1.2.2",
     "yauzl": "^2.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15857,14 +15857,14 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-simple-git@^3.4.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.5.0.tgz#3c3538f4d7a1b3c8f3904412b12740bdcad9c8b1"
-  integrity sha512-fZsaq5nzdxQRhMNs6ESGLpMUHoL5GRP+boWPhq9pMYMKwOGZV2jHOxi8AbFFA2Y/6u4kR99HoULizSbpzaODkA==
+simple-git@^3.15.0:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.15.1.tgz#57f595682cb0c2475d5056da078a05c8715a25ef"
+  integrity sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==
   dependencies:
     "@kwsites/file-exists" "^1.1.1"
     "@kwsites/promise-deferred" "^1.1.1"
-    debug "^4.3.3"
+    debug "^4.3.4"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
Signed-off-by: Kristen Tian <tyarong@amazon.com>

### Description
Bumps simple-git from 3.4.0 to 3.15.0: https://advisories.aws.barahmand.com/advisory/GHSA-9p95-fxvg-qgq2


Followed these steps to test with this change:
```
yarn remove @opensearch-project/opensearch
yarn osd clean
Check yarn.lock to make sure it is removed. If not, run
yarn osd bootstrap 
Go to packages/osd-opensearch/package.json remove @opensearch-project/opensearch

yarn add --dev file:../opensearch-js

Finally, run bootstrap
yarn osd bootstrap
yarn start
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 