### PR TITLE
[Manual backport 1.x][CCI] Replace `node` with `scripts/use_node` in functional tests

### DIFF
--- a/test/interpreter_functional/plugins/osd_tp_run_pipeline/package.json
+++ b/test/interpreter_functional/plugins/osd_tp_run_pipeline/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "@elastic/eui": "29.3.2",

--- a/test/plugin_functional/plugins/app_link_test/package.json
+++ b/test/plugin_functional/plugins/app_link_test/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/core_app_status/package.json
+++ b/test/plugin_functional/plugins/core_app_status/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/core_plugin_a/package.json
+++ b/test/plugin_functional/plugins/core_plugin_a/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/core_plugin_appleave/package.json
+++ b/test/plugin_functional/plugins/core_plugin_appleave/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/core_plugin_b/package.json
+++ b/test/plugin_functional/plugins/core_plugin_b/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/core_plugin_chromeless/package.json
+++ b/test/plugin_functional/plugins/core_plugin_chromeless/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/core_plugin_route_timeouts/package.json
+++ b/test/plugin_functional/plugins/core_plugin_route_timeouts/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/core_plugin_static_assets/package.json
+++ b/test/plugin_functional/plugins/core_plugin_static_assets/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/core_provider_plugin/package.json
+++ b/test/plugin_functional/plugins/core_provider_plugin/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/data_search/package.json
+++ b/test/plugin_functional/plugins/data_search/package.json
@@ -6,8 +6,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/doc_views_links_plugin/package.json
+++ b/test/plugin_functional/plugins/doc_views_links_plugin/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "docViewLinksPlugin",
+    "version": "1.0.0",
+    "main": "target/test/plugin_functional/plugins/doc_views_links_plugin",
+    "opensearchDashboards": {
+      "version": "opensearchDashboards",
+      "templateVersion": "1.0.0"
+    },
+    "license": "Apache-2.0",
+    "scripts": {
+      "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+      "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
+    },
+    "devDependencies": {
+      "typescript": "4.0.2"
+    }
+}

--- a/test/plugin_functional/plugins/doc_views_plugin/package.json
+++ b/test/plugin_functional/plugins/doc_views_plugin/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/index_patterns/package.json
+++ b/test/plugin_functional/plugins/index_patterns/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/management_test_plugin/package.json
+++ b/test/plugin_functional/plugins/management_test_plugin/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/opensearch_client_plugin/package.json
+++ b/test/plugin_functional/plugins/opensearch_client_plugin/package.json
@@ -6,8 +6,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/osd_sample_panel_action/package.json
+++ b/test/plugin_functional/plugins/osd_sample_panel_action/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "@elastic/eui": "29.3.2",

--- a/test/plugin_functional/plugins/osd_top_nav/package.json
+++ b/test/plugin_functional/plugins/osd_top_nav/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/osd_tp_custom_visualizations/package.json
+++ b/test/plugin_functional/plugins/osd_tp_custom_visualizations/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "@elastic/eui": "29.3.2",

--- a/test/plugin_functional/plugins/rendering_plugin/package.json
+++ b/test/plugin_functional/plugins/rendering_plugin/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/test/plugin_functional/plugins/ui_settings_plugin/package.json
+++ b/test/plugin_functional/plugins/ui_settings_plugin/package.json
@@ -8,8 +8,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "osd": "node ../../../../scripts/osd.js",
-    "build": "node ../../scripts/remove.js './target' && tsc"
+    "osd": "../../../../scripts/use_node ../../../../scripts/osd.js",
+    "build": "../../../../scripts/use_node ../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
     "typescript": "4.0.2"


### PR DESCRIPTION
Backport  8f890e98f1af903a10b07ccb48065a9c843da990 from https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3783

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. -->
<!-- Example: closes #1234 -->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
