### PR TITLE
[Maintenance] Exempt feature branches from changelog verification

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -1,6 +1,7 @@
 name: "Changelog Verifier"
 on:
   pull_request:
+    branches: [ '**', '!feature/**' ]
     types: [opened, edited, review_requested, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:


### PR DESCRIPTION
### Description
Skip CHANGELOG verification workflow for feature branches
 
### Issues Resolved
N/A - from discussion in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3107#issuecomment-1362175146

Because feature branch PRs may not be standalone changes once merged to `main`, it's not worth the development friction to enforce them on every PR to the feature branch, only when the branch itself is merged or sync'd with `main`.
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 