### PR TITLE
Chore/alias js client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### 🛠 Maintenance
 
 - Bumps `re2` and `supertest` ([3018](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3018))
+- Introduce @opensearch-project/opensearch@^2.1.0, aliased as @opensearch-project/opensearch-next ([#3469](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3469))
 
 ### 🪛 Refactoring
 

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "@hapi/vision": "^6.1.0",
     "@hapi/wreck": "^17.1.0",
     "@opensearch-project/opensearch": "^1.1.0",
+    "@opensearch-project/opensearch-next": "npm:@opensearch-project/opensearch@^2.1.0",
     "@osd/ace": "1.0.0",
     "@osd/analytics": "1.0.0",
     "@osd/apm-config-loader": "1.0.0",

--- a/src/plugins/data_source/server/client/client_pool.ts
+++ b/src/plugins/data_source/server/client/client_pool.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Client } from '@opensearch-project/opensearch';
+import { Client } from '@opensearch-project/opensearch-next';
 import { Client as LegacyClient } from 'elasticsearch';
 import LRUCache from 'lru-cache';
 import { Logger } from 'src/core/server';

--- a/src/plugins/data_source/server/client/configure_client.test.mocks.ts
+++ b/src/plugins/data_source/server/client/configure_client.test.mocks.ts
@@ -4,8 +4,8 @@
  */
 
 export const ClientMock = jest.fn();
-jest.doMock('@opensearch-project/opensearch', () => {
-  const actual = jest.requireActual('@opensearch-project/opensearch');
+jest.doMock('@opensearch-project/opensearch-next', () => {
+  const actual = jest.requireActual('@opensearch-project/opensearch-next');
   return {
     ...actual,
     Client: ClientMock,

--- a/src/plugins/data_source/server/client/configure_client.test.ts
+++ b/src/plugins/data_source/server/client/configure_client.test.ts
@@ -11,7 +11,7 @@ import { DataSourcePluginConfigType } from '../../config';
 import { ClientMock, parseClientOptionsMock } from './configure_client.test.mocks';
 import { OpenSearchClientPoolSetup } from './client_pool';
 import { configureClient } from './configure_client';
-import { ClientOptions } from '@opensearch-project/opensearch';
+import { ClientOptions } from '@opensearch-project/opensearch-next';
 // eslint-disable-next-line @osd/eslint/no-restricted-paths
 import { opensearchClientMock } from '../../../../core/server/opensearch/client/mocks';
 import { cryptographyServiceSetupMock } from '../cryptography_service.mocks';

--- a/src/plugins/data_source/server/client/configure_client.ts
+++ b/src/plugins/data_source/server/client/configure_client.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Client } from '@opensearch-project/opensearch';
+import { Client } from '@opensearch-project/opensearch-next';
 import { Logger, SavedObject, SavedObjectsClientContract } from '../../../../../src/core/server';
 import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../common';
 import {

--- a/src/plugins/data_source/server/lib/error.test.ts
+++ b/src/plugins/data_source/server/lib/error.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ApiResponse } from '@opensearch-project/opensearch';
+import { ApiResponse } from '@opensearch-project/opensearc-next';
 import {
   ConnectionError,
   NoLivingConnectionsError,

--- a/src/plugins/data_source/server/lib/error.ts
+++ b/src/plugins/data_source/server/lib/error.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ResponseError } from '@opensearch-project/opensearch/lib/errors';
+import { ResponseError } from '@opensearch-project/opensearch-next/lib/errors';
 import { errors as LegacyErrors } from 'elasticsearch';
 import { SavedObjectsErrorHelpers } from '../../../../../src/core/server';
 import { OsdError } from '../../../opensearch_dashboards_utils/common';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,10 @@
         "src/test_utils/public/*"
       ],
       "fixtures/*": ["src/fixtures/*"],
-      "@opensearch-project/opensearch": ["node_modules/@opensearch-project/opensearch/api/new"]
+      "@opensearch-project/opensearch": ["node_modules/@opensearch-project/opensearch/api/new"],
+      "@opensearch-project/opensearch-next": [
+        "node_modules/@opensearch-project/opensearch-next/api/new"
+      ]
     },
     // Support .tsx files and transform JSX into calls to React.createElement
     "jsx": "react",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2338,6 +2338,17 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@opensearch-project/opensearch-next@npm:@opensearch-project/opensearch@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@opensearch-project/opensearch/-/opensearch-2.2.0.tgz#2a31a67242bf3bacedc9644a0c68893eb5fb9420"
+  integrity sha512-E0f2Hooruz9y+17AF69oyyruikVMAEr1TxcQBNEQV4aQnI3o0+6CjqZS+t94SCZdWRTuN7HjIIVGbaYCJDpxgA==
+  dependencies:
+    aws4 "^1.11.0"
+    debug "^4.3.1"
+    hpagent "^1.2.0"
+    ms "^2.1.3"
+    secure-json-parse "^2.4.0"
+
 "@opensearch-project/opensearch@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@opensearch-project/opensearch/-/opensearch-1.1.0.tgz#8b3c8b4cbcea01755ba092d2997bf0b4ca7f22f7"
@@ -4751,7 +4762,7 @@ aws-sign2@~0.7.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
 
-aws4@^1.8.0:
+aws4@^1.11.0, aws4@^1.8.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.12.0.tgz#ce1c9d143389679e253b314241ea9aa5cec980d3"
   integrity sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==
@@ -9778,6 +9789,11 @@ hpagent@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/hpagent/-/hpagent-0.1.2.tgz#cab39c66d4df2d4377dbd212295d878deb9bdaa9"
   integrity sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==
+
+hpagent@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hpagent/-/hpagent-1.2.0.tgz#0ae417895430eb3770c03443456b8d90ca464903"
+  integrity sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==
 
 html-element-map@^1.2.0:
   version "1.3.1"


### PR DESCRIPTION
### Description

Add aliased opensearch js client as dependency to enable usage of `@opensearch-project/opensearch@^2.x` features without breaking plugins that directly depend on `1.x`.

[Multiple Data Sources] Update `data_source` plugin opensearch client usage to `2.x`
 
### Issues Resolved

### Check List
- [ ] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 