### PR TITLE
[CVE-2021-3803][1.x] Bump nth-check from 1.0.2 to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 🛡 Security
 
+- [CVE-2021-3803] Bump nth-check from `1.0.2` to `2.0.1` ([#3729](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3729))
+
 ### 📈 Features/Enhancements
 
 - [Optimizer] Increase timeout waiting for the exiting of an optimizer worker ([#3193](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3193))

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "**/node-jose": "^2.2.0",
     "**/node-jose/node-forge": "^0.10.0",
     "**/normalize-url": "^4.5.1",
+    "**/nth-check": "^2.0.1",
     "**/prismjs": "^1.23.0",
     "**/qs": "^6.11.0",
     "**/react-syntax-highlighter": "^15.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5126,10 +5126,10 @@ bonjour@^3.5.0:
     multicast-dns "^6.0.1"
     multicast-dns-service-types "^1.1.0"
 
-boolbase@~1.0.0:
+boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 boom@7.x.x, boom@^7.2.0:
   version "7.2.2"
@@ -15564,12 +15564,12 @@ npmlog@^4.0.0, npmlog@^4.1.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
-  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+nth-check@^2.0.1, nth-check@~1.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
-    boolbase "~1.0.0"
+    boolbase "^1.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
### Description
`nth-check` is @v1.0.2 and we needs @v2.0.1 to fix the CVE.
```
ubuntu@ip-172-31-55-237:~/work/OpenSearch-Dashboards$ yarn why nth-check
yarn why v1.22.19
[1/4] Why do we have the module "nth-check"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
warning Resolution field "shelljs@0.8.5" is incompatible with requested version "shelljs@^0.6.0"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "nth-check@1.0.2"
info Reasons this module exists
   - "_project_#cheerio#css-select" depends on it
   - Hoisted from "_project_#cheerio#css-select#nth-check"
info Disk size without dependencies: "24KB"
info Disk size with unique dependencies: "36KB"
info Disk size with transitive dependencies: "36KB"
info Number of shared dependencies: 1
Done in 1.02s.
```
Main is bumped via PR [here](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1422). As mentioned in the PR: `nth-check is a dependency of cheerio > css-select. Even though our dependency on cheerio@0.22.0 pulls in nth-check@~1.0.1, its signature hasn't changed* in nth-check@2.0.1 and a resolution to bump works. (*) The signature has changed but is backward compatible. `

Double checked and don't see breaking changes [here](https://github.com/fb55/nth-check/compare/v1.0.2...v2.1.1). Therefore, we should backport this PR.

Issue Resolve
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1081

Backport PR
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1422


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 