### PR TITLE
Add error types to VisLayers

### DIFF
--- a/src/plugins/vis_augmenter/public/index.ts
+++ b/src/plugins/vis_augmenter/public/index.ts
@@ -18,7 +18,7 @@ export {
   SavedObjectOpenSearchDashboardsServicesWithAugmentVis,
 } from './saved_augment_vis';
 
-export { VisLayer, VisLayers, VisLayerTypes } from './types';
+export { VisLayer, VisLayers, VisLayerTypes, VisLayerErrorTypes, VisLayerError } from './types';
 
 export * from './expressions';
 export * from './utils';

--- a/src/plugins/vis_augmenter/public/types.ts
+++ b/src/plugins/vis_augmenter/public/types.ts
@@ -7,6 +7,16 @@ export enum VisLayerTypes {
   PointInTimeEvents = 'PointInTimeEvents',
 }
 
+export enum VisLayerErrorTypes {
+  PERMISSIONS_FAILURE = 'PERMISSIONS_FAILURE',
+  FETCH_FAILURE = 'FETCH_FAILURE',
+}
+
+export interface VisLayerError {
+  type: keyof typeof VisLayerErrorTypes;
+  message?: string;
+}
+
 export type PluginResourceType = string;
 
 export interface PluginResource {
@@ -20,6 +30,7 @@ export interface VisLayer {
   type: keyof typeof VisLayerTypes;
   originPlugin: string;
   pluginResource: PluginResource;
+  error?: VisLayerError;
 }
 
 export type VisLayers = VisLayer[];


### PR DESCRIPTION
### Description
Add error types to VisLayers. This way, errors can be processed and handled in different ways, as described in #3580 .
 
### Issues Resolved
Closes #3267 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 