### PR TITLE
Make build scripts find and use the latest version of Node.js that satisfies `engines.node`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Data] Update `createAggConfig` so that newly created configs can be added to beginning of `aggConfig` array ([#3160](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3160))
 - Add disablePrototypePoisoningProtection configuration to prevent JS client from erroring when cluster utilizes JS reserved words ([#2992](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2992))
 - [Multiple DataSource] Add support for SigV4 authentication ([#3058](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3058))
+- Make build scripts find and use the latest version of Node.js that satisfies `engines.node` ([#3467](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3467))
 
 ### 🐛 Bug Fixes
 

--- a/src/dev/build/lib/config.test.ts
+++ b/src/dev/build/lib/config.test.ts
@@ -79,10 +79,10 @@ describe('#getOpenSearchDashboardsPkg()', () => {
   });
 });
 
-describe('#getNodeVersion()', () => {
-  it('returns the node version from the OpenSearch Dashboards package.json', async () => {
+describe('#getNodeRange()', () => {
+  it('returns the node version range from the OpenSearch Dashboards package.json', async () => {
     const config = await setup();
-    expect(config.getNodeVersion()).toEqual(pkg.engines.node);
+    expect(config.getNodeRange()).toEqual(pkg.engines.node);
   });
 });
 

--- a/src/dev/build/lib/config.ts
+++ b/src/dev/build/lib/config.ts
@@ -86,7 +86,7 @@ export class Config {
     private readonly targetAllPlatforms: boolean,
     private readonly targetPlatforms: TargetPlatforms,
     private readonly pkg: Package,
-    private readonly nodeVersion: string,
+    private readonly nodeRange: string,
     private readonly repoRoot: string,
     private readonly versionInfo: VersionInfo,
     public readonly isRelease: boolean
@@ -102,8 +102,8 @@ export class Config {
   /**
    * Get the node version required by OpenSearch Dashboards
    */
-  getNodeVersion() {
-    return this.nodeVersion;
+  getNodeRange() {
+    return this.nodeRange;
   }
 
   /**

--- a/src/dev/build/tasks/create_archives_sources_task.ts
+++ b/src/dev/build/tasks/create_archives_sources_task.ts
@@ -50,7 +50,7 @@ export const CreateArchivesSources: Task = {
 
         // copy node.js install
         await scanCopy({
-          source: getNodeDownloadInfo(config, platform).extractDir,
+          source: (await getNodeDownloadInfo(config, platform)).extractDir,
           destination: build.resolvePathForPlatform(platform, 'node'),
         });
 

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.ts
@@ -30,16 +30,17 @@
 
 import { download, GlobalTask } from '../../lib';
 import { getNodeShasums } from './node_shasums';
-import { getNodeDownloadInfo } from './node_download_info';
+import { getLatestNodeVersion, getNodeDownloadInfo } from './node_download_info';
 
 export const DownloadNodeBuilds: GlobalTask = {
   global: true,
   description: 'Downloading node.js builds for all platforms',
   async run(config, log) {
-    const shasums = await getNodeShasums(log, config.getNodeVersion());
+    const latestNodeVersion = await getLatestNodeVersion(config);
+    const shasums = await getNodeShasums(log, latestNodeVersion);
     await Promise.all(
       config.getTargetPlatforms().map(async (platform) => {
-        const { url, downloadPath, downloadName } = getNodeDownloadInfo(config, platform);
+        const { url, downloadPath, downloadName } = await getNodeDownloadInfo(config, platform);
         await download({
           log,
           url,

--- a/src/dev/build/tasks/nodejs/extract_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/extract_node_builds_task.ts
@@ -37,7 +37,7 @@ export const ExtractNodeBuilds: GlobalTask = {
   async run(config) {
     await Promise.all(
       config.getTargetPlatforms().map(async (platform) => {
-        const { downloadPath, extractDir } = getNodeDownloadInfo(config, platform);
+        const { downloadPath, extractDir } = await getNodeDownloadInfo(config, platform);
         if (platform.isWindows()) {
           await unzip(downloadPath, extractDir, { strip: 1 });
         } else {

--- a/src/dev/build/tasks/nodejs/node_download_info.ts
+++ b/src/dev/build/tasks/nodejs/node_download_info.ts
@@ -29,11 +29,15 @@
  */
 
 import { basename } from 'path';
+import fetch from 'node-fetch';
+import semver from 'semver';
 
 import { Config, Platform } from '../../lib';
 
-export function getNodeDownloadInfo(config: Config, platform: Platform) {
-  const version = config.getNodeVersion();
+const NODE_RANGE_CACHE: { [key: string]: string } = {};
+
+export async function getNodeDownloadInfo(config: Config, platform: Platform) {
+  const version = await getLatestNodeVersion(config);
   const arch = platform.getNodeArch();
 
   const downloadName = platform.isWindows()
@@ -51,4 +55,24 @@ export function getNodeDownloadInfo(config: Config, platform: Platform) {
     extractDir,
     version,
   };
+}
+
+export async function getLatestNodeVersion(config: Config) {
+  const range = config.getNodeRange();
+  // Check cache and return if known
+  if (NODE_RANGE_CACHE[range]) return NODE_RANGE_CACHE[range];
+
+  const releaseDoc = await fetch('https://nodejs.org/dist/index.json');
+  const releaseList: [{ version: string }] = await releaseDoc.json();
+  const releases = releaseList.map(({ version }) => version.replace(/^v/, ''));
+  const maxVersion = semver.maxSatisfying(releases, range);
+
+  if (!maxVersion) {
+    throw new Error(`Cannot find a version of Node.js that satisfies ${range}.`);
+  }
+
+  // Cache it
+  NODE_RANGE_CACHE[range] = maxVersion;
+
+  return maxVersion;
 }

--- a/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.ts
@@ -29,18 +29,19 @@
  */
 
 import { getFileHash, GlobalTask } from '../../lib';
-import { getNodeDownloadInfo } from './node_download_info';
+import { getNodeDownloadInfo, getLatestNodeVersion } from './node_download_info';
 import { getNodeShasums } from './node_shasums';
 
 export const VerifyExistingNodeBuilds: GlobalTask = {
   global: true,
   description: 'Verifying previously downloaded node.js build for all platforms',
   async run(config, log) {
-    const shasums = await getNodeShasums(log, config.getNodeVersion());
+    const latestNodeVersion = await getLatestNodeVersion(config);
+    const shasums = await getNodeShasums(log, latestNodeVersion);
 
     await Promise.all(
       config.getTargetPlatforms().map(async (platform) => {
-        const { downloadPath, downloadName } = getNodeDownloadInfo(config, platform);
+        const { downloadPath, downloadName } = await getNodeDownloadInfo(config, platform);
 
         const sha256 = await getFileHash(downloadPath, 'sha256');
         if (sha256 !== shasums[downloadName]) {

--- a/src/dev/build/tasks/notice_file_task.ts
+++ b/src/dev/build/tasks/notice_file_task.ts
@@ -57,7 +57,7 @@ export const CreateNoticeFile: Task = {
 
     log.info('Generating build notice');
 
-    const { extractDir: nodeDir, version: nodeVersion } = getNodeDownloadInfo(
+    const { extractDir: nodeDir, version: nodeVersion } = await getNodeDownloadInfo(
       config,
       config.hasSpecifiedPlatform()
         ? config.getPlatform(

--- a/src/dev/build/tasks/verify_env_task.ts
+++ b/src/dev/build/tasks/verify_env_task.ts
@@ -28,6 +28,7 @@
  * under the License.
  */
 
+import semver from 'semver';
 import { GlobalTask } from '../lib';
 
 export const VerifyEnv: GlobalTask = {
@@ -35,10 +36,12 @@ export const VerifyEnv: GlobalTask = {
   description: 'Verifying environment meets requirements',
 
   async run(config, log) {
-    const version = `v${config.getNodeVersion()}`;
+    const range = config.getNodeRange();
 
-    if (version !== process.version) {
-      throw new Error(`Invalid nodejs version, please use ${version}`);
+    if (!semver.satisfies(process.version, range)) {
+      throw new Error(
+        `Invalid Node.js version (${process.version}); please use a version that satisfies ${range}.`
+      );
     }
 
     log.success('Node.js version verified');


### PR DESCRIPTION
### Description
* While building distributables, Node.js runtime is downloaded to be placed in the archivea. This logicwas modified to honor a range for `engines.node` by fetching the latest release of Node.js that satisfied the range.
* Some tests covering the build, read a version from `.node-version` to compare with the results of actual function runs; these were changed to either use mocked values or honor the range and use the latest Node.js version.
* Some variable and functions referred to `engines.node` as a version; they were corrected to call it a range.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 