### PR TITLE
Feature: bump branch to 2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "private": true,
   "version": "2.6.0",
-  "branch": "2.x",
+  "branch": "2.6",
   "types": "./opensearch_dashboards.d.ts",
   "tsdocMetadata": "./build/tsdoc-metadata.json",
   "build": {


### PR DESCRIPTION
### Description
In 2.5 we use https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3274 to manually update `pkg.branch`.
We have raised https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3483 to do it automatically but shall not be able to catch up with 2.6 release, so do it manually.
 
### Issues Related
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3490
 
### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
  - [x] `yarn test:ftr`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 