### PR TITLE
Fix: Data Table rendering only in a small scrollable portion of the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Clean up and rebuild `@osd/pm` ([#3570](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3570))
 - [Vega] Add Filter custom label for opensearchDashboardsAddFilter ([#3640](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3640))
 - [Timeline] Fix y-axis label color in dark mode ([#3698](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3698))
+- [Table Visualization] Fix data table not adjusting height on the initial load ([#3816](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3816))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/vis_type_table/public/components/table_vis_app.scss
+++ b/src/plugins/vis_type_table/public/components/table_vis_app.scss
@@ -1,8 +1,15 @@
+.visTable {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 0;
+  overflow: auto;
+}
+
 .visTable__group {
   padding: $euiSizeS;
   margin-bottom: $euiSizeL;
 
-  > h3 {
+  >h3 {
     text-align: center;
   }
 }

--- a/src/plugins/vis_type_table/public/components/table_vis_app.scss
+++ b/src/plugins/vis_type_table/public/components/table_vis_app.scss
@@ -9,7 +9,7 @@
   padding: $euiSizeS;
   margin-bottom: $euiSizeL;
 
-  >h3 {
+  > h3 {
     text-align: center;
   }
 }


### PR DESCRIPTION
### Description
Makes table component adjust its height on initial load. Before that it had fixed height on first load, resulting in table being rendered only in a small scrollable portion of the screen.

### Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3737

### Check List

- [ ] All tests pass
  - [X] `yarn test:jest`
  - [X] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
