### PR TITLE
[Tests] Skip tests inside the docs folder

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -9,10 +9,12 @@ on:
     branches: [ '**', '!backport/**' ]
     paths-ignore:
       - '**/*.md'
+      - 'docs/**'
   pull_request:
     branches: [ '**' ]
     paths-ignore:
       - '**/*.md'
+      - 'docs/**'
 
 env:
   TEST_BROWSER_HEADLESS: 1


### PR DESCRIPTION
Signed-off-by: abbyhu2000 <abigailhu2000@gmail.com>

### Description
Since the upload of images in the docs folder cause tests to fail, add steps to skip tests for changes inside the docs folder.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3176#issuecomment-1373979340
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 