### PR TITLE
Fix: Update button position when number of rows per page is large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Clean up and rebuild `@osd/pm` ([#3570](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3570))
 - [Vega] Add Filter custom label for opensearchDashboardsAddFilter ([#3640](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3640))
 - [Timeline] Fix y-axis label color in dark mode ([#3698](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3698))
-- [Table Visualization][bug] Fix data table rendering empty space ([#3797](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3797))
+- [Table Visualization] Fix table rendering empty unused space ([#3797](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3797))
 
 ### 🚞 Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Clean up and rebuild `@osd/pm` ([#3570](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3570))
 - [Vega] Add Filter custom label for opensearchDashboardsAddFilter ([#3640](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3640))
 - [Timeline] Fix y-axis label color in dark mode ([#3698](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3698))
+- [Table Visualization][bug] Fix data table rendering empty space ([#3797](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3797))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/vis_type_table/public/utils/use_pagination.ts
+++ b/src/plugins/vis_type_table/public/utils/use_pagination.ts
@@ -9,7 +9,7 @@ import { TableVisConfig } from '../types';
 export const usePagination = (visConfig: TableVisConfig, nRow: number) => {
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: visConfig.perPage || 10,
+    pageSize: Math.min(visConfig.perPage || 10, nRow),
   });
   const onChangeItemsPerPage = useCallback(
     (pageSize) => setPagination((p) => ({ ...p, pageSize, pageIndex: 0 })),
@@ -20,7 +20,7 @@ export const usePagination = (visConfig: TableVisConfig, nRow: number) => {
   ]);
 
   useEffect(() => {
-    const perPage = visConfig.perPage || 10;
+    const perPage = Math.min(visConfig.perPage || 10, nRow);
     const maxiPageIndex = Math.ceil(nRow / perPage) - 1;
     setPagination((p) => ({
       pageIndex: p.pageIndex > maxiPageIndex ? maxiPageIndex : p.pageIndex,


### PR DESCRIPTION
### Description
After the fix the table component no longer renders unused space for extra rows. Before the fix when the option max rows per page was larger than actual number of results, the table component was rendered with height that could fit max number of rows per page and not the actual number. Screenshot from the issue https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3756:
![image](https://user-images.githubusercontent.com/67782303/230426246-f4d152cc-7b74-4fa8-8cdb-1287b03cbff2.png)
The number of results in this screen is 50, while the max number of rows per page is 100. As the result, half of the table component is empty and the update button is pushed far below. I have checked the component from the docs in the sandbox and this is expected behavior. 
Therefore, to prevent this bug I assumed that we need to ensure that max number of rows is never larger than number of rows in resulting table. This fix does exactly that. The same case (50 resulting rows, 100 max number of rows), 
![image](https://user-images.githubusercontent.com/67782303/230427812-1244a9af-c780-4e6e-9b3d-74c9502cc8d0.png)
The fix is achieved by updating `usePagination` hook.
### Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3756

### Check List

- [ ] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
