### PR TITLE
[Infrastructure] Add `untriaged` label to issues workflow

### DIFF
--- a/.github/workflows/add_untriaged_label.yml
+++ b/.github/workflows/add_untriaged_label.yml
@@ -1,0 +1,19 @@
+name: Apply 'untriaged' label during issue lifecycle
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['untriaged']
+            })


### PR DESCRIPTION
Credit to Peter Nied <petern@amazon.com> via https://github.com/opensearch-project/.github/pull/111

### Description

Automatically applies `untriaged` label to all new, reopened, and transferred issues. This helps us be able to trust that label, because it isn't dependent on issue templates.
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 