### PR TITLE
Add a new `augment-vis` saved object type

### DIFF
--- a/src/plugins/saved_objects/README.md
+++ b/src/plugins/saved_objects/README.md
@@ -2,77 +2,78 @@
 
 The saved object plugin provides all the core services and functionalities of saved objects. It is utilized by many core plugins such as [`visualization`](../visualizations/), [`dashboard`](../dashboard/) and [`visBuilder`](../vis_builder/), as well as external plugins. Saved object is the primary way to store app and plugin data in a standardized form in OpenSearch Dashboards. They allow plugin developers to manage creating, saving, editing and retrieving data for the application. They can also make reference to other saved objects and have useful features out of the box, such as migrations and strict typings. The saved objects can be managed by the Saved Object Management UI.
 
-## Save relationships to index pattern
+### Relationships
 
-Saved objects that have relationships to index patterns are saved using the [`kibanaSavedObjectMeta`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/saved_objects/public/saved_object/helpers/serialize_saved_object.ts#L59) attribute and the [`references`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/saved_objects/public/saved_object/helpers/serialize_saved_object.ts#L60) array structure. Functions from the data plugin are used by the saved object plugin to manage this index pattern relationship. 
+Saved objects can persist parent/child relationships to other saved objects via `references`. These relationships can be viewed on the UI in the [saved objects management plugin](src/core/server/saved_objects_management/README.md). Relationships can be useful to combine existing saved objects to produce new ones, such as using an index pattern as the source for a visualization, or a dashboard consisting of many visualizations.
 
-A standard saved object and its index pattern relationship:
+Some saved object fields have pre-defined logic. For example, if a saved object type has a `searchSource` field indicating an index pattern relationship, a reference will automatically be created using the [`kibanaSavedObjectMeta`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/saved_objects/public/saved_object/helpers/serialize_saved_object.ts#L59) attribute and the [`references`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/saved_objects/public/saved_object/helpers/serialize_saved_object.ts#L60) array structure. Functions from the data plugin are used by the saved object plugin to manage this index pattern relationship.
+
+An example of a visualization saved object and its index pattern relationship:
 
 ```ts
 
 "kibanaSavedObjectMeta" : {
     "searchSourceJSON" : """{"filter":[],"query":{"query":"","language":"kuery"},"indexRefName":"kibanaSavedObjectMeta.searchSourceJSON.index"}"""
-      }
-    },
-    "type" : "visualization",
-    "references" : [
-      {
-          "name" : "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type" : "index-pattern",
-          "id" : "90943e30-9a47-11e8-b64d-95841ca0b247"
-      }
-    ],
+}
+"type" : "visualization",
+"references" : [
+  {
+    "name" : "kibanaSavedObjectMeta.searchSourceJSON.index",
+    "type" : "index-pattern",
+    "id" : "90943e30-9a47-11e8-b64d-95841ca0b247"
+  }
+],
 
 ```
 
 ### Saving a saved object
 
-When saving a saved object and its relationship to the index pattern: 
+When saving a saved object and its relationship to the index pattern:
 
 1. A saved object will be built using [`buildSavedObject`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/saved_objects/public/saved_object/helpers/build_saved_object.ts#L46) function. Services such as hydrating index pattern, initializing and serializing the saved object are set, and configs such as saved object id, migration version are defined.
-2. The saved object will then be serialized by three steps: 
+2. The saved object will then be serialized by three steps:
 
-    a. By using [`extractReferences`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/data/common/search/search_source/extract_references.ts#L35) function from the data plugin, the index pattern information will be extracted using the index pattern id within the `kibanaSavedObjectMeta`, and the id will be replaced by a reference name, such as `indexRefName`. A corresponding index pattern object will then be created to include more detailed information of the index pattern: name (`kibanaSavedObjectMeta.searchSourceJSON.index`), type, and id.
+   a. By using [`extractReferences`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/data/common/search/search_source/extract_references.ts#L35) function from the data plugin, the index pattern information will be extracted using the index pattern id within the `kibanaSavedObjectMeta`, and the id will be replaced by a reference name, such as `indexRefName`. A corresponding index pattern object will then be created to include more detailed information of the index pattern: name (`kibanaSavedObjectMeta.searchSourceJSON.index`), type, and id.
 
-    ```ts
-     let searchSourceFields = { ...state };
-    const references = [];
+   ```ts
+   let searchSourceFields = { ...state };
+   const references = [];
 
-    if (searchSourceFields.index) {
-        const indexId = searchSourceFields.index.id || searchSourceFields.index;
-        const refName = 'kibanaSavedObjectMeta.searchSourceJSON.index';
-        references.push({
-            name: refName,
-            type: 'index-pattern',
-            id: indexId
-        });
-        searchSourceFields = { ...searchSourceFields,
-        indexRefName: refName,
-        index: undefined
-        };
-    }
-    ```
+   if (searchSourceFields.index) {
+     const indexId = searchSourceFields.index.id || searchSourceFields.index;
+     const refName = 'kibanaSavedObjectMeta.searchSourceJSON.index';
+     references.push({
+       name: refName,
+       type: 'index-pattern',
+       id: indexId,
+     });
+     searchSourceFields = { ...searchSourceFields, indexRefName: refName, index: undefined };
+   }
+   ```
 
-    b. The `indexRefName` along with other information will be stringified and saved into `kibanaSavedObjectMeta.searchSourceJSON`. 
-    
-    c. Saved object client will create the reference array attribute, and the index pattern object will be pushed into the  reference array.
+   b. The `indexRefName` along with other information will be stringified and saved into `kibanaSavedObjectMeta.searchSourceJSON`.
 
+   c. Saved object client will create the reference array attribute, and the index pattern object will be pushed into the reference array.
 
 ### Loading an existing or creating a new saved object
 
-1. When loading an existing object or creating a new saved object, [`initializeSavedObject`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/saved_objects/public/saved_object/helpers/initialize_saved_object.ts#L38) function will be called. 
+1. When loading an existing object or creating a new saved object, [`initializeSavedObject`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/saved_objects/public/saved_object/helpers/initialize_saved_object.ts#L38) function will be called.
 2. The saved object will be deserialized in the [`applyOpenSearchResp`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/saved_objects/public/saved_object/helpers/apply_opensearch_resp.ts#L50) function.
 
-    a. Using [`injectReferences`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/data/common/search/search_source/inject_references.ts#L34) function from the data plugin, the index pattern reference name within the `kibanaSavedObject` will be substituted by the index pattern id and the corresponding index pattern reference object will be deleted if filters are applied.
+   a. Using [`injectReferences`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/data/common/search/search_source/inject_references.ts#L34) function from the data plugin, the index pattern reference name within the `kibanaSavedObject` will be substituted by the index pattern id and the corresponding index pattern reference object will be deleted if filters are applied.
 
-    ```ts
-    searchSourceReturnFields.index = reference.id;
-    delete searchSourceReturnFields.indexRefName;
-    ```
+   ```ts
+   searchSourceReturnFields.index = reference.id;
+   delete searchSourceReturnFields.indexRefName;
+   ```
 
-### Others
- 
-If a saved object type wishes to have additional custom functionalities when extracting/injecting references, or after OpenSearch's response, it can define functions in the class constructor when extending the `SavedObjectClass`. For example, visualization plugin's [`SavedVis`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/visualizations/public/saved_visualizations/_saved_vis.ts#L91) class has additional `extractReferences`, `injectReferences` and `afterOpenSearchResp` functions defined in [`_saved_vis.ts`](../visualizations/public/saved_visualizations/_saved_vis.ts).
+### Creating a new saved object type
+
+Steps need to be done on both the public/client-side & the server-side for creating a new saved object type.
+
+Client-side:
+
+1. Define a class that extends `SavedObjectClass`. This is where custom functionalities, such as extracting/injecting references, or overriding `afterOpenSearchResp` can be set in the constructor. For example, visualization plugin's [`SavedVis`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/4a06f5a6fe404a65b11775d292afaff4b8677c33/src/plugins/visualizations/public/saved_visualizations/_saved_vis.ts#L91) class has additional `extractReferences`, `injectReferences` and `afterOpenSearchResp` functions defined in [`_saved_vis.ts`](../visualizations/public/saved_visualizations/_saved_vis.ts), and set in the `SavedVis` constructor.
 
 ```ts
 class SavedVis extends SavedObjectClass {
@@ -85,14 +86,71 @@ class SavedVis extends SavedObjectClass {
         afterOpenSearchResp: async (savedObject: SavedObject) => {
           const savedVis = (savedObject as any) as ISavedVis;
           ... ...
-          
+
           return (savedVis as any) as SavedObject;
         },
 ```
 
+2. Optionally create a loader class that extends `SavedObjectLoader`. This can be useful for performing default CRUD operations on this particular saved object type, as well as overriding default utility functions like `find`. For example, the `visualization` saved object overrides `mapHitSource` (used in `find` & `findAll`) to do additional checking on the returned source object, such as if the returned type is valid:
+
+```ts
+class SavedObjectLoaderVisualize extends SavedObjectLoader {
+  mapHitSource = (source: Record<string, any>, id: string) => {
+    const visTypes = visualizationTypes;
+    ... ...
+    let typeName = source.typeName;
+    if (source.visState) {
+      try {
+        typeName = JSON.parse(String(source.visState)).type;
+      } catch (e) {
+        /* missing typename handled below */
+      }
+    }
+
+    if (!typeName || !visTypes.get(typeName)) {
+      source.error = 'Unknown visualization type';
+      return source;
+    }
+    ... ...
+    return source;
+  };
+```
+
+The loader can then be instantiated once and referenced when needed. For example, the `visualizations` plugin creates and sets it in its `services` in the plugin's start lifecycle:
+
+```ts
+public start(
+  core: CoreStart,
+  { data, expressions, uiActions, embeddable, dashboard }: VisualizationsStartDeps
+): VisualizationsStart {
+  ... ...
+  const savedVisualizationsLoader = createSavedVisLoader({
+    savedObjectsClient: core.savedObjects.client,
+    indexPatterns: data.indexPatterns,
+    search: data.search,
+    chrome: core.chrome,
+    overlays: core.overlays,
+    visualizationTypes: types,
+  });
+  setSavedVisualizationsLoader(savedVisualizationsLoader);
+  ... ...
+}
+```
+
+Server-side:
+
+1. Define the new type that is of type `SavedObjectsType`, which is where various settings can be configured, including the index mappings when the object is stored in the system index. To see an example type definition, you can refer to the [visualization saved object type](src/plugins/visualizations/server/saved_objects/visualization.ts).
+2. Register the new type in the respective plugin's setup lifecycle function. For example, the `visualizations` plugin registers the `visualization` saved object type like below:
+
+```ts
+core.savedObjects.registerType(visualizationSavedObjectType);
+```
+
+To make the new type manageable in the `saved_objects_management` plugin, refer to the [plugin README](src/plugins/saved_objects_management/README.md)
+
 ## Migration
 
-When a saved object is created using a previous version, the migration will trigger if there is a new way of saving the saved object and the migration functions alter the structure of the old saved object to follow the new structure. Migrations can be defined in the specific saved object type in the plugin's server folder. For example, 
+When a saved object is created using a previous version, the migration will trigger if there is a new way of saving the saved object and the migration functions alter the structure of the old saved object to follow the new structure. Migrations can be defined in the specific saved object type in the plugin's server folder. For example,
 
 ```ts
 export const visualizationSavedObjectType: SavedObjectsType = {

--- a/src/plugins/saved_objects_management/opensearch_dashboards.json
+++ b/src/plugins/saved_objects_management/opensearch_dashboards.json
@@ -4,7 +4,14 @@
   "server": true,
   "ui": true,
   "requiredPlugins": ["management", "data"],
-  "optionalPlugins": ["dashboard", "visualizations", "discover", "home", "visBuilder"],
+  "optionalPlugins": [
+    "dashboard",
+    "visualizations",
+    "discover",
+    "home",
+    "visBuilder",
+    "visAugmenter"
+  ],
   "extraPublicDirs": ["public/lib"],
   "requiredBundles": ["opensearchDashboardsReact", "home"]
 }

--- a/src/plugins/saved_objects_management/public/lib/in_app_url.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/in_app_url.test.ts
@@ -77,6 +77,22 @@ describe('canViewInApp', () => {
     expect(canViewInApp(uiCapabilities, 'visualizations')).toEqual(false);
   });
 
+  it('should handle augment-vis', () => {
+    let uiCapabilities = createCapabilities({
+      visAugmenter: {
+        show: true,
+      },
+    });
+    expect(canViewInApp(uiCapabilities, 'augment-vis')).toEqual(true);
+
+    uiCapabilities = createCapabilities({
+      visAugmenter: {
+        show: false,
+      },
+    });
+    expect(canViewInApp(uiCapabilities, 'augment-vis')).toEqual(false);
+  });
+
   it('should handle index patterns', () => {
     let uiCapabilities = createCapabilities({
       management: {

--- a/src/plugins/saved_objects_management/public/lib/in_app_url.ts
+++ b/src/plugins/saved_objects_management/public/lib/in_app_url.ts
@@ -38,6 +38,8 @@ export function canViewInApp(uiCapabilities: Capabilities, type: string): boolea
     case 'visualization':
     case 'visualizations':
       return uiCapabilities.visualize.show as boolean;
+    case 'augment-vis':
+      return uiCapabilities.visAugmenter.show as boolean;
     case 'index-pattern':
     case 'index-patterns':
     case 'indexPatterns':

--- a/src/plugins/saved_objects_management/public/management_section/object_view/saved_object_view.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/saved_object_view.tsx
@@ -169,7 +169,7 @@ export class SavedObjectEdition extends Component<
     );
     if (confirmed) {
       await savedObjectsClient.delete(type, id);
-      notifications.toasts.addSuccess(`Deleted '${object!.attributes.title}' ${type} object`);
+      notifications.toasts.addSuccess(`Deleted ${this.formatTitle(object)} ${type} object`);
       this.redirectToListing();
     }
   }
@@ -179,8 +179,12 @@ export class SavedObjectEdition extends Component<
     const { object, type } = this.state;
 
     await savedObjectsClient.update(object!.type, object!.id, attributes, { references });
-    notifications.toasts.addSuccess(`Updated '${attributes.title}' ${type} object`);
+    notifications.toasts.addSuccess(`Updated ${this.formatTitle(object)} ${type} object`);
     this.redirectToListing();
+  };
+
+  formatTitle = (object: SimpleSavedObject<any> | undefined) => {
+    return object?.attributes?.title ? `'${object.attributes.title}'` : '';
   };
 
   redirectToListing() {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/relationships.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/relationships.test.tsx.snap
@@ -690,6 +690,151 @@ exports[`Relationships from legacy app should render visualizations normally 1`]
 </EuiFlyout>
 `;
 
+exports[`Relationships should render augment-vis objects normally 1`] = `
+<EuiFlyout
+  onClose={[MockFunction]}
+>
+  <EuiFlyoutHeader
+    hasBorder={true}
+  >
+    <EuiTitle
+      size="m"
+    >
+      <h2>
+        <EuiToolTip
+          content="augment-vis"
+          delay="regular"
+          position="top"
+        >
+          <EuiIcon
+            aria-label="augment-vis"
+            size="m"
+            type="savedObject"
+          />
+        </EuiToolTip>
+          
+        MyAugmentVisObject
+      </h2>
+    </EuiTitle>
+  </EuiFlyoutHeader>
+  <EuiFlyoutBody>
+    <div>
+      <EuiCallOut>
+        <p>
+          Here are the saved objects related to MyAugmentVisObject. Deleting this augment-vis affects its parent objects, but not its children.
+        </p>
+      </EuiCallOut>
+      <EuiSpacer />
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "center",
+              "description": "Type of the saved object",
+              "field": "type",
+              "name": "Type",
+              "render": [Function],
+              "sortable": false,
+              "width": "50px",
+            },
+            Object {
+              "data-test-subj": "directRelationship",
+              "dataType": "string",
+              "field": "relationship",
+              "name": "Direct relationship",
+              "render": [Function],
+              "sortable": false,
+              "width": "125px",
+            },
+            Object {
+              "dataType": "string",
+              "description": "Title of the saved object",
+              "field": "meta.title",
+              "name": "Title",
+              "render": [Function],
+              "sortable": false,
+            },
+            Object {
+              "actions": Array [
+                Object {
+                  "available": [Function],
+                  "data-test-subj": "relationshipsTableAction-inspect",
+                  "description": "Inspect this saved object",
+                  "icon": "inspect",
+                  "name": "Inspect",
+                  "onClick": [Function],
+                  "type": "icon",
+                },
+              ],
+              "name": "Actions",
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "id": "1",
+              "meta": Object {
+                "editUrl": "/management/opensearch-dashboards/objects/savedVisualizations/1",
+                "icon": "visualizeApp",
+                "inAppUrl": Object {
+                  "path": "/edit/1",
+                  "uiCapabilitiesPath": "visualize.show",
+                },
+                "title": "MyViz",
+              },
+              "relationship": "child",
+              "type": "visualization",
+            },
+          ]
+        }
+        pagination={true}
+        responsive={true}
+        rowProps={[Function]}
+        search={
+          Object {
+            "filters": Array [
+              Object {
+                "field": "relationship",
+                "multiSelect": "or",
+                "name": "Direct relationship",
+                "options": Array [
+                  Object {
+                    "name": "parent",
+                    "value": "parent",
+                    "view": "Parent",
+                  },
+                  Object {
+                    "name": "child",
+                    "value": "child",
+                    "view": "Child",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+              Object {
+                "field": "type",
+                "multiSelect": "or",
+                "name": "Type",
+                "options": Array [
+                  Object {
+                    "name": "visualization",
+                    "value": "visualization",
+                    "view": "visualization",
+                  },
+                ],
+                "type": "field_value_selection",
+              },
+            ],
+          }
+        }
+        tableLayout="fixed"
+      />
+    </div>
+  </EuiFlyoutBody>
+</EuiFlyout>
+`;
+
 exports[`Relationships should render dashboards normally 1`] = `
 <EuiFlyout
   onClose={[MockFunction]}

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
@@ -243,6 +243,55 @@ describe('Relationships', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('should render augment-vis objects normally', async () => {
+    const props: RelationshipsProps = {
+      goInspectObject: () => {},
+      canGoInApp: () => true,
+      basePath: httpServiceMock.createSetupContract().basePath,
+      getRelationships: jest.fn().mockImplementation(() => [
+        {
+          type: 'visualization',
+          id: '1',
+          relationship: 'child',
+          meta: {
+            title: 'MyViz',
+            icon: 'visualizeApp',
+            editUrl: '/management/opensearch-dashboards/objects/savedVisualizations/1',
+            inAppUrl: {
+              path: '/edit/1',
+              uiCapabilitiesPath: 'visualize.show',
+            },
+          },
+        },
+      ]),
+      savedObject: {
+        id: '1',
+        type: 'augment-vis',
+        attributes: {},
+        references: [],
+        meta: {
+          title: 'MyAugmentVisObject',
+          icon: 'savedObject',
+          editUrl: '/management/opensearch-dashboards/objects/savedAugmentVis/1',
+        },
+      },
+      close: jest.fn(),
+    };
+
+    const component = shallowWithI18nProvider(<Relationships {...props} />);
+
+    // Make sure we are showing loading
+    expect(component.find('EuiLoadingSpinner').length).toBe(1);
+
+    // Ensure all promises resolve
+    await new Promise((resolve) => process.nextTick(resolve));
+    // Ensure the state changes are reflected
+    component.update();
+
+    expect(props.getRelationships).toHaveBeenCalled();
+    expect(component).toMatchSnapshot();
+  });
+
   it('should render dashboards normally', async () => {
     const props: RelationshipsProps = {
       goInspectObject: () => {},

--- a/src/plugins/saved_objects_management/public/plugin.ts
+++ b/src/plugins/saved_objects_management/public/plugin.ts
@@ -38,6 +38,7 @@ import { DashboardStart } from '../../dashboard/public';
 import { DiscoverStart } from '../../discover/public';
 import { HomePublicPluginSetup, FeatureCatalogueCategory } from '../../home/public';
 import { VisualizationsStart } from '../../visualizations/public';
+import { VisAugmenterStart } from '../../vis_augmenter/public';
 import {
   SavedObjectsManagementActionService,
   SavedObjectsManagementActionServiceSetup,
@@ -75,6 +76,7 @@ export interface StartDependencies {
   data: DataPublicPluginStart;
   dashboard?: DashboardStart;
   visualizations?: VisualizationsStart;
+  visAugmenter?: VisAugmenterStart;
   discover?: DiscoverStart;
   visBuilder?: VisBuilderStart;
 }

--- a/src/plugins/saved_objects_management/public/register_services.ts
+++ b/src/plugins/saved_objects_management/public/register_services.ts
@@ -36,7 +36,10 @@ export const registerServices = async (
   registry: ISavedObjectsManagementServiceRegistry,
   getStartServices: StartServicesAccessor<StartDependencies, SavedObjectsManagementPluginStart>
 ) => {
-  const [, { dashboard, visualizations, discover, visBuilder }] = await getStartServices();
+  const [
+    ,
+    { dashboard, visualizations, visAugmenter, discover, visBuilder },
+  ] = await getStartServices();
 
   if (dashboard) {
     registry.register({
@@ -51,6 +54,14 @@ export const registerServices = async (
       id: 'savedVisualizations',
       title: 'visualizations',
       service: visualizations.savedVisualizationsLoader,
+    });
+  }
+
+  if (visAugmenter) {
+    registry.register({
+      id: 'savedAugmentVis',
+      title: 'augmentVis',
+      service: visAugmenter.savedAugmentVisLoader,
     });
   }
 

--- a/src/plugins/vis_augmenter/public/index.ts
+++ b/src/plugins/vis_augmenter/public/index.ts
@@ -13,6 +13,7 @@ export { VisAugmenterSetup, VisAugmenterStart };
 
 export {
   createSavedAugmentVisLoader,
+  createAugmentVisSavedObject,
   SavedAugmentVisLoader,
   SavedObjectOpenSearchDashboardsServicesWithAugmentVis,
 } from './saved_augment_vis';

--- a/src/plugins/vis_augmenter/public/index.ts
+++ b/src/plugins/vis_augmenter/public/index.ts
@@ -11,6 +11,10 @@ export function plugin(initializerContext: PluginInitializerContext) {
 }
 export { VisAugmenterSetup, VisAugmenterStart };
 
-export * from './saved_augment_vis';
+export {
+  createSavedAugmentVisLoader,
+  SavedAugmentVisLoader,
+  SavedObjectOpenSearchDashboardsServicesWithAugmentVis,
+} from './saved_augment_vis';
 
 export { ISavedAugmentVis, VisLayerExpressionFn, AugmentVisSavedObject } from './types';

--- a/src/plugins/vis_augmenter/public/index.ts
+++ b/src/plugins/vis_augmenter/public/index.ts
@@ -10,3 +10,7 @@ export function plugin(initializerContext: PluginInitializerContext) {
   return new VisAugmenterPlugin(initializerContext);
 }
 export { VisAugmenterSetup, VisAugmenterStart };
+
+export * from './saved_augment_vis';
+
+export { ISavedAugmentVis, VisLayerExpressionFn, AugmentVisSavedObject } from './types';

--- a/src/plugins/vis_augmenter/public/plugin.ts
+++ b/src/plugins/vis_augmenter/public/plugin.ts
@@ -6,12 +6,9 @@
 import { ExpressionsSetup } from '../../expressions/public';
 import { PluginInitializerContext, CoreSetup, CoreStart, Plugin } from '../../../core/public';
 import { DataPublicPluginSetup, DataPublicPluginStart } from '../../data/public';
-<<<<<<< HEAD
 import { visLayers } from './expressions';
-=======
 import { setSavedAugmentVisLoader } from './services';
 import { createSavedAugmentVisLoader, SavedAugmentVisLoader } from './saved_augment_vis';
->>>>>>> c3e46d9dc9 (Add augment-vis saved obj)
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface VisAugmenterSetup {}

--- a/src/plugins/vis_augmenter/public/plugin.ts
+++ b/src/plugins/vis_augmenter/public/plugin.ts
@@ -6,13 +6,19 @@
 import { ExpressionsSetup } from '../../expressions/public';
 import { PluginInitializerContext, CoreSetup, CoreStart, Plugin } from '../../../core/public';
 import { DataPublicPluginSetup, DataPublicPluginStart } from '../../data/public';
+<<<<<<< HEAD
 import { visLayers } from './expressions';
+=======
+import { setSavedAugmentVisLoader } from './services';
+import { createSavedAugmentVisLoader, SavedAugmentVisLoader } from './saved_augment_vis';
+>>>>>>> c3e46d9dc9 (Add augment-vis saved obj)
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface VisAugmenterSetup {}
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface VisAugmenterStart {}
+export interface VisAugmenterStart {
+  savedAugmentVisLoader: SavedAugmentVisLoader;
+}
 
 export interface VisAugmenterSetupDeps {
   data: DataPublicPluginSetup;
@@ -37,7 +43,15 @@ export class VisAugmenterPlugin
   }
 
   public start(core: CoreStart, { data }: VisAugmenterStartDeps): VisAugmenterStart {
-    return {};
+    const savedAugmentVisLoader = createSavedAugmentVisLoader({
+      savedObjectsClient: core.savedObjects.client,
+      indexPatterns: data.indexPatterns,
+      search: data.search,
+      chrome: core.chrome,
+      overlays: core.overlays,
+    });
+    setSavedAugmentVisLoader(savedAugmentVisLoader);
+    return { savedAugmentVisLoader };
   }
 
   public stop() {}

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/_saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/_saved_augment_vis.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @name SavedAugmentVis
+ *
+ * @extends SavedObject.
+ */
+import { get } from 'lodash';
+import {
+  createSavedObjectClass,
+  SavedObject,
+  SavedObjectOpenSearchDashboardsServices,
+} from '../../../saved_objects/public';
+import { IIndexPattern } from '../../../data/public';
+import { extractReferences, injectReferences } from './saved_augment_vis_references';
+
+export function createSavedAugmentVisClass(services: SavedObjectOpenSearchDashboardsServices) {
+  const SavedObjectClass = createSavedObjectClass(services);
+
+  class SavedAugmentVis extends SavedObjectClass {
+    public static type: string = 'augment-vis';
+    public static mapping: Record<string, string> = {
+      description: 'text',
+      pluginResourceId: 'text',
+      visId: 'keyword',
+      visLayerExpressionFn: 'object',
+      version: 'integer',
+    };
+
+    constructor(opts: Record<string, unknown> | string = {}) {
+      if (typeof opts !== 'object') {
+        opts = { id: opts };
+      }
+      super({
+        type: SavedAugmentVis.type,
+        mapping: SavedAugmentVis.mapping,
+        extractReferences,
+        injectReferences,
+        id: (opts.id as string) || '',
+        indexPattern: opts.indexPattern as IIndexPattern,
+        defaults: {
+          description: get(opts, 'description', ''),
+          pluginResourceId: get(opts, 'pluginResourceId', ''),
+          visId: get(opts, 'visId', ''),
+          visLayerExpressionFn: get(opts, 'visLayerExpressionFn', {}),
+          version: 1,
+        },
+      });
+      // TODO: determine if this saved obj should be visible in saved_obj_management plugin.
+      // if not, we can set showInRecentlyAccessed to false and not persist any edit URL
+      // probably set to false since this saved obj should be hidden by default
+      this.showInRecentlyAccessed = false;
+
+      // we probably don't need this below field. we aren't going to need a full path
+      // since we aren't going to allow editing by default
+      //   this.getFullPath = () => {
+      //     return `/app/visualize#/edit/${this.id}`;
+      //   };
+    }
+  }
+
+  return SavedAugmentVis as new (opts: Record<string, unknown> | string) => SavedObject;
+}

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/_saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/_saved_augment_vis.ts
@@ -17,16 +17,18 @@ import {
 import { IIndexPattern } from '../../../data/public';
 import { extractReferences, injectReferences } from './saved_augment_vis_references';
 
+const name = 'augment-vis';
+
 export function createSavedAugmentVisClass(services: SavedObjectOpenSearchDashboardsServices) {
   const SavedObjectClass = createSavedObjectClass(services);
 
   class SavedAugmentVis extends SavedObjectClass {
-    public static type: string = 'augment-vis';
+    public static type: string = name;
     public static mapping: Record<string, string> = {
       description: 'text',
       pluginResourceId: 'text',
       visId: 'keyword',
-      visLayerExpressionFn: 'object',
+      visLayerExpressionFn: 'text',
       version: 'integer',
     };
 
@@ -51,11 +53,9 @@ export function createSavedAugmentVisClass(services: SavedObjectOpenSearchDashbo
       });
       // TODO: determine if this saved obj should be visible in saved_obj_management plugin.
       // if not, we can set showInRecentlyAccessed to false and not persist any edit URL
-      // probably set to false since this saved obj should be hidden by default
+      // if yes, we will need to revisit this, and possibly provide an edit url if editing
+      // via saved objects management plugin.
       this.showInRecentlyAccessed = false;
-
-      // we probably don't need this below field. we aren't going to need a full path
-      // since we aren't going to allow editing by default
       //   this.getFullPath = () => {
       //     return `/app/visualize#/edit/${this.id}`;
       //   };

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/_saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/_saved_augment_vis.ts
@@ -51,14 +51,7 @@ export function createSavedAugmentVisClass(services: SavedObjectOpenSearchDashbo
           version: 1,
         },
       });
-      // TODO: determine if this saved obj should be visible in saved_obj_management plugin.
-      // if not, we can set showInRecentlyAccessed to false and not persist any edit URL
-      // if yes, we will need to revisit this, and possibly provide an edit url if editing
-      // via saved objects management plugin.
       this.showInRecentlyAccessed = false;
-      //   this.getFullPath = () => {
-      //     return `/app/visualize#/edit/${this.id}`;
-      //   };
     }
   }
 

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/index.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './saved_augment_vis';
+export * from './utils';

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.test.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.test.ts
@@ -19,23 +19,83 @@ describe('SavedObjectLoaderAugmentVis', () => {
       testArg: 'test-value',
     },
   } as VisLayerExpressionFn;
-  const obj1 = generateAugmentVisSavedObject('test-id-1', fn);
-  const obj2 = generateAugmentVisSavedObject('test-id-2', fn);
+  const validObj1 = generateAugmentVisSavedObject('valid-obj-id-1', fn);
+  const validObj2 = generateAugmentVisSavedObject('valid-obj-id-2', fn);
+  const invalidFnTypeObj = generateAugmentVisSavedObject('invalid-fn-obj-id-1', {
+    ...fn,
+    // @ts-ignore
+    type: 'invalid-type',
+  });
+  // @ts-ignore
+  const missingFnObj = generateAugmentVisSavedObject('missing-fn-obj-id-1', {});
 
-  it('findAll returns single saved obj', async () => {
+  it('find returns single saved obj', async () => {
     const loader = createSavedAugmentVisLoader({
-      savedObjectsClient: getMockAugmentVisSavedObjectClient([obj1]),
+      savedObjectsClient: getMockAugmentVisSavedObjectClient([validObj1]),
     } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
-    const resp = await loader.findAll();
-    expect(resp.hits.length === 1);
+    const resp = await loader.find();
+    expect(resp.hits.length).toEqual(1);
+    expect(resp.hits[0].id).toEqual('valid-obj-id-1');
+    expect(resp.hits[0].error).toEqual(undefined);
   });
 
-  // TODO: once done rebasing after VisLayer PR, can finish creating test cases here.
-  // right now they are failing since there is missing imports
+  it('find returns multiple saved objs', async () => {
+    const loader = createSavedAugmentVisLoader({
+      savedObjectsClient: getMockAugmentVisSavedObjectClient([validObj1, validObj2]),
+    } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+    const resp = await loader.find();
+    expect(resp.hits.length).toEqual(2);
+    expect(resp.hits[0].id).toEqual('valid-obj-id-1');
+    expect(resp.hits[1].id).toEqual('valid-obj-id-2');
+    expect(resp.hits[0].error).toEqual(undefined);
+    expect(resp.hits[1].error).toEqual(undefined);
+  });
 
-  // add test for empty response
-  // add test for multi obj response
-  // add test for invalid VisLayerType
-  // add test for missing reference
-  // add test for missing visLayerExpressionFn
+  it('find returns empty response', async () => {
+    const loader = createSavedAugmentVisLoader({
+      savedObjectsClient: getMockAugmentVisSavedObjectClient([]),
+    } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+    const resp = await loader.find();
+    expect(resp.hits.length).toEqual(0);
+  });
+
+  it('find does not return objs with errors', async () => {
+    const loader = createSavedAugmentVisLoader({
+      savedObjectsClient: getMockAugmentVisSavedObjectClient([invalidFnTypeObj]),
+    } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+    const resp = await loader.find();
+    expect(resp.hits.length).toEqual(0);
+  });
+
+  it('findAll returns obj with invalid VisLayer fn', async () => {
+    const loader = createSavedAugmentVisLoader({
+      savedObjectsClient: getMockAugmentVisSavedObjectClient([invalidFnTypeObj]),
+    } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+    const resp = await loader.findAll();
+    expect(resp.hits.length).toEqual(1);
+    expect(resp.hits[0].id).toEqual('invalid-fn-obj-id-1');
+    expect(resp.hits[0].error).toEqual('Unknown VisLayer expression function type');
+  });
+
+  it('findAll returns obj with missing VisLayer fn', async () => {
+    const loader = createSavedAugmentVisLoader({
+      savedObjectsClient: getMockAugmentVisSavedObjectClient([missingFnObj]),
+    } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+    const resp = await loader.findAll();
+    expect(resp.hits.length).toEqual(1);
+    expect(resp.hits[0].id).toEqual('missing-fn-obj-id-1');
+    expect(resp.hits[0].error).toEqual(
+      'visLayerExpressionFn is missing in augment-vis saved object'
+    );
+  });
+
+  it('findAll returns obj with missing reference', async () => {
+    const loader = createSavedAugmentVisLoader({
+      savedObjectsClient: getMockAugmentVisSavedObjectClient([validObj1], false),
+    } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+    const resp = await loader.findAll();
+    expect(resp.hits.length).toEqual(1);
+    expect(resp.hits[0].id).toEqual('valid-obj-id-1');
+    expect(resp.hits[0].error).toEqual('visReference is missing in augment-vis saved object');
+  });
 });

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.test.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { VisLayerExpressionFn } from '../types';
+import { VisLayerTypes } from '../../common';
 import {
   createSavedAugmentVisLoader,
   SavedObjectOpenSearchDashboardsServicesWithAugmentVis,
@@ -12,8 +13,7 @@ import { generateAugmentVisSavedObject, getMockAugmentVisSavedObjectClient } fro
 
 describe('SavedObjectLoaderAugmentVis', () => {
   const fn = {
-    // TODO: VisLayerTypes will resolve after rebasing with earlier PR
-    type: VisLayerTypes.PointInTimeEventsLayer,
+    type: VisLayerTypes.PointInTimeEvents,
     name: 'test-fn',
     args: {
       testArg: 'test-value',

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.test.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { VisLayerExpressionFn } from '../types';
+import {
+  createSavedAugmentVisLoader,
+  SavedObjectOpenSearchDashboardsServicesWithAugmentVis,
+} from './saved_augment_vis';
+import { generateAugmentVisSavedObject, getMockAugmentVisSavedObjectClient } from './utils';
+
+describe('SavedObjectLoaderAugmentVis', () => {
+  const fn = {
+    // TODO: VisLayerTypes will resolve after rebasing with earlier PR
+    type: VisLayerTypes.PointInTimeEventsLayer,
+    name: 'test-fn',
+    args: {
+      testArg: 'test-value',
+    },
+  } as VisLayerExpressionFn;
+  const obj1 = generateAugmentVisSavedObject('test-id-1', fn);
+  const obj2 = generateAugmentVisSavedObject('test-id-2', fn);
+
+  it('findAll returns single saved obj', async () => {
+    const loader = createSavedAugmentVisLoader({
+      savedObjectsClient: getMockAugmentVisSavedObjectClient([obj1]),
+    } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+    const resp = await loader.findAll();
+    expect(resp.hits.length === 1);
+  });
+
+  // TODO: once done rebasing after VisLayer PR, can finish creating test cases here.
+  // right now they are failing since there is missing imports
+
+  // add test for empty response
+  // add test for multi obj response
+  // add test for invalid VisLayerType
+  // add test for missing reference
+  // add test for missing visLayerExpressionFn
+});

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
@@ -27,16 +27,16 @@ export function createSavedAugmentVisLoader(
 
       if (isEmpty(source.visReference)) {
         source.error = 'visReference is missing in augment-vis saved object';
+        return source;
       }
       if (isEmpty(source.visLayerExpressionFn)) {
         source.error = 'visLayerExpressionFn is missing in augment-vis saved object';
+        return source;
       }
       if (!(get(source, 'visLayerExpressionFn.type', '') in VisLayerTypes)) {
         source.error = 'Unknown VisLayer expression function type';
+        return source;
       }
-
-      delete source.visReference;
-      delete source.visName;
       return source;
     };
 

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
@@ -9,6 +9,7 @@ import {
   SavedObjectOpenSearchDashboardsServices,
 } from '../../../saved_objects/public';
 import { createSavedAugmentVisClass } from './_saved_augment_vis';
+import { VisLayerTypes } from '../../common';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SavedObjectOpenSearchDashboardsServicesWithAugmentVis
@@ -30,7 +31,6 @@ export function createSavedAugmentVisLoader(
       if (isEmpty(source.visLayerExpressionFn)) {
         source.error = 'visLayerExpressionFn is missing in augment-vis saved object';
       }
-      // TODO: will resolve after rebasing with earlier PR
       if (!(get(source, 'visLayerExpressionFn.type', '') in VisLayerTypes)) {
         source.error = 'Unknown VisLayer expression function type';
       }

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { get, isEmpty } from 'lodash';
+import {
+  SavedObjectLoader,
+  SavedObjectOpenSearchDashboardsServices,
+} from '../../../saved_objects/public';
+import { createSavedAugmentVisClass } from './_saved_augment_vis';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SavedObjectOpenSearchDashboardsServicesWithAugmentVis
+  extends SavedObjectOpenSearchDashboardsServices {}
+export type SavedAugmentVisLoader = ReturnType<typeof createSavedAugmentVisLoader>;
+export function createSavedAugmentVisLoader(
+  services: SavedObjectOpenSearchDashboardsServicesWithAugmentVis
+) {
+  const { savedObjectsClient } = services;
+
+  class SavedObjectLoaderAugmentVis extends SavedObjectLoader {
+    mapHitSource = (source: Record<string, any>, id: string) => {
+      source.id = id;
+      source.visId = get(source, 'visReference.id', '');
+
+      if (isEmpty(source.visReference)) {
+        source.error = 'visReference is missing in augment-vis saved object';
+      }
+      if (isEmpty(source.visLayerExpressionFn)) {
+        source.error = 'visLayerExpressionFn is missing in augment-vis saved object';
+      }
+      // TODO: will resolve after rebasing with earlier PR
+      if (!(get(source, 'visLayerExpressionFn.type', '') in VisLayerTypes)) {
+        source.error = 'Unknown VisLayer expression function type';
+      }
+
+      delete source.visReference;
+      delete source.visName;
+      return source;
+    };
+
+    /**
+     * Updates hit.attributes to contain an id related to the referenced visualization
+     * (visId) and returns the updated attributes object.
+     * @param hit
+     * @returns {hit.attributes} The modified hit.attributes object, with an id and url field.
+     */
+    mapSavedObjectApiHits(hit: {
+      references: any[];
+      attributes: Record<string, unknown>;
+      id: string;
+    }) {
+      // For now we are assuming only one vis reference per saved object.
+      // If we change to multiple, we will need to dynamically handle that
+      const visReference = hit.references[0];
+      return this.mapHitSource({ ...hit.attributes, visReference }, hit.id);
+    }
+  }
+  const SavedAugmentVis = createSavedAugmentVisClass(services);
+  return new SavedObjectLoaderAugmentVis(SavedAugmentVis, savedObjectsClient) as SavedObjectLoader;
+}

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.test.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.test.ts
@@ -5,6 +5,7 @@
 
 import { extractReferences, injectReferences } from './saved_augment_vis_references';
 import { AugmentVisSavedObject } from '../types';
+import { VIS_REFERENCE_NAME } from './saved_augment_vis_references';
 
 describe('extractReferences()', () => {
   test('extracts nothing if visId is null', () => {
@@ -76,11 +77,11 @@ describe('injectReferences()', () => {
       id: '1',
       pluginResourceId: 'test-resource-id',
       visLayerExpressionFn: 'test-fn',
-      visName: 'visualization_0',
+      visName: VIS_REFERENCE_NAME,
     } as unknown) as AugmentVisSavedObject;
     const references = [
       {
-        name: 'visualization_0',
+        name: VIS_REFERENCE_NAME,
         type: 'visualization',
         id: 'test-id',
       },
@@ -101,10 +102,10 @@ describe('injectReferences()', () => {
       id: '1',
       pluginResourceId: 'test-resource-id',
       visLayerExpressionFn: 'test-fn',
-      visName: 'visualization_0',
+      visName: VIS_REFERENCE_NAME,
     } as unknown) as AugmentVisSavedObject;
     expect(() => injectReferences(context, [])).toThrowErrorMatchingInlineSnapshot(
-      `"Could not find visualization reference \\"visualization_0\\""`
+      `"Could not find visualization reference \\"${VIS_REFERENCE_NAME}\\""`
     );
   });
 });

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.test.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { extractReferences, injectReferences } from './saved_augment_vis_references';
+import { AugmentVisSavedObject } from '../types';
+
+describe('extractReferences()', () => {
+  test('extracts nothing if visId is null', () => {
+    const doc = {
+      id: '1',
+      attributes: {
+        foo: true,
+      },
+      references: [],
+    };
+    const updatedDoc = extractReferences(doc);
+    expect(updatedDoc).toMatchInlineSnapshot(`
+      Object {
+        "attributes": Object {
+          "foo": true,
+        },
+        "references": Array [],
+      }
+    `);
+  });
+
+  test('extracts references from visId', () => {
+    const doc = {
+      id: '1',
+      attributes: {
+        foo: true,
+        visId: 'test-id',
+      },
+      references: [],
+    };
+    const updatedDoc = extractReferences(doc);
+    expect(updatedDoc).toMatchInlineSnapshot(`
+      Object {
+        "attributes": Object {
+          "foo": true,
+          "visName": "visualization_0",
+        },
+        "references": Array [
+          Object {
+            "id": "test-id",
+            "name": "visualization_0",
+            "type": "visualization",
+          },
+        ],
+      }
+    `);
+  });
+});
+
+describe('injectReferences()', () => {
+  test('injects nothing when visName is null', () => {
+    const context = ({
+      id: '1',
+      pluginResourceId: 'test-resource-id',
+      visLayerExpressionFn: 'test-fn',
+    } as unknown) as AugmentVisSavedObject;
+    injectReferences(context, []);
+    expect(context).toMatchInlineSnapshot(`
+      Object {
+        "id": "1",
+        "pluginResourceId": "test-resource-id",
+        "visLayerExpressionFn": "test-fn",
+      }
+    `);
+  });
+
+  test('injects references into context', () => {
+    const context = ({
+      id: '1',
+      pluginResourceId: 'test-resource-id',
+      visLayerExpressionFn: 'test-fn',
+      visName: 'visualization_0',
+    } as unknown) as AugmentVisSavedObject;
+    const references = [
+      {
+        name: 'visualization_0',
+        type: 'visualization',
+        id: 'test-id',
+      },
+    ];
+    injectReferences(context, references);
+    expect(context).toMatchInlineSnapshot(`
+      Object {
+        "id": "1",
+        "pluginResourceId": "test-resource-id",
+        "visId": "test-id",
+        "visLayerExpressionFn": "test-fn",
+      }
+    `);
+  });
+
+  test(`fails when it can't find the saved object reference in the array`, () => {
+    const context = ({
+      id: '1',
+      pluginResourceId: 'test-resource-id',
+      visLayerExpressionFn: 'test-fn',
+      visName: 'visualization_0',
+    } as unknown) as AugmentVisSavedObject;
+    expect(() => injectReferences(context, [])).toThrowErrorMatchingInlineSnapshot(
+      `"Could not find visualization reference \\"visualization_0\\""`
+    );
+  });
+});

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectAttributes, SavedObjectReference } from '../../../../core/public';
+import { AugmentVisSavedObject } from '../types';
+
+/**
+ * Note that references aren't stored in the object's client-side interface (AugmentVisSavedObject).
+ * Rather, just the ID/type is. The concept of references is a server-side definition used to define
+ * relationships between saved objects. They are visible in the saved objs management page or
+ * when making direct saved obj API calls.
+ *
+ * So, we need helper fns to construct & deconstruct references when creating and reading the
+ * indexed/stored saved objects, respectively.
+ */
+
+/**
+ * Used during creation. Converting from AugmentVisSavedObject to the actual indexed saved object
+ * with references.
+ */
+export function extractReferences({
+  attributes,
+  references = [],
+}: {
+  attributes: SavedObjectAttributes;
+  references: SavedObjectReference[];
+}) {
+  const updatedAttributes = { ...attributes };
+  const updatedReferences = [...references];
+
+  // Extract saved object
+  if (updatedAttributes.visId) {
+    updatedReferences.push({
+      name: 'visualization_0',
+      type: 'visualization',
+      id: String(updatedAttributes.visId),
+    });
+    delete updatedAttributes.visId;
+    updatedAttributes.visName = 'visualization_0';
+  }
+  return {
+    references: updatedReferences,
+    attributes: updatedAttributes,
+  };
+}
+
+/**
+ * Used during reading. Converting from the indexed saved object with references
+ * to a AugmentVisSavedObject
+ */
+export function injectReferences(
+  savedObject: AugmentVisSavedObject,
+  references: SavedObjectReference[]
+) {
+  if (savedObject.visName) {
+    const visReference = references.find((reference) => reference.name === savedObject.visName);
+    if (!visReference) {
+      throw new Error(`Could not find visualization reference "${savedObject.visName}"`);
+    }
+    savedObject.visId = visReference.id;
+    delete savedObject.visName;
+  }
+}

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.ts
@@ -17,6 +17,14 @@ import { AugmentVisSavedObject } from '../types';
  */
 
 /**
+ * Using a constant value for the visualization name to easily extact/inject
+ * the reference. Setting as "_0" which could be expanded and incremented upon
+ * in the future if we decide to persist multiple visualizations per
+ * AugmentVisSavedObject.
+ */
+export const VIS_REFERENCE_NAME = 'visualization_0';
+
+/**
  * Used during creation. Converting from AugmentVisSavedObject to the actual indexed saved object
  * with references.
  */
@@ -33,12 +41,13 @@ export function extractReferences({
   // Extract saved object
   if (updatedAttributes.visId) {
     updatedReferences.push({
-      name: 'visualization_0',
+      name: VIS_REFERENCE_NAME,
       type: 'visualization',
       id: String(updatedAttributes.visId),
     });
     delete updatedAttributes.visId;
-    updatedAttributes.visName = 'visualization_0';
+
+    updatedAttributes.visName = VIS_REFERENCE_NAME;
   }
   return {
     references: updatedReferences,

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/utils/helpers.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/utils/helpers.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import _ from 'lodash';
+import { getSavedAugmentVisLoader } from '../../services';
+import { ISavedAugmentVis } from '../../../common';
+
+/**
+ * Create an augment vis saved object given an object that
+ * implements the ISavedAugmentVis interface
+ */
+export const createAugmentVisSavedObject = async (AugmentVis: ISavedAugmentVis): Promise<any> => {
+  const loader = getSavedAugmentVisLoader();
+  return await loader.get((AugmentVis as any) as Record<string, unknown>);
+};

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/utils/helpers.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/utils/helpers.ts
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import _ from 'lodash';
 import { getSavedAugmentVisLoader } from '../../services';
-import { ISavedAugmentVis } from '../../../common';
+import { ISavedAugmentVis } from '../../types';
 
 /**
  * Create an augment vis saved object given an object that

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/utils/index.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/utils/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './helpers';
+export * from './test_helpers';

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/utils/test_helpers.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/utils/test_helpers.ts
@@ -3,17 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty } from 'lodash';
-import { SavedObjectsClientContract } from 'opensearch-dashboards/public';
-import { getSavedAugmentVisLoader } from '../../services';
-import { ISavedAugmentVis } from '../../../common';
-import { VisLayerExpressionFn } from '../../types';
+import { VisLayerTypes } from '../../../common';
+import { VisLayerExpressionFn, ISavedAugmentVis } from '../../types';
 
 const id = 'test-id';
 const pluginResourceId = 'test-plugin-resource-id';
 const visLayerExpressionFn = {
-  // TODO: VisLayerTypes will resolve after rebasing with earlier PR
-  type: VisLayerTypes.PointInTimeEventsLayer,
+  type: VisLayerTypes.PointInTimeEvents,
   name: 'test-fn',
   args: {
     testArg: 'test-value',

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/utils/test_helpers.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/utils/test_helpers.ts
@@ -5,9 +5,9 @@
 
 import { cloneDeep } from 'lodash';
 import { VisLayerExpressionFn, ISavedAugmentVis } from '../../types';
+import { VIS_REFERENCE_NAME } from '../saved_augment_vis_references';
 
 const pluginResourceId = 'test-plugin-resource-id';
-const visName = 'visualization_0';
 const visId = 'test-vis-id';
 const version = 1;
 
@@ -16,7 +16,7 @@ export const generateAugmentVisSavedObject = (idArg: string, exprFnArg: VisLayer
     id: idArg,
     pluginResourceId,
     visLayerExpressionFn: exprFnArg,
-    visName,
+    VIS_REFERENCE_NAME,
     visId,
     version,
   } as ISavedAugmentVis;

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/utils/test_helpers.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/utils/test_helpers.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isEmpty } from 'lodash';
+import { SavedObjectsClientContract } from 'opensearch-dashboards/public';
+import { getSavedAugmentVisLoader } from '../../services';
+import { ISavedAugmentVis } from '../../../common';
+import { VisLayerExpressionFn } from '../../types';
+
+const id = 'test-id';
+const pluginResourceId = 'test-plugin-resource-id';
+const visLayerExpressionFn = {
+  // TODO: VisLayerTypes will resolve after rebasing with earlier PR
+  type: VisLayerTypes.PointInTimeEventsLayer,
+  name: 'test-fn',
+  args: {
+    testArg: 'test-value',
+  },
+};
+const visName = 'visualization_0';
+const visId = 'test-vis-id';
+const version = 1;
+
+export const generateAugmentVisSavedObject = (idArg?: string, exprFnArg?: VisLayerExpressionFn) => {
+  return {
+    testId: idArg ? idArg : id,
+    pluginResourceId,
+    visLayerExpressionFn: exprFnArg ? exprFnArg : visLayerExpressionFn,
+    visName,
+    visId,
+    version,
+  } as ISavedAugmentVis;
+};
+
+export const getMockAugmentVisSavedObjectClient = (
+  augmentVisSavedObjs?: ISavedAugmentVis[]
+): any => {
+  const savedObjs = augmentVisSavedObjs ? augmentVisSavedObjs : ([] as ISavedAugmentVis[]);
+
+  const client = {
+    findAll: jest.fn(() =>
+      Promise.resolve({
+        hits: savedObjs,
+      })
+    ),
+    find: jest.fn(() =>
+      Promise.resolve({
+        total: savedObjs.length,
+        savedObjects: savedObjs.map((savedObj) => {
+          const objVisId = savedObj.visId;
+          delete savedObj.visId;
+          return {
+            ...savedObj,
+            references: [
+              {
+                name: savedObj.visName,
+                type: 'visualization',
+                id: objVisId,
+              },
+            ],
+          };
+        }),
+      })
+    ),
+  } as any;
+  return client;
+};

--- a/src/plugins/vis_augmenter/public/services.ts
+++ b/src/plugins/vis_augmenter/public/services.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createGetterSetter } from '../../opensearch_dashboards_utils/common';
+import { SavedObjectLoader } from '../../saved_objects/public';
+
+export const [getSavedAugmentVisLoader, setSavedAugmentVisLoader] = createGetterSetter<
+  SavedObjectLoader
+>('savedAugmentVisLoader');

--- a/src/plugins/vis_augmenter/public/types.ts
+++ b/src/plugins/vis_augmenter/public/types.ts
@@ -4,6 +4,7 @@
  */
 
 import { SavedObject } from '../../saved_objects/public';
+import { VisLayerTypes } from '../common';
 
 export interface ISavedAugmentVis {
   id?: string;
@@ -16,7 +17,6 @@ export interface ISavedAugmentVis {
 }
 
 export interface VisLayerExpressionFn {
-  // TODO: VisLayerTypes will resolve after rebasing with earlier PR
   type: keyof typeof VisLayerTypes;
   name: string;
   // plugin expression fns can freely set custom arguments

--- a/src/plugins/vis_augmenter/public/types.ts
+++ b/src/plugins/vis_augmenter/public/types.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObject } from '../../saved_objects/public';
+
+export interface ISavedAugmentVis {
+  id?: string;
+  description?: string;
+  pluginResourceId: string;
+  visName?: string;
+  visId?: string;
+  visLayerExpressionFn: VisLayerExpressionFn;
+  version?: number;
+}
+
+export interface VisLayerExpressionFn {
+  // TODO: VisLayerTypes will resolve after rebasing with earlier PR
+  type: keyof typeof VisLayerTypes;
+  name: string;
+  // plugin expression fns can freely set custom arguments
+  args: { [key: string]: any };
+}
+
+export interface AugmentVisSavedObject extends SavedObject, ISavedAugmentVis {}

--- a/src/plugins/vis_augmenter/server/capabilities_provider.ts
+++ b/src/plugins/vis_augmenter/server/capabilities_provider.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const capabilitiesProvider = () => ({
+  visAugmenter: {
+    show: true,
+    delete: true,
+    save: true,
+    saveQuery: true,
+  },
+});

--- a/src/plugins/vis_augmenter/server/plugin.ts
+++ b/src/plugins/vis_augmenter/server/plugin.ts
@@ -11,6 +11,7 @@ import {
   Logger,
 } from '../../../core/server';
 import { augmentVisSavedObjectType } from './saved_objects';
+import { capabilitiesProvider } from './capabilities_provider';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface VisAugmenterPluginSetup {}
@@ -28,6 +29,7 @@ export class VisAugmenterPlugin
   public setup(core: CoreSetup) {
     this.logger.debug('VisAugmenter: Setup');
     core.savedObjects.registerType(augmentVisSavedObjectType);
+    core.capabilities.registerProvider(capabilitiesProvider);
     return {};
   }
 

--- a/src/plugins/vis_augmenter/server/plugin.ts
+++ b/src/plugins/vis_augmenter/server/plugin.ts
@@ -10,6 +10,7 @@ import {
   Plugin,
   Logger,
 } from '../../../core/server';
+import { augmentVisSavedObjectType } from './saved_objects';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface VisAugmenterPluginSetup {}
@@ -26,6 +27,7 @@ export class VisAugmenterPlugin
 
   public setup(core: CoreSetup) {
     this.logger.debug('VisAugmenter: Setup');
+    core.savedObjects.registerType(augmentVisSavedObjectType);
     return {};
   }
 

--- a/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
+++ b/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
@@ -9,6 +9,20 @@ export const augmentVisSavedObjectType: SavedObjectsType = {
   name: 'augment-vis',
   hidden: false,
   namespaceType: 'single',
+  management: {
+    // utilizing defaults for some of these fields
+    // icon: 'visualizeApp',
+    // defaultSearchField: 'id',
+    importableAndExportable: true,
+    getTitle(obj) {
+      return 'Augment-' + obj.attributes.visName;
+    },
+    getEditUrl(obj) {
+      return `/management/opensearch-dashboards/objects/savedAugmentVis/${encodeURIComponent(
+        obj.id
+      )}`;
+    },
+  },
   mappings: {
     properties: {
       description: { type: 'text' },

--- a/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
+++ b/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
@@ -16,6 +16,7 @@ export const augmentVisSavedObjectType: SavedObjectsType = {
       visName: { type: 'keyword', index: false, doc_values: false },
       visLayerExpressionFn: {
         properties: {
+          type: { type: 'text' },
           name: { type: 'text' },
           // keeping generic to not limit what users may pass as args to their fns
           // users may not have this field at all, if no args are needed

--- a/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
+++ b/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
@@ -10,12 +10,9 @@ export const augmentVisSavedObjectType: SavedObjectsType = {
   hidden: false,
   namespaceType: 'single',
   management: {
-    // utilizing defaults for some of these fields
-    // icon: 'visualizeApp',
-    // defaultSearchField: 'id',
     importableAndExportable: true,
     getTitle(obj) {
-      return 'Augment-' + obj.attributes.visName;
+      return obj.attributes.title;
     },
     getEditUrl(obj) {
       return `/management/opensearch-dashboards/objects/savedAugmentVis/${encodeURIComponent(
@@ -25,6 +22,7 @@ export const augmentVisSavedObjectType: SavedObjectsType = {
   },
   mappings: {
     properties: {
+      title: { type: 'text' },
       description: { type: 'text' },
       pluginResourceId: { type: 'text' },
       visName: { type: 'keyword', index: false, doc_values: false },

--- a/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
+++ b/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsType } from 'opensearch-dashboards/server';
+
+export const augmentVisSavedObjectType: SavedObjectsType = {
+  name: 'augment-vis',
+  hidden: false,
+  namespaceType: 'single',
+  mappings: {
+    properties: {
+      description: { type: 'text' },
+      pluginResourceId: { type: 'text' },
+      visName: { type: 'keyword', index: false, doc_values: false },
+      visLayerExpressionFn: {
+        properties: {
+          name: { type: 'text' },
+          // keeping generic to not limit what users may pass as args to their fns
+          // users may not have this field at all, if no args are needed
+          args: { type: 'object', dynamic: true },
+        },
+      },
+      version: { type: 'integer' },
+    },
+  },
+};

--- a/src/plugins/vis_augmenter/server/saved_objects/index.ts
+++ b/src/plugins/vis_augmenter/server/saved_objects/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { augmentVisSavedObjectType } from './augment_vis';

--- a/src/plugins/visualize/public/application/types.ts
+++ b/src/plugins/visualize/public/application/types.ts
@@ -57,7 +57,6 @@ import { SavedObjectsStart, SavedObject } from 'src/plugins/saved_objects/public
 import { EmbeddableStart } from 'src/plugins/embeddable/public';
 import { UrlForwardingStart } from 'src/plugins/url_forwarding/public';
 import { DashboardStart } from '../../../dashboard/public';
-import { VisAugmenterStart } from '../../../vis_augmenter/public';
 
 export type PureVisState = SavedVisState;
 

--- a/src/plugins/visualize/public/application/types.ts
+++ b/src/plugins/visualize/public/application/types.ts
@@ -57,6 +57,7 @@ import { SavedObjectsStart, SavedObject } from 'src/plugins/saved_objects/public
 import { EmbeddableStart } from 'src/plugins/embeddable/public';
 import { UrlForwardingStart } from 'src/plugins/url_forwarding/public';
 import { DashboardStart } from '../../../dashboard/public';
+import { VisAugmenterStart } from '../../../vis_augmenter/public';
 
 export type PureVisState = SavedVisState;
 
@@ -119,6 +120,7 @@ export interface VisualizeServices extends CoreStart {
   visualizations: VisualizationsStart;
   savedObjectsPublic: SavedObjectsStart;
   savedVisualizations: VisualizationsStart['savedVisualizationsLoader'];
+  savedAugmentVis: VisAugmenterStart['savedAugmentVisLoader'];
   setActiveUrl: (newUrl: string) => void;
   createVisEmbeddableFromObject: VisualizationsStart['__LEGACY']['createVisEmbeddableFromObject'];
   restorePreviousUrl: () => void;

--- a/src/plugins/visualize/public/application/types.ts
+++ b/src/plugins/visualize/public/application/types.ts
@@ -120,7 +120,6 @@ export interface VisualizeServices extends CoreStart {
   visualizations: VisualizationsStart;
   savedObjectsPublic: SavedObjectsStart;
   savedVisualizations: VisualizationsStart['savedVisualizationsLoader'];
-  savedAugmentVis: VisAugmenterStart['savedAugmentVisLoader'];
   setActiveUrl: (newUrl: string) => void;
   createVisEmbeddableFromObject: VisualizationsStart['__LEGACY']['createVisEmbeddableFromObject'];
   restorePreviousUrl: () => void;

--- a/src/plugins/visualize/public/plugin.ts
+++ b/src/plugins/visualize/public/plugin.ts
@@ -70,14 +70,12 @@ import {
 } from './services';
 import { visualizeFieldAction } from './actions/visualize_field_action';
 import { createVisualizeUrlGenerator } from './url_generator';
-import { VisAugmenterStart } from '../../vis_augmenter/public';
 
 export interface VisualizePluginStartDependencies {
   data: DataPublicPluginStart;
   navigation: NavigationStart;
   share?: SharePluginStart;
   visualizations: VisualizationsStart;
-  visAugmenter: VisAugmenterStart;
   embeddable: EmbeddableStart;
   urlForwarding: UrlForwardingStart;
   savedObjects: SavedObjectsStart;
@@ -198,7 +196,6 @@ export class VisualizePlugin
           localStorage: new Storage(localStorage),
           navigation: pluginsStart.navigation,
           savedVisualizations: pluginsStart.visualizations.savedVisualizationsLoader,
-          savedAugmentVis: pluginsStart.visAugmenter.savedAugmentVisLoader,
           share: pluginsStart.share,
           toastNotifications: coreStart.notifications.toasts,
           visualizeCapabilities: coreStart.application.capabilities.visualize,

--- a/src/plugins/visualize/public/plugin.ts
+++ b/src/plugins/visualize/public/plugin.ts
@@ -70,12 +70,14 @@ import {
 } from './services';
 import { visualizeFieldAction } from './actions/visualize_field_action';
 import { createVisualizeUrlGenerator } from './url_generator';
+import { VisAugmenterStart } from '../../vis_augmenter/public';
 
 export interface VisualizePluginStartDependencies {
   data: DataPublicPluginStart;
   navigation: NavigationStart;
   share?: SharePluginStart;
   visualizations: VisualizationsStart;
+  visAugmenter: VisAugmenterStart;
   embeddable: EmbeddableStart;
   urlForwarding: UrlForwardingStart;
   savedObjects: SavedObjectsStart;
@@ -196,6 +198,7 @@ export class VisualizePlugin
           localStorage: new Storage(localStorage),
           navigation: pluginsStart.navigation,
           savedVisualizations: pluginsStart.visualizations.savedVisualizationsLoader,
+          savedAugmentVis: pluginsStart.visAugmenter.savedAugmentVisLoader,
           share: pluginsStart.share,
           toastNotifications: coreStart.notifications.toasts,
           visualizeCapabilities: coreStart.application.capabilities.visualize,


### PR DESCRIPTION
### Description
This PR adds a new `augment-vis` saved object type. Details on the design can be found in the [related issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2893)

Specifically, this PR makes the following changes:

Client-side:
- creates & defines an augment vis saved object class
- creates helper fns to convert from client-side definition (with no references) to server-side definition (with references) & vice-versa
- introduce a saved object loader for the new saved object type. This loader provides a clean way to interact with all saved objects of this type, and can be consumed in dependent plugins for performing CRUD operations on saved objects of this type
- creates and sets the new loader in the `vis_augmenter` plugin's `start` lifecycle step

Server-side:
- creates & defines a augment vis saved object type + index mapping
- registers the new type in the `vis_augmenter` plugin's `setup` lifecycle step

It also registers the saved object in the Saved Objects Management plugin, by:
- adding a management section in the `augment-vis` saved object server-side definition,
- registering a capabilities provider to allow some of the actions to work in the management plugin, and
- adding the type to the plugin registry

Screenshots of an example `augment-vis` type in the Saved Objects Management plugin:

Fig. 1: new object is highlighted (note there is no link to the title since there is no dedicated plugin for this new saved object):
<img width="720" alt="Screen Shot 2023-01-04 at 2 02 25 PM" src="https://user-images.githubusercontent.com/62119629/210658767-3570e7c8-8ea0-4abc-9cce-5f94c13ea36f.png">

Fig. 2: viewing the relationship of the saved object, showing the visualization saved object as the child:
<img width="723" alt="Screen Shot 2023-01-04 at 2 02 52 PM" src="https://user-images.githubusercontent.com/62119629/210659342-f5964f87-5fbf-455b-9263-d658a8f602c0.png">


### Issues Resolved
Closes #2893 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 