### PR TITLE
Add internal server plugin for stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .signing-config.json
 .ackrc
 /.opensearch
+/.heap_snapshots
 /.chromium
 /package.json.bak
 .DS_Store

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -240,3 +240,6 @@
 
 # Set the value of this setting to false to hide the help menu link to the OpenSearch Dashboards user survey
 # opensearchDashboards.survey.url: "https://survey.opensearch.org"
+
+# Set the value of this setting to true to enable internal app stats. Use with caution.
+# internal.enabled: true

--- a/src/plugins/internal/README.md
+++ b/src/plugins/internal/README.md
@@ -1,0 +1,11 @@
+# internal
+
+A OpenSearch Dashboards plugin
+
+---
+
+## Development
+
+See the [OpenSearch Dashboards contributing
+guide](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/CONTRIBUTING.md) for instructions
+setting up your development environment.

--- a/src/plugins/internal/common/index.ts
+++ b/src/plugins/internal/common/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const PLUGIN_ID = 'internal';
+export const PLUGIN_NAME = 'internal';

--- a/src/plugins/internal/config.ts
+++ b/src/plugins/internal/config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema, TypeOf } from '@osd/config-schema';
+
+export const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: false }),
+});
+
+export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/src/plugins/internal/opensearch_dashboards.json
+++ b/src/plugins/internal/opensearch_dashboards.json
@@ -1,0 +1,9 @@
+{
+  "id": "internal",
+  "version": "1.0.0",
+  "opensearchDashboardsVersion": "opensearchDashboards",
+  "server": true,
+  "ui": false,
+  "requiredPlugins": ["navigation"],
+  "optionalPlugins": []
+}

--- a/src/plugins/internal/server/index.ts
+++ b/src/plugins/internal/server/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PluginConfigDescriptor, PluginInitializerContext } from '../../../core/server';
+import { ConfigSchema, configSchema } from '../config';
+import { InternalPlugin } from './plugin';
+
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new InternalPlugin(initializerContext);
+}
+
+export { InternalPluginSetup, InternalPluginStart } from './types';
+
+export const config: PluginConfigDescriptor<ConfigSchema> = {
+  schema: configSchema,
+};

--- a/src/plugins/internal/server/plugin.ts
+++ b/src/plugins/internal/server/plugin.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  PluginInitializerContext,
+  CoreSetup,
+  CoreStart,
+  Plugin,
+  Logger,
+} from '../../../core/server';
+
+import { InternalPluginSetup, InternalPluginStart } from './types';
+import { registerHeapRoute } from './routes';
+
+export class InternalPlugin implements Plugin<InternalPluginSetup, InternalPluginStart> {
+  private readonly logger: Logger;
+
+  constructor(initializerContext: PluginInitializerContext) {
+    this.logger = initializerContext.logger.get();
+  }
+
+  public setup(core: CoreSetup) {
+    this.logger.debug('internal: Setup');
+    const router = core.http.createRouter();
+
+    registerHeapRoute(router);
+
+    return {};
+  }
+
+  public start(_core: CoreStart) {
+    this.logger.debug('internal: Started');
+    return {};
+  }
+
+  public stop() {}
+}

--- a/src/plugins/internal/server/routes/heap.ts
+++ b/src/plugins/internal/server/routes/heap.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import moment from 'moment';
+
+import {
+  getHeapStatistics,
+  getHeapSpaceStatistics,
+  getHeapCodeStatistics,
+  writeHeapSnapshot,
+} from 'node:v8';
+import { createReadStream } from 'fs';
+import { Stream } from 'stream';
+import { IRouter } from 'opensearch-dashboards/server';
+
+const SNAPSHOT_BASE_PATH = '.heap_snapshots';
+
+export function registerHeapRoute(router: IRouter) {
+  router.get(
+    {
+      path: '/api/internal/heap/stats',
+      validate: false,
+    },
+    async (context, request, response) => {
+      const stats = getHeapStatistics();
+      return response.ok({
+        body: {
+          heap: stats,
+        },
+      });
+    }
+  );
+
+  router.get(
+    {
+      path: '/api/internal/heap/snapshot',
+      validate: false,
+    },
+    async (context, request, response) => {
+      const filename = `${moment.utc().format('YYYY-MM-DD-HH-mm-ss')}-${process.pid}.heapsnapshot`;
+      const path = writeHeapSnapshot(`${SNAPSHOT_BASE_PATH}/${filename}`);
+
+      const stream = new Stream.PassThrough();
+      createReadStream(path).pipe(stream);
+      return response.ok({
+        body: {
+          heap_snapshot: stream,
+        },
+      });
+    }
+  );
+
+  router.get(
+    {
+      path: '/api/internal/heap/space/stats',
+      validate: false,
+    },
+    async (context, request, response) => {
+      const stats = getHeapSpaceStatistics();
+      return response.ok({
+        body: {
+          heap_space: stats,
+        },
+      });
+    }
+  );
+
+  router.get(
+    {
+      path: '/api/internal/heap/code/stats',
+      validate: false,
+    },
+    async (context, request, response) => {
+      const stats = getHeapCodeStatistics();
+      return response.ok({
+        body: {
+          heap_code: stats,
+        },
+      });
+    }
+  );
+}

--- a/src/plugins/internal/server/routes/index.ts
+++ b/src/plugins/internal/server/routes/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { registerHeapRoute } from './heap';

--- a/src/plugins/internal/server/types.ts
+++ b/src/plugins/internal/server/types.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface InternalPluginSetup {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface InternalPluginStart {}


### PR DESCRIPTION
### Description

Add the internal APIs disabled by default
`/api/internal/heap/stats`
`/api/internal/heap/snapshot`
`/api/internal/heap/space/stats`
`/api/internal/heap/code/stats`

The routes can changed based on what we would like.

This is diff than the ops collector since it's not tracking over time. It is to get current stats at anytime.
### Issues Resolved
Resolves: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3588

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
