### PR TITLE
[backport-2.0] Update console to use core.http instead of jQuery.ajax (#3080)

### DIFF
--- a/src/plugins/console/public/application/contexts/services_context.tsx
+++ b/src/plugins/console/public/application/contexts/services_context.tsx
@@ -29,7 +29,7 @@
  */
 
 import React, { createContext, useContext, useEffect } from 'react';
-import { NotificationsSetup } from 'opensearch-dashboards/public';
+import { HttpSetup, NotificationsSetup } from 'opensearch-dashboards/public';
 import { History, Settings, Storage } from '../../services';
 import { ObjectStorageClient } from '../../../common/types';
 import { MetricsTracker } from '../../types';
@@ -43,6 +43,7 @@ interface ContextServices {
   objectStorageClient: ObjectStorageClient;
   trackUiMetric: MetricsTracker;
   opensearchHostService: OpenSearchHostService;
+  http: HttpSetup;
 }
 
 export interface ContextValue {

--- a/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/send_request_to_opensearch.test.ts
+++ b/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/send_request_to_opensearch.test.ts
@@ -1,0 +1,182 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import {
+  HttpFetchError,
+  HttpFetchOptionsWithPath,
+  HttpResponse,
+  HttpSetup,
+} from '../../../../../../core/public';
+import { OpenSearchRequestArgs, sendRequestToOpenSearch } from './send_request_to_opensearch';
+import * as opensearch from '../../../lib/opensearch/opensearch';
+
+const createMockResponse = (
+  statusCode: number,
+  statusText: string,
+  headers: Array<[string, string]>
+): Response => {
+  return {
+    // headers: {} as Headers,
+    headers: new Headers(headers),
+    ok: true,
+    redirected: false,
+    status: statusCode,
+    statusText,
+    type: 'basic',
+    url: '',
+    clone: jest.fn(),
+    body: (jest.fn() as unknown) as ReadableStream,
+    bodyUsed: true,
+    arrayBuffer: jest.fn(),
+    blob: jest.fn(),
+    text: jest.fn(),
+    formData: jest.fn(),
+    json: jest.fn(),
+  };
+};
+
+const createMockHttpResponse = (
+  statusCode: number,
+  statusText: string,
+  headers: Array<[string, string]>,
+  body: any
+): HttpResponse<any> => {
+  return {
+    fetchOptions: (jest.fn() as unknown) as Readonly<HttpFetchOptionsWithPath>,
+    request: (jest.fn() as unknown) as Readonly<Request>,
+    response: createMockResponse(statusCode, statusText, headers),
+    body,
+  };
+};
+const dummyArgs: OpenSearchRequestArgs = {
+  http: ({
+    post: jest.fn(),
+  } as unknown) as HttpSetup,
+  requests: [
+    {
+      method: 'GET',
+      url: '/dummy/api',
+      data: ['{}'],
+    },
+  ],
+};
+
+describe('test sendRequestToOpenSearch', () => {
+  it('test request success, json', () => {
+    const mockHttpResponse = createMockHttpResponse(
+      200,
+      'ok',
+      [['Content-Type', 'application/json, utf-8']],
+      {
+        ok: true,
+      }
+    );
+
+    jest.spyOn(opensearch, 'send').mockResolvedValue(mockHttpResponse);
+    sendRequestToOpenSearch(dummyArgs).then((result) => {
+      expect((result as any)[0].response.value).toBe('{\n  "ok": true\n}');
+    });
+  });
+
+  it('test request success, text', () => {
+    const mockHttpResponse = createMockHttpResponse(
+      200,
+      'ok',
+      [['Content-Type', 'text/plain']],
+      'response text'
+    );
+
+    jest.spyOn(opensearch, 'send').mockResolvedValue(mockHttpResponse);
+    sendRequestToOpenSearch(dummyArgs).then((result) => {
+      expect((result as any)[0].response.value).toBe('response text');
+    });
+  });
+
+  it('test request success, with warning', () => {
+    const mockHttpResponse = createMockHttpResponse(
+      200,
+      'ok',
+      [
+        ['Content-Type', 'text/plain'],
+        ['warning', 'dummy warning'],
+      ],
+      'response text'
+    );
+
+    jest.spyOn(opensearch, 'send').mockResolvedValue(mockHttpResponse);
+    sendRequestToOpenSearch(dummyArgs).then((result) => {
+      expect((result as any)[0].response.value).toBe(
+        '#! Deprecation: dummy warning\nresponse text'
+      );
+    });
+  });
+
+  it('test request 404', () => {
+    const mockHttpResponse = createMockHttpResponse(
+      404,
+      'not found',
+      [['Content-Type', 'text/plain']],
+      'response text'
+    );
+
+    jest.spyOn(opensearch, 'send').mockResolvedValue(mockHttpResponse);
+    sendRequestToOpenSearch(dummyArgs).then((result) => {
+      expect((result as any)[0].response.value).toBe('response text');
+    });
+  });
+
+  it('test request 500, json', () => {
+    const mockHttpError: HttpFetchError = new HttpFetchError(
+      'error message',
+      'name',
+      (jest.fn as unknown) as Request,
+      createMockResponse(500, 'Server Error', [['Content-Type', 'application/json, utf-8']]),
+      { errorMsg: 'message' }
+    );
+
+    jest.spyOn(opensearch, 'send').mockRejectedValue(mockHttpError);
+    sendRequestToOpenSearch(dummyArgs).catch((error) => {
+      expect(error.response.value).toBe('{\n  "errorMsg": "message"\n}');
+    });
+  });
+
+  it('test request 500, text', () => {
+    const mockHttpError: HttpFetchError = new HttpFetchError(
+      'error message',
+      'name',
+      (jest.fn as unknown) as Request,
+      createMockResponse(500, 'Server Error', [['Content-Type', 'text/plain']]),
+      'error message'
+    );
+
+    jest.spyOn(opensearch, 'send').mockRejectedValue(mockHttpError);
+    sendRequestToOpenSearch(dummyArgs).catch((error) => {
+      expect(error.response.value).toBe('error message');
+    });
+  });
+
+  it('test no connection', () => {
+    const mockHttpError: HttpFetchError = new HttpFetchError(
+      'error message',
+      'name',
+      (jest.fn as unknown) as Request,
+      undefined,
+      'error message'
+    );
+
+    jest.spyOn(opensearch, 'send').mockRejectedValue(mockHttpError);
+    sendRequestToOpenSearch(dummyArgs).catch((error) => {
+      expect(error.response.value).toBe(
+        "\n\nFailed to connect to Console's backend.\nPlease check the OpenSearch Dashboards server is up and running"
+      );
+    });
+  });
+});

--- a/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/use_send_current_request_to_opensearch.ts
+++ b/src/plugins/console/public/application/hooks/use_send_current_request_to_opensearch/use_send_current_request_to_opensearch.ts
@@ -40,7 +40,7 @@ import { retrieveAutoCompleteInfo } from '../../../lib/mappings/mappings';
 
 export const useSendCurrentRequestToOpenSearch = () => {
   const {
-    services: { history, settings, notifications, trackUiMetric },
+    services: { history, settings, notifications, trackUiMetric, http },
   } = useServicesContext();
 
   const dispatch = useRequestActionContext();
@@ -64,7 +64,7 @@ export const useSendCurrentRequestToOpenSearch = () => {
       // Fire and forget
       setTimeout(() => track(requests, editor, trackUiMetric), 0);
 
-      const results = await sendRequestToOpenSearch({ requests });
+      const results = await sendRequestToOpenSearch({ http, requests });
 
       results.forEach(({ request: { path, method, data } }) => {
         try {
@@ -112,5 +112,5 @@ export const useSendCurrentRequestToOpenSearch = () => {
         });
       }
     }
-  }, [dispatch, settings, history, notifications, trackUiMetric]);
+  }, [dispatch, settings, history, notifications, trackUiMetric, http]);
 };

--- a/src/plugins/console/public/application/index.tsx
+++ b/src/plugins/console/public/application/index.tsx
@@ -82,6 +82,7 @@ export function renderApp({
             notifications,
             trackUiMetric,
             objectStorageClient,
+            http,
           },
         }}
       >

--- a/test/functional/apps/console/_console.ts
+++ b/test/functional/apps/console/_console.ts
@@ -71,7 +71,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('default request response should include `"timed_out" : false`', async () => {
-      const expectedResponseContains = '"timed_out" : false,';
+      const expectedResponseContains = '"timed_out": false,';
       await PageObjects.console.clickPlay();
       await retry.try(async () => {
         const actualResponse = await PageObjects.console.getResponse();


### PR DESCRIPTION
* Update console to use core.http instead of jQuery.ajax

Signed-off-by: Yan Zeng <zengyan@amazon.com>
(cherry picked from commit 5764d6ca0b7199e49e0006a6f38daea6c14ddfeb)
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 