### PR TITLE
Allow relaxing the Node.js runtime version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Upgrade `vega-lite` dependency to ^5.6.0 ([#3076](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3076))
 - Bumps `re2` and `supertest` ([3018](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3018))
 - Bump `vega-tooltip` version from ^0.24.2 to ^0.30.0 ([#3358](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3358))
+- Allow relaxing the Node.js runtime version requirement ([3402](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3402))
 
 ### 🪛 Refactoring
 

--- a/src/setup_node_env/__snapshots__/node_version_validator.test.js.snap
+++ b/src/setup_node_env/__snapshots__/node_version_validator.test.js.snap
@@ -1,0 +1,755 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Node.js version validation fails if package.json has a 0.x.x engines.node 1`] = `"OpenSearch Dashboards did not report its required version of the Node.js runtime in a valid format. Please revert any changes that might have been made to the package.json file and try again."`;
+
+exports[`Node.js version validation fails if package.json has a blank engines.node 1`] = `"OpenSearch Dashboards did not report its required version of the Node.js runtime. Please revert any changes that might have been made to the package.json file and try again."`;
+
+exports[`Node.js version validation fails if package.json has an invalid engines.node 1`] = `"OpenSearch Dashboards did not report its required version of the Node.js runtime in a valid format. Please revert any changes that might have been made to the package.json file and try again."`;
+
+exports[`Node.js version validation fails if package.json is missing engines 1`] = `"OpenSearch Dashboards did not report its required version of the Node.js runtime. Please revert any changes that might have been made to the package.json file and try again."`;
+
+exports[`Node.js version validation fails if package.json is missing engines.node 1`] = `"OpenSearch Dashboards did not report its required version of the Node.js runtime. Please revert any changes that might have been made to the package.json file and try again."`;
+
+exports[`Node.js version validation fails if process.version is not reported 1`] = `"OpenSearch Dashboards cannot start up because the JavaScript runtime did not report its version. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation fails if process.version reports an invalid value 1`] = `"OpenSearch Dashboards cannot start up because the JavaScript runtime did not report its version in a discernible format. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and no operator 4, should not accept v3.0.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and no operator 4, should not accept v3.0.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and no operator 4, should not accept v3.1.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and no operator 4, should not accept v3.1.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and no operator 4, should not accept v5.0.0, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.0.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and no operator 4, should not accept v5.0.1, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.0.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and no operator 4, should not accept v5.1.0, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.1.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and no operator 4, should not accept v5.1.1, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.1.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the caret operator ^4, should not accept v3.0.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the caret operator ^4, should not accept v3.0.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the caret operator ^4, should not accept v3.1.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the caret operator ^4, should not accept v3.1.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the caret operator ^4, should not accept v5.0.0, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.0.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the caret operator ^4, should not accept v5.0.1, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.0.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the caret operator ^4, should not accept v5.1.0, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.1.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the caret operator ^4, should not accept v5.1.1, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.1.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the equals operator =4, should not accept v3.0.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the equals operator =4, should not accept v3.0.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the equals operator =4, should not accept v3.1.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the equals operator =4, should not accept v3.1.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the equals operator =4, should not accept v5.0.0, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.0.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the equals operator =4, should not accept v5.0.1, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.0.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the equals operator =4, should not accept v5.1.0, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.1.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the equals operator =4, should not accept v5.1.1, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.1.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than operator >4, should not accept v3.0.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.0. Please use a Node.js runtime version that is v5.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than operator >4, should not accept v3.0.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.1. Please use a Node.js runtime version that is v5.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than operator >4, should not accept v3.1.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.0. Please use a Node.js runtime version that is v5.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than operator >4, should not accept v3.1.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.1. Please use a Node.js runtime version that is v5.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than operator >4, should not accept v4.0.0, the exact version 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.0.0. Please use a Node.js runtime version that is v5.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than operator >4, should not accept v4.0.1, a patch upgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.0.1. Please use a Node.js runtime version that is v5.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than operator >4, should not accept v4.1.0, a minor upgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.1.0. Please use a Node.js runtime version that is v5.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than operator >4, should not accept v4.1.1, a minor upgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.1.1. Please use a Node.js runtime version that is v5.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than-or-equals operator >=4, should not accept v3.0.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.0. Please use a Node.js runtime version that is v4.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than-or-equals operator >=4, should not accept v3.0.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.1. Please use a Node.js runtime version that is v4.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than-or-equals operator >=4, should not accept v3.1.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.0. Please use a Node.js runtime version that is v4.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the greater-than-or-equals operator >=4, should not accept v3.1.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.1. Please use a Node.js runtime version that is v4.0.0 or greater."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the tilde operator ~4, should not accept v3.0.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the tilde operator ~4, should not accept v3.0.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.0.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the tilde operator ~4, should not accept v3.1.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the tilde operator ~4, should not accept v3.1.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.1.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the tilde operator ~4, should not accept v5.0.0, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.0.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the tilde operator ~4, should not accept v5.0.1, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.0.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the tilde operator ~4, should not accept v5.1.0, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.1.0. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new major Node.js version using a comparator with a version missing its patch and minor, and the tilde operator ~4, should not accept v5.1.1, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.1.1. Please use a Node.js runtime version that is v4.0.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.54.0, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.54.1, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.55.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.55.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.56.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.56.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v4.54.0, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v4.54.1, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v4.56.0, a minor upgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v4.56.1, a minor upgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.54.0, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.54.1, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.55.0, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.55.1, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.56.0, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.56.1, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.54.0, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.54.1, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.55.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.55.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.56.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.56.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v4.54.0, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v4.54.1, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.54.0, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.54.1, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.55.0, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.55.1, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.56.0, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.56.1, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.54.0, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.54.1, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.55.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.55.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.56.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.56.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v4.54.0, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v4.54.1, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v4.56.0, a minor upgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v4.56.1, a minor upgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.54.0, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.54.1, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.55.0, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.55.1, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.56.0, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.56.1, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.54.0, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.0. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.54.1, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.1. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.55.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.0. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.55.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.1. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.56.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.0. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.56.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.1. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v4.54.0, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.0. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v4.54.1, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.1. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v4.55.0, the exact version 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.0. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v4.55.1, a patch upgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.1. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.54.0, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.0. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.54.1, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.1. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.55.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.0. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.55.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.1. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.56.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.0. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.56.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.1. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v4.54.0, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.0. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v4.54.1, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.1. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.54.0, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.54.1, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.55.0, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.55.1, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.56.0, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.56.1, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v4.54.0, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v4.54.1, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v4.56.0, a minor upgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v4.56.1, a minor upgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.54.0, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.54.1, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.55.0, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.55.1, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.56.0, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.0. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation new minor Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.56.1, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.1. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v4.55.665, a patch downgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v4.55.667, a patch upgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v4.56.665, a minor upgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v4.56.666, a minor upgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v4.56.667, a minor upgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v5.54.665, a major upgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v5.54.666, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v5.54.667, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v5.55.665, a major upgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v5.55.666, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v5.55.667, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v5.56.665, a major upgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v5.56.666, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and no operator 4.55.666, should not accept v5.56.667, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v4.55.665, a patch downgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v5.54.665, a major upgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v5.54.666, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v5.54.667, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v5.55.665, a major upgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v5.55.666, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v5.55.667, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v5.56.665, a major upgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v5.56.666, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the caret operator ^4.55.666, should not accept v5.56.667, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v4.55.665, a patch downgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v4.55.667, a patch upgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v4.56.665, a minor upgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v4.56.666, a minor upgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v4.56.667, a minor upgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v5.54.665, a major upgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v5.54.666, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v5.54.667, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v5.55.665, a major upgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v5.55.666, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v5.55.667, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v5.56.665, a major upgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.665. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v5.56.666, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.666. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the equals operator =4.55.666, should not accept v5.56.667, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.667. Please use Node.js v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v4.55.665, a patch downgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.665. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than operator >4.55.666, should not accept v4.55.666, the exact version 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.666. Please use a Node.js runtime version that is greater than v4.55.666."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the greater-than-or-equals operator >=4.55.666, should not accept v4.55.665, a patch downgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.665. Please use a Node.js runtime version that is v4.55.666 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v4.55.665, a patch downgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v4.56.665, a minor upgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v4.56.666, a minor upgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v4.56.667, a minor upgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v5.54.665, a major upgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v5.54.666, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v5.54.667, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v5.55.665, a major upgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v5.55.666, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v5.55.667, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v5.56.665, a major upgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.665. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v5.56.666, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.666. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a complete version, and the tilde operator ~4.55.666, should not accept v5.56.667, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.667. Please use a Node.js runtime version that is v4.55.666 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v4.56.665, a minor upgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v4.56.666, a minor upgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v4.56.667, a minor upgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.54.665, a major upgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.54.666, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.54.667, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.55.665, a major upgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.55.666, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.55.667, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.56.665, a major upgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.56.666, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and no operator 4.55, should not accept v5.56.667, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.54.665, a major upgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.54.666, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.54.667, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.55.665, a major upgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.55.666, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.55.667, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.56.665, a major upgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.56.666, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the caret operator ^4.55, should not accept v5.56.667, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v5.0.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v4.56.665, a minor upgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v4.56.666, a minor upgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v4.56.667, a minor upgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.54.665, a major upgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.54.666, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.54.667, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.55.665, a major upgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.55.666, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.55.667, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.56.665, a major upgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.56.666, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the equals operator =4.55, should not accept v5.56.667, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v4.55.665, a patch downgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.665. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v4.55.666, the exact version 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.666. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than operator >4.55, should not accept v4.55.667, a patch upgrade 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.55.667. Please use a Node.js runtime version that is v4.56.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the greater-than-or-equals operator >=4.55, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use a Node.js runtime version that is v4.55.0 or greater."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.54.665, a major downgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.54.666, a major downgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.54.667, a major downgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.55.665, a major downgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.55.666, a major downgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.55.667, a major downgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.55.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.56.665, a major downgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.56.666, a major downgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v3.56.667, a major downgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v3.56.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v4.54.665, a minor downgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v4.54.666, a minor downgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v4.54.667, a minor downgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v4.56.665, a minor upgrade with lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v4.56.666, a minor upgrade with same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v4.56.667, a minor upgrade with higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v4.56.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.54.665, a major upgrade with lower minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.54.666, a major upgrade with lower minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.54.667, a major upgrade with lower minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.54.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.55.665, a major upgrade with same minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.55.666, a major upgrade with same minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.55.667, a major upgrade with same minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.55.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.56.665, a major upgrade with higher minor and lower patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.665. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.56.666, a major upgrade with higher minor and same patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.666. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;
+
+exports[`Node.js version validation non-new Node.js version using a comparator with a version missing its patch, and the tilde operator ~4.55, should not accept v5.56.667, a major upgrade with higher minor and higher patch 1`] = `"OpenSearch Dashboards cannot start up using the Node.js runtime v5.56.667. Please use a Node.js runtime version that is v4.55.0 or greater and lower than v4.56.0."`;

--- a/src/setup_node_env/node_version_validator.js
+++ b/src/setup_node_env/node_version_validator.js
@@ -28,27 +28,217 @@
  * under the License.
  */
 
+/* Note:
+ *   This file uses ES5 in order to provide meaningful output even if an old Node.js runtime is used.
+ *
+ * The exit codes facilitating the testing are:
+ *   21: JS runtime version doesn't satisfy the range specific in `engines.node` of `package.json`.
+ *   22: `package.json` is missing `engines.node` or it is not a string.
+ *   23: `package.json` has a `engines.node` that is not a valid semver range.
+ *   24: `package.json` has a `engines.node` that has a major of zero.
+ *   25: JS runtime did not report `process.version`.
+ *   26: JS runtime returned a `process.version` that didn't match semver.
+ */
+
 var pkg = require('../../package.json');
 
-// Note: This is written in ES5 so we can run this before anything else
-// and gives support for older NodeJS versions
-var currentVersion = (process && process.version) || null;
-var rawRequiredVersion = (pkg && pkg.engines && pkg.engines.node) || null;
-var requiredVersion = rawRequiredVersion ? 'v' + rawRequiredVersion : rawRequiredVersion;
-var currentVersionMajorMinorPatch = currentVersion.match(/^v(\d+)\.(\d+)\.(\d+)/);
-var requiredVersionMajorMinorPatch = requiredVersion.match(/^v(\d+)\.(\d+)\.(\d+)/);
-var isVersionValid =
-  currentVersionMajorMinorPatch[1] === requiredVersionMajorMinorPatch[1] &&
-  currentVersionMajorMinorPatch[2] === requiredVersionMajorMinorPatch[2] &&
-  parseInt(currentVersionMajorMinorPatch[3], 10) >= parseInt(requiredVersionMajorMinorPatch[3], 10);
+var versionMatcher = /^\s*v?\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\D.*)?$/;
+var rangeMatcher = /^\s*(>=?|\^|~|=)?\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[^\d.].*)?$/;
 
-// Validates current the NodeJS version compatibility when OpenSearch Dashboards starts.
-if (!isVersionValid) {
-  var errorMessage =
-    `OpenSearch Dashboards was built with ${requiredVersion} and does not support the current Node.js version ${currentVersion}. ` +
-    `Please use Node.js ${requiredVersion} or a higher patch version.`;
+var ERR_MISSING_REQUIREMENTS =
+  'OpenSearch Dashboards did not report its required version of the Node.js runtime';
+var ERR_BAD_REQUIREMENTS = ERR_MISSING_REQUIREMENTS + ' in a valid format';
+var _BAD_REQUIREMENTS_SUFFIX =
+  '. Please revert any changes that might have been made to the package.json file and try again.';
+ERR_MISSING_REQUIREMENTS += _BAD_REQUIREMENTS_SUFFIX;
+ERR_BAD_REQUIREMENTS += _BAD_REQUIREMENTS_SUFFIX;
 
-  // Actions to apply when validation fails: error report + exit.
-  console.error(errorMessage);
-  process.exit(1);
+var pkgEngineNodeVersion = pkg && pkg.engines && pkg.engines.node;
+if (!pkgEngineNodeVersion || typeof pkgEngineNodeVersion !== 'string') {
+  console.error(ERR_MISSING_REQUIREMENTS);
+  process.exit(22);
+}
+
+/* Basic semver parsing: This is a very limited subset of what semver supports where only a single comparator, composed
+ * of an operator and a version, is supported.
+ * [https://github.com/npm/node-semver/blob/cb1ca1d5480a6c07c12ac31ba5f2071ed530c4ed/README.md#ranges]
+ *
+ * The supported operators are:
+ *   >    Greater than
+ *   >=   Greater than or equal to
+ *   =    Equal
+ *   ~    Tilde ranges: Allows patch changes if a minor version is specified but if only a major version is specified,
+ *          it allows minor changes.
+ *   ^    Caret ranges: Allows patch and minor updates when major is non-zero (and we will never have that).
+ *
+ * Note: If no operator is specified, equality is assumed.
+ */
+var requiredParts = pkgEngineNodeVersion.match(rangeMatcher);
+if (requiredParts === null) {
+  console.error(ERR_BAD_REQUIREMENTS);
+  process.exit(23);
+}
+
+var comparatorVersion = {
+  major: requiredParts[2],
+  minor: requiredParts[3],
+  patch: requiredParts[4],
+};
+var comparatorOperator = requiredParts[1] || '=';
+var rangeBottom = {
+  major: parseInt(comparatorVersion.major, 10) || 0,
+  minor: parseInt(comparatorVersion.minor, 10) || 0,
+  patch: parseInt(comparatorVersion.patch, 10) || 0,
+  inclusive: comparatorOperator.indexOf('>') === -1 || comparatorOperator.indexOf('=') > -1,
+};
+var rangeTop = undefined;
+
+if (!rangeBottom.major) {
+  console.error(ERR_BAD_REQUIREMENTS);
+  process.exit(24);
+}
+
+if (comparatorOperator === '>') {
+  if (!comparatorVersion.minor) {
+    // >3 is >=4.0.0
+    rangeBottom.major += 1;
+    rangeBottom.inclusive = true;
+  } else if (!comparatorVersion.patch) {
+    // >3.1 is >=3.2.0
+    rangeBottom.minor += 1;
+    rangeBottom.inclusive = true;
+  }
+}
+
+// =3 is ~3.0.0 and =3.1 is ~3.1.0
+if (comparatorOperator === '=' && (!comparatorVersion.minor || !comparatorVersion.patch)) {
+  comparatorOperator = '~';
+}
+
+// =3.1.4
+if (comparatorOperator === '=') {
+  rangeTop = {
+    major: rangeBottom.major,
+    minor: rangeBottom.minor,
+    patch: rangeBottom.patch,
+    inclusive: true,
+  };
+} else if (comparatorOperator === '~') {
+  if (comparatorVersion.minor) {
+    // ~3.1.4 and ~3.1 are <3.2.0
+    rangeTop = {
+      major: rangeBottom.major,
+      minor: rangeBottom.minor + 1,
+      patch: 0,
+    };
+  } else {
+    // ~3 is <4.0.0
+    rangeTop = {
+      major: rangeBottom.major + 1,
+      minor: 0,
+      patch: 0,
+    };
+  }
+} else if (comparatorOperator === '^') {
+  // ^3.1.4 is <4.0.0
+  rangeTop = {
+    major: rangeBottom.major + 1,
+    minor: 0,
+    patch: 0,
+  };
+}
+
+function getVersionCompatibilityMessage() {
+  var versionBottom = 'v' + rangeBottom.major + '.' + rangeBottom.minor + '.' + rangeBottom.patch;
+  if (comparatorOperator === '=') {
+    return 'Please use Node.js ' + versionBottom + '.';
+  }
+
+  var message = 'Please use a Node.js runtime version that is greater than ' + versionBottom;
+  if (rangeBottom.inclusive) {
+    message = 'Please use a Node.js runtime version that is ' + versionBottom + ' or greater';
+  }
+
+  if (!rangeTop) return message + '.';
+
+  var versionTop = 'v' + rangeTop.major + '.' + rangeTop.minor + '.' + rangeTop.patch;
+  // The only operator with a truthy `rangeTop.inclusive` is the `=` which was handled above
+  return message + ' and lower than ' + versionTop + '.';
+}
+
+/* Compares the 2 versions and returns
+ *   1: A  >  B
+ *   0: A === B
+ *  -1: A  <  B
+ */
+function versionCompare(versionA, versionB) {
+  // 4.x.x > 3.1.4
+  if (versionA.major > versionB.major) return 1;
+  else if (versionA.major === versionB.major) {
+    // 3.2.x > 3.1.4
+    if (versionA.minor > versionB.minor) return 1;
+    else if (versionA.minor === versionB.minor) {
+      // 3.1.5 >= 3.1.4
+      if (versionA.patch > versionB.patch) return 1;
+      // 3.1.4 = 3.1.4
+      else if (versionA.patch === versionB.patch) return 0;
+    }
+  }
+
+  return -1;
+}
+
+var currentVersion = process && process.version;
+if (!currentVersion) {
+  console.error(
+    'OpenSearch Dashboards cannot start up because the JavaScript runtime did not report its version. ' +
+      getVersionCompatibilityMessage()
+  );
+  process.exit(25);
+}
+
+var currentParts = currentVersion.match(versionMatcher);
+if (currentParts === null) {
+  console.error(
+    'OpenSearch Dashboards cannot start up because the JavaScript runtime did not report its version in a ' +
+      'discernible format. ' +
+      getVersionCompatibilityMessage()
+  );
+  process.exit(26);
+}
+
+var version = {
+  major: parseInt(currentParts[1], 10) || 0,
+  minor: parseInt(currentParts[2], 10) || 0,
+  patch: parseInt(currentParts[3], 10) || 0,
+};
+
+var satisfiesBottom = false;
+
+// Check if version is greater than rangeBottom or if equal, that `rangeBottom` is inclusive
+var versionComparedToRangeBottom = versionCompare(version, rangeBottom);
+if (versionComparedToRangeBottom === 1) satisfiesBottom = true;
+else if (rangeBottom.inclusive && versionComparedToRangeBottom === 0) satisfiesBottom = true;
+
+var satisfiesTop = false;
+
+if (satisfiesBottom && rangeTop) {
+  var versionComparedToRangeTop = versionCompare(version, rangeTop);
+  if (versionComparedToRangeTop === -1) satisfiesTop = true;
+  else if (rangeTop.inclusive && versionComparedToRangeTop === 0) satisfiesTop = true;
+}
+
+// Fail if the Node.js version doesn't satisfy the requirements of OpenSearch Dashboards
+if (!satisfiesBottom || (rangeTop && !satisfiesTop)) {
+  console.error(
+    'OpenSearch Dashboards cannot start up using the Node.js runtime v' +
+      version.major +
+      '.' +
+      version.minor +
+      '.' +
+      version.patch +
+      '. ' +
+      getVersionCompatibilityMessage()
+  );
+  process.exit(21);
 }

--- a/src/setup_node_env/node_version_validator.test.js
+++ b/src/setup_node_env/node_version_validator.test.js
@@ -28,83 +28,279 @@
  * under the License.
  */
 
-const exec = require('child_process').exec;
-const pkg = require('../../package.json');
+const semver = require('semver');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
 
-const REQUIRED_NODE_JS_VERSION = 'v' + pkg.engines.node;
+const allPossibleCombinations = [
+  'a patch downgrade',
+  'the exact version',
+  'a patch upgrade',
 
-describe('NodeVersionValidator', function () {
-  it('should run the script WITHOUT error when the version is the same', function (done) {
-    testValidateNodeVersion(done, REQUIRED_NODE_JS_VERSION);
-  });
+  'a minor upgrade with lower patch',
+  'a minor upgrade with same patch',
+  'a minor upgrade with higher patch',
 
-  it('should run the script WITHOUT error when only the patch version is higher', function (done) {
-    testValidateNodeVersion(done, requiredNodeVersionWithDiff(0, 0, +1));
-  });
+  'a minor downgrade with lower patch',
+  'a minor downgrade with same patch',
+  'a minor downgrade with higher patch',
 
-  it('should run the script WITH error if the patch version is lower', function (done) {
-    const lowerPatchversion = requiredNodeVersionWithDiff(0, 0, -1);
-    testValidateNodeVersion(
-      done,
-      lowerPatchversion,
-      REQUIRED_NODE_JS_VERSION !== lowerPatchversion
+  'a major upgrade with same minor and lower patch',
+  'a major upgrade with same minor and same patch',
+  'a major upgrade with same minor and higher patch',
+
+  'a major downgrade with same minor and lower patch',
+  'a major downgrade with same minor and same patch',
+  'a major downgrade with same minor and higher patch',
+
+  'a major upgrade with lower minor and lower patch',
+  'a major upgrade with lower minor and same patch',
+  'a major upgrade with lower minor and higher patch',
+
+  'a major downgrade with lower minor and lower patch',
+  'a major downgrade with lower minor and same patch',
+  'a major downgrade with lower minor and higher patch',
+
+  'a major upgrade with higher minor and lower patch',
+  'a major upgrade with higher minor and same patch',
+  'a major upgrade with higher minor and higher patch',
+
+  'a major downgrade with higher minor and lower patch',
+  'a major downgrade with higher minor and same patch',
+  'a major downgrade with higher minor and higher patch',
+];
+
+const allPossibleOperators = [
+  { title: 'no operator', operator: '' },
+  { title: 'the equals operator', operator: '=' },
+  { title: 'the greater-than operator', operator: '>' },
+  { title: 'the greater-than-or-equals operator', operator: '>=' },
+  { title: 'the caret operator', operator: '^' },
+  { title: 'the tilde operator', operator: '~' },
+];
+
+// Regex pattern to parse test titles which gets used to create new versions
+const testTitleMatcher = /(?:(major|minor|patch)\s+(upgrade|downgrade)|(higher|lower)\s+(major|minor|patch))/g;
+const testTitleChanges = {
+  upgrade: 1,
+  downgrade: -1,
+  higher: 1,
+  lower: -1,
+};
+
+const titleChangesCache = new Map();
+
+// Parse the test title and generate a new version
+const getUpdatedVersion = (testedVersion, title) => {
+  let matches;
+  let majorChange = 0;
+  let minorChange = 0;
+  let patchChange = 0;
+
+  if (titleChangesCache.has(title)) {
+    const cache = titleChangesCache.get(title);
+    majorChange = cache.majorChange;
+    minorChange = cache.minorChange;
+    patchChange = cache.patchChange;
+  } else {
+    while ((matches = testTitleMatcher.exec(title)) !== null) {
+      const change = testTitleChanges[matches[2]] || testTitleChanges[matches[3]];
+      if (matches[1] === 'major' || matches[4] === 'major') majorChange = change;
+      else if (matches[1] === 'minor' || matches[4] === 'minor') minorChange = change;
+      else if (matches[1] === 'patch' || matches[4] === 'patch') patchChange = change;
+    }
+
+    titleChangesCache.set(title, { majorChange, minorChange, patchChange });
+  }
+
+  return testedVersion.change(majorChange, minorChange, patchChange);
+};
+
+const getMockedPackageJson = (requiredRange) => {
+  switch (requiredRange) {
+    case 'BLANK':
+      return `{ engines: { node: '' }}`;
+    case 'NO_NODE':
+      return `{ engines: { }}`;
+    case 'NO_ENGINES':
+      return `{}`;
+    default:
+      return `{ engines: { node: '${requiredRange}' }}`;
+  }
+};
+
+const checkNodeVersionValidation = async (nodeVersion, requiredRange) => {
+  const mockedProcessVersion = `Object.defineProperty(process, 'version', { value: '${
+    nodeVersion ? 'v' + nodeVersion : ''
+  }', writable: true });`;
+  // Node + Windows doesn't like line-feeds
+  const mockedRequire =
+    `const Module = require('module');` +
+    `const req = Module.prototype.require;` +
+    `Module.prototype.require = name =>` +
+    `name === '../../package.json' ?` +
+    getMockedPackageJson(requiredRange) +
+    `: req(name);`;
+  try {
+    /* ToDo: Implement changes so these tests can contribute to the code coverage report
+     * `jest --coverage` is not capable of handling child processes: https://github.com/facebook/jest/issues/5274
+     *
+     * The workaround is to do
+     *   1. `nyc node scripts/jest`
+     *      This cleans the cached `.nyc_output` and correctly instruments subprocesses
+     *   2. `nyc report --reporter=lcov --reporter=text-summary --report-dir target/opensearch-dashboards-coverage/jest`
+     *      This generates the lcov report and shows a summary
+     *   3. Clean up `.nyc_output`
+     *
+     *   Note: src/dev/jest/config.js should be checked for any other config that we would like to pass to nyc
+     */
+    await exec(
+      `node -e "${mockedProcessVersion}${mockedRequire}require('./node_version_validator.js')"`,
+      { cwd: __dirname }
+    );
+  } catch (ex) {
+    if (ex.stderr?.indexOf('OpenSearch Dashboards') > -1)
+      return {
+        error: ex.code,
+        stderr: ex.stderr,
+      };
+
+    throw ex;
+  }
+
+  return {
+    error: 0,
+  };
+};
+
+// Create an appropriate test based on how semver feels about the version and range
+const defineTest = (title, testedVersion, requiredRange) => {
+  const version = getUpdatedVersion(testedVersion, title);
+
+  return semver.satisfies(version, requiredRange)
+    ? it(`${requiredRange}, should accept v${version}, ${title}`, async () => {
+        const { error, stderr } = await checkNodeVersionValidation(version, requiredRange);
+        expect(error).toEqual(0); // The exit code indicating an acceptable version
+        expect(stderr).toStrictEqual(undefined);
+      })
+    : it(`${requiredRange}, should not accept v${version}, ${title}`, async () => {
+        const { error, stderr } = await checkNodeVersionValidation(version, requiredRange);
+        expect(error).toEqual(21); // The exit code indicating an unacceptable version
+        expect(stderr.trim()).toMatchSnapshot();
+      });
+};
+
+const describeSuites = (testsToRun, testedVersion, comparatorVersion) => {
+  describe.each(allPossibleOperators)('$title', ({ operator }) => {
+    testsToRun.forEach((title) =>
+      defineTest(title, testedVersion, `${operator}${comparatorVersion}`)
     );
   });
+};
 
-  it('should run the script WITH error if the major version is higher', function (done) {
-    testValidateNodeVersion(done, requiredNodeVersionWithDiff(+1, 0, 0), true);
+const parseVersion = (version) => {
+  const parts = version?.match(/^\s*v?\s*(\d+)\.(\d+)\.(\d+)(\D.*)?$/) || null;
+  if (parts === null) throw `<${version}> is not a parsable version.`;
+  const numericParts = {
+    major: parseInt(parts[1], 10) || 0,
+    minor: parseInt(parts[2], 10) || 0,
+    patch: parseInt(parts[3], 10) || 0,
+  };
+
+  // prettier-ignore
+  const change = (majorChange = 0, minorChange = 0, patchChange = 0) =>
+    (numericParts.major + majorChange) +
+    '.' +
+    (numericParts.minor + minorChange) +
+    '.' +
+    (numericParts.patch + patchChange);
+
+  return {
+    get exact() {
+      return change();
+    },
+    change,
+  };
+};
+
+describe('Node.js version validation', () => {
+  describe('non-new Node.js version using a comparator with a complete version, and', () => {
+    const comparatorVersion = '4.55.666';
+    const testedVersion = parseVersion('4.55.666');
+    const testsToRun = allPossibleCombinations;
+
+    describeSuites(testsToRun, testedVersion, comparatorVersion);
   });
 
-  it('should run the script WITH error if the major version is lower', function (done) {
-    const lowerMajorVersion = requiredNodeVersionWithDiff(-1, 0, 0);
-    testValidateNodeVersion(
-      done,
-      lowerMajorVersion,
-      REQUIRED_NODE_JS_VERSION !== lowerMajorVersion
+  describe('non-new Node.js version using a comparator with a version missing its patch, and', () => {
+    const comparatorVersion = '4.55';
+    const testedVersion = parseVersion('4.55.666');
+    const testsToRun = allPossibleCombinations;
+
+    describeSuites(testsToRun, testedVersion, comparatorVersion);
+  });
+
+  describe('new minor Node.js version using a comparator with a version missing its patch, and', () => {
+    const comparatorVersion = '4.55';
+    const testedVersion = parseVersion('4.55.0');
+    // The tested version has zero for its patch value so exclude tests that lower it
+    const testsToRun = allPossibleCombinations.filter(
+      (title) => !/(patch downgrade|lower patch)/.test(title)
     );
+
+    describeSuites(testsToRun, testedVersion, comparatorVersion);
   });
 
-  it('should run the script WITH error if the minor version is higher', function (done) {
-    testValidateNodeVersion(done, requiredNodeVersionWithDiff(0, +1, 0), true);
-  });
-
-  it('should run the script WITH error if the minor version is lower', function (done) {
-    const lowerMinorVersion = requiredNodeVersionWithDiff(0, -1, 0);
-    testValidateNodeVersion(
-      done,
-      lowerMinorVersion,
-      REQUIRED_NODE_JS_VERSION !== lowerMinorVersion
+  describe('new major Node.js version using a comparator with a version missing its patch and minor, and', () => {
+    const comparatorVersion = '4';
+    const testedVersion = parseVersion('4.0.0');
+    // The tested version has zeros for patch and minor values so exclude tests that lower them
+    const testsToRun = allPossibleCombinations.filter(
+      (title) => !/((patch|minor) downgrade|lower (patch|minor))/.test(title)
     );
+
+    describeSuites(testsToRun, testedVersion, comparatorVersion);
+  });
+
+  it('fails if package.json is missing engines', async () => {
+    const { error, stderr } = await checkNodeVersionValidation('4.55.666', 'NO_ENGINES');
+    expect(error).toEqual(22); // The exit code indicating missing engines.node range
+    expect(stderr.trim()).toMatchSnapshot();
+  });
+
+  it('fails if package.json is missing engines.node', async () => {
+    const { error, stderr } = await checkNodeVersionValidation('4.55.666', 'NO_NODE');
+    expect(error).toEqual(22); // The exit code indicating missing engines.node range
+    expect(stderr.trim()).toMatchSnapshot();
+  });
+
+  it('fails if package.json has a blank engines.node', async () => {
+    const { error, stderr } = await checkNodeVersionValidation('4.55.666', 'BLANK');
+    expect(error).toEqual(22); // The exit code indicating missing engines.node range
+    expect(stderr.trim()).toMatchSnapshot();
+  });
+
+  it('fails if package.json has an invalid engines.node', async () => {
+    const { error, stderr } = await checkNodeVersionValidation('4.55.666', 'INVALID');
+    expect(error).toEqual(23); // The exit code indicating an unacceptable engines.node range
+    expect(stderr.trim()).toMatchSnapshot();
+  });
+
+  it('fails if package.json has a 0.x.x engines.node', async () => {
+    const { error, stderr } = await checkNodeVersionValidation('4.55.666', '0.11.222');
+    expect(error).toEqual(24); // The exit code indicating an unacceptable engines.node range
+    expect(stderr.trim()).toMatchSnapshot();
+  });
+
+  it('fails if process.version is not reported', async () => {
+    const { error, stderr } = await checkNodeVersionValidation('', '4.55.666');
+    expect(error).toEqual(25); // The exit code indicating an unacceptable process.version
+    expect(stderr.trim()).toMatchSnapshot();
+  });
+
+  it('fails if process.version reports an invalid value', async () => {
+    const { error, stderr } = await checkNodeVersionValidation('INVALID', '4.55.666');
+    expect(error).toEqual(26); // The exit code indicating an unacceptable process.version
+    expect(stderr.trim()).toMatchSnapshot();
   });
 });
-
-function requiredNodeVersionWithDiff(majorDiff, minorDiff, patchDiff) {
-  const matches = REQUIRED_NODE_JS_VERSION.match(/^v(\d+)\.(\d+)\.(\d+)/);
-  const major = Math.max(parseInt(matches[1], 10) + majorDiff, 0);
-  const minor = Math.max(parseInt(matches[2], 10) + minorDiff, 0);
-  const patch = Math.max(parseInt(matches[3], 10) + patchDiff, 0);
-
-  return `v${major}.${minor}.${patch}`;
-}
-
-function testValidateNodeVersion(done, versionToTest, expectError = false) {
-  const processVersionOverwrite = `Object.defineProperty(process, 'version', { value: '${versionToTest}', writable: true });`;
-  const command = `node -e "${processVersionOverwrite}require('./node_version_validator.js')"`;
-
-  exec(command, { cwd: __dirname }, function (error, _stdout, stderr) {
-    expect(stderr).toBeDefined();
-    if (expectError) {
-      expect(error.code).toBe(1);
-
-      const speficicErrorMessage =
-        `OpenSearch Dashboards was built with ${REQUIRED_NODE_JS_VERSION} and does not support the current Node.js version ${versionToTest}. ` +
-        `Please use Node.js ${REQUIRED_NODE_JS_VERSION} or a higher patch version.\n`;
-
-      expect(stderr).toStrictEqual(speficicErrorMessage);
-    } else {
-      expect(error).toBeNull();
-      expect(stderr).toHaveLength(0);
-    }
-    done();
-  });
-}


### PR DESCRIPTION
Signed-off-by: Miki <miki@amazon.com>

### Description
With this change, the `engines.node` of `package.json` need not be a fixed version; it can be a range using a subset of formats defined by `semver`.

A very limited subset of what [semver](https://github.com/npm/node-semver/blob/cb1ca1d5480a6c07c12ac31ba5f2071ed530c4ed/README.md#ranges) supports has been added; only a single comparator, composed of an operator and a version, is supported.

The supported operators are
 *   `>`    Greater than
 *   `>=`   Greater than or equal to
 *   `=`    Equal
 *   `~`    Tilde ranges: Allows patch changes if a minor version is specified but if only a major version is specified, it allows minor changes.
 *   `^`    Caret ranges: Allows patch and minor updates when major is non-zero (and we will never have that).
 
If no operator is specified, equality is assumed.
 
### Issues Resolved
Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2088
Supersedes https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2091
Partially serves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3095
 
### Check List
- [ ] All tests pass
  - [X] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 