### PR TITLE
[search telemetry] Fixes search telemetry's observable object that won't be GC-ed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Region Maps] Fixes bug that prevents selected join field to be used ([#3213](Fix bug that prevents selected join field to be used))
 - [Multi DataSource]Update test connection button text([#3247](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3247))
 - [Region Maps] Add ui setting to configure custom vector map's size parameter([#3399](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3399))
+- [Search Telemetry] Fixes search telemetry's observable object that won't be GC-ed([#3390](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3390))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/data/server/plugin.ts
+++ b/src/plugins/data/server/plugin.ts
@@ -96,7 +96,7 @@ export class DataServerPlugin
     this.autocompleteService = new AutocompleteService(initializerContext);
   }
 
-  public setup(
+  public async setup(
     core: CoreSetup<DataPluginStartDependencies, DataPluginStart>,
     { expressions, usageCollection, dataSource }: DataPluginSetupDependencies
   ) {
@@ -108,7 +108,7 @@ export class DataServerPlugin
 
     core.uiSettings.register(getUiSettings());
 
-    const searchSetup = this.searchService.setup(core, {
+    const searchSetup = await this.searchService.setup(core, {
       registerFunction: expressions.registerFunction,
       usageCollection,
       dataSource,

--- a/src/plugins/data/server/search/collectors/usage.ts
+++ b/src/plugins/data/server/search/collectors/usage.ts
@@ -28,8 +28,7 @@
  * under the License.
  */
 
-import { CoreSetup, PluginInitializerContext } from 'opensearch-dashboards/server';
-import { first } from 'rxjs/operators';
+import { CoreSetup } from 'opensearch-dashboards/server';
 import { Usage } from './register';
 import { ConfigSchema } from '../../../config';
 
@@ -40,16 +39,9 @@ export interface SearchUsage {
   trackSuccess(duration: number): Promise<void>;
 }
 
-export function usageProvider(
-  core: CoreSetup,
-  initializerContext: PluginInitializerContext<ConfigSchema>
-): SearchUsage {
+export function usageProvider(core: CoreSetup, config: ConfigSchema): SearchUsage {
   const getTracker = (eventType: keyof Usage) => {
     return async (duration?: number) => {
-      const config = await initializerContext.config
-        .create<ConfigSchema>()
-        .pipe(first())
-        .toPromise();
       if (config?.search?.usageTelemetry?.enabled) {
         const repository = await core
           .getStartServices()

--- a/src/plugins/data/server/search/search_service.test.ts
+++ b/src/plugins/data/server/search/search_service.test.ts
@@ -53,7 +53,7 @@ describe('Search service', () => {
 
   describe('setup()', () => {
     it('exposes proper contract', async () => {
-      const setup = plugin.setup(mockCoreSetup, ({
+      const setup = await plugin.setup(mockCoreSetup, ({
         packageInfo: { version: '8' },
         registerFunction: jest.fn(),
       } as unknown) as SearchServiceSetupDependencies);

--- a/src/plugins/data/server/search/search_service.ts
+++ b/src/plugins/data/server/search/search_service.ts
@@ -105,11 +105,15 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
     private readonly logger: Logger
   ) {}
 
-  public setup(
+  public async setup(
     core: CoreSetup<{}, DataPluginStart>,
     { registerFunction, usageCollection, dataSource }: SearchServiceSetupDependencies
-  ): ISearchSetup {
-    const usage = usageCollection ? usageProvider(core, this.initializerContext) : undefined;
+  ): Promise<ISearchSetup> {
+    const config = await this.initializerContext.config
+      .create<ConfigSchema>()
+      .pipe(first())
+      .toPromise();
+    const usage = usageCollection ? usageProvider(core, config) : undefined;
 
     const router = core.http.createRouter();
     const routeDependencies = {


### PR DESCRIPTION
Signed-off-by: Tao Liu <liutaoaz@amazon.com>

### Description
The search telemetry was disabled by default, there is a issue when search telemetry read configuration and creates an Observable object that won't be GC-ed. 

### Issues Resolved

 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 