### PR TITLE
[Console][Multiple Datasource]Fine tuned dev tool datasource selector UI

### DIFF
--- a/src/plugins/dev_tools/public/application.tsx
+++ b/src/plugins/dev_tools/public/application.tsx
@@ -154,51 +154,40 @@ function DevToolsWrapper({
 
   return (
     <main className="devApp">
-      <div>
-        <EuiFlexGroup gutterSize="none">
-          <EuiFlexItem>
-            <EuiTabs>
-              {devTools.map((currentDevTool) => (
-                <EuiToolTip content={currentDevTool.tooltipContent} key={currentDevTool.id}>
-                  <EuiTab
-                    disabled={currentDevTool.isDisabled()}
-                    isSelected={currentDevTool === activeDevTool}
-                    onClick={() => {
-                      if (!currentDevTool.isDisabled()) {
-                        updateRoute(`/${currentDevTool.id}`);
-                      }
-                    }}
-                  >
-                    {currentDevTool.title}
-                  </EuiTab>
-                </EuiToolTip>
-              ))}
-            </EuiTabs>
-          </EuiFlexItem>
-          {dataSourceEnabled ? (
-            <EuiFlexItem grow={false} className="dataSourceSelector">
-              <EuiComboBox
-                aria-label={i18n.translate('devTool.devToolWrapper.DataSourceComboBoxAriaLabel', {
-                  defaultMessage: 'Select a Data Source',
-                })}
-                placeholder={i18n.translate(
-                  'devTool.devToolWrapper.DataSourceComboBoxPlaceholder',
-                  {
-                    defaultMessage: 'Select a Data Source',
-                  }
-                )}
-                singleSelection={{ asPlainText: true }}
-                options={dataSources}
-                selectedOptions={selectedOptions}
-                onChange={onChange}
-                prepend="DataSource"
-                compressed
-                isDisabled={!dataSourceEnabled}
-              />
-            </EuiFlexItem>
-          ) : null}
-        </EuiFlexGroup>
-      </div>
+      <EuiTabs className="devAppTabs">
+        {devTools.map((currentDevTool) => (
+          <EuiToolTip content={currentDevTool.tooltipContent} key={currentDevTool.id}>
+            <EuiTab
+              disabled={currentDevTool.isDisabled()}
+              isSelected={currentDevTool === activeDevTool}
+              onClick={() => {
+                if (!currentDevTool.isDisabled()) {
+                  updateRoute(`/${currentDevTool.id}`);
+                }
+              }}
+            >
+              {currentDevTool.title}
+            </EuiTab>
+          </EuiToolTip>
+        ))}
+        <div className="devAppDataSourcePicker">
+          <EuiComboBox
+            aria-label={i18n.translate('devTool.devToolWrapper.DataSourceComboBoxAriaLabel', {
+              defaultMessage: 'Select a Data Source',
+            })}
+            placeholder={i18n.translate('devTool.devToolWrapper.DataSourceComboBoxPlaceholder', {
+              defaultMessage: 'Select a Data Source',
+            })}
+            singleSelection={{ asPlainText: true }}
+            options={dataSources}
+            selectedOptions={selectedOptions}
+            onChange={onChange}
+            prepend="DataSource"
+            compressed
+            isDisabled={!dataSourceEnabled}
+          />
+        </div>
+      </EuiTabs>
 
       <div
         className="devApp__container"

--- a/src/plugins/dev_tools/public/application.tsx
+++ b/src/plugins/dev_tools/public/application.tsx
@@ -170,23 +170,25 @@ function DevToolsWrapper({
             </EuiTab>
           </EuiToolTip>
         ))}
-        <div className="devAppDataSourcePicker">
-          <EuiComboBox
-            aria-label={i18n.translate('devTool.devToolWrapper.DataSourceComboBoxAriaLabel', {
-              defaultMessage: 'Select a Data Source',
-            })}
-            placeholder={i18n.translate('devTool.devToolWrapper.DataSourceComboBoxPlaceholder', {
-              defaultMessage: 'Select a Data Source',
-            })}
-            singleSelection={{ asPlainText: true }}
-            options={dataSources}
-            selectedOptions={selectedOptions}
-            onChange={onChange}
-            prepend="DataSource"
-            compressed
-            isDisabled={!dataSourceEnabled}
-          />
-        </div>
+        {dataSourceEnabled ? (
+          <div className="devAppDataSourcePicker">
+            <EuiComboBox
+              aria-label={i18n.translate('devTool.devToolWrapper.DataSourceComboBoxAriaLabel', {
+                defaultMessage: 'Select a Data Source',
+              })}
+              placeholder={i18n.translate('devTool.devToolWrapper.DataSourceComboBoxPlaceholder', {
+                defaultMessage: 'Select a Data Source',
+              })}
+              singleSelection={{ asPlainText: true }}
+              options={dataSources}
+              selectedOptions={selectedOptions}
+              onChange={onChange}
+              prepend="DataSource"
+              compressed
+              isDisabled={!dataSourceEnabled}
+            />
+          </div>
+        ) : null}
       </EuiTabs>
 
       <div

--- a/src/plugins/dev_tools/public/index.scss
+++ b/src/plugins/dev_tools/public/index.scss
@@ -22,7 +22,13 @@
   flex-grow: 1;
 }
 
-.dataSourceSelector {
-  margin: 5px 10px 5px 5px;
+.devAppDataSourcePicker {
+  margin: 7px 8px 0 0;
   min-width: 400px;
+}
+
+.devAppTabs {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
 }


### PR DESCRIPTION
### Description

[Console][Multiple Datasource]Fine tuned dev tool datasource selector UI

Coming from @KrooshalUX 's feedback https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3754#issuecomment-1499715892. Tuned the UI to make it look nicer, while not breaking the pattern of other dev tool registered plugins

![image](https://user-images.githubusercontent.com/32652829/230672737-37c2dc4e-66a9-4db3-bc8e-1c7f53bcfce6.png)



### Issues Resolved

<!-- List any issues this PR will resolve. -->
<!-- Example: closes #1234 -->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
