### PR TITLE
[Feature Anywhere] Fix visibleVisLayers ser/deser

### DIFF
--- a/src/plugins/vis_augmenter/public/test_constants.ts
+++ b/src/plugins/vis_augmenter/public/test_constants.ts
@@ -344,6 +344,19 @@ export const TEST_VIS_LAYERS_SINGLE_INVALID_BOUNDS = [
   },
 ];
 
+export const TEST_VIS_LAYERS_SINGLE_EMPTY_EVENTS = [
+  {
+    originPlugin: TEST_PLUGIN,
+    type: VisLayerTypes.PointInTimeEvents,
+    pluginResource: {
+      type: TEST_PLUGIN_RESOURCE_TYPE,
+      id: TEST_PLUGIN_RESOURCE_ID,
+      name: TEST_PLUGIN_RESOURCE_NAME,
+      urlPath: TEST_PLUGIN_RESOURCE_PATH,
+    },
+  },
+];
+
 export const TEST_VIS_LAYERS_SINGLE_ON_BOUNDS = [
   {
     originPlugin: TEST_PLUGIN,

--- a/src/plugins/vis_augmenter/public/vega/helpers.test.ts
+++ b/src/plugins/vis_augmenter/public/vega/helpers.test.ts
@@ -37,6 +37,7 @@ import {
   TEST_SPEC_SINGLE_VIS_LAYER,
   TEST_VIS_LAYERS_MULTIPLE,
   TEST_VIS_LAYERS_SINGLE,
+  TEST_VIS_LAYERS_SINGLE_EMPTY_EVENTS,
   TEST_VIS_LAYERS_SINGLE_INVALID_BOUNDS,
   TEST_VIS_LAYERS_SINGLE_ON_BOUNDS,
 } from '../test_constants';
@@ -81,11 +82,11 @@ describe('helpers', function () {
       const updatedConfig = enableVisLayersInSpecConfig({ config: baseConfig }, [
         pointInTimeEventsVisLayer,
       ]);
-      const expectedMap = new Map<VisLayerTypes, boolean>([
-        [VisLayerTypes.PointInTimeEvents, true],
-      ]);
+      const expectedArr = [
+        ...new Map<VisLayerTypes, boolean>([[VisLayerTypes.PointInTimeEvents, true]]),
+      ];
       // @ts-ignore
-      baseConfig.kibana.visibleVisLayers = expectedMap;
+      baseConfig.kibana.visibleVisLayers = expectedArr;
       expect(updatedConfig).toStrictEqual(baseConfig);
     });
     it('updates config with a valid and invalid VisLayer', function () {
@@ -98,11 +99,11 @@ describe('helpers', function () {
         pointInTimeEventsVisLayer,
         invalidVisLayer,
       ]);
-      const expectedMap = new Map<VisLayerTypes, boolean>([
-        [VisLayerTypes.PointInTimeEvents, true],
-      ]);
+      const expectedArr = [
+        ...new Map<VisLayerTypes, boolean>([[VisLayerTypes.PointInTimeEvents, true]]),
+      ];
       // @ts-ignore
-      baseConfig.kibana.visibleVisLayers = expectedMap;
+      baseConfig.kibana.visibleVisLayers = expectedArr;
       expect(updatedConfig).toStrictEqual(baseConfig);
     });
     it('does not update config if no valid VisLayer', function () {
@@ -113,7 +114,7 @@ describe('helpers', function () {
       };
       const updatedConfig = enableVisLayersInSpecConfig({ config: baseConfig }, [invalidVisLayer]);
       // @ts-ignore
-      baseConfig.kibana.visibleVisLayers = new Map<VisLayerTypes, boolean>();
+      baseConfig.kibana.visibleVisLayers = [...new Map<VisLayerTypes, boolean>()];
       expect(updatedConfig).toStrictEqual(baseConfig);
     });
     it('does not update config if empty VisLayer list', function () {
@@ -124,7 +125,7 @@ describe('helpers', function () {
       };
       const updatedConfig = enableVisLayersInSpecConfig({ config: baseConfig }, []);
       // @ts-ignore
-      baseConfig.kibana.visibleVisLayers = new Map<VisLayerTypes, boolean>();
+      baseConfig.kibana.visibleVisLayers = [...new Map<VisLayerTypes, boolean>()];
       expect(updatedConfig).toStrictEqual(baseConfig);
     });
   });
@@ -386,6 +387,19 @@ describe('helpers', function () {
           TEST_DATATABLE_NO_VIS_LAYERS,
           TEST_DIMENSIONS,
           TEST_VIS_LAYERS_SINGLE_INVALID_BOUNDS
+        )
+      ).toStrictEqual(TEST_DATATABLE_SINGLE_VIS_LAYER_EMPTY);
+    });
+    // below case should not happen since only VisLayers with a populated
+    // set of events should be passed from the plugins. but, if it does
+    // happen, we can handle it more gracefully instead of throwing an error
+    it('vis layer with empty events adds nothing to datatable', function () {
+      expect(
+        addPointInTimeEventsLayersToTable(
+          TEST_DATATABLE_NO_VIS_LAYERS,
+          TEST_DIMENSIONS,
+          // @ts-ignore
+          TEST_VIS_LAYERS_SINGLE_EMPTY_EVENTS
         )
       ).toStrictEqual(TEST_DATATABLE_SINGLE_VIS_LAYER_EMPTY);
     });

--- a/src/plugins/vis_augmenter/public/vega/helpers.ts
+++ b/src/plugins/vis_augmenter/public/vega/helpers.ts
@@ -26,7 +26,7 @@ import {
 } from '../';
 
 // Given any visLayers, create a map to indicate which VisLayer types are present.
