### PR TITLE
Dashboard Lists Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Use mirrors to download Node.js binaries to escape sporadic 404 errors ([#3619](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3619))
 - [Multiple DataSource] Refactor dev tool console to use opensearch-js client to send requests ([#3544](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3544))
 - [Data] Add geo shape filter field ([#3605](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3605))
-- Add Dashboards-list integrations for Plugins ([#3090](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3090) )
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [I18n] Register ru, ru-RU locale ([#2817](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2817))
 - Add yarn opensearch arg to setup plugin dependencies ([#2544](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2544))
 - [Multi DataSource] Test the connection to an external data source when creating or updating ([#2973](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2973))
+- Add Dashboards-list integrations for Plugins ([#3090](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3090) )
 - [Table Visualization] Refactor table visualization using React and DataGrid component ([#2863](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2863))
 - [Vis Builder] Add redux store persistence ([#3088](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3088))
 - [Multi DataSource] Improve test connection ([#3110](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3110))
@@ -70,6 +71,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Use mirrors to download Node.js binaries to escape sporadic 404 errors ([#3619](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3619))
 - [Multiple DataSource] Refactor dev tool console to use opensearch-js client to send requests ([#3544](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3544))
 - [Data] Add geo shape filter field ([#3605](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3605))
+- Add Dashboards-list integrations for Plugins ([#3090](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3090) )
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/dashboard/public/application/application.ts
+++ b/src/plugins/dashboard/public/application/application.ts
@@ -45,6 +45,7 @@ import {
   AppMountParameters,
 } from 'opensearch-dashboards/public';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/public';
+import { DashboardProvider } from 'src/plugins/dashboard/public/types';
 import { Storage } from '../../../opensearch_dashboards_utils/public';
 // @ts-ignore
 import { initDashboardApp } from './legacy_app';
@@ -71,6 +72,7 @@ export interface RenderDeps {
   navigation: NavigationStart;
   savedObjectsClient: SavedObjectsClientContract;
   savedDashboards: SavedObjectLoader;
+  dashboardProviders: () => { [key: string]: DashboardProvider };
   dashboardConfig: OpenSearchDashboardsLegacyStart['dashboardConfig'];
   dashboardCapabilities: any;
   embeddableCapabilities: {
@@ -79,7 +81,6 @@ export interface RenderDeps {
   };
   uiSettings: IUiSettingsClient;
   chrome: ChromeStart;
-  addBasePath: (path: string) => string;
   savedQueryService: DataPublicPluginStart['query']['savedQueries'];
   embeddable: EmbeddableStart;
   localStorage: Storage;
@@ -141,12 +142,11 @@ function createLocalAngularModule() {
   createLocalI18nModule();
   createLocalIconModule();
 
-  const dashboardAngularModule = angular.module(moduleName, [
+  return angular.module(moduleName, [
     ...thirdPartyAngularDependencies,
     'app/dashboard/I18n',
     'app/dashboard/icon',
   ]);
-  return dashboardAngularModule;
 }
 
 function createLocalIconModule() {

--- a/src/plugins/dashboard/public/application/legacy_app.js
+++ b/src/plugins/dashboard/public/application/legacy_app.js
@@ -164,11 +164,11 @@ export function initDashboardApp(app, deps) {
             };
           };
 
-          $scope.editItem = ({ appId, editUrl }) => {
-            deps.core.application.navigateToApp(appId, { path: editUrl });
+          $scope.editItem = ({ editUrl }) => {
+            history.push(deps.addBasePath(editUrl));
           };
-          $scope.viewItem = ({ appId, viewUrl }) => {
-            deps.core.application.navigateToApp(appId, { path: viewUrl });
+          $scope.viewItem = ({ viewUrl }) => {
+            history.push(deps.addBasePath(viewUrl));
           };
           $scope.delete = (dashboards) => {
             return service.delete(dashboards.map((d) => d.id));

--- a/src/plugins/dashboard/public/application/legacy_app.js
+++ b/src/plugins/dashboard/public/application/legacy_app.js
@@ -53,9 +53,10 @@ export function initDashboardApp(app, deps) {
   app.directive('dashboardListing', function (reactDirective) {
     return reactDirective(DashboardListing, [
       ['core', { watchDepth: 'reference' }],
+      ['dashboardProviders', { watchDepth: 'reference' }],
       ['createItem', { watchDepth: 'reference' }],
-      ['getViewUrl', { watchDepth: 'reference' }],
       ['editItem', { watchDepth: 'reference' }],
+      ['viewItem', { watchDepth: 'reference' }],
       ['findItems', { watchDepth: 'reference' }],
       ['deleteItems', { watchDepth: 'reference' }],
       ['listingLimit', { watchDepth: 'reference' }],
@@ -127,14 +128,47 @@ export function initDashboardApp(app, deps) {
           $scope.create = () => {
             history.push(DashboardConstants.CREATE_NEW_DASHBOARD_URL);
           };
-          $scope.find = (search) => {
-            return service.find(search, $scope.listingLimit);
+          $scope.dashboardProviders = deps.dashboardProviders() || [];
+          $scope.dashboardListTypes = Object.keys($scope.dashboardProviders);
+
+          const mapListAttributesToDashboardProvider = (obj) => {
+            const provider = $scope.dashboardProviders[obj.type];
+            return {
+              id: obj.id,
+              appId: provider.appId,
+              type: provider.savedObjectsName,
+              ...obj.attributes,
+              updated_at: obj.updated_at,
+              viewUrl: provider.viewUrlPathFn(obj),
+              editUrl: provider.editUrlPathFn(obj),
+            };
           };
-          $scope.editItem = ({ id }) => {
-            history.push(`${createDashboardEditUrl(id)}?_a=(viewMode:edit)`);
+
+          $scope.find = async (search) => {
+            const savedObjectsClient = deps.savedObjectsClient;
+
+            const res = await savedObjectsClient.find({
+              type: $scope.dashboardListTypes,
+              search: search ? `${search}*` : undefined,
+              fields: ['title', 'type', 'description', 'updated_at'],
+              perPage: $scope.initialPageSize,
+              page: 1,
+              searchFields: ['title^3', 'type', 'description'],
+              defaultSearchOperator: 'AND',
+            });
+            const list = res.savedObjects?.map(mapListAttributesToDashboardProvider) || [];
+
+            return {
+              total: list.length,
+              hits: list,
+            };
           };
-          $scope.getViewUrl = ({ id }) => {
-            return deps.addBasePath(`#${createDashboardEditUrl(id)}`);
+
+          $scope.editItem = ({ appId, editUrl }) => {
+            deps.core.application.navigateToApp(appId, { path: editUrl });
+          };
+          $scope.viewItem = ({ appId, viewUrl }) => {
+            deps.core.application.navigateToApp(appId, { path: viewUrl });
           };
           $scope.delete = (dashboards) => {
             return service.delete(dashboards.map((d) => d.id));

--- a/src/plugins/dashboard/public/application/listing/__snapshots__/create_button.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/listing/__snapshots__/create_button.test.tsx.snap
@@ -1,0 +1,558 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`create button no props renders empty when no providers given 1`] = `
+<CreateButton
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+/>
+`;
+
+exports[`create button with props renders button dropdown menu when two providers given 1`] = `
+<CreateButton
+  dashboardProviders={
+    Array [
+      Object {
+        "appId": "test",
+        "createLinkText": "test2",
+        "createSortText": "test2",
+        "createUrl": "test2",
+        "editUrlPathFn": [Function],
+        "savedObjectsName": "test2",
+        "savedObjectsType": "test2",
+        "viewUrlPathFn": [Function],
+      },
+      Object {
+        "appId": "test",
+        "createLinkText": "test1",
+        "createSortText": "test1",
+        "createUrl": "test1",
+        "editUrlPathFn": [Function],
+        "savedObjectsName": "test1",
+        "savedObjectsType": "test1",
+        "viewUrlPathFn": [Function],
+      },
+    ]
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+>
+  <EuiFlexItem
+    grow={false}
+  >
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <EuiPopover
+        anchorPosition="downRight"
+        button={
+          <EuiButton
+            data-test-subj="createMenuDropdown"
+            fill={true}
+            iconSide="right"
+            iconType="arrowDown"
+            onClick={[Function]}
+          >
+            <FormattedMessage
+              defaultMessage="Create"
+              id="dashboard.listing.createButtonText"
+              values={Object {}}
+            />
+          </EuiButton>
+        }
+        closePopover={[Function]}
+        display="inlineBlock"
+        hasArrow={true}
+        id="createMenuPopover"
+        isOpen={false}
+        ownFocus={true}
+        panelPaddingSize="none"
+      >
+        <div
+          className="euiPopover euiPopover--anchorDownRight"
+          id="createMenuPopover"
+        >
+          <div
+            className="euiPopover__anchor"
+          >
+            <EuiButton
+              data-test-subj="createMenuDropdown"
+              fill={true}
+              iconSide="right"
+              iconType="arrowDown"
+              onClick={[Function]}
+            >
+              <EuiButtonDisplay
+                baseClassName="euiButton"
+                data-test-subj="createMenuDropdown"
+                disabled={false}
+                element="button"
+                fill={true}
+                iconSide="right"
+                iconType="arrowDown"
+                isDisabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <button
+                  className="euiButton euiButton--primary euiButton--fill"
+                  data-test-subj="createMenuDropdown"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "minWidth": undefined,
+                    }
+                  }
+                  type="button"
+                >
+                  <EuiButtonContent
+                    className="euiButton__content"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    textProps={
+                      Object {
+                        "className": "euiButton__text",
+                      }
+                    }
+                  >
+                    <span
+                      className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                    >
+                      <EuiIcon
+                        className="euiButtonContent__icon"
+                        color="inherit"
+                        size="m"
+                        type="arrowDown"
+                      >
+                        <span
+                          className="euiButtonContent__icon"
+                          color="inherit"
+                          data-euiicon-type="arrowDown"
+                          size="m"
+                        />
+                      </EuiIcon>
+                      <span
+                        className="euiButton__text"
+                      >
+                        <FormattedMessage
+                          defaultMessage="Create"
+                          id="dashboard.listing.createButtonText"
+                          values={Object {}}
+                        >
+                          Create
+                        </FormattedMessage>
+                      </span>
+                    </span>
+                  </EuiButtonContent>
+                </button>
+              </EuiButtonDisplay>
+            </EuiButton>
+          </div>
+        </div>
+      </EuiPopover>
+    </div>
+  </EuiFlexItem>
+</CreateButton>
+`;
+
+exports[`create button with props renders single button when one provider given 1`] = `
+<CreateButton
+  dashboardProviders={
+    Array [
+      Object {
+        "appId": "test",
+        "createLinkText": "TestModule",
+        "createSortText": "TestModule",
+        "createUrl": "createUrl",
+        "editUrlPathFn": [Function],
+        "savedObjectsName": "Test",
+        "savedObjectsType": "test",
+        "viewUrlPathFn": [Function],
+      },
+    ]
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+>
+  <EuiFlexItem
+    grow={false}
+  >
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <EuiButton
+        data-test-subj="newItemButton"
+        fill={true}
+        href="createUrl"
+        iconType="plusInCircle"
+      >
+        <EuiButtonDisplay
+          baseClassName="euiButton"
+          data-test-subj="newItemButton"
+          element="a"
+          fill={true}
+          href="createUrl"
+          iconType="plusInCircle"
+          isDisabled={false}
+          rel="noreferrer"
+        >
+          <a
+            className="euiButton euiButton--primary euiButton--fill"
+            data-test-subj="newItemButton"
+            disabled={false}
+            href="createUrl"
+            rel="noreferrer"
+            style={
+              Object {
+                "minWidth": undefined,
+              }
+            }
+          >
+            <EuiButtonContent
+              className="euiButton__content"
+              iconSide="left"
+              iconType="plusInCircle"
+              textProps={
+                Object {
+                  "className": "euiButton__text",
+                }
+              }
+            >
+              <span
+                className="euiButtonContent euiButton__content"
+              >
+                <EuiIcon
+                  className="euiButtonContent__icon"
+                  color="inherit"
+                  size="m"
+                  type="plusInCircle"
+                >
+                  <span
+                    className="euiButtonContent__icon"
+                    color="inherit"
+                    data-euiicon-type="plusInCircle"
+                    size="m"
+                  />
+                </EuiIcon>
+                <span
+                  className="euiButton__text"
+                >
+                  <FormattedMessage
+                    defaultMessage="Create"
+                    id="dashboard.listing.createButtonText"
+                    values={Object {}}
+                  >
+                    Create
+                  </FormattedMessage>
+                   
+                  TestModule
+                </span>
+              </span>
+            </EuiButtonContent>
+          </a>
+        </EuiButtonDisplay>
+      </EuiButton>
+    </div>
+  </EuiFlexItem>
+</CreateButton>
+`;

--- a/src/plugins/dashboard/public/application/listing/__snapshots__/dashboard_listing.test.js.snap
+++ b/src/plugins/dashboard/public/application/listing/__snapshots__/dashboard_listing.test.js.snap
@@ -3,11 +3,7 @@
 exports[`after fetch hideWriteControls 1`] = `
 <I18nProvider>
   <TableListView
-    createButton={
-      <CreateButton
-        dashboardItemCreators={[Function]}
-      />
-    }
+    createButton={null}
     createItem={null}
     deleteItems={null}
     editItem={null}
@@ -94,11 +90,7 @@ exports[`after fetch hideWriteControls 1`] = `
 exports[`after fetch initialFilter 1`] = `
 <I18nProvider>
   <TableListView
-    createButton={
-      <CreateButton
-        dashboardItemCreators={[Function]}
-      />
-    }
+    createButton={<CreateButton />}
     createItem={[Function]}
     deleteItems={[Function]}
     editItem={[Function]}
@@ -229,11 +221,7 @@ exports[`after fetch initialFilter 1`] = `
 exports[`after fetch renders call to action when no dashboards exist 1`] = `
 <I18nProvider>
   <TableListView
-    createButton={
-      <CreateButton
-        dashboardItemCreators={[Function]}
-      />
-    }
+    createButton={<CreateButton />}
     createItem={[Function]}
     deleteItems={[Function]}
     editItem={[Function]}
@@ -364,11 +352,7 @@ exports[`after fetch renders call to action when no dashboards exist 1`] = `
 exports[`after fetch renders table rows 1`] = `
 <I18nProvider>
   <TableListView
-    createButton={
-      <CreateButton
-        dashboardItemCreators={[Function]}
-      />
-    }
+    createButton={<CreateButton />}
     createItem={[Function]}
     deleteItems={[Function]}
     editItem={[Function]}
@@ -499,11 +483,7 @@ exports[`after fetch renders table rows 1`] = `
 exports[`after fetch renders warning when listingLimit is exceeded 1`] = `
 <I18nProvider>
   <TableListView
-    createButton={
-      <CreateButton
-        dashboardItemCreators={[Function]}
-      />
-    }
+    createButton={<CreateButton />}
     createItem={[Function]}
     deleteItems={[Function]}
     editItem={[Function]}
@@ -634,11 +614,7 @@ exports[`after fetch renders warning when listingLimit is exceeded 1`] = `
 exports[`renders empty page in before initial fetch to avoid flickering 1`] = `
 <I18nProvider>
   <TableListView
-    createButton={
-      <CreateButton
-        dashboardItemCreators={[Function]}
-      />
-    }
+    createButton={<CreateButton />}
     createItem={[Function]}
     deleteItems={[Function]}
     editItem={[Function]}

--- a/src/plugins/dashboard/public/application/listing/__snapshots__/dashboard_listing.test.js.snap
+++ b/src/plugins/dashboard/public/application/listing/__snapshots__/dashboard_listing.test.js.snap
@@ -3,6 +3,11 @@
 exports[`after fetch hideWriteControls 1`] = `
 <I18nProvider>
   <TableListView
+    createButton={
+      <CreateButton
+        dashboardItemCreators={[Function]}
+      />
+    }
     createItem={null}
     deleteItems={null}
     editItem={null}
@@ -41,6 +46,12 @@ exports[`after fetch hideWriteControls 1`] = `
         },
         Object {
           "dataType": "string",
+          "field": "type",
+          "name": "Type",
+          "sortable": true,
+        },
+        Object {
+          "dataType": "string",
           "field": "description",
           "name": "Description",
           "sortable": true,
@@ -75,6 +86,7 @@ exports[`after fetch hideWriteControls 1`] = `
         },
       }
     }
+    viewItem={null}
   />
 </I18nProvider>
 `;
@@ -82,6 +94,11 @@ exports[`after fetch hideWriteControls 1`] = `
 exports[`after fetch initialFilter 1`] = `
 <I18nProvider>
   <TableListView
+    createButton={
+      <CreateButton
+        dashboardItemCreators={[Function]}
+      />
+    }
     createItem={[Function]}
     deleteItems={[Function]}
     editItem={[Function]}
@@ -164,6 +181,12 @@ exports[`after fetch initialFilter 1`] = `
         },
         Object {
           "dataType": "string",
+          "field": "type",
+          "name": "Type",
+          "sortable": true,
+        },
+        Object {
+          "dataType": "string",
           "field": "description",
           "name": "Description",
           "sortable": true,
@@ -198,6 +221,7 @@ exports[`after fetch initialFilter 1`] = `
         },
       }
     }
+    viewItem={[Function]}
   />
 </I18nProvider>
 `;
@@ -205,6 +229,11 @@ exports[`after fetch initialFilter 1`] = `
 exports[`after fetch renders call to action when no dashboards exist 1`] = `
 <I18nProvider>
   <TableListView
+    createButton={
+      <CreateButton
+        dashboardItemCreators={[Function]}
+      />
+    }
     createItem={[Function]}
     deleteItems={[Function]}
     editItem={[Function]}
@@ -287,6 +316,12 @@ exports[`after fetch renders call to action when no dashboards exist 1`] = `
         },
         Object {
           "dataType": "string",
+          "field": "type",
+          "name": "Type",
+          "sortable": true,
+        },
+        Object {
+          "dataType": "string",
           "field": "description",
           "name": "Description",
           "sortable": true,
@@ -321,6 +356,7 @@ exports[`after fetch renders call to action when no dashboards exist 1`] = `
         },
       }
     }
+    viewItem={[Function]}
   />
 </I18nProvider>
 `;
@@ -328,6 +364,11 @@ exports[`after fetch renders call to action when no dashboards exist 1`] = `
 exports[`after fetch renders table rows 1`] = `
 <I18nProvider>
   <TableListView
+    createButton={
+      <CreateButton
+        dashboardItemCreators={[Function]}
+      />
+    }
     createItem={[Function]}
     deleteItems={[Function]}
     editItem={[Function]}
@@ -410,6 +451,12 @@ exports[`after fetch renders table rows 1`] = `
         },
         Object {
           "dataType": "string",
+          "field": "type",
+          "name": "Type",
+          "sortable": true,
+        },
+        Object {
+          "dataType": "string",
           "field": "description",
           "name": "Description",
           "sortable": true,
@@ -444,6 +491,7 @@ exports[`after fetch renders table rows 1`] = `
         },
       }
     }
+    viewItem={[Function]}
   />
 </I18nProvider>
 `;
@@ -451,6 +499,11 @@ exports[`after fetch renders table rows 1`] = `
 exports[`after fetch renders warning when listingLimit is exceeded 1`] = `
 <I18nProvider>
   <TableListView
+    createButton={
+      <CreateButton
+        dashboardItemCreators={[Function]}
+      />
+    }
     createItem={[Function]}
     deleteItems={[Function]}
     editItem={[Function]}
@@ -533,6 +586,12 @@ exports[`after fetch renders warning when listingLimit is exceeded 1`] = `
         },
         Object {
           "dataType": "string",
+          "field": "type",
+          "name": "Type",
+          "sortable": true,
+        },
+        Object {
+          "dataType": "string",
           "field": "description",
           "name": "Description",
           "sortable": true,
@@ -567,6 +626,7 @@ exports[`after fetch renders warning when listingLimit is exceeded 1`] = `
         },
       }
     }
+    viewItem={[Function]}
   />
 </I18nProvider>
 `;
@@ -574,6 +634,11 @@ exports[`after fetch renders warning when listingLimit is exceeded 1`] = `
 exports[`renders empty page in before initial fetch to avoid flickering 1`] = `
 <I18nProvider>
   <TableListView
+    createButton={
+      <CreateButton
+        dashboardItemCreators={[Function]}
+      />
+    }
     createItem={[Function]}
     deleteItems={[Function]}
     editItem={[Function]}
@@ -582,6 +647,7 @@ exports[`renders empty page in before initial fetch to avoid flickering 1`] = `
     findItems={[Function]}
     headingId="dashboardListingHeading"
     initialFilter=""
+    initialPageSize={10}
     listingLimit={1000}
     noItemsFragment={
       <div>
@@ -655,6 +721,12 @@ exports[`renders empty page in before initial fetch to avoid flickering 1`] = `
         },
         Object {
           "dataType": "string",
+          "field": "type",
+          "name": "Type",
+          "sortable": true,
+        },
+        Object {
+          "dataType": "string",
           "field": "description",
           "name": "Description",
           "sortable": true,
@@ -689,6 +761,7 @@ exports[`renders empty page in before initial fetch to avoid flickering 1`] = `
         },
       }
     }
+    viewItem={[Function]}
   />
 </I18nProvider>
 `;

--- a/src/plugins/dashboard/public/application/listing/create_button.test.tsx
+++ b/src/plugins/dashboard/public/application/listing/create_button.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
+import { findTestSubject } from '@elastic/eui/lib/test';
+
+import React from 'react';
+
+import { CreateButton } from './create_button';
+import { DashboardProvider } from '../../types';
+
+const provider = (type?: string, url?: string, text?: string): DashboardProvider => {
+  return {
+    appId: 'test',
+    savedObjectsType: type || 'test',
+    savedObjectsName: type || 'Test',
+    createUrl: url || 'createUrl',
+    createLinkText: text || 'TestModule',
+    createSortText: text || 'TestModule',
+    viewUrlPathFn: (id) => `/${type || 'test'}_plugin/${id}`,
+    editUrlPathFn: (id) => `/${type || 'test'}_plugin/${id}/edit`,
+  };
+};
+
+function mountComponent(props?: any) {
+  return mountWithIntl(<CreateButton {...props} />);
+}
+
+describe('create button no props', () => {
+  test('renders empty when no providers given', () => {
+    const component = mountComponent();
+
+    expect(component).toMatchSnapshot();
+  });
+});
+describe('create button with props', () => {
+  test('renders single button when one provider given', () => {
+    const component = mountComponent({ dashboardProviders: [provider()] });
+    expect(component).toMatchSnapshot();
+    const links = findTestSubject(component, 'newItemButton');
+    expect(links.length).toBe(1);
+  });
+  test('renders button dropdown menu when two providers given', () => {
+    const provider1 = provider('test1', 'test1', 'test1');
+    const provider2 = provider('test2', 'test2', 'test2');
+    const component = mountComponent({ dashboardProviders: [provider2, provider1] });
+    expect(component).toMatchSnapshot();
+    const createButtons = findTestSubject(component, 'newItemButton');
+    expect(createButtons.length).toBe(0);
+    const createDropdown = findTestSubject(component, 'createMenuDropdown');
+    createDropdown.simulate('click');
+    const contextMenus = findTestSubject(component, 'contextMenuItem');
+    expect(contextMenus.length).toBe(2);
+    expect(contextMenus.at(0).prop('href')).toBe('test1');
+  });
+});

--- a/src/plugins/dashboard/public/application/listing/create_button.tsx
+++ b/src/plugins/dashboard/public/application/listing/create_button.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import React, { useState } from 'react';
+import { FormattedMessage } from '@osd/i18n/react';
+import {
+  EuiButton,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFlexItem,
+  EuiPopover,
+} from '@elastic/eui';
+import type { DashboardProvider } from '../../types';
+
+interface CreateButtonProps {
+  dashboardProviders?: DashboardProvider[];
+}
+
+const CreateButton = (props: CreateButtonProps) => {
+  const [isPopoverOpen, setPopover] = useState(false);
+
+  const onMenuButtonClick = () => {
+    setPopover(!isPopoverOpen);
+  };
+
+  const closePopover = () => {
+    setPopover(false);
+  };
+
+  const getPopupMenuItems = () => {
+    const providers = Object.values(props.dashboardProviders || {});
+    return providers
+      .sort((a: DashboardProvider, b: DashboardProvider) =>
+        a.createSortText.localeCompare(b.createSortText)
+      )
+      .map((provider: DashboardProvider) => (
+        <EuiContextMenuItem
+          key={provider.savedObjectsType}
+          href={provider.createUrl}
+          data-test-subj="contextMenuItem"
+        >
+          {provider.createLinkText}
+        </EuiContextMenuItem>
+      ));
+  };
+
+  const renderCreateMenuDropDown = () => {
+    const button = (
+      <EuiButton
+        iconType="arrowDown"
+        iconSide="right"
+        onClick={onMenuButtonClick}
+        fill
+        data-test-subj="createMenuDropdown"
+      >
+        <FormattedMessage id="dashboard.listing.createButtonText" defaultMessage="Create" />
+      </EuiButton>
+    );
+
+    return (
+      <EuiFlexItem grow={false}>
+        <EuiPopover
+          id="createMenuPopover"
+          button={button}
+          isOpen={isPopoverOpen}
+          closePopover={closePopover}
+          panelPaddingSize="none"
+          anchorPosition="downRight"
+        >
+          <EuiContextMenuPanel items={getPopupMenuItems()} size="s" />
+        </EuiPopover>
+      </EuiFlexItem>
+    );
+  };
+
+  const renderCreateSingleButton = () => {
+    const provider: DashboardProvider = Object.values(props.dashboardProviders!)[0];
+    return (
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          href={provider.createUrl}
+          data-test-subj="newItemButton"
+          iconType="plusInCircle"
+          fill
+        >
+          <FormattedMessage id="dashboard.listing.createButtonText" defaultMessage="Create" />
+          &nbsp;{provider.createLinkText}
+        </EuiButton>
+      </EuiFlexItem>
+    );
+  };
+
+  const renderMenu = () => {
+    if (!props.dashboardProviders || Object.keys(props.dashboardProviders!).length === 0) {
+      return null;
+    } else if (Object.keys(props.dashboardProviders!).length === 1) {
+      return renderCreateSingleButton();
+    } else {
+      return renderCreateMenuDropDown();
+    }
+  };
+
+  return renderMenu();
+};
+
+export { CreateButton };

--- a/src/plugins/dashboard/public/application/listing/dashboard_listing.js
+++ b/src/plugins/dashboard/public/application/listing/dashboard_listing.js
@@ -37,6 +37,7 @@ import { i18n } from '@osd/i18n';
 import { EuiLink, EuiButton, EuiEmptyPrompt } from '@elastic/eui';
 
 import { TableListView } from '../../../../opensearch_dashboards_react/public';
+import { CreateButton } from './create_button';
 
 export const EMPTY_FILTER = '';
 
@@ -56,9 +57,15 @@ export class DashboardListing extends React.Component {
         <TableListView
           headingId="dashboardListingHeading"
           createItem={this.props.hideWriteControls ? null : this.props.createItem}
+          createButton={
+            this.props.hideWriteControls ? null : (
+              <CreateButton dashboardProviders={this.props.dashboardProviders} />
+            )
+          }
           findItems={this.props.findItems}
           deleteItems={this.props.hideWriteControls ? null : this.props.deleteItems}
           editItem={this.props.hideWriteControls ? null : this.props.editItem}
+          viewItem={this.props.hideWriteControls ? null : this.props.viewItem}
           tableColumns={this.getTableColumns()}
           listingLimit={this.props.listingLimit}
           initialFilter={this.props.initialFilter}
@@ -163,7 +170,13 @@ export class DashboardListing extends React.Component {
 
   getTableColumns() {
     const dateFormat = this.props.core.uiSettings.get('dateFormat');
-    const tableColumns = [
+
+    const urlLinkProps = (record) =>
+      this.props.getUrl
+        ? { href: () => this.props.getUrl(record) }
+        : { onClick: () => this.props.viewItem(record) };
+
+    return [
       {
         field: 'title',
         name: i18n.translate('dashboard.listing.table.titleColumnName', {
@@ -172,12 +185,20 @@ export class DashboardListing extends React.Component {
         sortable: true,
         render: (field, record) => (
           <EuiLink
-            href={this.props.getViewUrl(record)}
+            {...urlLinkProps(record)}
             data-test-subj={`dashboardListingTitleLink-${record.title.split(' ').join('-')}`}
           >
             {field}
           </EuiLink>
         ),
+      },
+      {
+        field: 'type',
+        name: i18n.translate('dashboard.listing.table.typeColumnName', {
+          defaultMessage: 'Type',
+        }),
+        dataType: 'string',
+        sortable: true,
       },
       {
         field: 'description',
@@ -201,16 +222,18 @@ export class DashboardListing extends React.Component {
         render: (updatedAt) => updatedAt && moment(updatedAt).format(dateFormat),
       },
     ];
-    return tableColumns;
   }
 }
 
 DashboardListing.propTypes = {
-  createItem: PropTypes.func.isRequired,
+  createItem: PropTypes.func,
+  dashboardProviders: PropTypes.object,
   findItems: PropTypes.func.isRequired,
   deleteItems: PropTypes.func.isRequired,
   editItem: PropTypes.func.isRequired,
-  getViewUrl: PropTypes.func.isRequired,
+  getViewUrl: PropTypes.func,
+  editItemAvailable: PropTypes.func,
+  viewItem: PropTypes.func,
   listingLimit: PropTypes.number.isRequired,
   hideWriteControls: PropTypes.bool.isRequired,
   initialFilter: PropTypes.string,

--- a/src/plugins/dashboard/public/application/listing/dashboard_listing.js
+++ b/src/plugins/dashboard/public/application/listing/dashboard_listing.js
@@ -171,11 +171,6 @@ export class DashboardListing extends React.Component {
   getTableColumns() {
     const dateFormat = this.props.core.uiSettings.get('dateFormat');
 
-    const urlLinkProps = (record) =>
-      this.props.getUrl
-        ? { href: () => this.props.getUrl(record) }
-        : { onClick: () => this.props.viewItem(record) };
-
     return [
       {
         field: 'title',
@@ -185,7 +180,7 @@ export class DashboardListing extends React.Component {
         sortable: true,
         render: (field, record) => (
           <EuiLink
-            {...urlLinkProps(record)}
+            href={record.viewUrl}
             data-test-subj={`dashboardListingTitleLink-${record.title.split(' ').join('-')}`}
           >
             {field}

--- a/src/plugins/dashboard/public/application/listing/dashboard_listing.test.js
+++ b/src/plugins/dashboard/public/application/listing/dashboard_listing.test.js
@@ -70,7 +70,10 @@ test('renders empty page in before initial fetch to avoid flickering', () => {
       deleteItems={() => {}}
       createItem={() => {}}
       editItem={() => {}}
-      getViewUrl={() => {}}
+      viewItem={() => {}}
+      dashboardItemCreatorClickHandler={() => {}}
+      dashboardItemCreators={() => []}
+      initialPageSize={10}
       listingLimit={1000}
       hideWriteControls={false}
       core={{ notifications: { toasts: {} }, uiSettings: { get: jest.fn(() => 10) } }}
@@ -87,7 +90,9 @@ describe('after fetch', () => {
         deleteItems={() => {}}
         createItem={() => {}}
         editItem={() => {}}
-        getViewUrl={() => {}}
+        viewItem={() => {}}
+        dashboardItemCreatorClickHandler={() => {}}
+        dashboardItemCreators={() => []}
         listingLimit={1000}
         hideWriteControls={false}
         initialPageSize={10}
@@ -111,7 +116,9 @@ describe('after fetch', () => {
         deleteItems={() => {}}
         createItem={() => {}}
         editItem={() => {}}
-        getViewUrl={() => {}}
+        viewItem={() => {}}
+        dashboardItemCreatorClickHandler={() => {}}
+        dashboardItemCreators={() => []}
         listingLimit={1000}
         initialPageSize={10}
         hideWriteControls={false}
@@ -134,7 +141,9 @@ describe('after fetch', () => {
         deleteItems={() => {}}
         createItem={() => {}}
         editItem={() => {}}
-        getViewUrl={() => {}}
+        viewItem={() => {}}
+        dashboardItemCreatorClickHandler={() => {}}
+        dashboardItemCreators={() => []}
         listingLimit={1}
         initialPageSize={10}
         hideWriteControls={false}
@@ -157,7 +166,9 @@ describe('after fetch', () => {
         deleteItems={() => {}}
         createItem={() => {}}
         editItem={() => {}}
-        getViewUrl={() => {}}
+        viewItem={() => {}}
+        dashboardItemCreatorClickHandler={() => {}}
+        dashboardItemCreators={() => []}
         listingLimit={1}
         initialPageSize={10}
         hideWriteControls={true}
@@ -180,7 +191,9 @@ describe('after fetch', () => {
         deleteItems={() => {}}
         createItem={() => {}}
         editItem={() => {}}
-        getViewUrl={() => {}}
+        viewItem={() => {}}
+        dashboardItemCreatorClickHandler={() => {}}
+        dashboardItemCreators={() => []}
         listingLimit={1}
         initialPageSize={10}
         hideWriteControls={false}

--- a/src/plugins/dashboard/public/application/listing/dashboard_listing_ng_wrapper.html
+++ b/src/plugins/dashboard/public/application/listing/dashboard_listing_ng_wrapper.html
@@ -1,8 +1,10 @@
 <dashboard-listing
   core="core"
   create-item="create"
-  get-view-url="getViewUrl"
+  dashboard-providers="dashboardProviders"
   edit-item="editItem"
+  view-item="viewItem"
+  edit-item-available="editItemAvailable"
   find-items="find"
   delete-items="delete"
   listing-limit="listingLimit"

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -346,7 +346,7 @@ export class DashboardPlugin
       savedObjectsName: 'Dashboard',
       appId: 'dashboards',
       viewUrlPathFn: (obj) => `#/view/${obj.id}`,
-      editUrlPathFn: (obj) => `#/view/${obj.id}?_a=(viewMode:edit)`,
+      editUrlPathFn: (obj) => `/view/${obj.id}?_a=(viewMode:edit)`,
       createUrl: core.http.basePath.prepend('/app/dashboards#/create'),
       createSortText: 'Dashboard',
       createLinkText: (

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -32,6 +32,7 @@ import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
 
 import {
   App,
@@ -45,6 +46,7 @@ import {
   ScopedHistory,
 } from 'src/core/public';
 import { UrlForwardingSetup, UrlForwardingStart } from 'src/plugins/url_forwarding/public';
+import { isEmpty } from 'lodash';
 import { UsageCollectionSetup } from '../../usage_collection/public';
 import {
   CONTEXT_MENU_TRIGGER,
@@ -119,6 +121,7 @@ import {
   AttributeServiceOptions,
   ATTRIBUTE_SERVICE_KEY,
 } from './attribute_service/attribute_service';
+import { DashboardProvider } from './types';
 
 declare module '../../share/public' {
   export interface UrlGeneratorStateMapping {
@@ -156,7 +159,11 @@ interface StartDependencies {
   savedObjects: SavedObjectsStart;
 }
 
-export type DashboardSetup = void;
+export type RegisterDashboardProviderFn = (provider: DashboardProvider) => void;
+
+export interface DashboardSetup {
+  registerDashboardProvider: RegisterDashboardProviderFn;
+}
 
 export interface DashboardStart {
   getSavedDashboardLoader: () => SavedObjectLoader;
@@ -200,6 +207,7 @@ export class DashboardPlugin
   private currentHistory: ScopedHistory | undefined = undefined;
   private dashboardFeatureFlagConfig?: DashboardFeatureFlagConfig;
 
+  private dashboardProviders: { [key: string]: DashboardProvider } = {};
   private dashboardUrlGenerator?: DashboardUrlGenerator;
 
   public setup(
@@ -308,6 +316,48 @@ export class DashboardPlugin
       stopUrlTracker();
     };
 
+    const registerDashboardProvider: RegisterDashboardProviderFn = (
+      provider: DashboardProvider
+    ) => {
+      const found = this.dashboardProviders[provider.savedObjectsType];
+      if (found) {
+        throw new Error(`DashboardProvider ${provider.savedObjectsType} is registered twice`);
+      }
+      if (
+        isEmpty(provider.createSortText) ||
+        isEmpty(provider.createUrl) ||
+        isEmpty(provider.createLinkText)
+      ) {
+        throw new Error(
+          `DashboardProvider ${provider.savedObjectsType} requires 'createSortText', 'createLinkText', and 'createUrl'`
+        );
+      }
+      if (isEmpty(provider.savedObjectsType || isEmpty(provider.savedObjectsName))) {
+        throw new Error(
+          `DashboardProvider ${provider.savedObjectsType} requires 'savedObjectsId', and 'savedObjectsType'`
+        );
+      }
+
+      this.dashboardProviders[provider.savedObjectsType] = provider;
+    };
+
+    registerDashboardProvider({
+      savedObjectsType: 'dashboard',
+      savedObjectsName: 'Dashboard',
+      appId: 'dashboards',
+      viewUrlPathFn: (obj) => `#/view/${obj.id}`,
+      editUrlPathFn: (obj) => `#/view/${obj.id}?_a=(viewMode:edit)`,
+      createUrl: core.http.basePath.prepend('/app/dashboards#/create'),
+      createSortText: 'Dashboard',
+      createLinkText: (
+        <FormattedMessage
+          id="opensearch-dashboards-react.tableListView.listing.createNewItemButtonLabel"
+          defaultMessage="{entityName}"
+          values={{ entityName: 'Dashboard' }}
+        />
+      ),
+    });
+
     const app: App = {
       id: DashboardConstants.DASHBOARDS_ID,
       title: 'Dashboard',
@@ -341,6 +391,7 @@ export class DashboardPlugin
           data: dataStart,
           savedObjectsClient: coreStart.savedObjects.client,
           savedDashboards: dashboardStart.getSavedDashboardLoader(),
+          dashboardProviders: () => this.dashboardProviders,
           chrome: coreStart.chrome,
           addBasePath: coreStart.http.basePath.prepend,
           uiSettings: coreStart.uiSettings,
@@ -420,6 +471,10 @@ export class DashboardPlugin
         order: 100,
       });
     }
+
+    return {
+      registerDashboardProvider,
+    };
   }
 
   private addEmbeddableToDashboard(

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -141,3 +141,74 @@ export interface StagedFilter {
   operator: string;
   index: string;
 }
+
+export interface DashboardProvider {
+  // appId :
+  // The appId used to register this Plugin application.
+  // This value needs to be repeated here as the 'app' of this plugin
+  // is not directly referenced in the details below, and the 'app' object
+  // is not linked in the Dashboards List surrounding code.
+  appId: string;
+
+  // savedObjectstype :
+  // This string should be the SavedObjects 'type' that you
+  // have registered for your objects.  This must match the value
+  // used by your Plugin's Server setup with `savedObjects.registerType()` call.
+  savedObjectsType: string;
+
+  // savedObjectsName :
+  // This string should be the display-name that will be used on the
+  // Dashboads / Dashboards table in a column named "Type".
+  savedObjectsName: string;
+
+  // savedObjectsId : Optional
+  // If provided, this string will override the use of the `savedObjectsType`
+  // for use with querying the SavedObjects index for your objects.
+  // The default value for this string is implicitly set to the `savedObjectsType`
+  savedObjectsId?: string;
+
+  // createLinkText :
+  // this is the string or Element that will be used to construct the
+  // OUI MenuPopup of Create options.
+  createLinkText: string | JSX.Element;
+
+  // createSortText :
+  // This string will be used in sorting the Create options.  Use
+  // the verbatim string here, not any interpolation or function.
+  createSortText: string;
+
+  // createUrl :
+  // This string should be the url-path for your plugin's Create
+  // feature.
+  createUrl: string;
+
+  // viewUrlPathFn :
+  // This function will be called on every iteratee of your objects
+  // while querying the SavedObjects for Dashboards / Dashboards
+  // This function should return the url-path to the View page
+  // for your Plugin's objects, within the "app" basepath.
+  // For instance :
+  //   appId = "myplugin"
+  //   app.basepath is then "/app/myplugin"
+  // then
+  //   viewUrlPathFn: (obj) => `#/view/${obj.id}`
+  //
+  // At onClick of rendered table "view" link for item {id: 'abc123', ...}, the navigated path will be:
+  //   "http://../app/myplugin#/view/abc123"
+  viewUrlPathFn: (obj: SavedObjectType) => string;
+
+  // editUrlPathFn :
+  // This function will be called on every iteratee of your objects
+  // while querying the SavedObjects for Dashboards / Dashboards
+  // This function should return the url-path to the Edit page
+  // for your Plugin's objects, within the "app" basepath.
+  // For instance :
+  //   appId = "myplugin"
+  //   app.basepath is then "/app/myplugin"
+  // then
+  //   editUrlPathFn: (obj) => `#/edit/${obj.id}`
+  //
+  // At onClick of rendered table "edit" link for item {id: 'abc123', ...}, the navigated path will be:
+  //   "http://../app/myplugin#/edit/abc123"
+  editUrlPathFn: (obj: SavedObjectType) => string;
+}

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/README.md
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/README.md
@@ -1,0 +1,44 @@
+# TableListView
+An OpenDashboardsReact component
+
+## Overview
+TableListView is a component composed of several OUI modules, wrapped in a convenient way for flexibility of options and input data.  
+
+The TableListView contains :
+- OUI InMemoryTable, including pagination and sortable columns
+- OUI SearchBar
+- Create button child component or callback handler.
+
+## Props
+- createButton - JSX.Element (optinoal)
+
+  - if provided, this element will be rendered at Right of SearchBox.  Element component and callback-handling is expected to be controlled by the component wrapping this TableListView.
+
+- createItem - Function () => void (optional)
+
+  - if provided, and no `createButton`, a default "Create" button will be rendered, using this prop function as callback to the default <Button> `onClick` handler.
+
+- deleteItems - Function (items) ? (items: object[]): Promise<void> (optional)
+
+  - if provided, upon multi-selection of one or more listed items, a "Delete x dashboard" button with "Trashcan" icon will be displayed, using this prop as `onClick` handler.
+
+- editItem - Function (item: object): void (optional)
+
+  - if provided, this function will be called with each item in the items collection.  The function is expected to perform any logic to display or navigate-to the "edit" view/page of the item.  The function returns no value.
+
+- entityName - string
+- entityNamePlural - string
+- findItems - Function (query: string): Promise<{ total: number; hits: object[] }>
+
+  - This function will be called any time the InMemoryTable requires refreshed items.
+- listingLimit: number
+- initialFilter: string
+- initialPageSize: number
+- noItemsFragment: JSX.Element
+- tableColumns: Column[]
+- tableListTitle: string
+- toastNotifications: ToastsStart
+
+- headingId: string (optional)
+  - Id of the heading element describing the table. This id will be used as `aria-labelledby` of the wrapper element.  If the table is not empty, this component renders its own h1 element using the same id.
+ 

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
@@ -61,6 +61,7 @@ interface Item {
 }
 
 export interface TableListViewProps {
+  createButton?: JSX.Element;
   createItem?(): void;
   deleteItems?(items: object[]): Promise<void>;
   editItem?(item: object): void;
@@ -93,6 +94,7 @@ export interface TableListViewState {
   filter: string;
   selectedIds: string[];
   totalItems: number;
+  isCreatePopoverOpen: boolean;
 }
 
 // saved object client does not support sorting by title because title is only mapped as analyzed
@@ -122,6 +124,7 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
       showLimitError: false,
       filter: props.initialFilter,
       selectedIds: [],
+      isCreatePopoverOpen: false,
     };
   }
 
@@ -230,11 +233,7 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
   }
 
   hasNoItems() {
-    if (!this.state.isFetchingItems && this.state.items.length === 0 && !this.state.filter) {
-      return true;
-    }
-
-    return false;
+    return !this.state.isFetchingItems && this.state.items.length === 0 && !this.state.filter;
   }
 
   renderConfirmDeleteModal() {
@@ -498,25 +497,25 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
   }
 
   renderListing() {
-    let createButton;
-    if (this.props.createItem) {
-      createButton = (
-        <EuiFlexItem grow={false}>
-          <EuiButton
-            onClick={this.props.createItem}
-            data-test-subj="newItemButton"
-            iconType="plusInCircle"
-            fill
-          >
-            <FormattedMessage
-              id="opensearch-dashboards-react.tableListView.listing.createNewItemButtonLabel"
-              defaultMessage="Create {entityName}"
-              values={{ entityName: this.props.entityName }}
-            />
-          </EuiButton>
-        </EuiFlexItem>
-      );
-    }
+    const defaultCreateButton = this.props.createItem ? (
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          onClick={this.props.createItem}
+          data-test-subj="newItemButton"
+          iconType="plusInCircle"
+          fill
+        >
+          <FormattedMessage
+            id="opensearch-dashboards-react.tableListView.listing.createNewItemButtonLabel"
+            defaultMessage="Create {entityName}"
+            values={{ entityName: this.props.entityName }}
+          />
+        </EuiButton>
+      </EuiFlexItem>
+    ) : (
+      false
+    );
+
     return (
       <div>
         {this.state.showDeleteModal && this.renderConfirmDeleteModal()}
@@ -528,7 +527,7 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
             </EuiTitle>
           </EuiFlexItem>
 
-          {createButton}
+          {this.props.createButton || defaultCreateButton}
         </EuiFlexGroup>
 
         <EuiSpacer size="m" />

--- a/test/functional/apps/dashboard/dashboard_clone.js
+++ b/test/functional/apps/dashboard/dashboard_clone.js
@@ -40,7 +40,7 @@ export default function ({ getService, getPageObjects }) {
     const clonedDashboardName = dashboardName + ' Copy';
 
     before(async function () {
-      return PageObjects.dashboard.initTests();
+      await PageObjects.dashboard.initTests();
     });
 
     it('Clone saves a copy', async function () {

--- a/test/functional/services/common/browser.ts
+++ b/test/functional/services/common/browser.ts
@@ -196,7 +196,7 @@ export async function BrowserProvider({ getService }: FtrProviderContext) {
      * @param {boolean} insertTimestamp Optional
      * @return {Promise<void>}
      */
-    public async get(url: string, insertTimestamp: boolean = false) {
+    public async get(url: string, insertTimestamp: boolean = true) {
       if (insertTimestamp) {
         const urlWithTime = modifyUrl(url, (parsed) => {
           (parsed.query as any)._t = Date.now();

--- a/test/functional/services/common/browser.ts
+++ b/test/functional/services/common/browser.ts
@@ -196,7 +196,7 @@ export async function BrowserProvider({ getService }: FtrProviderContext) {
      * @param {boolean} insertTimestamp Optional
      * @return {Promise<void>}
      */
-    public async get(url: string, insertTimestamp: boolean = true) {
+    public async get(url: string, insertTimestamp: boolean = false) {
       if (insertTimestamp) {
         const urlWithTime = modifyUrl(url, (parsed) => {
           (parsed.query as any)._t = Date.now();


### PR DESCRIPTION
### Description

* Configure types for registration of Dashboard List "Providers"

These changes enable the interactions demonstrated in this animation:


Audio starts at 0:05.    Unmute to listen.

https://user-images.githubusercontent.com/11318/220466340-f069ffa8-bc30-4094-8922-20848a982390.mov


References : [observability#1308](https://github.com/opensearch-project/observability/pull/1308)

### Issues WIP

[[FEATURE] Dashboards List Extensibility & Integrate Observability Apps/Panels/EventAnalytics](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1866)
- includes alternate solutions, example animation, and further explanation of this solution.

### Testing Failures vs UX/CX of Linking "integrated" Plugins

#### Using EUILink w/ href=
**Pros :**
* Works in test suite w/o change.

**Cons :**
* Causes browser-reload in production due to operation of React Router / SPA and navigating "between" SPA's

#### Using EUILink w/ onClick=(() => navigateToApp(app, path) )
**Pros :**
* Runs on browser production without reload when navigating "between" SPA's

**Cons :**
* Test suite fails on Dashboard-Clone test, when trying to click on Dashboard-List for any existing Dashboard item.
* `http://.../app/dashboard?_t=123456#/list?_g=...`


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 