### PR TITLE
[Docs] Fix documentation link for date math

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -338,6 +338,8 @@ export class DocLinksService {
               close: `${OPENSEARCH_VERSIONED_DOCS}rest-api/index-apis/close-index/`,
             },
           },
+          // https://opensearch.org/docs/latest/opensearch/supported-field-types/date/#date-math
+          dateMath: `${OPENSEARCH_VERSIONED_DOCS}supported-field-types/date/#date-math`,
         },
         opensearchDashboards: {
           // https://opensearch.org/docs/latest/dashboards/index/
@@ -386,6 +388,7 @@ export class DocLinksService {
             // https://opensearch.org/docs/latest/dashboards/dql/#nested-field-query
             nested_query: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}dql/#nested-field-query`,
           },
+          // https://opensearch.org/docs/latest/dashboards/browser-compatibility
           browser: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}browser-compatibility`,
         },
         noDocumentation: {
@@ -425,7 +428,6 @@ export class DocLinksService {
           },
           addData: `${OPENSEARCH_WEBSITE_DOCS}`,
           vega: `${OPENSEARCH_DASHBOARDS_VERSIONED_DOCS}`,
-          dateMath: `${OPENSEARCH_WEBSITE_DOCS}`,
           savedObject: {
             manageSavedObject: `https://opensearch.org/docs/latest/guide/en/kibana/current/managing-saved-objects.html#_export`,
           },
@@ -718,6 +720,7 @@ export interface DocLinksStart {
           readonly close: string;
         };
       };
+      readonly dateMath: string;
     };
     readonly opensearchDashboards: {
       readonly introduction: string;
@@ -777,7 +780,6 @@ export interface DocLinksStart {
       readonly visualize: Record<string, string>;
       readonly addData: string;
       readonly vega: string;
-      readonly dateMath: string;
       readonly savedObject: {
         readonly manageSavedObject: string;
       };

--- a/src/plugins/vis_default_editor/public/components/controls/date_ranges.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/date_ranges.tsx
@@ -139,7 +139,7 @@ function DateRangesParamEditor({
     <EuiFormRow display={'rowCompressed'} fullWidth>
       <>
         <EuiText size="xs">
-          <EuiLink href={services.docLinks.links.noDocumentation.dateMath} target="_blank">
+          <EuiLink href={services.docLinks.links.opensearch.dateMath} target="_blank">
             <FormattedMessage
               id="visDefaultEditor.controls.dateRanges.acceptedDateFormatsLinkText"
               defaultMessage="Acceptable date formats"


### PR DESCRIPTION
### Description

- Add new documentation link
- move from `noDocumentation` to `opensearch`
 
### Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2849
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 