### PR TITLE
Remove KUI usage in home first step

### DIFF
--- a/src/plugins/home/public/application/components/tutorial/number_parameter.js
+++ b/src/plugins/home/public/application/components/tutorial/number_parameter.js
@@ -30,6 +30,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { EuiFieldNumber, EuiFormRow } from '@elastic/eui';
 
 export function NumberParameter({ id, label, value, setParameter }) {
   const handleChange = (evt) => {
@@ -37,20 +38,13 @@ export function NumberParameter({ id, label, value, setParameter }) {
   };
 
   return (
-    <div className="visEditorSidebar__formRow">
-      <label className="visEditorSidebar__formLabel" htmlFor={id}>
-        {label}
-      </label>
-      <div className="visEditorSidebar__formControl kuiFieldGroupSection--wide">
-        <input
-          className="kuiTextInput"
-          type="number"
-          value={value}
-          onChange={handleChange}
-          id={id}
-        />
-      </div>
-    </div>
+    <EuiFormRow label={label}>
+      <EuiFieldNumber
+        value={value}
+        onChange={handleChange}
+        fullWidth
+      />
+  </EuiFormRow>
   );
 }
 

--- a/src/plugins/home/public/application/components/tutorial/string_parameter.js
+++ b/src/plugins/home/public/application/components/tutorial/string_parameter.js
@@ -30,6 +30,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { EuiFieldText, EuiFormRow } from '@elastic/eui';
 
 export function StringParameter({ id, label, value, setParameter }) {
   const handleChange = (evt) => {
@@ -37,12 +38,9 @@ export function StringParameter({ id, label, value, setParameter }) {
   };
 
   return (
-    <div className="visEditorSidebar__formRow">
-      <label className="visEditorSidebar__formLabel">{label}</label>
-      <div className="visEditorSidebar__formControl kuiFieldGroupSection--wide">
-        <input className="kuiTextInput" type="text" value={value} onChange={handleChange} />
-      </div>
-    </div>
+    <EuiFormRow label={label}>
+        <EuiFieldText value={value} onChange={handleChange} />
+  </EuiFormRow>
   );
 }
 


### PR DESCRIPTION
### Description
Home plugin uses a couple .kui* namespaced classes.
This PR replaces kui namespaced classes with OUI.



### Issues Resolved

fixes #3828

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
