### PR TITLE
[CCI] Fix bottom notification bar width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Table Visualization] Fix table rendering empty unused space ([#3797](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3797))
 - [Table Visualization] Fix data table not adjusting height on the initial load ([#3816](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3816))
 - Cleanup unused url ([#3847](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3847))
+- [BUG] Docked navigation impacts visibility of bottom bar component ([#3804](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3804))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/advanced_settings/public/management_app/_advanced_settings.scss
+++ b/src/plugins/advanced_settings/public/management_app/_advanced_settings.scss
@@ -80,3 +80,7 @@
 .osdBody--mgtAdvancedSettingsHasBottomBar .mgtPage__body {
   padding-bottom: $euiSizeXL * 2;
 }
+
+.euiBody--hasFlyout .euiBottomBar {
+  left: 320px !important;
+}


### PR DESCRIPTION
### Description

Fix the width of the bottom notification bar. 

It is not possible to override the width without `!important` because the `OuiBottomBar` component uses inline styles. We have the option of not using `!important` in our styles, but then we would have to remove the default inline styles in the `OuiBottomBar` component so we have more flexibility with the styles.

https://user-images.githubusercontent.com/17855243/230597250-6b18dcec-72af-44e5-846c-ef66902ff6f7.mov

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3336

### Check List

- [X] All tests pass
  - [X] `yarn test:jest`
  - [X] `yarn test:jest_integration`
  - [X] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
