### PR TITLE
[Manual] [Backport 1.x] Automates chromedriver version selection for tests (#2990)

### DIFF
--- a/.github/workflows/pr_check_workflow.yml
+++ b/.github/workflows/pr_check_workflow.yml
@@ -45,15 +45,15 @@ jobs:
         id: job_successful
         run: cat job_successful 2>/dev/null || echo 'false'
 
-      - name: Get the previous linter results 
+      - name: Get the previous linter results
         id: linter_results
         run: cat linter_results 2>/dev/null || echo 'default'
 
-      - name: Get the previous unit tests results 
+      - name: Get the previous unit tests results
         id: unit_tests_results
         run: cat unit_tests_results 2>/dev/null || echo 'default'
 
-      - name: Get the previous integration tests results 
+      - name: Get the previous integration tests results
         id: integration_tests_results
         run: cat integration_tests_results 2>/dev/null || echo 'default'
 
@@ -99,13 +99,13 @@ jobs:
       - name: Run integration tests
         if: steps.integration_tests_results.outputs.integration_tests_results != 'success'
         id: integration-tests
-        run: node scripts/jest_integration --ci --colors --max-old-space-size=5120 
+        run: node scripts/jest_integration --ci --colors --max-old-space-size=5120
 
       # Set cache if linter, unit tests, and integration tests were successful then the job will be marked successful
       # Sets individual results to empower re-runs of the same build without re-running successful steps.
-      - if: | 
-          (steps.linter.outcome == 'success' || steps.linter.outcome == 'skipped') && 
-          (steps.unit-tests.outcome == 'success' || steps.unit-tests.outcome == 'skipped') && 
+      - if: |
+          (steps.linter.outcome == 'success' || steps.linter.outcome == 'skipped') &&
+          (steps.unit-tests.outcome == 'success' || steps.unit-tests.outcome == 'skipped') &&
           (steps.integration-tests.outcome == 'success' || steps.integration-tests.outcome == 'skipped')
         run: echo "::set-output name=job_successful::true" > job_successful
       - if: steps.linter.outcome == 'success' || steps.linter.outcome == 'skipped'
@@ -118,7 +118,7 @@ jobs:
     needs: [ build-lint-test ]
     runs-on: ubuntu-latest
     name: Run functional tests
-    strategy: 
+    strategy:
       matrix:
         group: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
     steps:
@@ -136,7 +136,7 @@ jobs:
           restore-keys: |
             ${{ github.run_id }}-${{ github.job }}-${{ matrix.group }}-${{ github.sha }}
 
-      - name: Get the cached tests results 
+      - name: Get the cached tests results
         id: ftr_tests_results
         run: cat ftr_tests_results 2>/dev/null || echo 'default'
 
@@ -176,7 +176,7 @@ jobs:
       # github virtual env is the latest chrome
       - name: Setup chromedriver
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'
-        run: yarn add --dev chromedriver@106.0.0
+        run: node scripts/upgrade_chromedriver.js
 
       - name: Run bootstrap
         if: steps.ftr_tests_results.outputs.ftr_tests_results != 'success'
@@ -194,6 +194,6 @@ jobs:
           CI_PARALLEL_PROCESS_NUMBER: ciGroup${{ matrix.group }}
           JOB: ci${{ matrix.group }}
           CACHE_DIR: ciGroup${{ matrix.group }}
-      
+
       - if: steps.ftr-tests.outcome == 'success' || steps.ftr-tests.outcome == 'skipped'
         run: echo "::set-output name=ftr_tests_results::success" > ftr_tests_results

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .ackrc
 /.opensearch
 /.chromium
+/package.json.bak
 .DS_Store
 .node_binaries
 .native_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Add CHANGELOG.md and related workflows ([#2414](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2414))
 - Update backport custom branch name to utilize head template ([#2766](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2766))
+- Add automatic selection of the appropriate version of chrome driver to run functional tests ([#2990](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2990))
 
 ### 📝 Documentation
 

--- a/scripts/upgrade_chromedriver.js
+++ b/scripts/upgrade_chromedriver.js
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Upgrades the chromedriver dev-dependency to the one supported by the version of Google Chrome
+ * installed on the machine.
+ *
+ * Usage: node scripts/upgrade_chromedriver.js [--install]
+ */
+
+/* eslint no-restricted-syntax: 0 */
+const { execSync, spawnSync } = require('child_process');
+const { createReadStream, createWriteStream, unlinkSync, renameSync, existsSync } = require('fs');
+const { createInterface } = require('readline');
+
+if (!process.argv.includes(__filename)) {
+  console.error('Usage: node scripts/upgrade_chromedriver.js [--install]');
+  process.exit(1);
+}
+
+const versionCheckCommands = [];
+
+switch (process.platform) {
+  case 'win32':
+    versionCheckCommands.push(
+      'powershell "(Get-Item \\"$Env:Programfiles/Google/Chrome/Application/chrome.exe\\").VersionInfo.FileVersion"'
+    );
+    break;
+
+  case 'darwin':
+    versionCheckCommands.push(
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --version'
+    );
+    break;
+
+  default:
+    versionCheckCommands.push(
+      ...[
+        '/usr/bin',
+        '/usr/local/bin',
+        '/usr/sbin',
+        '/usr/local/sbin',
+        '/opt/bin',
+        '/usr/bin/X11',
+        '/usr/X11R6/bin',
+      ].flatMap((loc) =>
+        [
+          'google-chrome --version',
+          'google-chrome-stable --version',
+          'chromium --version',
+          'chromium-browser --version',
+        ].map((cmd) => `${loc}/${cmd}`)
+      )
+    );
+}
+
+let versionCheckOutput;
+versionCheckCommands.some((cmd) => {
+  try {
+    console.log(cmd);
+    versionCheckOutput = execSync(cmd, { encoding: 'utf8' })?.trim?.();
+    return true;
+  } catch (e) {
+    console.log('Failed to get version using', cmd);
+  }
+});
+
+// Versions 90+
+const majorVersion = versionCheckOutput?.match?.(/(?:^|\s)(9\d|\d{3})\./)?.[1];
+
+if (majorVersion) {
+  if (process.argv.includes('--install')) {
+    console.log(`Installing chromedriver@^${majorVersion}`);
+
+    spawnSync(`yarn add --dev chromedriver@^${majorVersion}`, {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+      shell: true,
+    });
+  } else {
+    console.log(`Upgrading to chromedriver@^${majorVersion}`);
+
+    let upgraded = false;
+    const writeStream = createWriteStream('package.json.upgrading-chromedriver', { flags: 'w' });
+    const rl = createInterface({
+      input: createReadStream('package.json'),
+      crlfDelay: Infinity,
+    });
+    rl.on('line', (line) => {
+      if (line.includes('"chromedriver": "')) {
+        line = line.replace(
+          /"chromedriver":\s*"[~^]?\d[\d.]*\d"/,
+          `"chromedriver": "^${majorVersion}"`
+        );
+        upgraded = true;
+      }
+      writeStream.write(line + '\n', 'utf8');
+    });
+    rl.on('close', () => {
+      writeStream.end();
+      if (upgraded) {
+        // Remove any previous backups
+        if (existsSync('package.json.bak')) unlinkSync('package.json.bak');
+
+        renameSync('package.json', 'package.json.bak');
+        renameSync('package.json.upgrading-chromedriver', 'package.json');
+
+        console.log(`Backed up package.json and updated chromedriver to ${majorVersion}`);
+      } else {
+        unlinkSync('package.json.upgrading-chromedriver');
+        console.error(
+          `Failed to update chromedriver to ${majorVersion}. Try adding the \`--install\` switch.`
+        );
+      }
+    });
+  }
+} else {
+  console.debug(versionCheckOutput);
+  console.error(`Failed to extract the version of the installed Google Chrome.`);
+}


### PR DESCRIPTION
backport a26fb43cc3e4072a45e32c40ba59e37ae65cb83b from #2990 

Note that I manually ported the changes from [.github/workflows/build_and_test_workflow.yml](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2990/files#diff-c0983182839615df54f21254770a452eda733bc01ed0c7805ac1f4d48b1e47c9) to [.github/workflows/pr_check_workflow.yml](https://github.com/opensearch-project/OpenSearch-Dashboards/compare/1.x...joshuarrrr:OpenSearch-Dashboards:backport/backport-2990-to-1.x?expand=1#diff-8dbcf55675442f749d73e30a0314188743c4171c3622b787032768d06358f878)