### PR TITLE
[1.3] Update MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,13 +1,27 @@
-# OpenSearch-Dashboards Maintainers
+## Overview
 
-## Maintainers
-| Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Anan | [ananzh](https://github.com/ananzh) | Amazon |
-| Bishoy Boktor | [boktorbb-amzn](https://github.com/boktorbb-amzn) | Amazon |
-| Mihir Soni | [mihirsoni](https://github.com/mihirsoni) | Amazon |
-| Rocky | [kavilla](https://github.com/kavilla) | Amazon |
-| Sean Neumann | [seanneumann](https://github.com/seanneumann) | Amazon | 
-| Tommy Markley | [tmarkley](https://github.com/tmarkley) | Amazon | 
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
 
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+## Current Maintainers
+
+| Maintainer                | GitHub ID                                           | Affiliation |
+| ------------------------- | --------------------------------------------------- | ----------- |
+| Anan Zhuang               | [ananzh](https://github.com/ananzh)                 | Amazon      |
+| Bishoy Boktor             | [boktorbb](https://github.com/boktorbb)             | Amazon      |
+| Mihir Soni                | [mihirsoni](https://github.com/mihirsoni)           | Amazon      |
+| Kawika (Rocky) Avilla     | [kavilla](https://github.com/kavilla)               | Amazon      |
+| Sean Neumann              | [seanneumann](https://github.com/seanneumann)       | Amazon      |
+| Miki Barahmand            | [AMoo-Miki](https://github.com/AMoo-Miki)           | Amazon      |
+| Ashwin P Chandran         | [ashwin-pc](https://github.com/ashwin-pc)           | Amazon      |
+| Josh Romero               | [joshuarrrr](https://github.com/joshuarrrr)         | Amazon      |
+| Abby Hu                   | [abbyhu2000](https://github.com/abbyhu2000)         | Amazon      |
+| Yan Zeng                  | [zengyan-amazon](https://github.com/zengyan-amazon) | Amazon      |
+| Kristen Tian              | [kristenTian](https://github.com/kristenTian)       | Amazon      |
+| Zhongnan Su               | [zhongnansu](https://github.com/zhongnansu)         | Amazon      |
+| Manasvini B Suryanarayana | [manasvinibs](https://github.com/manasvinibs)       | Amazon      |
+
+## Emeritus
+
+| Maintainer    | GitHub ID                               | Affiliation |
+| ------------- | --------------------------------------- | ----------- |
+| Tommy Markley | [tmarkley](https://github.com/tmarkley) | Amazon      |


### PR DESCRIPTION
Coming from opensearch-project/.github#121, updated MAINTAINERS.md to match opensearch-project recommended format. Also modify this file to include all the missing updates.

Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3338


 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 