### PR TITLE
Use mirrors to download Node.js binaries to escape sporadic 404 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple DataSource] Refactor test connection to support SigV4 auth type ([#3456](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3456))
 - [Darwin] Add support for Darwin for running OpenSearch snapshots with `yarn opensearch snapshot` ([#3537](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3537))
 - [Vis Builder] Add metric to metric, bucket to bucket aggregation persistence ([#3495](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3495))
+- Use mirrors to download Node.js binaries to escape sporadic 404 errors ([#3619](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3619))
 
 ### 🐛 Bug Fixes
 

--- a/src/dev/build/tasks/nodejs/node_download_info.ts
+++ b/src/dev/build/tasks/nodejs/node_download_info.ts
@@ -44,7 +44,7 @@ export async function getNodeDownloadInfo(config: Config, platform: Platform) {
     ? `node-v${version}-win-x64.zip`
     : `node-v${version}-${arch}.tar.gz`;
 
-  const url = `https://nodejs.org/dist/v${version}/${downloadName}`;
+  const url = `https://mirrors.nodejs.org/dist/v${version}/${downloadName}`;
   const downloadPath = config.resolveFromRepo('.node_binaries', version, basename(downloadName));
   const extractDir = config.resolveFromRepo('.node_binaries', version, arch);
 


### PR DESCRIPTION
Issue Resolved:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3618

 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 