### PR TITLE
[CVE-2021-23382][1.x] Bump postcss from 8.2.10 to 8.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 🛡 Security
 
+- [CVE-2021-23382] Bump postcss from `8.2.10` to `8.2.13` ([#3739](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3739))
+
 ### 📈 Features/Enhancements
 
 - [Optimizer] Increase timeout waiting for the exiting of an optimizer worker ([#3193](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3193))

--- a/package.json
+++ b/package.json
@@ -458,7 +458,7 @@
     "nyc": "^14.1.1",
     "pixelmatch": "^5.1.0",
     "pngjs": "^3.4.0",
-    "postcss": "^8.2.10",
+    "postcss": "^8.2.13",
     "prettier": "^2.1.1",
     "prop-types": "^15.7.2",
     "react-grid-layout": "^0.16.2",

--- a/packages/osd-optimizer/package.json
+++ b/packages/osd-optimizer/package.json
@@ -33,7 +33,7 @@
     "node-sass": "sass/node-sass#v5",
     "normalize-path": "^3.0.0",
     "pirates": "^4.0.1",
-    "postcss": "^8.2.10",
+    "postcss": "^8.2.13",
     "rxjs": "^6.5.5",
     "source-map-support": "^0.5.19",
     "terser-webpack-plugin": "^2.1.2",

--- a/packages/osd-ui-framework/package.json
+++ b/packages/osd-ui-framework/package.json
@@ -54,7 +54,7 @@
     "keymirror": "0.1.1",
     "moment": "^2.24.0",
     "node-sass": "sass/node-sass#v5",
-    "postcss": "^8.2.10",
+    "postcss": "^8.2.13",
     "postcss-loader": "^3.0.0",
     "raw-loader": "^3.1.0",
     "react-dom": "^16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6303,7 +6303,7 @@ color@3.0.x:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
-colorette@^1.2.0, colorette@^1.2.2:
+colorette@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
@@ -15136,10 +15136,10 @@ nano-css@^5.2.1:
     stacktrace-js "^2.0.0"
     stylis "3.5.0"
 
-nanoid@^3.1.22:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
+nanoid@^3.3.4:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
 nanomatch@^1.2.9:
   version "1.2.9"
@@ -16558,6 +16558,16 @@ phin@^2.9.1:
   resolved "https://registry.yarnpkg.com/phin/-/phin-2.9.3.tgz#f9b6ac10a035636fb65dfc576aaaa17b8743125c"
   integrity sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==
 
+picocolors@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
+  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
@@ -16766,22 +16776,21 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2, postcss-value-parser@^
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
 postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.36"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.36.tgz#056f8cffa939662a8f5905950c07d5285644dfcb"
-  integrity sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==
+  version "7.0.39"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
   dependencies:
-    chalk "^2.4.2"
+    picocolors "^0.2.1"
     source-map "^0.6.1"
-    supports-color "^6.1.0"
 
-postcss@^8.2.10:
-  version "8.2.10"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.10.tgz#ca7a042aa8aff494b334d0ff3e9e77079f6f702b"
-  integrity sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==
+postcss@^8.2.13:
+  version "8.4.21"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.21.tgz#c639b719a57efc3187b13a1d765675485f4134f4"
+  integrity sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==
   dependencies:
-    colorette "^1.2.2"
-    nanoid "^3.1.22"
-    source-map "^0.6.1"
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -19180,6 +19189,11 @@ source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"


### PR DESCRIPTION
### Issue Resolve
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1094

### Description

This CVE requires to bump `postcss` to be `<7.0.36||>=8.0.0 <8.2.13`. `The package postcss versions before 7.0.36 or between 8.0.0 and 8.2.13 are vulnerable to Regular Expression Denial of Service (ReDoS) via getAnnotationURL() and loadAnnotation() in lib/previous-map.js. The vulnerable regexes are caused mainly by the sub-pattern /*\s* sourceMappingURL=(.*).` In 1.x we are using `postcss` under two versions, 8.2.10 and 7.0.36. 

```
ubuntu@ip-172-31-55-237:~/work/OpenSearch-Dashboards$ yarn why postcss
yarn why v1.22.19
[1/4] Why do we have the module "postcss"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
warning Resolution field "shelljs@0.8.5" is incompatible with requested version "shelljs@^0.6.0"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "postcss@8.2.10"
info Has been hoisted to "postcss"
info Reasons this module exists
   - "workspace-aggregator-ba40e46f-2bf0-45d1-a0c7-52702aefb59c" depends on it
   - Specified in "devDependencies"
   - Hoisted from "_project_#@osd#optimizer#postcss"
   - Hoisted from "_project_#@osd#ui-framework#postcss"
   - Hoisted from "_project_#postcss"
info Disk size without dependencies: "312KB"
info Disk size with unique dependencies: "1.25MB"
info Disk size with transitive dependencies: "1.25MB"
info Number of shared dependencies: 3
=> Found "postcss-loader#postcss@7.0.36"
info This module exists because "_project_#@osd#ui-framework#postcss-loader" depends on it.
info Disk size without dependencies: "684KB"
info Disk size with unique dependencies: "1.58MB"
info Disk size with transitive dependencies: "1.81MB"
info Number of shared dependencies: 7
=> Found "autoprefixer#postcss@7.0.36"
info This module exists because "_project_#@osd#optimizer#autoprefixer" depends on it.
info Disk size without dependencies: "684KB"
info Disk size with unique dependencies: "1.58MB"
info Disk size with transitive dependencies: "1.81MB"
info Number of shared dependencies: 7
=> Found "css-loader#postcss@7.0.36"
info This module exists because "_project_#@osd#ui-framework#css-loader" depends on it.
info Disk size without dependencies: "684KB"
info Disk size with unique dependencies: "1.58MB"
info Disk size with transitive dependencies: "1.81MB"
info Number of shared dependencies: 7
=> Found "icss-utils#postcss@7.0.36"
info This module exists because "_project_#@osd#ui-framework#css-loader#icss-utils" depends on it.
info Disk size without dependencies: "684KB"
info Disk size with unique dependencies: "1.58MB"
info Disk size with transitive dependencies: "1.81MB"
info Number of shared dependencies: 7
=> Found "postcss-modules-local-by-default#postcss@7.0.36"
info This module exists because "_project_#@osd#ui-framework#css-loader#postcss-modules-local-by-default" depends on it.
info Disk size without dependencies: "684KB"
info Disk size with unique dependencies: "1.58MB"
info Disk size with transitive dependencies: "1.81MB"
info Number of shared dependencies: 7
=> Found "postcss-modules-extract-imports#postcss@7.0.36"
info This module exists because "_project_#@osd#ui-framework#css-loader#postcss-modules-extract-imports" depends on it.
info Disk size without dependencies: "684KB"
info Disk size with unique dependencies: "1.58MB"
info Disk size with transitive dependencies: "1.81MB"
info Number of shared dependencies: 7
=> Found "postcss-modules-scope#postcss@7.0.36"
info This module exists because "_project_#@osd#ui-framework#css-loader#postcss-modules-scope" depends on it.
info Disk size without dependencies: "684KB"
info Disk size with unique dependencies: "1.58MB"
info Disk size with transitive dependencies: "1.81MB"
info Number of shared dependencies: 7
=> Found "postcss-modules-values#postcss@7.0.36"
info This module exists because "_project_#@osd#ui-framework#css-loader#postcss-modules-values" depends on it.
info Disk size without dependencies: "684KB"
info Disk size with unique dependencies: "1.58MB"
info Disk size with transitive dependencies: "1.81MB"
info Number of shared dependencies: 7
Done in 1.12s.
```
Since 7.0.36 is a safe version. We only need to bump 8.2.10 to 8.2.13, which seems no breaking changes by [comparing the two versions](https://github.com/postcss/postcss/compare/8.2.10...8.2.13).

 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 