### PR TITLE
[Manual Backport 1.3][CVE-2022-25860] Bumps simple-git from 3.15.1 to 3.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [CVE-2022-25901] Bump supertest ([#3222](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3322))
 - [CVE-2022-46175] Bumps json5 version from 1.0.1 and 2.2.1 to 1.0.2 and 2.2.3 ([#3201](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3201))
 - [CVE-2022-25912] Bumps simple-git from 3.4.0 to 3.15.0 ([#3036](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3036))
+- [CVE-2022-25860] Bumps simple-git from 3.15.1 to 3.16.0 ([#3345](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3345))
 
 ### 📈 Features/Enhancements
 

--- a/package.json
+++ b/package.json
@@ -468,7 +468,7 @@
     "resize-observer-polyfill": "^1.5.0",
     "sass-lint": "^1.12.1",
     "selenium-webdriver": "^4.0.0-alpha.7",
-    "simple-git": "^3.15.0",
+    "simple-git": "^3.16.0",
     "sinon": "^7.4.2",
     "strip-ansi": "^6.0.0",
     "supertest": "^6.3.3",

--- a/packages/osd-opensearch/package.json
+++ b/packages/osd-opensearch/package.json
@@ -22,7 +22,7 @@
     "getopts": "^2.2.5",
     "glob": "^7.1.7",
     "node-fetch": "^2.6.7",
-    "simple-git": "^3.15.0",
+    "simple-git": "^3.16.0",
     "tar-fs": "^2.1.0",
     "tree-kill": "^1.2.2",
     "yauzl": "^2.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19162,7 +19162,7 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-simple-git@^3.15.0:
+simple-git@^3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.16.0.tgz#421773e24680f5716999cc4a1d60127b4b6a9dec"
   integrity sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==


### PR DESCRIPTION
Backport PR
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3345

Issue Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3329


 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 