### PR TITLE
Prevent primitive linting limitations from being applied to unit tests found under `src/setup_node_env`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -459,7 +459,7 @@ module.exports = {
      * Files that run BEFORE node version check
      */
     {
-      files: ['scripts/**/*.js', 'src/setup_node_env/**/*.js'],
+      files: ['scripts/**/*.js', 'src/setup_node_env/**/!(*.test).js'],
       rules: {
         'import/no-commonjs': 'off',
         'prefer-object-spread/prefer-object-spread': 'off',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Tests] Bumps `chromedriver` to v107 ([#3017](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3017))
 - [Vis Builder] Adds field unit tests ([#3211](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3211))
 - [BWC Tests] Add BWC tests for 2.6.0 ([#3356](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3356))
+- Prevent primitive linting limitations from being applied to unit tests found under `src/setup_node_env` ([#3403](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3403))
 
 ## [2.x]
 

--- a/src/setup_node_env/node_version_validator.test.js
+++ b/src/setup_node_env/node_version_validator.test.js
@@ -28,10 +28,10 @@
  * under the License.
  */
 
-var exec = require('child_process').exec;
-var pkg = require('../../package.json');
+const exec = require('child_process').exec;
+const pkg = require('../../package.json');
 
-var REQUIRED_NODE_JS_VERSION = 'v' + pkg.engines.node;
+const REQUIRED_NODE_JS_VERSION = 'v' + pkg.engines.node;
 
 describe('NodeVersionValidator', function () {
   it('should run the script WITHOUT error when the version is the same', function (done) {
@@ -43,7 +43,7 @@ describe('NodeVersionValidator', function () {
   });
 
   it('should run the script WITH error if the patch version is lower', function (done) {
-    var lowerPatchversion = requiredNodeVersionWithDiff(0, 0, -1);
+    const lowerPatchversion = requiredNodeVersionWithDiff(0, 0, -1);
     testValidateNodeVersion(
       done,
       lowerPatchversion,
@@ -56,7 +56,7 @@ describe('NodeVersionValidator', function () {
   });
 
   it('should run the script WITH error if the major version is lower', function (done) {
-    var lowerMajorVersion = requiredNodeVersionWithDiff(-1, 0, 0);
+    const lowerMajorVersion = requiredNodeVersionWithDiff(-1, 0, 0);
     testValidateNodeVersion(
       done,
       lowerMajorVersion,
@@ -69,7 +69,7 @@ describe('NodeVersionValidator', function () {
   });
 
   it('should run the script WITH error if the minor version is lower', function (done) {
-    var lowerMinorVersion = requiredNodeVersionWithDiff(0, -1, 0);
+    const lowerMinorVersion = requiredNodeVersionWithDiff(0, -1, 0);
     testValidateNodeVersion(
       done,
       lowerMinorVersion,
@@ -79,24 +79,24 @@ describe('NodeVersionValidator', function () {
 });
 
 function requiredNodeVersionWithDiff(majorDiff, minorDiff, patchDiff) {
-  var matches = REQUIRED_NODE_JS_VERSION.match(/^v(\d+)\.(\d+)\.(\d+)/);
-  var major = Math.max(parseInt(matches[1], 10) + majorDiff, 0);
-  var minor = Math.max(parseInt(matches[2], 10) + minorDiff, 0);
-  var patch = Math.max(parseInt(matches[3], 10) + patchDiff, 0);
+  const matches = REQUIRED_NODE_JS_VERSION.match(/^v(\d+)\.(\d+)\.(\d+)/);
+  const major = Math.max(parseInt(matches[1], 10) + majorDiff, 0);
+  const minor = Math.max(parseInt(matches[2], 10) + minorDiff, 0);
+  const patch = Math.max(parseInt(matches[3], 10) + patchDiff, 0);
 
   return `v${major}.${minor}.${patch}`;
 }
 
 function testValidateNodeVersion(done, versionToTest, expectError = false) {
-  var processVersionOverwrite = `Object.defineProperty(process, 'version', { value: '${versionToTest}', writable: true });`;
-  var command = `node -e "${processVersionOverwrite}require('./node_version_validator.js')"`;
+  const processVersionOverwrite = `Object.defineProperty(process, 'version', { value: '${versionToTest}', writable: true });`;
+  const command = `node -e "${processVersionOverwrite}require('./node_version_validator.js')"`;
 
   exec(command, { cwd: __dirname }, function (error, _stdout, stderr) {
     expect(stderr).toBeDefined();
     if (expectError) {
       expect(error.code).toBe(1);
 
-      var speficicErrorMessage =
+      const speficicErrorMessage =
         `OpenSearch Dashboards was built with ${REQUIRED_NODE_JS_VERSION} and does not support the current Node.js version ${versionToTest}. ` +
         `Please use Node.js ${REQUIRED_NODE_JS_VERSION} or a higher patch version.\n`;
 

--- a/src/setup_node_env/root/force.test.js
+++ b/src/setup_node_env/root/force.test.js
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-var forceRoot = require('./force');
+const forceRoot = require('./force');
 
 describe('forceRoot', function () {
   it('with flag', function () {
@@ -40,7 +40,7 @@ describe('forceRoot', function () {
   });
 
   test('remove argument', function () {
-    var args = ['--allow-root', 'foo'];
+    const args = ['--allow-root', 'foo'];
     forceRoot(args);
     expect(args.includes('--allow-root')).toBeFalsy();
   });

--- a/src/setup_node_env/root/is_root.test.js
+++ b/src/setup_node_env/root/is_root.test.js
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-var isRoot = require('./is_root');
+const isRoot = require('./is_root');
 
 describe('isRoot', function () {
   test('0 is root', function () {


### PR DESCRIPTION
Signed-off-by: Miki <miki@amazon.com>

### Description
Previously, test files under `src/setup_node_env` were held to the same low standard as the other `*.js` files that need to support ancient versions of Node.js because they are run before a version check has occurred. This change, allows those tests to now include modern concepts, since they cannot run without complete bootstrapping anyway.
 
### Check List
- [ ] All tests pass
  - [X] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 