### PR TITLE
Use `exec` in the CLI shell scripts to prevent new process creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `styled-components` from 5.3.5 to 5.3.9 ([#3678](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3678))
 - Bump `js-yaml` from 3.14.0 to 4.1.0 ([#3770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3770))
 - Bump `oui` from `1.0.0` to `1.1.1` ([#3884](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3884))
+- Use `exec` in the CLI shell scripts to prevent new process creation ([#3955](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3955))
 - Adding @ZilongX and @Flyingliuhub as maintainers. ([#4137](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4137))
 
 ### 🪛 Refactoring

--- a/scripts/use_node
+++ b/scripts/use_node
@@ -91,7 +91,7 @@ fi
 
 # If a file path was provided for execution, prefix with OSD_HOME; use relative paths to avoid the need for this.
 if [ ! -z "$OSD_USE_NODE_JS_FILE_PATH" ]; then
-  NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS" "${NODE}" "${OSD_HOME}${OSD_USE_NODE_JS_FILE_PATH}" "${@}"
+  NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS" exec "${NODE}" "${OSD_HOME}${OSD_USE_NODE_JS_FILE_PATH}" "${@}"
 elif [ $# -ne 0 ]; then
-  NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS" "${NODE}" "${@}"
+  NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS" exec "${NODE}" "${@}"
 fi

--- a/src/dev/build/tasks/bin/scripts/opensearch-dashboards
+++ b/src/dev/build/tasks/bin/scripts/opensearch-dashboards
@@ -28,4 +28,4 @@ done
 # Get an absolute path for OSD_HOME
 OSD_HOME="$(cd "$(dirname "${SCRIPT}")/.."; pwd)"
 
-OSD_NODE_OPTS_PREFIX="--no-warnings --max-http-header-size=65536" OSD_USE_NODE_JS_FILE_PATH=/src/cli/dist NODE_ENV=production ${OSD_HOME}/bin/use_node "${@}"
+OSD_NODE_OPTS_PREFIX="--no-warnings --max-http-header-size=65536" OSD_USE_NODE_JS_FILE_PATH=/src/cli/dist NODE_ENV=production exec ${OSD_HOME}/bin/use_node "${@}"

--- a/src/dev/build/tasks/bin/scripts/opensearch-dashboards-plugin
+++ b/src/dev/build/tasks/bin/scripts/opensearch-dashboards-plugin
@@ -28,4 +28,4 @@ done
 # Get an absolute path for OSD_HOME
 OSD_HOME="$(cd "$(dirname "${SCRIPT}")/.."; pwd)"
 
-OSD_NODE_OPTS_PREFIX="--no-warnings" OSD_USE_NODE_JS_FILE_PATH=/src/cli_plugin/dist NODE_ENV=production ${OSD_HOME}/bin/use_node "${@}"
+OSD_NODE_OPTS_PREFIX="--no-warnings" OSD_USE_NODE_JS_FILE_PATH=/src/cli_plugin/dist NODE_ENV=production exec ${OSD_HOME}/bin/use_node "${@}"


### PR DESCRIPTION
### Description

OSD 2.6 in prior used `exec` in the CLI scripts to invoke `node`; this was removed when `use_node` was introduced. This change reintroduces `exec` which will prevent new processes from being created.

`exec` executes a command that completely replaces the current process where the current shell process is destroyed. When you exec a command, it replaces bash entirely — no new process is forked, no new PID is created, and all memory controlled by bash is destroyed and overwritten ([ref](https://www.computerhope.com/unix/bash/exec.htm)). This is useful for when the `bin` file calls `use_node` who then calls `node`; instead of having 3 PIDs to check for health, 2 of which will be doing nothing, `exec` allows `use_node` to replace the `bin` script and then `node` to replace the `use_node`, leaving us with just one PID.

### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
