### PR TITLE
[Vega] Add Filter custom label for opensearchDashboardsAddFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Region Maps] Add ui setting to configure custom vector map's size parameter([#3399](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3399))
 - [Search Telemetry] Fixes search telemetry's observable object that won't be GC-ed([#3390](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3390))
 - Clean up and rebuild `@osd/pm` ([#3570](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3570))
+- [Vega] Add Filter custom label for opensearchDashboardsAddFilter ([#3640](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3640))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -315,10 +315,15 @@ export class VegaBaseView {
   /**
    * @param {object} query Query DSL snippet, as used in the query DSL editor
    * @param {string} [index] as defined in OpenSearch Dashboards, or default if missing
+   * @param {string} alias OpenSearch Query DSL's Custom label for opensearchDashboardsAddFilter, as used in '+ Add Filter'
    */
-  async addFilterHandler(query, index) {
+  async addFilterHandler(query, index, alias) {
     const indexId = await this.findIndex(Utils.handleNonStringIndex(index));
-    const filter = opensearchFilters.buildQueryFilter(Utils.handleInvalidQuery(query), indexId);
+    const filter = opensearchFilters.buildQueryFilter(
+      Utils.handleInvalidQuery(query),
+      indexId,
+      alias
+    );
     this._applyFilter({ filters: [filter] });
   }
 

--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -315,7 +315,7 @@ export class VegaBaseView {
   /**
    * @param {object} query Query DSL snippet, as used in the query DSL editor
    * @param {string} [index] as defined in OpenSearch Dashboards, or default if missing
-   * @param {string} alias OpenSearch Query DSL's Custom label for opensearchDashboardsAddFilter, as used in '+ Add Filter'
+   * @param {string} alias OpenSearch Query DSL's custom label for `opensearchDashboardsAddFilter`, as used in '+ Add Filter'
    */
   async addFilterHandler(query, index, alias) {
     const indexId = await this.findIndex(Utils.handleNonStringIndex(index));


### PR DESCRIPTION
### Description
Vega 'opensearchDashboardsAddFilter' allows to add OpenSearch Query DSL and index. The implementation buildQueryFilter takes in third parameter to set a custom label in 'Add Filter'. At the moment, opensearchDashboardsAddFilter can only take query and index parameters. 
 
### Issues Resolved 
This PR adds in the third 'alias' parameter to set the custom label from Vega

`buildQueryFilter = (query: QueryStringFilter['query'], index: string, alias: string)`

Below image is self explanatory. The first filter in the image is without custom label (ugly, in my opinion), and the second filter is with custom label set in Vega.

![Vega_OSDAddFilter](https://user-images.githubusercontent.com/32518356/210779556-248b2850-afe0-47a9-beb1-c69ec351a0b7.png)
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 