### PR TITLE
Add custom tooltips and clicking functionality to vega charts

### DIFF
--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -281,6 +281,16 @@ export class VegaBaseView {
         this._addDestroyHandler(() => tthandler.hideTooltip());
       }
 
+      view.addEventListener('click', function (event, item) {
+        // TODO: add filtering on item. Only open flyout when item is an event/annotation datapoint.
+
+        console.log('click triggered');
+
+        // below commented lines will be added as part of the view events flyout PR
+        // const { savedObjectId } = get(view, '_opensearchDashboardsView._visInput', {});
+        // getUiActions().getTrigger(OPEN_EVENTS_FLYOUT_TRIGGER).exec({ savedObjectId });
+      });
+
       return view.runAsync(); // Allows callers to await rendering
     }
   }

--- a/src/plugins/vis_type_vega/public/vega_view/vega_tooltip.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_tooltip.js
@@ -87,7 +87,8 @@ export class TooltipHandler {
     // Sanitized HTML is created by the tooltip library,
     // with a large number of tests, hence suppressing eslint here.
     // eslint-disable-next-line no-unsanitized/property
-    el.innerHTML = createTooltipContent(value, _.escape, 2);
+    // el.innerHTML = createTooltipContent(value, _.escape, 2);
+    el.innerHTML = this.createTooltipHtml(value);
 
     // add to DOM to calculate tooltip size
     document.body.appendChild(el);
@@ -115,6 +116,13 @@ export class TooltipHandler {
     );
 
     el.setAttribute('style', `top: ${pos.top}px; left: ${pos.left}px`);
+  }
+
+  // TODO: impelement returning different html based on the item (value) being hovered on.
+  // show custom if it's an annotation datapoint, otherwise can probably use the default
+  // way that existed before: createTooltipContent(value, _.escape, 2);
+  createTooltipHtml(value) {
+    return '<p>some custom tooltip<p>';
   }
 
   hideTooltip() {


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
This is a draft PR highlighting the entry points for injecting custom tooltips and custom clicking functionality in the vega charts.

These may be moved depending on where they will live, potentially in a new Vega View. Details in the related issue #3317 