### PR TITLE
[Vis Builder] Add metric to metric, bucket to bucket aggregation persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Make build scripts find and use the latest version of Node.js that satisfies `engines.node` ([#3467](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3467))
 - [Multiple DataSource] Refactor test connection to support SigV4 auth type ([#3456](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3456))
 - [Darwin] Add support for Darwin for running OpenSearch snapshots with `yarn opensearch snapshot` ([#3537](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3537))
+- [Vis Builder] Add metric to metric, bucket to bucket aggregation persistence ([#3495](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3495))
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Darwin] Add support for Darwin for running OpenSearch snapshots with `yarn opensearch snapshot` ([#3537](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3537))
 - [Vis Builder] Add metric to metric, bucket to bucket aggregation persistence ([#3495](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3495))
 
+
 ### 🐛 Bug Fixes
 
 - [Vis Builder] Fixes auto bounds for timeseries bar chart visualization ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Darwin] Add support for Darwin for running OpenSearch snapshots with `yarn opensearch snapshot` ([#3537](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3537))
 - [Vis Builder] Add metric to metric, bucket to bucket aggregation persistence ([#3495](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3495))
 
-
 ### 🐛 Bug Fixes
 
 - [Vis Builder] Fixes auto bounds for timeseries bar chart visualization ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))

--- a/src/plugins/vis_builder/public/application/components/right_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/right_nav.tsx
@@ -34,8 +34,13 @@ export const RightNav = () => {
   const StyleSection = ui.containerConfig.style.render;
 
   const { activeVisualization } = useTypedSelector((state) => state.visualization);
-  const oldAggParams = activeVisualization?.aggConfigParams ?? [];
-  const persistedAggParams = usePersistedAggParams(types, oldAggParams, activeVisName, newVisType);
+  const aggConfigParams = activeVisualization?.aggConfigParams ?? [];
+  const persistedAggParams = usePersistedAggParams(
+    types,
+    aggConfigParams,
+    activeVisName,
+    newVisType
+  );
 
   const options: Array<EuiSuperSelectOption<string>> = types.all().map(({ name, icon, title }) => ({
     value: name,
@@ -77,7 +82,7 @@ export const RightNav = () => {
               setActiveVisualization({
                 name: newVisType,
                 style: types.get(newVisType)?.ui.containerConfig.style.defaults,
-                aggParams: persistedAggParams,
+                aggConfigParams: persistedAggParams,
               })
             );
 

--- a/src/plugins/vis_builder/public/application/components/right_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/right_nav.tsx
@@ -17,7 +17,12 @@ import { useVisualizationType } from '../utils/use';
 import './side_nav.scss';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { VisBuilderServices } from '../../types';
-import { setActiveVisualization, useTypedDispatch } from '../utils/state_management';
+import {
+  setActiveVisualization,
+  useTypedDispatch,
+  useTypedSelector,
+} from '../utils/state_management';
+import { usePersistedAggParams } from '../utils/use/use_persisted_agg_params';
 
 export const RightNav = () => {
   const [newVisType, setNewVisType] = useState<string>();
@@ -27,6 +32,10 @@ export const RightNav = () => {
   const { ui, name: activeVisName } = useVisualizationType();
   const dispatch = useTypedDispatch();
   const StyleSection = ui.containerConfig.style.render;
+
+  const { activeVisualization } = useTypedSelector((state) => state.visualization);
+  const oldAggParams = activeVisualization?.aggConfigParams ?? [];
+  const persistedAggParams = usePersistedAggParams(types, oldAggParams, activeVisName, newVisType);
 
   const options: Array<EuiSuperSelectOption<string>> = types.all().map(({ name, icon, title }) => ({
     value: name,
@@ -68,6 +77,7 @@ export const RightNav = () => {
               setActiveVisualization({
                 name: newVisType,
                 style: types.get(newVisType)?.ui.containerConfig.style.defaults,
+                aggParams: persistedAggParams,
               })
             );
 

--- a/src/plugins/vis_builder/public/application/utils/mocks.ts
+++ b/src/plugins/vis_builder/public/application/utils/mocks.ts
@@ -54,17 +54,8 @@ export const createVisBuilderServicesMock = () => {
             },
           },
         },
-        {
-          name: 'viz',
-          ui: {
-            containerConfig: {
-              style: {
-                defaults: 'style default states',
-              },
-            },
-          },
-        },
       ],
+      get: jest.fn(),
     },
   };
 

--- a/src/plugins/vis_builder/public/application/utils/mocks.ts
+++ b/src/plugins/vis_builder/public/application/utils/mocks.ts
@@ -54,6 +54,16 @@ export const createVisBuilderServicesMock = () => {
             },
           },
         },
+        {
+          name: 'viz',
+          ui: {
+            containerConfig: {
+              style: {
+                defaults: 'style default states',
+              },
+            },
+          },
+        },
       ],
     },
   };

--- a/src/plugins/vis_builder/public/application/utils/state_management/shared_actions.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/shared_actions.ts
@@ -10,7 +10,7 @@ import { VisualizationType } from '../../../services/type_service/visualization_
 interface ActiveVisPayload {
   name: VisualizationType['name'];
   style: VisualizationType['ui']['containerConfig']['style']['defaults'];
-  aggParams: CreateAggConfigParams[];
+  aggConfigParams: CreateAggConfigParams[];
 }
 
 export const setActiveVisualization = createAction<ActiveVisPayload>('setActiveVisualzation');

--- a/src/plugins/vis_builder/public/application/utils/state_management/shared_actions.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/shared_actions.ts
@@ -4,11 +4,13 @@
  */
 
 import { createAction } from '@reduxjs/toolkit';
+import { CreateAggConfigParams } from '../../../../../data/common';
 import { VisualizationType } from '../../../services/type_service/visualization_type';
 
 interface ActiveVisPayload {
   name: VisualizationType['name'];
   style: VisualizationType['ui']['containerConfig']['style']['defaults'];
+  aggParams: CreateAggConfigParams[];
 }
 
 export const setActiveVisualization = createAction<ActiveVisPayload>('setActiveVisualzation');

--- a/src/plugins/vis_builder/public/application/utils/state_management/visualization_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/visualization_slice.ts
@@ -123,7 +123,7 @@ export const slice = createSlice({
     builder.addCase(setActiveVisualization, (state, action) => {
       state.activeVisualization = {
         name: action.payload.name,
-        aggConfigParams: action.payload.aggParams,
+        aggConfigParams: action.payload.aggConfigParams,
       };
     });
   },

--- a/src/plugins/vis_builder/public/application/utils/state_management/visualization_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/visualization_slice.ts
@@ -123,7 +123,7 @@ export const slice = createSlice({
     builder.addCase(setActiveVisualization, (state, action) => {
       state.activeVisualization = {
         name: action.payload.name,
-        aggConfigParams: [],
+        aggConfigParams: action.payload.aggParams,
       };
     });
   },

--- a/src/plugins/vis_builder/public/application/utils/use/use_persisted_agg_params.test.tsx
+++ b/src/plugins/vis_builder/public/application/utils/use/use_persisted_agg_params.test.tsx
@@ -1,0 +1,201 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CreateAggConfigParams } from '../../../../../data/common';
+import { AggGroupNames } from '../../../../../data/common';
+import { Schema } from '../../../../../vis_default_editor/public';
+import { VisBuilderServices } from '../../../types';
+import { createVisBuilderServicesMock } from '../mocks';
+import {
+  AggMapping,
+  getSchemaMapping,
+  updateAggParams,
+  usePersistedAggParams,
+} from './use_persisted_agg_params';
+
+describe('new usePersistedAggParams', () => {
+  beforeEach(() => {});
+
+  test('return the correct metric to metric, bucket to bucket mapping', () => {});
+
+  test('drop the aggregations if it exceeds the max count', () => {});
+
+  test('drop the aggregation when there is no schema', () => {});
+});
+
+describe('updateAggParams', () => {
+  let oldAggParam: CreateAggConfigParams;
+  let aggMap: Map<string, AggMapping>;
+  let assignNewSchemaType: any;
+
+  beforeEach(() => {
+    oldAggParam = {
+      type: '',
+      enabled: true,
+      schema: '',
+    };
+    aggMap = new Map<string, AggMapping>();
+    aggMap.set('old metric', {
+      currentCount: 0,
+      maxCount: 1,
+      name: 'new metric',
+    });
+    aggMap.set('old bucket', {
+      currentCount: 0,
+      maxCount: 1,
+      name: 'new bucket',
+    });
+    assignNewSchemaType = jest.fn();
+  });
+
+  test('return with the undefined schema if the old schema title does not get a mapping', () => {
+    const newAgg = updateAggParams(oldAggParam, aggMap);
+    expect(newAgg).toEqual(oldAggParam);
+  });
+
+  test('return the original aggregation with undefined schema', () => {
+    oldAggParam.schema = 'noMappingSchema';
+    const newAgg = updateAggParams(oldAggParam, aggMap);
+    expect(newAgg).toEqual({
+      type: '',
+      enabled: true,
+      schema: undefined,
+    });
+  });
+
+  test('return with the updated schema for metric', () => {
+    oldAggParam.schema = 'old metric';
+    const newAgg = updateAggParams(oldAggParam, aggMap);
+    expect(newAgg).toEqual({
+      type: '',
+      enabled: true,
+      schema: 'new metric',
+    });
+    expect(aggMap.get('old metric')).toEqual({
+      currentCount: 1,
+      maxCount: 1,
+      name: 'new metric',
+    });
+  });
+
+  test('return with the undefined schema if the mapped schema fields already reach max count', () => {
+    oldAggParam.schema = 'old metric';
+    aggMap.set('old metric', {
+      currentCount: 1,
+      maxCount: 1,
+      name: 'new metric',
+    });
+    const newAgg = updateAggParams(oldAggParam, aggMap);
+    expect(newAgg).toEqual({
+      type: '',
+      enabled: true,
+      schema: undefined,
+    });
+  });
+});
+
+describe('getSchemaMapping', () => {
+  let oldVisualizationType: Schema[];
+  let newVisualizationType: Schema[];
+  let schemaMetricTemplate: Schema;
+  let schemaBucketTemplate: Schema;
+
+  beforeEach(() => {
+    schemaMetricTemplate = {
+      aggFilter: [],
+      editor: '',
+      group: AggGroupNames.Metrics,
+      max: 1,
+      min: 1,
+      name: '',
+      params: [],
+      title: '',
+      defaults: '',
+    };
+    schemaBucketTemplate = {
+      aggFilter: [],
+      editor: '',
+      group: AggGroupNames.Buckets,
+      max: 1,
+      min: 1,
+      name: '',
+      params: [],
+      title: '',
+      defaults: '',
+    };
+  });
+
+  test('map metric schema to metric schema, bucket schema to bucket schema according to order', async () => {
+    oldVisualizationType = [
+      { ...schemaMetricTemplate, name: 'old metric 1' },
+      { ...schemaBucketTemplate, name: 'old bucket 1' },
+      { ...schemaMetricTemplate, name: 'old metric 2' },
+      { ...schemaBucketTemplate, name: 'old bucket 2' },
+      { ...schemaBucketTemplate, name: 'old bucket 3' },
+      { ...schemaBucketTemplate, name: 'old bucket 4' },
+      { ...schemaBucketTemplate, group: AggGroupNames.None, name: 'none' },
+    ];
+    newVisualizationType = [
+      { ...schemaMetricTemplate, name: 'new metric 1', max: 1 },
+      { ...schemaMetricTemplate, name: 'new metric 2', max: 2 },
+      { ...schemaMetricTemplate, name: 'new metric 3', max: 3 },
+      { ...schemaBucketTemplate, name: 'new bucket 1', max: 4 },
+      { ...schemaBucketTemplate, name: 'new bucket 2', max: 5 },
+      { ...schemaBucketTemplate, name: 'new bucket 3', max: 6 },
+    ];
+    const mappingResult = getSchemaMapping(oldVisualizationType, newVisualizationType);
+    expect(mappingResult).toMatchInlineSnapshot(`
+      Map {
+        "old metric 1" => Object {
+          "currentCount": 0,
+          "maxCount": 1,
+          "name": "new metric 1",
+        },
+        "old metric 2" => Object {
+          "currentCount": 0,
+          "maxCount": 2,
+          "name": "new metric 2",
+        },
+        "old bucket 1" => Object {
+          "currentCount": 0,
+          "maxCount": 4,
+          "name": "new bucket 1",
+        },
+        "old bucket 2" => Object {
+          "currentCount": 0,
+          "maxCount": 5,
+          "name": "new bucket 2",
+        },
+        "old bucket 3" => Object {
+          "currentCount": 0,
+          "maxCount": 6,
+          "name": "new bucket 3",
+        },
+      }
+    `);
+  });
+});
+
+describe('usePersistedAggParams', () => {
+  let mockServices: jest.Mocked<VisBuilderServices>;
+  let types: any;
+  let aggConfigParams: CreateAggConfigParams[];
+  let oldVisType: string | undefined;
+  let newVisType: string | undefined;
+
+  beforeEach(() => {
+    mockServices = createVisBuilderServicesMock();
+    types = mockServices.types;
+    aggConfigParams = [];
+    oldVisType = 'oldVisType';
+    newVisType = 'newVisType';
+  });
+
+  test('return an empty array when there is no old vis type or new vis type', async () => {
+    oldVisType = '';
+    const persistResult = usePersistedAggParams(types, aggConfigParams, oldVisType, newVisType);
+    expect(persistResult).toEqual([]);
+  });
+});

--- a/src/plugins/vis_builder/public/application/utils/use/use_persisted_agg_params.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_persisted_agg_params.ts
@@ -3,13 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { integer } from '@opensearch-project/opensearch/api/types';
 import { AggGroupNames, CreateAggConfigParams } from '../../../../../data/common';
 import { Schema } from '../../../../../vis_default_editor/public';
 
 export const usePersistedAggParams = (
   types,
-  oldAggParams: CreateAggConfigParams[],
+  aggConfigParams: CreateAggConfigParams[],
   oldVisType?: string,
   newVisType?: string
 ): CreateAggConfigParams[] => {
@@ -17,10 +16,10 @@ export const usePersistedAggParams = (
     const oldVisualizationType = types.get(oldVisType)?.ui.containerConfig.data.schemas.all;
     const newVisualizationType = types.get(newVisType)?.ui.containerConfig.data.schemas.all;
     const aggMapping = getSchemaMapping(oldVisualizationType, newVisualizationType);
-    const newAggParams = oldAggParams.map((newAggParam: CreateAggConfigParams) =>
-      updateAggParams(newAggParam, aggMapping)
+    const updatedAggConfigParams = aggConfigParams.map((aggConfigParam: CreateAggConfigParams) =>
+      updateAggParams(aggConfigParam, aggMapping)
     );
-    return newAggParams;
+    return updatedAggConfigParams;
   }
   return [];
 };
@@ -41,8 +40,8 @@ export const getSchemaMapping = (
 
 export interface AggMapping {
   name: string;
-  maxCount: integer;
-  currentCount: integer;
+  maxCount: number;
+  currentCount: number;
 }
 
 export const mapAggParamsSchema = (
@@ -70,29 +69,27 @@ export const updateAggParams = (
   oldAggParam: CreateAggConfigParams,
   aggMap: Map<string, AggMapping>
 ) => {
-  const newAggParam = {
-    params: oldAggParam.params,
-    type: oldAggParam.type,
-    enabled: oldAggParam.enabled,
-    id: oldAggParam.id,
-    schema: oldAggParam.schema,
-  };
+  const newAggParam = { ...oldAggParam };
   if (oldAggParam.schema) {
     const newSchema = aggMap.get(oldAggParam.schema);
-    if (newSchema) {
-      if (newSchema.currentCount < newSchema.maxCount) {
-        newAggParam.schema = aggMap.get(oldAggParam.schema)?.name;
-        aggMap.set(oldAggParam.schema, {
-          name: newSchema.name,
-          maxCount: newSchema.maxCount,
-          currentCount: newSchema.currentCount + 1,
-        });
-      } else {
-        newAggParam.schema = undefined;
-      }
-    } else {
-      newAggParam.schema = undefined;
-    }
+    newAggParam.schema = newSchema
+      ? newSchema.currentCount < newSchema.maxCount
+        ? assignNewSchemaType(oldAggParam, aggMap, newSchema)
+        : undefined
+      : undefined;
   }
   return newAggParam;
+};
+
+export const assignNewSchemaType = (
+  oldAggParam: any,
+  aggMap: Map<string, AggMapping>,
+  newSchema: AggMapping
+) => {
+  aggMap.set(oldAggParam.schema, {
+    name: newSchema.name,
+    maxCount: newSchema.maxCount,
+    currentCount: newSchema.currentCount + 1,
+  });
+  return aggMap.get(oldAggParam.schema)?.name;
 };

--- a/src/plugins/vis_builder/public/application/utils/use/use_persisted_agg_params.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_persisted_agg_params.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { integer } from '@opensearch-project/opensearch/api/types';
+import { AggGroupNames, CreateAggConfigParams } from '../../../../../data/common';
+import { Schema } from '../../../../../vis_default_editor/public';
+
+export const usePersistedAggParams = (
+  types,
+  oldAggParams: CreateAggConfigParams[],
+  oldVisType?: string,
+  newVisType?: string
+): CreateAggConfigParams[] => {
+  if (oldVisType && newVisType) {
+    const oldVisualizationType = types.get(oldVisType)?.ui.containerConfig.data.schemas.all;
+    const newVisualizationType = types.get(newVisType)?.ui.containerConfig.data.schemas.all;
+    const aggMapping = getSchemaMapping(oldVisualizationType, newVisualizationType);
+    return oldAggParams.map((newAggParam: CreateAggConfigParams) =>
+      updateAggParams(newAggParam, aggMapping)
+    );
+  }
+  return [];
+};
+
+// may need to update the value to include a max count, currently all values are adding
+
+// Map metric fields to metric fields, bucket fields to bucket fields
+export const getSchemaMapping = (
+  oldVisualizationType: Schema[],
+  newVisualizationType: Schema[]
+): Map<string, AggMapping> => {
+  const aggMap = new Map<string, AggMapping>();
+
+  // currently Metrics, Buckets, and None are the three groups. We simply drop the aggregations that belongs to the None group
+  mapAggParamsSchema(oldVisualizationType, newVisualizationType, AggGroupNames.Metrics, aggMap);
+  mapAggParamsSchema(oldVisualizationType, newVisualizationType, AggGroupNames.Buckets, aggMap);
+
+  return aggMap;
+};
+
+export interface AggMapping {
+  name: string;
+  maxCount: integer;
+}
+
+export const mapAggParamsSchema = (
+  oldVisualizationType: Schema[],
+  newVisualizationType: Schema[],
+  aggGroup: string,
+  map: Map<string, AggMapping>
+) => {
+  const oldSchemas = oldVisualizationType.filter((type) => type.group === aggGroup);
+  const newSchemas = newVisualizationType.filter((type) => type.group === aggGroup);
+
+  // console.log("newNames", newNames)
+  oldSchemas.forEach((oldSchema, index) => {
+    // what if first array is longer than the second one?
+    if (newSchemas[index]) {
+      const mappedNewSchema = {
+        name: newSchemas[index].name,
+        maxCount: newSchemas[index].max,
+      };
+      map.set(oldSchema.name, mappedNewSchema);
+    }
+  });
+};
+
+export const updateAggParams = (
+  oldAggParam: CreateAggConfigParams,
+  aggMap: Map<string, AggMapping>
+) => {
+  const newAggParam = {
+    params: oldAggParam.params,
+    type: oldAggParam.type,
+    enabled: oldAggParam.enabled,
+    id: oldAggParam.id,
+    schema: oldAggParam.schema,
+  };
+  if (oldAggParam.schema) {
+    newAggParam.schema = aggMap.has(oldAggParam.schema)
+      ? aggMap.get(oldAggParam.schema)?.name
+      : undefined;
+  }
+  return newAggParam;
+};


### PR DESCRIPTION
### Description
This PR implements the aggregation persistence feature in Vis Builder when switching vis type. 

Detailed research doc can be found here: #2900
The proposal, mapping rules and examples can be found here: #3482 

### Issues Resolved
#3482 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 