### PR TITLE
[Test] Fix windows chomedriver version to match linux workflow

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -206,7 +206,7 @@ jobs:
 
       # image has the latest chrome v99
       - name: Setup chromedriver
-        run: yarn add --dev chromedriver@106.0.1
+        run: yarn add --dev chromedriver@99.0.0
 
       - name: Run bootstrap
         run: yarn osd bootstrap


### PR DESCRIPTION
### Description

When we backported automation workflow for windows, we didn't ensure that the windows workflows use the same version as the linux workflows.
 
### Issues Resolved

Hopefully will fix all the failed windows workflows on the `2.x` branch 😓 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 