### PR TITLE
Adds config override to fix obsolete theme:version config value of v8 (beta) rendering issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Table Visualization][BUG] Fix Url content display issue in table ([#2918](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2918))
 - Fixes misleading embaddable plugin error message ([#3043](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3043))
 - [MD] Update dummy url in tests to follow lychee url allowlist ([#3099](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3099))
+- Adds config override to fix obsolete theme:version config value of v8 (beta) rendering issue ([#3045](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3045))
+
 
 ### 🚞 Infrastructure
 

--- a/src/core/server/ui_settings/ui_settings_client.test.ts
+++ b/src/core/server/ui_settings/ui_settings_client.test.ts
@@ -624,6 +624,29 @@ describe('ui settings', () => {
       expect(await uiSettings.get('dateFormat')).toBe('foo');
     });
 
+    it('returns the overridden value for key theme:version', async () => {
+      const opensearchDocSource = { 'theme:version': 'v8 (beta)' };
+      const overrides = { 'theme:version': 'v7' };
+      const { uiSettings } = setup({ opensearchDocSource, overrides });
+
+      expect(await uiSettings.get('theme:version')).toBe('v7');
+    });
+
+    it('returns the overridden value for key theme:version when doc source is empty', async () => {
+      const opensearchDocSource = {};
+      const overrides = { 'theme:version': 'v7' };
+      const { uiSettings } = setup({ opensearchDocSource, overrides });
+
+      expect(await uiSettings.get('theme:version')).toBe('v7');
+    });
+
+    it('rewrites the key theme:version value without override', async () => {
+      const opensearchDocSource = { 'theme:version': 'v8 (beta)' };
+      const { uiSettings } = setup({ opensearchDocSource });
+
+      expect(await uiSettings.get('theme:version')).toBe('v8 (beta)');
+    });
+
     it('returns the default value for an override with value null', async () => {
       const opensearchDocSource = { dateFormat: 'YYYY-MM-DD' };
       const overrides = { dateFormat: null };

--- a/src/core/server/ui_settings/ui_settings_config.ts
+++ b/src/core/server/ui_settings/ui_settings_config.ts
@@ -38,7 +38,12 @@ const deprecations: ConfigDeprecationProvider = ({ unused, renameFromRoot }) => 
 ];
 
 const configSchema = schema.object({
-  overrides: schema.object({}, { unknowns: 'allow' }),
+  overrides: schema.object(
+    {
+      'theme:version': schema.string({ defaultValue: 'v7' }),
+    },
+    { unknowns: 'allow' }
+  ),
 });
 
 export type UiSettingsConfigType = TypeOf<typeof configSchema>;


### PR DESCRIPTION
Signed-off-by: Manasvini B Suryanarayana <manasvis@amazon.com>

### Description
The theme was marked hidden in Advanced Settings within the UI but is still can be utilized and configurable. Users who have originally set the theme version from v7 (or unset) to v8 (beta) experienced rendering issues within OpenSearch Dashboards. With this changes, we are adding override to the `theme:version` config property to always default to `v7`.
 
### Issues Resolved
[#3032](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3032)
 
### Check List
- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [X] New functionality includes testing.
- [x] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 