### PR TITLE
[CI] Fix detection of Chrome's version on Darwin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add automatic selection of the appropriate version of chrome driver to run functional tests ([#2990](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2990))
 - Add recording of functional test artifacts if they fail ([#3190](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3190))
 - Improve yarn's performance in workflows by caching yarn's cache folder ([#3194](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3194))
+- Fix detection of Chrome's version on Darwin during CI ([#3296](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3296))
 
 ### 📝 Documentation
 

--- a/scripts/upgrade_chromedriver.js
+++ b/scripts/upgrade_chromedriver.js
@@ -31,7 +31,7 @@ switch (process.platform) {
 
   case 'darwin':
     versionCheckCommands.push(
-      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --version'
+      '/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --version'
     );
     break;
 


### PR DESCRIPTION
Signed-off-by: Miki <miki@amazon.com>

### Description
A bad copy-paste made the detection not escape the white-spaces in the path to Chrome.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 