### PR TITLE
Increment version from 2.5.0 to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update backport custom branch name to utilize head template ([#2766](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2766))
 - Add automatic selection of the appropriate version of chrome driver to run functional tests ([#2990](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2990))
 - Improve yarn's performance in workflows by caching yarn's cache folder ([#3194](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3194))
+- Increment the version on the parent branch (2.x) to the next development iteration (2.6)([3229](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3229))
 
 ### 📝 Documentation
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dashboarding"
   ],
   "private": true,
-  "version": "2.5.0",
+  "version": "2.6.0",
   "branch": "2.x",
   "types": "./opensearch_dashboards.d.ts",
   "tsdocMetadata": "./build/tsdoc-metadata.json",


### PR DESCRIPTION
Signed-off-by: Manasvini B Suryanarayana <manasvis@amazon.com>

### Description
Increment the version on the parent branch (2.x) to the next development iteration (2.6) after 2.5 branch cut.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3228
 
### Check List
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 