### PR TITLE
feat: modify the branch to 2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "private": true,
   "version": "2.5.0",
-  "branch": "2.x",
+  "branch": "2.5",
   "types": "./opensearch_dashboards.d.ts",
   "tsdocMetadata": "./build/tsdoc-metadata.json",
   "build": {


### PR DESCRIPTION
Signed-off-by: suzhou <suzhou@amazon.com>

### Description
IM plugin has an issue that the docLinks’ version is not correct. It gives 2.x in 2.5 build.
![image](https://user-images.githubusercontent.com/13493605/212291570-cb011331-d91f-44ce-8cd1-81df771c7343.png)
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
  - [x] `yarn test:ftr`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 

### TODO
Need to add a test to check the branch property when we build any artifacts.