### PR TITLE
fix(vis_type_vega): Use default categorical color palette directly

### DIFF
--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.test.js
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.test.js
@@ -30,6 +30,7 @@
 
 import { cloneDeep } from 'lodash';
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
+import { euiPaletteColorBlind } from '@elastic/eui';
 import { VegaParser } from './vega_parser';
 import { bypassExternalUrlCheck } from '../vega_view/vega_base_view';
 
@@ -88,7 +89,7 @@ describe(`VegaParser._setDefaultColors`, () => {
           tickColor: euiThemeVars.euiColorChartLines,
         },
         background: 'transparent',
-        range: { category: { scheme: 'elastic' } },
+        range: { category: euiPaletteColorBlind() },
         mark: { color: '#54B399' },
         style: {
           'group-title': {
@@ -121,7 +122,7 @@ describe(`VegaParser._setDefaultColors`, () => {
           tickColor: euiThemeVars.euiColorChartLines,
         },
         background: 'transparent',
-        range: { category: { scheme: 'elastic' } },
+        range: { category: euiPaletteColorBlind() },
         arc: { fill: '#54B399' },
         area: { fill: '#54B399' },
         line: { stroke: '#54B399' },

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
@@ -677,7 +677,7 @@ The URL is an identifier only. OpenSearch Dashboards and your browser will never
    */
   _setDefaultColors() {
     // Default category coloring to the OpenSearch color scheme
-    this._setDefaultValue({ scheme: 'elastic' }, 'config', 'range', 'category');
+    this._setDefaultValue(euiPaletteColorBlind(), 'config', 'range', 'category');
 
     if (this.isVegaLite) {
       // Vega-Lite: set default color, works for fill and strike --  config: { mark:  { color: '#54B399' }}

--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -41,7 +41,7 @@ import { opensearchFilters } from '../../../data/public';
 import { getEnableExternalUrls, getData } from '../services';
 import { extractIndexPatternsFromSpec } from '../lib/extract_index_pattern';
 
-vega.scheme('elastic', euiPaletteColorBlind());
+vega.scheme('euiPaletteColorBlind', euiPaletteColorBlind());
 
 // Vega's extension functions are global. When called,
 // we forward execution to the instance-specific handler


### PR DESCRIPTION
### Description

rather than relying on vega.scheme. Also update vega.scheme name

#### Before

https://user-images.githubusercontent.com/1679762/228105161-4688eba4-cb85-4fea-9149-18e1df25cde9.mov

#### After

(note that the color palette scale is still applied correctly)
 
https://user-images.githubusercontent.com/1679762/228105170-39bdadb5-1d1c-4dcd-b520-9b37fada789b.mov


#### Possible Breaking Change

The only usage of the `elastic` custom scheme previously was to set the default value for `config.range.category`, and that behavior is restored by this PR. However, it was previously possible to explicitly set `scheme: "elastic"` within a spec - that's no longer possible. I think it's highly unlikely that there's a vega property that accepts a `scheme` property that doesn't also use the default `config.range.category`, but it may be possible. I'm also unsure if elastic ever documented any such usage. But my personal judgement is that this is unlikely to break any real user specs.

### Issues Resolved
Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3582
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 