### PR TITLE
[BUG][Dashboard listing] push to history if dashboard otherwise nav

### DIFF
--- a/src/plugins/dashboard/public/application/legacy_app.js
+++ b/src/plugins/dashboard/public/application/legacy_app.js
@@ -163,11 +163,19 @@ export function initDashboardApp(app, deps) {
             };
           };
 
-          $scope.editItem = ({ editUrl }) => {
-            history.push(editUrl);
+          $scope.editItem = ({ appId, editUrl }) => {
+            if (appId === 'dashboard') {
+              history.push(editUrl);
+            } else {
+              deps.core.application.navigateToUrl(editUrl);
+            }
           };
-          $scope.viewItem = ({ viewUrl }) => {
-            history.push(deps.addBasePath(viewUrl));
+          $scope.viewItem = ({ appId, viewUrl }) => {
+            if (appId === 'dashboard') {
+              history.push(viewUrl);
+            } else {
+              deps.core.application.navigateToUrl(viewUrl);
+            }
           };
           $scope.delete = (dashboards) => {
             const ids = dashboards.map((d) => ({ id: d.id, appId: d.appId }));

--- a/src/plugins/dashboard/public/application/listing/create_button.test.tsx
+++ b/src/plugins/dashboard/public/application/listing/create_button.test.tsx
@@ -57,7 +57,7 @@ describe('create button with props', () => {
     expect(createButtons.length).toBe(0);
     const createDropdown = findTestSubject(component, 'createMenuDropdown');
     createDropdown.simulate('click');
-    const contextMenus = findTestSubject(component, 'contextMenuItem');
+    const contextMenus = findTestSubject(component, 'contextMenuItem-test');
     expect(contextMenus.length).toBe(2);
     expect(contextMenus.at(0).prop('href')).toBe('test1');
   });

--- a/src/plugins/dashboard/public/application/listing/create_button.tsx
+++ b/src/plugins/dashboard/public/application/listing/create_button.tsx
@@ -38,7 +38,7 @@ const CreateButton = (props: CreateButtonProps) => {
         <EuiContextMenuItem
           key={provider.savedObjectsType}
           href={provider.createUrl}
-          data-test-subj="contextMenuItem"
+          data-test-subj={`contextMenuItem-${provider.appId}`}
         >
           {provider.createLinkText}
         </EuiContextMenuItem>

--- a/test/plugin_functional/config.ts
+++ b/test/plugin_functional/config.ts
@@ -52,6 +52,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       require.resolve('./test_suites/doc_views_links'),
       require.resolve('./test_suites/application_links'),
       require.resolve('./test_suites/data_plugin'),
+      require.resolve('./test_suites/dashboard_listing_plugin'),
     ],
     services: {
       ...functionalConfig.get('services'),

--- a/test/plugin_functional/plugins/dashboard_listing_test_plugin/opensearch_dashboards.json
+++ b/test/plugin_functional/plugins/dashboard_listing_test_plugin/opensearch_dashboards.json
@@ -1,0 +1,9 @@
+{
+  "id": "dashboard_listing_test_plugin",
+  "version": "0.0.1",
+  "opensearchDashboardsVersion": "opensearchDashboards",
+  "configPath": ["dashboard_listing_test_plugin"],
+  "server": false,
+  "ui": true,
+  "requiredPlugins": ["dashboard"]
+}

--- a/test/plugin_functional/plugins/dashboard_listing_test_plugin/package.json
+++ b/test/plugin_functional/plugins/dashboard_listing_test_plugin/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dashboard_listing_test_plugin",
+  "version": "1.0.0",
+  "main": "target/test/plugin_functional/plugins/dashboard_listing_test_plugin",
+  "opensearchDashboards": {
+    "version": "opensearchDashboards",
+    "templateVersion": "1.0.0"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
+  },
+  "devDependencies": {
+    "typescript": "4.0.2"
+  }
+}

--- a/test/plugin_functional/plugins/dashboard_listing_test_plugin/public/index.ts
+++ b/test/plugin_functional/plugins/dashboard_listing_test_plugin/public/index.ts
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { PluginInitializer } from 'opensearch-dashboards/public';
+import {
+  DashboardListingTestPlugin,
+  DashboardListingTestPluginSetup,
+  DashboardListingTestPluginStart,
+} from './plugin';
+
+export const plugin: PluginInitializer<
+  DashboardListingTestPluginSetup,
+  DashboardListingTestPluginStart
+> = () => new DashboardListingTestPlugin();

--- a/test/plugin_functional/plugins/dashboard_listing_test_plugin/public/plugin.tsx
+++ b/test/plugin_functional/plugins/dashboard_listing_test_plugin/public/plugin.tsx
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import * as React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { Router, Switch, Route, Link } from 'react-router-dom';
+import { CoreSetup, Plugin } from 'opensearch-dashboards/public';
+
+export class DashboardListingTestPlugin
+  implements Plugin<DashboardListingTestPluginSetup, DashboardListingTestPluginStart> {
+  public setup(core: CoreSetup, setupDeps: SetupDependencies) {
+    const ID = 'dashboard_listing_test_plugin';
+    const BASE_URL = core.http.basePath.prepend(`/app/${ID}#`);
+    setupDeps.dashboard.registerDashboardProvider({
+      appId: ID,
+      savedObjectsType: 'dashboardTest',
+      savedObjectsName: 'Dashboard Test',
+      editUrlPathFn: (obj: SavedObject) => `${BASE_URL}/${obj.id}/edit`,
+      viewUrlPathFn: (obj: SavedObject) => `${BASE_URL}/${obj.id}`,
+      createLinkText: 'Test Dashboard',
+      createSortText: 'Test Dashboard',
+      createUrl: `${BASE_URL}/create`,
+    });
+
+    core.application.register({
+      id: ID,
+      title: 'Dashboard Listing Test Plugin',
+      appRoute: `app/${ID}`,
+      async mount(context, { element }) {
+        render(
+          <h1 data-test-subj="dashboardListingTestHeader">Dashboard Listing Test Header</h1>,
+          element
+        );
+
+        return () => unmountComponentAtNode(element);
+      },
+    });
+  }
+
+  public start() {}
+  public stop() {}
+}
+
+export type DashboardListingTestPluginSetup = ReturnType<DashboardListingTestPlugin['setup']>;
+export type DashboardListingTestPluginStart = ReturnType<DashboardListingTestPlugin['start']>;

--- a/test/plugin_functional/plugins/dashboard_listing_test_plugin/tsconfig.json
+++ b/test/plugin_functional/plugins/dashboard_listing_test_plugin/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./target",
+    "skipLibCheck": true
+  },
+  "include": [
+    "index.ts",
+    "public/**/*.ts",
+    "public/**/*.tsx",
+    "../../../../typings/**/*",
+  ],
+  "exclude": [],
+  "references": [
+    { "path": "../../../../src/core/tsconfig.json" }
+  ]
+}

--- a/test/plugin_functional/test_suites/dashboard_listing_plugin/dashboard_listing_plugin.ts
+++ b/test/plugin_functional/test_suites/dashboard_listing_plugin/dashboard_listing_plugin.ts
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import url from 'url';
+import expect from '@osd/expect';
+
+const getPathWithHash = (absoluteUrl: string) => {
+  const parsed = url.parse(absoluteUrl);
+  return `${parsed.path}${parsed.hash ?? ''}`;
+};
+
+export default function ({ getService, getPageObjects }) {
+  const testSubjects = getService('testSubjects');
+  const PageObjects = getPageObjects(['common', 'dashboard', 'header']);
+  const browser = getService('browser');
+  const listingTable = getService('listingTable');
+  const find = getService('find');
+
+  describe('dashboard listing plugin', function describeIndexTests() {
+    const dashboardName = 'Dashboard Test';
+
+    before(async () => {
+      await PageObjects.dashboard.initTests({
+        opensearchDashboardsIndex: '../functional/fixtures/opensearch_archiver/dashboard/legacy',
+      });
+      await PageObjects.dashboard.clickCreateDashboardPrompt();
+      await PageObjects.dashboard.saveDashboard('default');
+      await PageObjects.dashboard.gotoDashboardLandingPage();
+    });
+
+    it('should be able to navigate to create a dashboard', async () => {
+      await testSubjects.click('createMenuDropdown');
+      await testSubjects.click('contextMenuItem-dashboard');
+      await PageObjects.dashboard.saveDashboard(dashboardName);
+
+      await PageObjects.dashboard.gotoDashboardLandingPage();
+      await listingTable.searchAndExpectItemsCount('dashboard', dashboardName, 1);
+    });
+
+    it('should be able to navigate to view dashboard', async () => {
+      await listingTable.clickItemLink('dashboard', dashboardName);
+      await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+      await PageObjects.dashboard.getIsInViewMode();
+      await PageObjects.dashboard.gotoDashboardLandingPage();
+    });
+
+    it('should be able to navigate to edit dashboard', async () => {
+      await listingTable.searchForItemWithName(dashboardName);
+      const editBttn = await find.allByCssSelector('.euiToolTipAnchor');
+      await editBttn[0].click();
+      await PageObjects.dashboard.clickCancelOutOfEditMode();
+      await PageObjects.dashboard.gotoDashboardLandingPage();
+    });
+
+    it('should be able to navigate to create a test dashboard', async () => {
+      await testSubjects.click('createMenuDropdown');
+      await testSubjects.click('contextMenuItem-dashboard_listing_test_plugin');
+      expect(getPathWithHash(await browser.getCurrentUrl())).to.eql(
+        '/app/dashboard_listing_test_plugin#/create'
+      );
+    });
+  });
+}

--- a/test/plugin_functional/test_suites/dashboard_listing_plugin/index.ts
+++ b/test/plugin_functional/test_suites/dashboard_listing_plugin/index.ts
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+export default function ({ getService, loadTestFile }) {
+  const browser = getService('browser');
+  const opensearchArchiver = getService('opensearchArchiver');
+
+  async function loadLogstash() {
+    await browser.setWindowSize(1200, 900);
+    await opensearchArchiver.loadIfNeeded(
+      '../functional/fixtures/opensearch_archiver/logstash_functional'
+    );
+  }
+
+  async function unloadLogstash() {
+    await opensearchArchiver.unload(
+      '../functional/fixtures/opensearch_archiver/logstash_functional'
+    );
+  }
+
+  describe('dashboard listing plugin', () => {
+    before(loadLogstash);
+    after(unloadLogstash);
+
+    loadTestFile(require.resolve('./dashboard_listing_plugin'));
+  });
+}


### PR DESCRIPTION
### Description

History push will just to the current route. However, dashboardsProvider was implemented with the expectation that it was a different app.

So when a plugin registered it was attempting to navigate to `app/dashboard#/app/{url}`

### Issues Resolved

n/a

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
