### PR TITLE
Fix bug that prevents selected join field to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [MD] Update dummy url in tests to follow lychee url allowlist ([#3099](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3099))
 - Adds config override to fix obsolete theme:version config value of v8 (beta) rendering issue ([#3045](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3045))
 - [CI] Update test workflow to increase network-timeout for yarn for installing dependencies ([#3118](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3118))
+- [Region Maps] Fixes bug that prevents selected join field to be used ([#3213](Fix bug that prevents selected join field to be used))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/region_map/public/region_map_visualization.js
+++ b/src/plugins/region_map/public/region_map_visualization.js
@@ -158,7 +158,6 @@ export function createRegionMapVisualization({
       let selectedLayer;
       if (DEFAULT_MAP_CHOICE === this._params.layerChosenByUser && this._params.selectedLayer) {
         selectedLayer = await this._loadConfig(this._params.selectedLayer);
-        this._params.selectedJoinField = selectedLayer?.fields[0];
       } else if (
         CUSTOM_MAP_CHOICE === this._params.layerChosenByUser &&
         this._params.selectedCustomLayer


### PR DESCRIPTION
### Description
Remove updating join field to first field always.

Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>
 
### Issues Resolved
#2888  
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 