### PR TITLE
[Backport 2.x][Manual][CI] update yarn timeout for GitHub workflow on Windows (#3118)

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -100,8 +100,13 @@ jobs:
           npm uninstall -g yarn
           npm i -g yarn@1.22.10
 
+      # https://github.com/yarnpkg/yarn/issues/8242#issuecomment-776561223
+      # Increase network timeout for Windows, retry once if bootstrap fails
       - name: Run bootstrap
-        run: yarn osd bootstrap
+        run: | 
+          yarn cache clean
+          yarn config set network-timeout 1000000 -g
+          yarn osd bootstrap || yarn osd bootstrap
 
       - name: Run linter
         id: linter
@@ -208,8 +213,13 @@ jobs:
       - name: Setup chromedriver
         run: yarn add --dev chromedriver@106.0.1
 
+      # https://github.com/yarnpkg/yarn/issues/8242#issuecomment-776561223
+      # Increase network timeout for Windows, retry once if bootstrap fails
       - name: Run bootstrap
-        run: yarn osd bootstrap
+        run: | 
+          yarn cache clean
+          yarn config set network-timeout 1000000 -g
+          yarn osd bootstrap || yarn osd bootstrap
 
       - name: Build plugins
         run: node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Save Object Aggregation View] Fix for export all after scroll count response changed in PR#2656 ([#2696](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2696))
 
 ### 🐛 Bug Fixes
+
 * [Vis Builder] Fixes auto bounds for timeseries bar chart visualization ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))
 * [Vis Builder] Fixes visualization shift when editing agg ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))
 * [Vis Builder] Renames "Histogram" to "Bar" in vis type picker ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))
@@ -49,6 +50,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [Multi DataSource] Apply get indices error handling in step index pattern ([#2652](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2652))
 * Removed Leftover X Pack references ([#2638](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2638))
 * Bumped `del` version to fix MacOS race condition ([#2847](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2873))
+* [CI] Update test workflow to increase network-timeout for yarn for installing dependencies ([#3118](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3118))
 
 ### 🚞 Infrastructure
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -36,6 +36,11 @@ $ npm i -g yarn
 $ yarn osd bootstrap # This command will also install npm dependencies
 ```
 
+If you experience a network timeout while bootstrapping, you can update the timeout by configuring it in the `.yarnrc`. For example:
+```
+network-timeout 1000000
+```
+
 ### Configure OpenSearch Dashboards
 
 *This step is only mandatory if you have https/authentication enabled, or if you use the OpenSearch Docker image in its default configuration.*


### PR DESCRIPTION
Yarn 1.x seems to have an issue with timing on windows and mac when running.

Source:
https://github.com/yarnpkg/yarn/issues/8242#issuecomment-776561223

Increase timeout for Windows only.

Issue:
n/a

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
(cherry picked from commit 038968d154c8bcc9d9c75e7abbf9b9435b9a0e42)
Signed-off-by: Manasvini B Suryanarayana <manasvis@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 