### PR TITLE
fix(timeline): Fix yaxis label color in dark mode

### DIFF
--- a/packages/osd-ui-shared-deps/flot_charts/jquery_flot_axislabels.js
+++ b/packages/osd-ui-shared-deps/flot_charts/jquery_flot_axislabels.js
@@ -159,6 +159,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                       'Label" " class="axisLabels" style="position:absolute;">'
                       + this.opts.axisLabel + '</div>');
         this.plot.getPlaceholder().append(this.elem);
+        if (this.opts.axisLabelColour) {
+            this.elem.css('color', this.opts.axisLabelColour);
+        }
         if (this.position == 'top') {
             this.elem.css('left', box.left + box.width/2 - this.labelWidth/2 +
                           'px');
@@ -261,6 +264,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                       'Label" style="position:absolute; ' +
                       this.transforms(offsets.degrees, offsets.x, offsets.y) +
                       '">' + this.opts.axisLabel + '</div>');
+        if (this.opts.axisLabelColour) {
+            this.elem.css('color', this.opts.axisLabelColour);
+        }
         this.plot.getPlaceholder().append(this.elem);
     };
 

--- a/src/plugins/vis_type_timeline/public/components/timeline_vis.scss
+++ b/src/plugins/vis_type_timeline/public/components/timeline_vis.scss
@@ -7,12 +7,15 @@
   // Custom Jquery FLOT / schema selectors
   // Cannot change at the moment
 
-  .chart-top-title {
+  .chart-top-title, .axisLabels {
     @include euiFontSizeXS;
 
+    font-weight: $euiFontWeightBold;
+  }
+
+  .chart-top-title {
     flex: 0;
     text-align: center;
-    font-weight: $euiFontWeightBold;
   }
 
   .chart-canvas {

--- a/src/plugins/vis_type_timeline/server/series_functions/yaxis.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/yaxis.js
@@ -143,7 +143,7 @@ export default new Chainable('yaxis', {
       myAxis.axisLabelFontSizePixels = 11;
       myAxis.axisLabel = label;
       myAxis.axisLabelColour = color;
-      myAxis.axisLabelUseCanvas = true;
+      myAxis.axisLabelUseCanvas = false;
 
       if (tickDecimals) {
         myAxis.tickDecimals = tickDecimals < 0 ? 0 : tickDecimals;


### PR DESCRIPTION
### Description

- Render label as HTML instead of in the Canvas so that it picks up text color from CSS theme
- Update CSS styles of yaxis label to match chart title
- Update HTML rendering to support custom color overrides via inline styles
 
### Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2250
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 