### PR TITLE
[CI][Perf] automate tests and calling stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ trash
 target
 /build
 /bwc_tmp
+/perf_tmp
 .jruby
 .idea
 *.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Upgrade yarn version to be compatible with @openearch-project/opensearch ([#3443](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3443))
 - [CI] Reduce redundancy by using matrix strategy on Windows and Linux workflows ([#3514](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3514))
 - Add an achievement badger to the PR ([#3721](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3721))
+- [CI] Add performance tests scripts ([#3958](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3958))
 
 ### 📝 Documentation
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,6 +7,7 @@ Overview
     - [Integration tests](#integration-tests)
     - [Functional tests](#functional-tests)
     - [Backwards Compatibility tests](#backwards-compatibility-tests)
+    - [Performance Tests](#performance-tests)
     - [Additional checks](#additional-checks)
 - [Writing Tests](#writing-tests)
 - [Continuous Integration](#continuous-integration)
@@ -77,6 +78,26 @@ To generate test data that will be utilized for backwards compatibility tests:
 `yarn test:bwc -o [test path to opensearch.tar.gz] -d [test path to opensearch-dashboards.tar.gz] -g true`
 
 This will create an archive of the data based on the OpenSearch Dashboards version you have provided. For example, if a tarball of 2.0.0 was passed then an `osd-2.0.0.zip` will be created. This command is intended to be executed when needed per a version. For example, when end-users cannot migrate directly from `vPrevious` to `vNext`. If `osd-vCurrent.zip` does not exist, then this command be ran and the output sourced controlled for future use.
+
+### Performance tests
+To run all the performance tests on OpenSearch Dashboards without security:
+
+`yarn test:perf -o [test path to opensearch.tar.gz] -d [test path to opensearch-dashboards.tar.gz]`
+
+To run all the performance tests on OpenSearch Dashboards with security, pass the security parameter to the test:
+
+`yarn test:perf -o [test path to opensearch.tar.gz] -d [test path to opensearch-dashboards.tar.gz] -s true`
+
+To run specific tests, pass a CSV cypress tests to run:
+
+`yarn test:perf -o [test path to opensearch.tar.gz] -d [test path to opensearch-dashboards.tar.gz] -t "test1,test2"`
+
+To upload test results to a running OpenSearch Cluster:
+
+`yarn test:perf -u true`
+
+This will take the results produced by a previous performance test run and index the data into `osd-stats-$OSD_VERSION`.
+Requires a running version of OpenSearch.
 
 ### Additional checks
 Make sure you run lint checker before submitting a pull request. To run lint checker:

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "opensearch": "scripts/use_node scripts/opensearch",
     "test": "grunt test",
     "test:bwc": "./scripts/bwctest_osd.sh",
+    "test:perf": "./scripts/perftest_osd.sh",
     "test:jest": "scripts/use_node scripts/jest",
     "test:jest:coverage": "scripts/use_node scripts/jest --coverage",
     "test:jest:ci": "scripts/use_node scripts/jest --ci --colors --runInBand",

--- a/perftest.sh
+++ b/perftest.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Any modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+#
+
+set -e
+
+DEFAULT_TESTS="core-opensearch-dashboards/opensearch-dashboards/*.js"
+
+function usage() {
+    echo ""
+    echo "This script is used to run bwc tests on a remote OpenSearch/Dashboards cluster."
+    echo "--------------------------------------------------------------------------"
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Required arguments:"
+    echo -e "-d DASHBOARDS\t, Specify the url of the build/dist of OpenSearch Dashboards"
+    echo ""
+    echo "Optional arguments:"
+    echo -e "-o OPENSEARCH\t, Specify the url of the build/dist of OpenSearch"
+    echo -e "-b BIND_ADDRESS\t, defaults to localhost | 127.0.0.1, can be changed to any IP or domain name for the cluster location."
+    echo -e "-p BIND_PORT\t, defaults to 9200 or 5601 depends on OpenSearch or Dashboards, can be changed to any port for the cluster location."
+    echo -e "-s SECURITY_ENABLED\t(true | false), defaults to true. Specify the OpenSearch/Dashboards have security enabled or not."
+    echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
+    echo -e "-u UPLOAD_RESULTS\t(true | false), defaults to false. Upload stats results from perf_tmp to running OpenSearch"
+    echo -e "-t TESTS\t, defaults to core tests. Specify tests in cypress/integration folder as a CSV to execute tests."
+    echo -e "-h\tPrint this message."
+    echo "--------------------------------------------------------------------------"
+}
+
+while getopts ":h:b:p:s:c:u:t:o:d:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        b)
+            BIND_ADDRESS=$OPTARG
+            ;;
+        p)
+            BIND_PORT=$OPTARG
+            ;;
+        s)
+            SECURITY_ENABLED=$OPTARG
+            ;;
+        c)
+            CREDENTIAL=$OPTARG
+            ;;
+        u)
+            UPLOAD_RESULTS=$OPTARG
+            ;;
+        t)
+            TESTS=$OPTARG
+            ;;
+        o)
+            OPENSEARCH=$OPTARG
+            ;;
+        d)
+            DASHBOARDS=$OPTARG
+            ;;
+        :)
+            echo "-${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${OPTARG}"
+            exit 1
+            ;;
+    esac
+done
+
+[ -z "$BIND_ADDRESS" ] && BIND_ADDRESS="localhost"
+[ -z "$BIND_PORT" ] && BIND_PORT="5601"
+[ -z "$SECURITY_ENABLED" ] && SECURITY_ENABLED="false"
+[ -z "$CREDENTIAL" ] && CREDENTIAL="admin:admin"
+[ -z "$CI" ] && CI=1
+[ -z "$UPLOAD_RESULTS" ] && UPLOAD_RESULTS="false"
+[ -z "$TESTS" ] && TESTS=$DEFAULT_TESTS
+
+# If no OpenSearch build was passed then this constructs the version
+if [ -z "$OPENSEARCH" ]; then
+    IFS='/' read -ra SLASH_ARR <<< "$DASHBOARDS"
+    # Expected to be opensearch-x.y.z-platform-arch.tar.gz or opensearch-x.y.z-qualifier-platform-arch.tar.gz
+    # Playground is supported path to enable sandbox testing
+    [[ "$DASHBOARDS" == *"Playground"* ]] && TARBALL="${SLASH_ARR[14]}" || TARBALL="${SLASH_ARR[13]}"
+    IFS='-' read -ra DASH_ARR <<< "$TARBALL"
+    # If it contains a qualifer it will be length of 6
+    [[ ${#DASH_ARR[@]} == 6 ]] && HAS_QUALIFER=true || HAS_QUALIFER=false
+    # Expected to be arch.tar.gz
+    [ $HAS_QUALIFER == true ] && DOTS="${DASH_ARR[5]}" || DOTS="${DASH_ARR[4]}"
+    IFS='.' read -ra DOTS_ARR <<< "$DOTS"
+
+    [ $HAS_QUALIFER == true ] && VERSION="${DASH_ARR[2]}-${DASH_ARR[3]}" || VERSION="${DASH_ARR[2]}"
+    [ $HAS_QUALIFER == true ] && PLATFORM="${DASH_ARR[4]}" || PLATFORM="${DASH_ARR[3]}"
+    ARCH="${DOTS_ARR[0]}"
+
+    OPENSEARCH="https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/$VERSION/latest/$PLATFORM/$ARCH/tar/dist/opensearch/opensearch-$VERSION-$PLATFORM-$ARCH.tar.gz"
+fi
+
+source scripts/perftest_osd.sh -b $BIND_ADDRESS -p $BIND_PORT -s $SECURITY_ENABLED -c $CREDENTIAL -o $OPENSEARCH -d $DASHBOARDS -u $UPLOAD_RESULTS -t $TESTS

--- a/scripts/perf/opensearch_dashboards_service.sh
+++ b/scripts/perf/opensearch_dashboards_service.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+function setup_dashboards() {
+  cd "$DASHBOARDS_DIR"
+  [ $SECURITY_ENABLED == "false" ] && [ -d "plugins/securityDashboards" ] && ./bin/opensearch-dashboards-plugin remove securityDashboards
+  [ $SECURITY_ENABLED == "false" ] && rm config/opensearch_dashboards.yml && touch config/opensearch_dashboards.yml
+  [ $SECURITY_ENABLED == "false" ] && echo "server.host: 0.0.0.0" >> config/opensearch_dashboards.yml
+  echo "csp.warnLegacyBrowsers: false" >> config/opensearch_dashboards.yml
+  echo "--max-old-space-size=5120" >> config/node.options
+}
+
+# Starts OpenSearch Dashboards
+function run_dashboards() {
+  echo "[ Attempting to start OpenSearch Dashboards... ]"
+  cd "$DASHBOARDS_DIR"
+  spawn_process_and_save_PID "./bin/opensearch-dashboards > ${LOGS_DIR}/opensearch_dashboards.log 2>&1 &"
+}
+
+# Checks the running status of OpenSearch Dashboards
+# it calls check_status and passes the OpenSearch Dashboards tmp file path, error msg, url, and arguments
+# if success, the while loop in the check_status will end and it prints out "OpenSearch Dashboards is up!"
+function check_dashboards_status {
+  echo "Checking the OpenSearch Dashboards..."
+  cd "$DIR"
+  check_status $DASHBOARDS_PATH "$DASHBOARDS_MSG" $DASHBOARDS_URL "$OPENSEARCH_ARGS" >> /dev/null 2>&1
+  echo "OpenSearch Dashboards is up!"
+}
+
+function get_dashboards_stats {
+  curl $DASHBOARDS_BASE_URL/api/stats $OPENSEARCH_ARGS >> $STATS_PATH || true
+  echo "" >> $STATS_PATH || true
+}

--- a/scripts/perf/opensearch_service.sh
+++ b/scripts/perf/opensearch_service.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+function setup_opensearch() {
+  cd "$OPENSEARCH_DIR"
+  echo "network.host: 0.0.0.0" >> config/opensearch.yml
+  echo "discovery.type: single-node" >> config/opensearch.yml
+  [ $SECURITY_ENABLED == "false" ] && [ -d "plugins/opensearch-security" ] && echo "plugins.security.disabled: true" >> config/opensearch.yml
+  # Required for IM
+  [ -d "plugins/opensearch-index-management" ] && echo "path.repo: [/tmp]" >> config/opensearch.yml
+  # Required for Alerting
+  [ -d "plugins/opensearch-alerting" ] && echo "plugins.destination.host.deny_list: [\"10.0.0.0/8\", \"127.0.0.1\"]" >> config/opensearch.yml
+  # Required for SQL
+  [ -d "plugins/opensearch-sql" ] && echo "script.context.field.max_compilations_rate: 1000/1m" >> config/opensearch.yml
+  # Required for PA
+  [ -d "plugins/opensearch-performance-analyzer" ] && echo "webservice-bind-host = 0.0.0.0" >> config/opensearch-performance-analyzer/performance-analyzer.properties
+}
+
+# Starts OpenSearch, if verifying a distribution it will install the certs then start.
+function run_opensearch() {
+  echo "[ Attempting to start OpenSearch... ]"
+  cd "$OPENSEARCH_DIR"
+  spawn_process_and_save_PID "./opensearch-tar-install.sh > ${LOGS_DIR}/opensearch.log 2>&1 &"
+}
+
+# Checks the running status of OpenSearch
+# it calls check_status and passes the OpenSearch tmp file path, error msg, url, and arguments
+# if success, the while loop in the check_status will end and it prints out "OpenSearch is up!"
+function check_opensearch_status() {
+  echo "Checking the status OpenSearch..."
+  cd "$DIR"
+  check_status $OPENSEARCH_PATH "$OPENSEARCH_MSG" $OPENSEARCH_URL "$OPENSEARCH_ARGS" >> /dev/null 2>&1  &
+  echo "OpenSearch is up!" 
+} 

--- a/scripts/perf/utils.sh
+++ b/scripts/perf/utils.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+function open_artifact() {
+  artifact_dir=$1
+  artifact=$2
+  cd $artifact_dir
+  
+  # check if artifact provided is URL or attempt if passing by absolute path
+  if curl -I -L $artifact; then
+    curl -L $artifact | tar -xz --strip-components=1
+  else
+    tar -xf $artifact --strip-components=1
+  fi
+}
+
+# remove the running opensearch process
+function clean() {
+  echo "Attempt to Terminate Process with PID: ${PARENT_PID_LIST[*]}"
+  for pid_kill in "${PARENT_PID_LIST[@]}"
+  do
+    echo "Closing PID $pid_kill"
+    kill $pid_kill || true
+  done
+  PARENT_PID_LIST=()
+}
+
+function spawn_process_and_save_PID() {
+    echo "Spawn '$@'"
+    eval $@
+    curr_pid=$!
+    echo "PID: $curr_pid"
+    PARENT_PID_LIST+=( $curr_pid )
+}
+
+# Print out a textfile line by line
+function print_txt() {
+  while IFS= read -r line; do
+    echo "text read from $1: $line"
+  done < $1
+}
+
+# this function is used to check the running status of OpenSearch or OpenSearch Dashboards
+# $1 is the path to the tmp file which saves the running status 
+# $2 is the error msg to check
+# $3 is the url to curl
+# $4 contains arguments that need to be passed to the curl command
+function check_status() {
+  while [ ! -f $1 ] || ! grep -q "$2" $1; do 
+     if [ -f $1 ]; then rm $1; fi  
+     curl $3 $4 > $1 || true
+  done
+  rm $1
+}
+
+function get_dashboards_package_version() {
+  DASHBOARDS_PACKAGE_VERSION=$(cat $DASHBOARDS_DIR/package.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $2 }' \
+  | sed 's/[",]//g' \
+  | tr -d [:space:])
+  
+  echo "$DASHBOARDS_PACKAGE_VERSION"
+}
+
+function upload_results(){
+  DASHBOARDS_PACKAGE_VERSION=$(cat $DASHBOARDS_DIR/package.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $2 }' \
+  | sed 's/[",]//g' \
+  | tr -d [:space:])
+
+  INDEX="osd-stats-$DASHBOARDS_PACKAGE_VERSION"
+  curl -X PUT $OPENSEARCH_BASE_URL/$INDEX $OPENSEARCH_ARGS >> /dev/null 2>&1  &
+  while IFS="" read -r p || [ -n "$p" ]
+  do
+    curl -X POST $OPENSEARCH_BASE_URL/$INDEX/_doc -H "Content-Type: application/json" -d" $p"
+  done < $STATS_PATH
+}

--- a/scripts/perftest_osd.sh
+++ b/scripts/perftest_osd.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+. scripts/perf/utils.sh
+. scripts/perf/opensearch_service.sh
+. scripts/perf/opensearch_dashboards_service.sh
+
+# If not defining test suite, it will default to this group of tests
+DEFAULT_TESTS="core-opensearch-dashboards/opensearch-dashboards/*.js"
+DEFAULT_INTERVAL=5
+
+function usage() {
+    echo ""
+    echo "This script is used to run performance tests for OpenSearch Dashboards"
+    echo "--------------------------------------------------------------------------"
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Required arguments:"
+    echo -e "-o OPENSEARCH\t, Specify the tested OpenSearch."
+    echo -e "-d DASHBOARDS\t, Specify the tested OpenSearch Dashboards."
+    echo ""
+    echo "Optional arguments:"
+    echo -e "-b BIND_ADDRESS\t, defaults to localhost | 127.0.0.1, can be changed to any IP or domain name for the cluster location."
+    echo -e "-p BIND_PORT\t, defaults to 5601 depends on OpenSearch or Dashboards, can be changed to any port for the cluster location."
+    echo -e "-s SECURITY_ENABLED\t(true | false), defaults to true. Specify the OpenSearch/Dashboards have security enabled or not."
+    echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
+    echo -e "-u UPLOAD_RESULTS\t(true | false), defaults to false. Upload stats results from perf_tmp to running OpenSearch"
+    echo -e "-t TESTS\t, defaults to core tests. Specify tests in cypress/integration folder as a CSV to execute tests."
+    echo -e "-h\tPrint this message."
+    echo "--------------------------------------------------------------------------"
+}
+
+while getopts ":h:b:p:s:c:u:t:o:d:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        b)
+            BIND_ADDRESS=$OPTARG
+            ;;
+        p)
+            BIND_PORT=$OPTARG
+            ;;    
+        s)
+            SECURITY_ENABLED=$OPTARG
+            ;;
+        c)
+            CREDENTIAL=$OPTARG
+            ;;
+        u)
+            UPLOAD_RESULTS=$OPTARG
+            ;;
+        t)
+            TESTS=$OPTARG
+            ;;
+        o)
+            OPENSEARCH=$OPTARG
+            ;;    
+        d)
+            DASHBOARDS=$OPTARG
+            ;;     
+        :)
+            echo "-${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${OPTARG}"
+            exit 1
+            ;;
+    esac
+done
+
+[ -z "$BIND_ADDRESS" ] && BIND_ADDRESS="localhost"
+[ -z "$BIND_PORT" ] && BIND_PORT="5601"
+[ -z "$SECURITY_ENABLED" ] && SECURITY_ENABLED="false"
+[ -z "$CREDENTIAL" ] && CREDENTIAL="admin:admin"
+[ -z "$UPLOAD_RESULTS" ] && UPLOAD_RESULTS="false"
+[ -z "$TESTS" ] && TESTS=$DEFAULT_TESTS
+
+TOTAL_TEST_FAILURES=0
+# OpenSearch and OpenSearch Dashboards Process IDs
+PARENT_PID_LIST=()
+# define test path
+CWD=$(pwd)
+DIR="$CWD/perf_tmp"
+TEST_DIR="$DIR/test"
+LOGS_DIR="$TEST_DIR/cypress/results/local-cluster-logs"
+STATS_DIR="$TEST_DIR/cypress/results/stats"
+OPENSEARCH_DIR="$DIR/opensearch"
+DASHBOARDS_DIR="$DIR/opensearch-dashboards"
+[ ! -d "$DIR" ] && mkdir "$DIR"
+[ ! -d "$TEST_DIR" ] && mkdir "$TEST_DIR"
+[ -d "$OPENSEARCH_DIR" ] && [ $UPLOAD_RESULTS == "false" ] && rm -rf "$OPENSEARCH_DIR"
+[ $UPLOAD_RESULTS == "false" ] && mkdir "$OPENSEARCH_DIR"
+[ -d "$DASHBOARDS_DIR" ] && [ $UPLOAD_RESULTS == "false" ] && rm -rf "$DASHBOARDS_DIR"
+[ $UPLOAD_RESULTS == "false" ] && mkdir "$DASHBOARDS_DIR"
+[ -d "$STATS_DIR" ] && [ $UPLOAD == "false" ] && rm -rf "$STATS_DIR"
+
+# define other paths and tmp files
+OPENSEARCH_FILE='opensearch.txt'
+DASHBOARDS_FILE='dashboards.txt'
+STATS_FILE='stats.txt'
+OPENSEARCH_PATH="$DIR/$OPENSEARCH_FILE"
+DASHBOARDS_PATH="$DIR/$DASHBOARDS_FILE"
+STATS_PATH="$STATS_DIR/$STATS_FILE"
+DASHBOARDS_MSG="\"state\":\"green\",\"title\":\"Green\",\"nickname\":\"Looking good\",\"icon\":\"success\""
+DASHBOARDS_BASE_URL="http://$BIND_ADDRESS:$BIND_PORT"
+DASHBOARDS_URL="$DASHBOARDS_BASE_URL/api/status"
+if [ $SECURITY_ENABLED == "false" ]; 
+then 
+  OPENSEARCH_MSG="\"status\":\"green\""
+  OPENSEARCH_BASE_URL="http://$BIND_ADDRESS:9200"
+  OPENSEARCH_URL="$OPENSEARCH_BASE_URL/_cluster/health"
+  OPENSEARCH_ARGS=""
+else 
+  OPENSEARCH_MSG="\"status\":\"yellow\""
+  OPENSEARCH_BASE_URL="https://$BIND_ADDRESS:9200"
+  OPENSEARCH_URL="$OPENSEARCH_BASE_URL/_cluster/health"
+  OPENSEARCH_ARGS="-u $CREDENTIAL --insecure"
+fi
+
+if [ $UPLOAD_RESULTS == "true" ]; then
+  upload_results
+  echo ""
+  echo "Upload results complete"
+  exit 0
+fi
+
+# un-tar OpenSearch and OpenSearch Dashboards
+echo "[ unzip OpenSearch and OpenSearch Dashboards ]"
+echo $OPENSEARCH
+open_artifact $OPENSEARCH_DIR $OPENSEARCH
+open_artifact $DASHBOARDS_DIR $DASHBOARDS
+
+# this function sets up the cypress env
+function setup_cypress() {
+  echo "[ Setup the cypress test environment ]"
+  git clone --depth=1 https://github.com/opensearch-project/opensearch-dashboards-functional-test "$TEST_DIR"
+  [ ! -d "$LOGS_DIR" ] && mkdir -p "$LOGS_DIR"
+  [ ! -d "$STATS_DIR" ] && mkdir -p "$STATS_DIR"
+  cd "$TEST_DIR"
+  npm install
+  echo "Cypress is ready!"
+}
+
+function run_cypress() {
+    TEST_ARRAY=("$@")
+    SPEC_FILES=""
+    for test in "${TEST_ARRAY[@]}"
+    do
+      SPEC_FILES+="$TEST_DIR/cypress/integration/$test,"
+    done
+    success_msg="PERF tests for core passed ($SPEC_FILES)"
+    error_msg="PERF tests for core failed ($SPEC_FILES)"
+    [ "$CI" == '1' ] && cypress_args="--browser chromium" || cypress_args=""
+    env NO_COLOR=1 npx cypress run $cypress_args --headless --spec $SPEC_FILES --env SECURITY_ENABLED=$SECURITY_ENABLED,openSearchUrl=$OPENSEARCH_BASE_URL || test_failures=$?
+    [ -z $test_failures ] && test_failures=0
+    [ $test_failures == 0 ] && echo $success_msg || echo "$error_msg::TEST_FAILURES: $test_failures"
+    TOTAL_TEST_FAILURES=$(( $TOTAL_TEST_FAILURES + $test_failures ))
+}
+
+# Runs the PERF test using cypress for the required version
+function run_perf() {
+  cd "$TEST_DIR"
+  IFS=',' read -r -a cypress_tests <<<"$TESTS"
+  run_cypress "${cypress_tests[@]}"
+}
+
+function get_stats() {
+  while ps -p "${PARENT_PID_LIST[1]}" > /dev/null; do
+    get_dashboards_stats
+    sleep $DEFAULT_INTERVAL
+  done
+}
+
+# Main function
+function execute_tests() {
+  setup_opensearch >> /dev/null 2>&1  &
+  setup_dashboards >> /dev/null 2>&1  &
+
+  run_opensearch
+  check_opensearch_status
+  run_dashboards
+  check_dashboards_status
+
+  get_stats >> /dev/null 2>&1  &
+  run_perf
+
+  # kill the running OpenSearch process
+  clean
+}
+ 
+# setup the cypress test env
+[ ! -d "$TEST_DIR/cypress" ] && setup_cypress
+
+execute_tests
+echo "Completed PERF tests"
+echo "Total test failures: $TOTAL_TEST_FAILURES"
+exit $TOTAL_TEST_FAILURES


### PR DESCRIPTION
### Description

Automate calling tests and tracking OSD stats. Also, allow for uploading test results to a running cluster.

Update test docs.

Example of the results after creating an index pattern and heap visualization:

![Screenshot 2023-04-28 at 11 38 25 AM](https://user-images.githubusercontent.com/12060704/235260500-004f4612-f54b-474c-b509-86d72a99a362.png)

As you can see, the test results on the left side is the heap usage of the period of time of the tests for 2.6 while the right side shows the heap usage of the period of time of the tests for 2.7

### Issues Resolved

closes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3588

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
