### PR TITLE
[Manual Backport 2.x]Updates NOTICE file, adds validation to GitHub CI

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -67,6 +67,10 @@ jobs:
         id: linter
         run: yarn lint
 
+      - name: Validate NOTICE file
+        id: notice-validate
+        run: yarn notice:validate
+
       - name: Run unit tests with coverage
         id: unit-tests
         run: yarn test:jest:ci:coverage
@@ -134,6 +138,10 @@ jobs:
       - name: Run linter
         id: linter
         run: yarn lint
+
+      - name: Validate NOTICE file
+        id: notice-validate
+        run: yarn notice:validate
 
       - name: Run unit tests with coverage
         id: unit-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### 🚞 Infrastructure
 
 ### 📝 Documentation
+- Updates NOTICE file, adds validation to GitHub CI ([#3051](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3051))
 
 ### 🛠 Maintenance
 - Bumps `re2` and `supertest` ([3018](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3018))

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,7 +1,15 @@
-OpenSearch
-Copyright 2021 OpenSearch Contributors
-This product includes software, including Kibana source code, developed by Elasticsearch (http://www.elastic.co).
-Copyright 2012-2021 Elasticsearch B.V.
+OpenSearch (https://opensearch.org/)
+Copyright OpenSearch Contributors
+
+This product includes software, including Kibana source code,
+developed by Elasticsearch (http://www.elastic.co).
+Copyright 2009-2018 Elasticsearch B.V.
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/)
+
+This product includes software developed by
+Joda.org (http://www.joda.org/).
 ---
 Pretty handling of logarithmic axes.
 Copyright (c) 2007-2014 IOLA and Ole Laursen.
@@ -116,80 +124,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ---
-This product uses Noto fonts that are licensed under the SIL Open
-Font License, Version 1.1.
-
----
 Based on the scroll-into-view-if-necessary module from npm
 https://github.com/stipsan/compute-scroll-into-view/blob/master/src/index.ts#L269-L340
 
 MIT License
 
 Copyright (c) 2018 Cody Olsen
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-Detection Rules
-Copyright 2020 Elasticsearch B.V.
-
----
-This product bundles rules based on https://github.com/BlueTeamLabs/sentinel-attack
-which is available under a "MIT" license. The files based on this license are:
-
-- defense_evasion_via_filter_manager
-- discovery_process_discovery_via_tasklist_command
-- persistence_priv_escalation_via_accessibility_features
-- persistence_via_application_shimming
-- defense_evasion_execution_via_trusted_developer_utilities
-
-MIT License
-
-Copyright (c) 2019 Edoardo Gerosa, Olaf Hartong
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-This product bundles rules based on https://github.com/FSecureLABS/leonidas
-which is available under a "MIT" license. The files based on this license are:
-
-- credential_access_secretsmanager_getsecretvalue.toml
-
-MIT License
-
-Copyright (c) 2020 F-Secure LABS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -305,44 +245,3 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
----
-This product includes code in the function applyCubicBezierStyles that was
-inspired by a public Codepen, which was available under a "MIT" license.
-
-Copyright (c) 2020 by Guillaume (https://codepen.io/guillaumethomas/pen/xxbbBKO)
-MIT License http://www.opensource.org/licenses/mit-license
-
----
-This product includes code that is adapted from mapbox-gl-js, which is
-available under a "BSD-3-Clause" license.
-https://github.com/mapbox/mapbox-gl-js/blob/master/src/util/image.js
-
-Copyright (c) 2016, Mapbox
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-    * Neither the name of Mapbox GL JS nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "test:ftr:server": "node scripts/functional_tests_server",
     "test:ftr:runner": "node scripts/functional_test_runner",
     "checkLicenses": "node scripts/check_licenses --dev",
+    "notice:validate": "node scripts/notice --validate",
+    "notice:generate": "node scripts/notice",
     "build-platform": "node scripts/build",
     "build": "node scripts/build --all-platforms",
     "start": "node scripts/opensearch_dashboards --dev",

--- a/src/dev/build/tasks/notice_file_task.ts
+++ b/src/dev/build/tasks/notice_file_task.ts
@@ -42,7 +42,7 @@ export const CreateNoticeFile: Task = {
     log.info('Generating notice from source');
     log.indent(4);
     const noticeFromSource = await generateNoticeFromSource({
-      productName: 'OpenSearch',
+      productName: 'OpenSearch (https://opensearch.org/)',
       directory: build.resolvePath(),
       log,
     });

--- a/src/dev/notice/cli.js
+++ b/src/dev/notice/cli.js
@@ -80,7 +80,7 @@ if (opts.help) {
 (async function run() {
   const path = resolve(REPO_ROOT, 'NOTICE.txt');
   const newContent = await generateNoticeFromSource({
-    productName: 'OpenSearch Dashboards source code',
+    productName: 'OpenSearch (https://opensearch.org/)',
     directory: REPO_ROOT,
     log,
   });

--- a/src/dev/notice/generate_notice_from_source.ts
+++ b/src/dev/notice/generate_notice_from_source.ts
@@ -33,6 +33,17 @@ import { ToolingLog } from '@osd/dev-utils';
 
 const NOTICE_COMMENT_RE = /\/\*[\s\n\*]*@notice([\w\W]+?)\*\//g;
 const NEWLINE_RE = /\r?\n/g;
+const NOTICE_TEXT = `Copyright OpenSearch Contributors
+
+This product includes software, including Kibana source code,
+developed by Elasticsearch (http://www.elastic.co).
+Copyright 2009-2018 Elasticsearch B.V.
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/)
+
+This product includes software developed by
+Joda.org (http://www.joda.org/).`;
 
 interface Options {
   /**
@@ -89,17 +100,10 @@ export async function generateNoticeFromSource({ productName, directory, log }: 
       .on('end', resolve);
   });
 
-  let noticeText = '';
-  noticeText += `${productName}\n`;
-  noticeText += `Copyright ${new Date().getUTCFullYear()} OpenSearch Contributors\n\n`;
-  noticeText += `This product includes software developed by Elasticsearch (http://www.elastic.co).\n`;
-  noticeText += `Copyright 2009-2018 Elasticsearch\n\n`;
-  noticeText += `This product includes software developed by The Apache Software Foundation (http://www.apache.org/)\n\n`;
-  noticeText += `This product includes software developed by Joda.org (http://www.joda.org/).\n`;
-
+  let notice = `${productName}\n` + NOTICE_TEXT;
   for (const comment of noticeComments.sort()) {
-    noticeText += '\n---\n';
-    noticeText += comment
+    notice += '\n---\n';
+    notice += comment
       .split(NEWLINE_RE)
       .map((line) =>
         line
@@ -110,11 +114,9 @@ export async function generateNoticeFromSource({ productName, directory, log }: 
       )
       .join('\n')
       .trim();
-    noticeText += '\n';
+    notice += '\n';
   }
-
-  noticeText += '\n';
-
-  log.debug(`notice text:\n\n${noticeText}`);
-  return noticeText;
+  notice += '\n';
+  log.debug(`notice text:\n\n${notice}`);
+  return notice;
 }


### PR DESCRIPTION
### Description
* Aligns NOTICE with rules outlined in opensearch-project/.github#21.
* Adds NOTICE validation to the build and test workflow.
* Fixes product name discrepancies between repository NOTICE file and the generated NOTICE file for the build.
* Skips template-izing the build and test workflow since that's being worked on in https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2991

### Resolved Issue
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/765

### Backport PR
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3051

 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 