### PR TITLE
[CVE-2022-48285][1.x] Bump jszip from 3.7.1 to 3.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [CVE-2022-25858] Bump terser from `4.8.0` to `4.8.1` ([#3726](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3726))
 - [CVE-2021-35065] Bump glob-parent from `6.0.0` to `6.0.2` ([#3742](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3742))
 - [CVE-2022-25851] Bump jpeg-js from `0.4.1` to `0.4.4` ([#3741](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3741))
+- [CVE-2022-48285] Bump jszip from `3.7.1` to `3.10.1` ([#3740](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3740))
 
 ### 📈 Features/Enhancements
 

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "**/jest-jasmine2": "npm:@amoo-miki/jest-jasmine2@26.4.2-rc.1",
     "**/jsonpointer": "^5.0.0",
     "**/json-schema": "^0.4.0",
+    "**/jszip": "^3.8.0",
     "**/kind-of": ">=6.0.3",
     "**/loader-utils": "^2.0.4",
     "**/lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "**/jest-jasmine2": "npm:@amoo-miki/jest-jasmine2@26.4.2-rc.1",
     "**/jsonpointer": "^5.0.0",
     "**/json-schema": "^0.4.0",
-    "**/jszip": "^3.8.0",
     "**/kind-of": ">=6.0.3",
     "**/loader-utils": "^2.0.4",
     "**/lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13550,7 +13550,7 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.4.1:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
 
-jszip@^3.2.2, jszip@^3.8.0:
+jszip@^3.2.2:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
   integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13550,15 +13550,15 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.4.1:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
 
-jszip@^3.2.2:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.7.1.tgz#bd63401221c15625a1228c556ca8a68da6fda3d9"
-  integrity sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==
+jszip@^3.2.2, jszip@^3.8.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
   dependencies:
     lie "~3.3.0"
     pako "~1.0.2"
     readable-stream "~2.3.6"
-    set-immediate-shim "~1.0.1"
+    setimmediate "^1.0.5"
 
 junk@^3.1.0:
   version "3.1.0"
@@ -18968,7 +18968,7 @@ set-harmonic-interval@^1.0.1:
   resolved "https://registry.yarnpkg.com/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz#e1773705539cdfb80ce1c3d99e7f298bb3995249"
   integrity sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==
 
-set-immediate-shim@^1.0.0, set-immediate-shim@~1.0.1:
+set-immediate-shim@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
   integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
@@ -18983,10 +18983,10 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 setprototypeof@1.1.0:
   version "1.1.0"


### PR DESCRIPTION
### Description
This CVE is caught in github. It is about that `loadAsync` in `jszip` before 3.8.0 allows Directory Traversal via a crafted ZIP archive. `jszip` is a dependency of `selenium-webdriver` . This CVE requires to bump `jszip` to 3.8.0+. In 1.x, we are currently using `jszip@3.7.1` .

```
ubuntu@ip-172-31-55-237:~/work/OpenSearch-Dashboards$ yarn why jszip
yarn why v1.22.19
[1/4] Why do we have the module "jszip"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
warning Resolution field "shelljs@0.8.5" is incompatible with requested version "shelljs@^0.6.0"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "jszip@3.7.1"
info Reasons this module exists
   - "_project_#selenium-webdriver" depends on it
   - Hoisted from "_project_#selenium-webdriver#jszip"
info Disk size without dependencies: "796KB"
info Disk size with unique dependencies: "1.93MB"
info Disk size with transitive dependencies: "2.21MB"
info Number of shared dependencies: 11
Done in 1.05s.
```
```
ubuntu@ip-172-31-55-237:~/work/OpenSearch-Dashboards$ yarn why selenium-webdriver
yarn why v1.22.19
[1/4] Why do we have the module "selenium-webdriver"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
warning Resolution field "shelljs@0.8.5" is incompatible with requested version "shelljs@^0.6.0"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "selenium-webdriver@4.0.0-alpha.7"
info Has been hoisted to "selenium-webdriver"
info Reasons this module exists
   - "workspace-aggregator-b86b8a47-7a5d-4547-95f7-e0849c232835" depends on it
   - Specified in "devDependencies"
   - Hoisted from "_project_#selenium-webdriver"
info Disk size without dependencies: "972KB"
info Disk size with unique dependencies: "1.79MB"
info Disk size with transitive dependencies: "3.52MB"
info Number of shared dependencies: 24
Done in 1.04s.
```
`selenium-webdriver` doesn’t actively upgrade `jszip` in [package.json](https://github.com/SeleniumHQ/selenium/blob/trunk/package.json), which is still `"^3.7.1"` and from [4.7.0](https://github.com/SeleniumHQ/selenium/blob/selenium-4.7.0/package-lock.json) they actually start to use `3.10.1` (package-lock). Since we are gradually remove all selenium tests. I think it is a bit waste of time to investigate the changes between "selenium-webdriver@4.0.0-alpha.7" and 4.7.0. 

Since there is [no breaking changes](https://github.com/Stuk/jszip/commits/v3.8.0) between 3.7.1 and 3.8.0 on `jszip`, We could just make a simple resolution.
 
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 