### PR TITLE
Add downgrade logic for branch in DocLinkService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,7 +200,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add path ignore for markdown files for CI ([#2312](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2312))
 - Updating WS scans to ignore BWC artifacts in `cypress` ([#2408](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2408))
 - [CI] Run functional test repo as workflow ([#2503](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2503))
-- [CI] Patch pkg.branch according to pkg.version when build ([#3483](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3483))
+- Add downgrade logic for branch in DocLinkService([#3483](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3483))
 
 ### 📝 Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add path ignore for markdown files for CI ([#2312](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2312))
 - Updating WS scans to ignore BWC artifacts in `cypress` ([#2408](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2408))
 - [CI] Run functional test repo as workflow ([#2503](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2503))
+- [CI] Patch pkg.branch according to pkg.version when build ([#3483](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3483))
 
 ### 📝 Documentation
 

--- a/src/core/public/doc_links/doc_links_service.test.ts
+++ b/src/core/public/doc_links/doc_links_service.test.ts
@@ -64,4 +64,16 @@ describe('DocLinksService#start()', () => {
       'https://opensearch.org/docs/1.1/dashboards/index/'
     );
   });
+
+  it('templates the doc links with the build version from injectedMetadata', () => {
+    const injectedMetadata = injectedMetadataServiceMock.createStartContract();
+    injectedMetadata.getOpenSearchDashboardsBranch.mockReturnValue('test-branch');
+    injectedMetadata.getOpenSearchDashboardsVersion.mockReturnValue('1.1.2');
+    const service = new DocLinksService();
+    const api = service.start({ injectedMetadata });
+    expect(api.DOC_LINK_VERSION).toEqual('1.1');
+    expect(api.links.opensearchDashboards.introduction).toEqual(
+      'https://opensearch.org/docs/1.1/dashboards/index/'
+    );
+  });
 });

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -51,19 +51,14 @@ export class DocLinksService {
     if (pkgBranch === 'main') {
       branch = 'latest';
     } else {
+      const validDocPathsPattern = /^\d+\.\d+$/;
       const parsedBuildVersion = parse(buildVersion);
-      if (parsedBuildVersion) {
+      if (validDocPathsPattern.test(pkgBranch)) {
+        branch = pkgBranch;
+      } else if (parsedBuildVersion) {
         branch = `${parsedBuildVersion.major}.${parsedBuildVersion.minor}`;
       } else {
-        const validDocPathsPattern = /^\d+\.\d+$/;
-        if (validDocPathsPattern.test(pkgBranch)) {
-          branch = pkgBranch;
-        } else {
-          // package version was not parsable and branch is unusable
-          throw new Error(
-            `Failed to identify documentation path while parsing package.json: encountered invalid build version (${buildVersion}) and branch property (${pkgBranch}).`
-          );
-        }
+        branch = pkgBranch;
       }
     }
     const DOC_LINK_VERSION = branch;

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -53,12 +53,8 @@ export class DocLinksService {
     } else {
       const validDocPathsPattern = /^\d+\.\d+$/;
       const parsedBuildVersion = parse(buildVersion);
-      if (validDocPathsPattern.test(pkgBranch)) {
-        branch = pkgBranch;
-      } else if (parsedBuildVersion) {
+      if (!validDocPathsPattern.test(pkgBranch) && parsedBuildVersion) {
         branch = `${parsedBuildVersion.major}.${parsedBuildVersion.minor}`;
-      } else {
-        branch = pkgBranch;
       }
     }
     const DOC_LINK_VERSION = branch;

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -47,7 +47,7 @@ export class DocLinksService {
      * build links to the documentation. If set to `main`, it would use `/latest`
      * and if not, it would use the `version` to construct URLs.
      */
-    let branch;
+    let branch = pkgBranch;
     if (pkgBranch === 'main') {
       branch = 'latest';
     } else {

--- a/src/dev/build/tasks/create_package_json_task.ts
+++ b/src/dev/build/tasks/create_package_json_task.ts
@@ -42,7 +42,7 @@ export const CreatePackageJson: Task = {
      * OpenSearch server has a logic that if the pkg.branch is "main",
      * set the docVersion to latest. So here we exclude main.
      */
-    const semverResult = parse(config.getBuildVersion());
+    const semverResult = parse(pkg.version);
     const shouldPatch = semverResult && pkg.branch !== 'main';
     const branch = shouldPatch ? `${semverResult.major}.${semverResult.minor}` : pkg.branch;
     if (shouldPatch) {

--- a/src/dev/build/tasks/create_package_json_task.ts
+++ b/src/dev/build/tasks/create_package_json_task.ts
@@ -54,7 +54,7 @@ export const CreatePackageJson: Task = {
         log.info(`Updating package.branch to ${branch}`);
       } else {
         const validDocPathsPattern = /^\d+\.\d+$/;
-        if (validDocPathsPattern.test(pkg.branch)) {
+        if (validDocPathsPattern.test(pkg.branch as string)) {
           branch = pkg.branch;
         } else {
           // package version was not parsable and branch is unusable

--- a/src/dev/build/tasks/create_package_json_task.ts
+++ b/src/dev/build/tasks/create_package_json_task.ts
@@ -39,14 +39,30 @@ export const CreatePackageJson: Task = {
   async run(config, log, build) {
     const pkg = config.getOpenSearchDashboardsPkg();
     /**
-     * OpenSearch server has a logic that if the pkg.branch is "main",
-     * set the docVersion to latest. So here we exclude main.
+     * OpenSearch server uses the `branch` property from `package.json` to
+     * build links to the documentation. If set to `main`, it would use `/latest`
+     * and if not, it would use the `version` to construct URLs.
      */
-    const semverResult = parse(config.getBuildVersion());
-    const shouldPatch = semverResult && pkg.branch !== 'main';
-    const branch = shouldPatch ? `${semverResult.major}.${semverResult.minor}` : pkg.branch;
-    if (shouldPatch) {
-      log.info(`Patch branch property: ${branch}`);
+    const buildVersion = config.getBuildVersion();
+    let branch;
+    if (pkg.branch === 'main') {
+      branch = pkg.branch;
+    } else {
+      const parsedBuildVersion = parse(buildVersion);
+      if (parsedBuildVersion) {
+        branch = `${parsedBuildVersion.major}.${parsedBuildVersion.minor}`;
+        log.info(`Updating package.branch to ${branch}`);
+      } else {
+        const validDocPathsPattern = /^\d+\.\d+$/;
+        if (validDocPathsPattern.test(pkg.branch)) {
+          branch = pkg.branch;
+        } else {
+          // package version was not parsable and branch is unusable
+          throw new Error(
+            `Failed to identify documentation path while generating package.json: encountered invalid build version (${buildVersion}) and branch property (${pkg.branch}).`
+          );
+        }
+      }
     }
 
     const newPkg = {
@@ -54,7 +70,7 @@ export const CreatePackageJson: Task = {
       private: true,
       description: pkg.description,
       keywords: pkg.keywords,
-      version: config.getBuildVersion(),
+      version: buildVersion,
       branch,
       build: {
         number: config.getBuildNumber(),

--- a/src/dev/build/tasks/create_package_json_task.ts
+++ b/src/dev/build/tasks/create_package_json_task.ts
@@ -29,7 +29,6 @@
  */
 
 import { copyWorkspacePackages } from '@osd/pm';
-import { parse } from 'semver';
 
 import { read, write, Task } from '../lib';
 
@@ -38,16 +37,6 @@ export const CreatePackageJson: Task = {
 
   async run(config, log, build) {
     const pkg = config.getOpenSearchDashboardsPkg();
-    /**
-     * OpenSearch server has a logic that if the pkg.branch is "main",
-     * set the docVersion to latest. So here we exclude main.
-     */
-    const semverResult = parse(pkg.version);
-    const shouldPatch = semverResult && pkg.branch !== 'main';
-    const branch = shouldPatch ? `${semverResult.major}.${semverResult.minor}` : pkg.branch;
-    if (shouldPatch) {
-      log.info(`Patch branch property: ${branch}`);
-    }
 
     const newPkg = {
       name: pkg.name,
@@ -55,7 +44,7 @@ export const CreatePackageJson: Task = {
       description: pkg.description,
       keywords: pkg.keywords,
       version: config.getBuildVersion(),
-      branch,
+      branch: pkg.branch,
       build: {
         number: config.getBuildNumber(),
         sha: config.getBuildSha(),

--- a/src/dev/build/tasks/create_package_json_task.ts
+++ b/src/dev/build/tasks/create_package_json_task.ts
@@ -54,7 +54,7 @@ export const CreatePackageJson: Task = {
         log.info(`Updating package.branch to ${branch}`);
       } else {
         const validDocPathsPattern = /^\d+\.\d+$/;
-        if (validDocPathsPattern.test(pkg.branch as string)) {
+        if (validDocPathsPattern.test(pkg.branch)) {
           branch = pkg.branch;
         } else {
           // package version was not parsable and branch is unusable

--- a/src/dev/build/tasks/create_package_json_task.ts
+++ b/src/dev/build/tasks/create_package_json_task.ts
@@ -42,7 +42,7 @@ export const CreatePackageJson: Task = {
      * OpenSearch server has a logic that if the pkg.branch is "main",
      * set the docVersion to latest. So here we exclude main.
      */
-    const semverResult = parse(pkg.version);
+    const semverResult = parse(config.getBuildVersion());
     const shouldPatch = semverResult && pkg.branch !== 'main';
     const branch = shouldPatch ? `${semverResult.major}.${semverResult.minor}` : pkg.branch;
     if (shouldPatch) {


### PR DESCRIPTION
### Description
This is a TODO after [PR](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3274).
The `CoreStart.docLinks.docVersion` is using `pkg.branch`. In 2.5 we changed it manually.
In this PR I want to add a mechanism into CI flow to prevent human error(If build team forget to change the value, which is `2.x` now in current build flow, it will break down all the new doc links inside IM plugin because the link will become like `https://opensearch.org/docs/2.x/api-reference/index-apis/create-index/`.).
 
### Issues Resolved
#3490 https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3490
 
### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
  - [x] `yarn test:ftr`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 