### PR TITLE
[CI][Windows] increase timeout to check run_worker process exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [MD] Update dummy url in tests to follow lychee url allowlist ([#3099](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3099))
 - Adds config override to fix obsolete theme:version config value of v8 (beta) rendering issue ([#3045](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3045))
 - [CI] Update test workflow to increase network-timeout for yarn for installing dependencies ([#3118](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3118))
+- [CI][Windows] increase timeout from 5 seconds to 10 seconds to check `run_worker` process exit for Windows([#3185](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3185))
 
 ### 🚞 Infrastructure
 

--- a/packages/osd-optimizer/src/worker/run_worker.ts
+++ b/packages/osd-optimizer/src/worker/run_worker.ts
@@ -44,6 +44,8 @@ import {
 
 import { runCompilers } from './run_compilers';
 
+export const TIMEOUT_MS = process.platform === 'win32' ? 10000 : 5000;
+
 /**
  **
  **
@@ -78,11 +80,11 @@ const exit = (code: number) => {
   setTimeout(() => {
     send(
       workerMsgs.error(
-        new Error('process did not automatically exit within 5 seconds, forcing exit')
+        new Error(`process did not automatically exit within ${TIMEOUT_MS} ms, forcing exit`)
       )
     );
     process.exit(1);
-  }, 5000).unref();
+  }, TIMEOUT_MS).unref();
 };
 
 // check for connected parent on an unref'd timer rather than listening


### PR DESCRIPTION
### Description
Increasing the timeout if platform is on Windows to 10 seconds from 5 seconds.

Origin:
https://github.com/opensearch-project/OpenSearch-Dashboards/actions/runs/3850790218/jobs/6561333017

In this run, the error:
```
ERROR UNHANDLED ERROR
ERROR Error: process did not automatically exit within 5 seconds, forcing exit
          at Timeout._onTimeout (D:\a\OpenSearch-Dashboards\OpenSearch-Dashboards\packages\osd-optimizer\src\worker\run_worker.ts:81:9)
```

Occurred for Windows when running:
```
node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers 10
```

The process appears not to end in the expected time given for the Windows CI and based on known performance issues, this increases the timeout for windows to allow for the Windows processes to attempt to naturally end within 10 seconds rather than 5 seconds.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 