### PR TITLE
[Multiple DataSource]Refactor authentication type selection in create and edit data source forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Console] Replace jQuery.ajax with core.http when calling OSD APIs in console ([#3080](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3080))
 - [I18n] Fix Listr type errors and error handlers ([#3629](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3629))
 - [Multiple DataSource]Refactor authentication type selection in create and edit data source forms to use EuiSelect ([#3693](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3693))
+
 ### 🔩 Tests
 
 - [Multi DataSource] Add unit test coverage for Update Data source management stack ([#2567](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2567))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,7 +167,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Vis Builder] Removed Hard Coded Strings and Used i18n to transalte([#2867](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2867))
 - [Console] Replace jQuery.ajax with core.http when calling OSD APIs in console ([#3080](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3080))
 - [I18n] Fix Listr type errors and error handlers ([#3629](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3629))
-- [Multiple DataSource]Refactor authentication type selection in create and edit data source forms to use EuiSelect ([#3693](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3693))
+- [Multiple DataSource] Present the authentication type choices in a drop-down ([#3693](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3693))
 
 ### 🔩 Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,7 +167,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Vis Builder] Removed Hard Coded Strings and Used i18n to transalte([#2867](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2867))
 - [Console] Replace jQuery.ajax with core.http when calling OSD APIs in console ([#3080](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3080))
 - [I18n] Fix Listr type errors and error handlers ([#3629](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3629))
-
+- [Multiple DataSource]Refactor authentication type selection in create and edit data source forms to use EuiSelect ([#3693](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3693))
 ### 🔩 Tests
 
 - [Multi DataSource] Add unit test coverage for Update Data source management stack ([#2567](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2567))

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.test.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.test.tsx
@@ -51,17 +51,12 @@ describe('Datasource Management: Create Datasource form', () => {
     component.find(testSubjId).last().simulate('blur');
   };
 
-  const setAuthTypeValue = (
-    comp: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>,
-    value: AuthType
-  ) => {
-    // @ts-ignore
-    comp
-      .find(authTypeIdentifier)
-      .first()
-      // @ts-ignore
-      .prop('onChange')(value);
-    comp.update();
+  const setAuthTypeValue = (testSubjId: string, value: string) => {
+    component.find(testSubjId).last().simulate('change', {
+      target: {
+        value,
+      },
+    });
   };
 
   beforeEach(() => {
@@ -98,7 +93,7 @@ describe('Datasource Management: Create Datasource form', () => {
   /* Change option: No Authentication */
   test('should validate when auth type changed & previously submit button clicked', () => {
     /* Update Eui Super Select Value to No Auth*/
-    setAuthTypeValue(component, AuthType.NoAuth);
+    setAuthTypeValue(authTypeIdentifier, AuthType.NoAuth);
     component.update();
 
     /* Click on submit without any user input */
@@ -106,7 +101,7 @@ describe('Datasource Management: Create Datasource form', () => {
 
     const { authType, username, password } = getFields(component);
 
-    expect(authType.prop('idSelected')).toBe(AuthType.NoAuth);
+    expect(authType.prop('value')).toBe(AuthType.NoAuth);
     expect(username.exists()).toBeFalsy(); // username field does not exist when No Auth option is selected
     expect(password.exists()).toBeFalsy(); // password field does not exist when No Auth option is selected
   });
@@ -138,7 +133,7 @@ describe('Datasource Management: Create Datasource form', () => {
   /* Username & Password */
   test('should create data source with username & password when all fields are valid', () => {
     /* set form fields */
-    setAuthTypeValue(component, AuthType.UsernamePasswordType);
+    setAuthTypeValue(authTypeIdentifier, AuthType.UsernamePasswordType);
     changeTextFieldValue(titleIdentifier, 'test');
     changeTextFieldValue(descriptionIdentifier, 'test');
     changeTextFieldValue(endpointIdentifier, 'https://test.com');
@@ -155,7 +150,7 @@ describe('Datasource Management: Create Datasource form', () => {
   /* No Auth - Username & Password */
   test('should create data source with No Auth when all fields are valid', () => {
     /* set form fields */
-    setAuthTypeValue(component, AuthType.NoAuth); // No auth
+    setAuthTypeValue(authTypeIdentifier, AuthType.NoAuth); // No auth
     changeTextFieldValue(titleIdentifier, 'test');
     changeTextFieldValue(descriptionIdentifier, 'test');
     changeTextFieldValue(endpointIdentifier, 'https://test.com');

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
@@ -13,7 +13,7 @@ import {
   EuiForm,
   EuiFormRow,
   EuiPageContent,
-  EuiRadioGroup,
+  EuiSelect,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -120,8 +120,8 @@ export class CreateDataSourceForm extends React.Component<
     });
   };
 
-  onChangeAuthType = (value: string) => {
-    this.setState({ auth: { ...this.state.auth, type: value as AuthType } });
+  onChangeAuthType = (e: { target: { value: any } }) => {
+    this.setState({ auth: { ...this.state.auth, type: e.target.value as AuthType } });
   };
 
   onChangeUsername = (e: { target: { value: any } }) => {
@@ -555,10 +555,10 @@ export class CreateDataSourceForm extends React.Component<
           {/* Credential source */}
           <EuiSpacer size="l" />
           <EuiFormRow>
-            <EuiRadioGroup
+            <EuiSelect
               options={credentialSourceOptions}
-              idSelected={this.state.auth.type}
-              onChange={(id) => this.onChangeAuthType(id)}
+              value={this.state.auth.type}
+              onChange={(e) => this.onChangeAuthType(e)}
               name="Credential"
               data-test-subj="createDataSourceFormAuthTypeSelect"
             />

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
@@ -120,7 +120,7 @@ export class CreateDataSourceForm extends React.Component<
     });
   };
 
-  onChangeAuthType = (e: { target: { value: any } }) => {
+  onChangeAuthType = (e: React.ChangeEvent<HTMLSelectElement>) => {
     this.setState({ auth: { ...this.state.auth, type: e.target.value as AuthType } });
   };
 

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.test.tsx
@@ -290,7 +290,7 @@ describe('Datasource Management: Edit Datasource Form', () => {
     });
 
     /* Save Changes */
-    test('should update the form with NoAUth on click save chan ges', async () => {
+    test('should update the form with NoAuth on click save changes', async () => {
       await new Promise((resolve) =>
         setTimeout(() => {
           updateInputFieldAndBlur(component, descriptionFieldIdentifier, '');

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.test.tsx
@@ -22,7 +22,7 @@ const titleFormRowIdentifier = '[data-test-subj="editDataSourceTitleFormRow"]';
 const endpointFieldIdentifier = '[data-test-subj="editDatasourceEndpointField"]';
 const descriptionFieldIdentifier = 'dataSourceDescription';
 const descriptionFormRowIdentifier = '[data-test-subj="editDataSourceDescriptionFormRow"]';
-const authTypeRadioIdentifier = '[data-test-subj="editDataSourceSelectAuthType"]';
+const authTypeSelectIdentifier = '[data-test-subj="editDataSourceSelectAuthType"]';
 const usernameFieldIdentifier = 'datasourceUsername';
 const usernameFormRowIdentifier = '[data-test-subj="editDatasourceUsernameFormRow"]';
 const passwordFieldIdentifier = '[data-test-subj="updateDataSourceFormPasswordField"]';
@@ -47,6 +47,14 @@ describe('Datasource Management: Edit Datasource Form', () => {
       field.last().simulate('focus').simulate('blur');
     });
     comp.update();
+  };
+
+  const setAuthTypeValue = (testSubjId: string, value: string) => {
+    component.find(testSubjId).last().simulate('change', {
+      target: {
+        value,
+      },
+    });
   };
 
   describe('Case 1: With Username & Password', () => {
@@ -147,10 +155,7 @@ describe('Datasource Management: Edit Datasource Form', () => {
       expect(component.find('UpdatePasswordModal').exists()).toBe(false);
     });
     test("should hide username & password fields when 'No Authentication' is selected as the credential type", () => {
-      act(() => {
-        // @ts-ignore
-        component.find(authTypeRadioIdentifier).first().prop('onChange')(AuthType.NoAuth);
-      });
+      setAuthTypeValue(authTypeSelectIdentifier, AuthType.NoAuth);
       component.update();
       expect(component.find(usernameFormRowIdentifier).exists()).toBe(false);
       expect(component.find(passwordFieldIdentifier).exists()).toBe(false);
@@ -255,13 +260,7 @@ describe('Datasource Management: Edit Datasource Form', () => {
     /* functionality */
 
     test("should show username & password fields when 'Username & Password' is selected as the credential type", () => {
-      act(() => {
-        // @ts-ignore
-        component.find(authTypeRadioIdentifier).first().prop('onChange')(
-          // @ts-ignore
-          AuthType.UsernamePasswordType
-        );
-      });
+      setAuthTypeValue(authTypeSelectIdentifier, AuthType.UsernamePasswordType);
       component.update();
       expect(component.find(usernameFormRowIdentifier).exists()).toBe(true);
       expect(component.find(passwordFieldIdentifier).exists()).toBe(true);
@@ -270,13 +269,7 @@ describe('Datasource Management: Edit Datasource Form', () => {
     /* validation - Password */
 
     test('should validate password as required field', () => {
-      act(() => {
-        // @ts-ignore
-        component.find(authTypeRadioIdentifier).first().prop('onChange')(
-          // @ts-ignore
-          AuthType.UsernamePasswordType
-        );
-      });
+      setAuthTypeValue(authTypeSelectIdentifier, AuthType.UsernamePasswordType);
       component.update();
 
       /* Validate empty username - required */
@@ -297,7 +290,7 @@ describe('Datasource Management: Edit Datasource Form', () => {
     });
 
     /* Save Changes */
-    test('should update the form with NoAUth on click save changes', async () => {
+    test('should update the form with NoAUth on click save chan ges', async () => {
       await new Promise((resolve) =>
         setTimeout(() => {
           updateInputFieldAndBlur(component, descriptionFieldIdentifier, '');

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -162,7 +162,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
     });
   };
 
-  onChangeAuthType = (e: { target: { value: any } }) => {
+  onChangeAuthType = (e: React.ChangeEvent<HTMLSelectElement>) => {
     this.setState({ auth: { ...this.state.auth, type: e.target.value as AuthType } }, () => {
       this.onChangeFormValues();
     });
@@ -738,13 +738,6 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             defaultMessage: 'Credential',
           })}
         >
-          {/* <EuiRadioGroup
-            options={credentialSourceOptions}
-            idSelected={this.state.auth.type}
-            onChange={(id) => this.onChangeAuthType(id)}
-            name="Credential"
-            data-test-subj="editDataSourceSelectAuthType"
-          /> */}
           <EuiSelect
             options={credentialSourceOptions}
             value={this.state.auth.type}

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -17,7 +17,7 @@ import {
   EuiFormRow,
   EuiHorizontalRule,
   EuiPanel,
-  EuiRadioGroup,
+  EuiSelect,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -162,8 +162,8 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
     });
   };
 
-  onChangeAuthType = (value: string) => {
-    this.setState({ auth: { ...this.state.auth, type: value as AuthType } }, () => {
+  onChangeAuthType = (e: { target: { value: any } }) => {
+    this.setState({ auth: { ...this.state.auth, type: e.target.value as AuthType } }, () => {
       this.onChangeFormValues();
     });
   };
@@ -738,10 +738,17 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             defaultMessage: 'Credential',
           })}
         >
-          <EuiRadioGroup
+          {/* <EuiRadioGroup
             options={credentialSourceOptions}
             idSelected={this.state.auth.type}
             onChange={(id) => this.onChangeAuthType(id)}
+            name="Credential"
+            data-test-subj="editDataSourceSelectAuthType"
+          /> */}
+          <EuiSelect
+            options={credentialSourceOptions}
+            value={this.state.auth.type}
+            onChange={(e) => this.onChangeAuthType(e)}
             name="Credential"
             data-test-subj="editDataSourceSelectAuthType"
           />

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -741,7 +741,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
           <EuiSelect
             options={credentialSourceOptions}
             value={this.state.auth.type}
-            onChange={(e) => this.onChangeAuthType(e)}
+            onChange={this.onChangeAuthType}
             name="Credential"
             data-test-subj="editDataSourceSelectAuthType"
           />

--- a/src/plugins/data_source_management/public/types.ts
+++ b/src/plugins/data_source_management/public/types.ts
@@ -56,12 +56,6 @@ export enum AuthType {
   SigV4 = 'sigv4',
 }
 
-// export const credentialSourceOptions = [
-//   { id: AuthType.NoAuth, label: 'No authentication' },
-//   { id: AuthType.UsernamePasswordType, label: 'Username & Password' },
-//   { id: AuthType.SigV4, label: 'AWS SigV4' },
-// ];
-
 export const credentialSourceOptions = [
   { value: AuthType.NoAuth, text: 'No authentication' },
   { value: AuthType.UsernamePasswordType, text: 'Username & Password' },

--- a/src/plugins/data_source_management/public/types.ts
+++ b/src/plugins/data_source_management/public/types.ts
@@ -15,6 +15,7 @@ import {
 } from 'src/core/public';
 import { ManagementAppMountParams } from 'src/plugins/management/public';
 import { SavedObjectAttributes } from 'src/core/types';
+import { i18n } from '@osd/i18n';
 import { OpenSearchDashboardsReactContextValue } from '../../opensearch_dashboards_react/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -57,9 +58,24 @@ export enum AuthType {
 }
 
 export const credentialSourceOptions = [
-  { value: AuthType.NoAuth, text: 'No authentication' },
-  { value: AuthType.UsernamePasswordType, text: 'Username & Password' },
-  { value: AuthType.SigV4, text: 'AWS SigV4' },
+  {
+    value: AuthType.NoAuth,
+    text: i18n.translate('dataSourceManagement.credentialSourceOptions.NoAuthentication', {
+      defaultMessage: 'No authentication',
+    }),
+  },
+  {
+    value: AuthType.UsernamePasswordType,
+    text: i18n.translate('dataSourceManagement.credentialSourceOptions.UsernamePassword', {
+      defaultMessage: 'Username & Password',
+    }),
+  },
+  {
+    value: AuthType.SigV4,
+    text: i18n.translate('dataSourceManagement.credentialSourceOptions.AwsSigV4', {
+      defaultMessage: 'AWS SigV4',
+    }),
+  },
 ];
 
 export interface DataSourceAttributes extends SavedObjectAttributes {

--- a/src/plugins/data_source_management/public/types.ts
+++ b/src/plugins/data_source_management/public/types.ts
@@ -56,10 +56,16 @@ export enum AuthType {
   SigV4 = 'sigv4',
 }
 
+// export const credentialSourceOptions = [
+//   { id: AuthType.NoAuth, label: 'No authentication' },
+//   { id: AuthType.UsernamePasswordType, label: 'Username & Password' },
+//   { id: AuthType.SigV4, label: 'AWS SigV4' },
+// ];
+
 export const credentialSourceOptions = [
-  { id: AuthType.NoAuth, label: 'No authentication' },
-  { id: AuthType.UsernamePasswordType, label: 'Username & Password' },
-  { id: AuthType.SigV4, label: 'AWS SigV4' },
+  { value: AuthType.NoAuth, text: 'No authentication' },
+  { value: AuthType.UsernamePasswordType, text: 'Username & Password' },
+  { value: AuthType.SigV4, text: 'AWS SigV4' },
 ];
 
 export interface DataSourceAttributes extends SavedObjectAttributes {


### PR DESCRIPTION
### Description
[Multiple DataSource]Refactor authentication type selection in create and edit data source forms to use EuiSelect component
Based on https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2110#issuecomment-1426591168, I made the UI changes to multiple datasource creation page

Current UI:
![image](https://user-images.githubusercontent.com/32652829/229203829-19deffb6-dd60-415b-980b-58d317d8ea23.png)

Updated UI:
![image](https://user-images.githubusercontent.com/32652829/227754980-e45e19eb-e871-4946-b70a-d4bd94f8b952.png)
![image](https://user-images.githubusercontent.com/32652829/227754987-f5e096f9-1bba-4c0f-829d-496e0750003c.png)

 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3551
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2110#issuecomment-1426591168
 
### Check List
- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 