### PR TITLE
[2.5][CVE-2022-37601][CVE-2022-37599] Bump loader-utils to 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecations
 
 ### 🛡 Security
+- [CVE-2022-37601][CVE-2022-37599] Bump loader-utils to 2.0.4 ([#3318](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3318))
 
 ### 📈 Features/Enhancements
 
@@ -100,7 +101,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update `leaflet-vega` and fixed its usage ([#3005](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3005))
 
 ### 🔩 Tests
- 
+
 - Correct the linting logic for `no-restricted-path` to ignore trailing slashes ([#3020](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3020))
 
 ## [2.4.0]

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "**/hoist-non-react-statics": "^3.3.2",
     "**/json-schema": "^0.4.0",
     "**/kind-of": ">=6.0.3",
-    "**/loader-utils": "^2.0.3",
+    "**/loader-utils": "^2.0.4",
     "**/node-jose": "^2.1.0",
     "**/nth-check": "^2.0.1",
     "**/qs": "^6.10.3",

--- a/packages/osd-optimizer/package.json
+++ b/packages/osd-optimizer/package.json
@@ -50,7 +50,7 @@
     "babel-loader": "^8.2.3",
     "css-loader": "^5.2.7",
     "file-loader": "^6.2.0",
-    "loader-utils": "^1.2.3",
+    "loader-utils": "^2.0.4",
     "postcss-loader": "^4.2.0",
     "raw-loader": "^4.0.2",
     "sass-loader": "^10.2.0",

--- a/packages/osd-ui-shared-deps/package.json
+++ b/packages/osd-ui-shared-deps/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "css-loader": "^5.2.7",
     "del": "^6.1.1",
-    "loader-utils": "^1.2.3",
+    "loader-utils": "^2.0.4",
     "val-loader": "^2.1.2",
     "webpack": "^4.41.5"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11807,10 +11807,10 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.2.3, loader-utils@^2.0.0, loader-utils@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.3.tgz#d4b15b8504c63d1fc3f2ade52d41bc8459d6ede1"
-  integrity sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==
+loader-utils@^1.2.3, loader-utils@^2.0.0, loader-utils@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"


### PR DESCRIPTION
Issue Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3306

Signed-off-by: Anan Zhuang <ananzh@amazon.com>

 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 