-// Serialize to an array since ES6 Maps cannot be stringified.
+// Convert to an array since ES6 Maps cannot be stringified.
 export const enableVisLayersInSpecConfig = (spec: object, visLayers: VisLayers): {} => {
   const config = get(spec, 'config', { kibana: {} });
   const visibleVisLayers = new Map<VisLayerTypes, boolean>();

--- a/src/plugins/vis_augmenter/public/vega/helpers.ts
+++ b/src/plugins/vis_augmenter/public/vega/helpers.ts
@@ -25,6 +25,8 @@ import {
   VisLayerTypes,
 } from '../';
 
+// Given any visLayers, create a map to indicate which VisLayer types are present.
+// Serialize to an array since ES6 Maps cannot be stringified.
 export const enableVisLayersInSpecConfig = (spec: object, visLayers: VisLayers): {} => {
   const config = get(spec, 'config', { kibana: {} });
   const visibleVisLayers = new Map<VisLayerTypes, boolean>();
@@ -41,7 +43,7 @@ export const enableVisLayersInSpecConfig = (spec: object, visLayers: VisLayers):
     ...config,
     kibana: {
       ...config.kibana,
-      visibleVisLayers,
+      visibleVisLayers: [...visibleVisLayers],
     },
   };
 };
@@ -176,9 +178,7 @@ export const addPointInTimeEventsLayersToTable = (
       },
     });
 
-    if (augmentedTable.rows.length === 0) {
-      return false;
-    }
+    if (augmentedTable.rows.length === 0 || isEmpty(visLayer.events)) return false;
 
     // if only one row / one datapoint, put all events into this bucket
     if (augmentedTable.rows.length === 1) {

--- a/src/plugins/vis_type_vega/public/data_model/types.ts
+++ b/src/plugins/vis_type_vega/public/data_model/types.ts
@@ -32,6 +32,7 @@ import { SearchResponse, SearchParams } from 'elasticsearch';
 
 import { Filter } from 'src/plugins/data/public';
 import { DslQuery } from 'src/plugins/data/common';
+import { VisLayerTypes } from 'src/plugins/vis_augmenter/public';
 import { OpenSearchQueryParser } from './opensearch_query_parser';
 import { EmsFileParser } from './ems_file_parser';
 import { UrlParser } from './url_parser';
@@ -113,6 +114,7 @@ export interface OpenSearchDashboards {
   hideWarnings: boolean;
   type: string;
   renderer: Renderer;
+  visibleVisLayers?: Map<VisLayerTypes, boolean>;
 }
 
 export interface VegaSpec {

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.test.js
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.test.js
@@ -33,6 +33,7 @@ import { euiThemeVars } from '@osd/ui-shared-deps/theme';
 import { euiPaletteColorBlind } from '@elastic/eui';
 import { VegaParser } from './vega_parser';
 import { bypassExternalUrlCheck } from '../vega_view/vega_base_view';
+import { VisLayerTypes } from '../../../vis_augmenter/public';
 
 jest.mock('../services');
 
@@ -388,6 +389,25 @@ describe('VegaParser._parseConfig', () => {
     check({ config: { kibana: { a: 1 } } }, { a: 1 }, { config: {} })
   );
   test('_hostConfig', check({ _hostConfig: { a: 1 } }, { a: 1 }, {}, 1));
+  test(
+    'visibleVisLayers conversion to map',
+    check(
+      {
+        config: {
+          kibana: {
+            hideWarnings: true,
+            visibleVisLayers: [[VisLayerTypes.PointInTimeEvents, true]],
+          },
+        },
+      },
+      {
+        hideWarnings: true,
+        visibleVisLayers: new Map([[VisLayerTypes.PointInTimeEvents, true]]),
+      },
+      { config: {} },
+      0
+    )
+  );
 });
 
 describe('VegaParser._compileWithAutosize', () => {

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
@@ -405,6 +405,10 @@ The URL is an identifier only. OpenSearch Dashboards and your browser will never
             )
           );
         }
+        // deserializing the visibleVisLayers array -> map
+        if (result.visibleVisLayers !== undefined && Array.isArray(result.visibleVisLayers)) {
+          result.visibleVisLayers = new Map<VisLayerTypes, boolean>(result.visibleVisLayers);
+        }
       }
     }
     return result || {};

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
@@ -405,7 +405,7 @@ The URL is an identifier only. OpenSearch Dashboards and your browser will never
             )
           );
         }
-        // deserializing the visibleVisLayers array -> map
+        // Converting the visibleVisLayers array back to a map
         if (result.visibleVisLayers !== undefined && Array.isArray(result.visibleVisLayers)) {
           result.visibleVisLayers = new Map<VisLayerTypes, boolean>(result.visibleVisLayers);
         }


### PR DESCRIPTION
### Description
The change to using a `Map` for persisting visible `VisLayer`s in the vega spec config had a bug where during the string serialization/deserialization (necessary for passing through the expression functions), the `Map` obj could not be properly stringified which was leading to an empty `Map` when parsing in the `VegaParser`. This was causing no `VisLayer`s to be able to render.

This fixes that by converting the `Map` => array when serializing, and converting back to a `Map` when deserializing in the parser. 

Note another option could have been using a basic JS obj `{}` for persisting this, but that would limit us in not being able to use the `VisLayerTypes` enum as keys, and would need other conversion as well.

Also hardens a helper method by handling a case where `events` is undefined or empty, + a regression test for that.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 