### PR TITLE
feat: update aggregation config

### DIFF
--- a/src/plugins/data/common/search/aggs/buckets/geo_hash.ts
+++ b/src/plugins/data/common/search/aggs/buckets/geo_hash.ts
@@ -64,7 +64,7 @@ export const getGeoHashBucketAgg = () =>
       {
         name: 'field',
         type: 'field',
-        filterFieldTypes: OSD_FIELD_TYPES.GEO_POINT,
+        filterFieldTypes: [OSD_FIELD_TYPES.GEO_POINT, OSD_FIELD_TYPES.GEO_SHAPE],
       },
       {
         name: 'autoPrecision',
@@ -94,6 +94,7 @@ export const getGeoHashBucketAgg = () =>
         write: () => {},
       },
     ],
+    //!!!
     getRequestAggs(agg) {
       const aggs = [];
       const params = agg.params;

--- a/src/plugins/data/common/search/aggs/buckets/geo_tile.ts
+++ b/src/plugins/data/common/search/aggs/buckets/geo_tile.ts
@@ -55,7 +55,7 @@ export const getGeoTitleBucketAgg = () =>
       {
         name: 'field',
         type: 'field',
-        filterFieldTypes: OSD_FIELD_TYPES.GEO_POINT,
+        filterFieldTypes: [OSD_FIELD_TYPES.GEO_POINT, OSD_FIELD_TYPES.GEO_SHAPE],
       },
       {
         name: 'useGeocentroid',

--- a/src/plugins/vis_default_editor/public/components/agg_params_map.ts
+++ b/src/plugins/vis_default_editor/public/components/agg_params_map.ts
@@ -46,6 +46,9 @@ const buckets = {
   [BUCKET_TYPES.FILTERS]: {
     filters: controls.FiltersParamEditor,
   },
+  [BUCKET_TYPES.GEOTILE_GRID]: {
+    useGeocentroid: controls.UseGeocentroidParamEditor,
+  },
   [BUCKET_TYPES.GEOHASH_GRID]: {
     autoPrecision: controls.AutoPrecisionParamEditor,
     precision: controls.PrecisionParamEditor,

--- a/src/plugins/vis_default_editor/public/components/controls/use_geocentroid.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/use_geocentroid.tsx
@@ -28,24 +28,57 @@
  * under the License.
  */
 
-import React from 'react';
-import { EuiSwitch, EuiFormRow } from '@elastic/eui';
+import React, { useState, useEffect } from 'react';
+import { EuiSwitch, EuiFormRow, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { AggParamEditorProps } from '../agg_param_props';
+import { OSD_FIELD_TYPES } from '../../../../../plugins/data/common';
 
-function UseGeocentroidParamEditor({ value = false, setValue }: AggParamEditorProps<boolean>) {
+function UseGeocentroidParamEditor({ agg, value = false, setValue }: AggParamEditorProps<boolean>) {
+  const [disabled, setDisabled] = useState(false);
+
   const label = i18n.translate('visDefaultEditor.controls.placeMarkersOffGridLabel', {
     defaultMessage: 'Place markers off grid (use geocentroid)',
   });
 
+  const tooltipLabel = i18n.translate(
+    'visDefaultEditor.controls.placeMarkersOffGridLabelUnsupport',
+    {
+      defaultMessage: 'Currently geo_shape type field does not support centroid aggregation.',
+    }
+  );
+
+  useEffect(() => {
+    //geo_shape type field does not support centroid aggregation
+    if (agg?.params?.field?.type === OSD_FIELD_TYPES.GEO_SHAPE) {
+      setDisabled(true);
+      setValue(false);
+    } else {
+      setDisabled(false);
+    }
+  }, [agg]);
+
   return (
     <EuiFormRow display={'rowCompressed'}>
-      <EuiSwitch
-        compressed={true}
-        label={label}
-        checked={value}
-        onChange={(ev) => setValue(ev.target.checked)}
-      />
+      {disabled ? (
+        <EuiToolTip content={tooltipLabel}>
+          <EuiSwitch
+            compressed={true}
+            disabled={true}
+            label={label}
+            checked={value}
+            onChange={(ev) => setValue(ev.target.checked)}
+          />
+        </EuiToolTip>
+      ) : (
+        <EuiSwitch
+          compressed={true}
+          disabled={false}
+          label={label}
+          checked={value}
+          onChange={(ev) => setValue(ev.target.checked)}
+        />
+      )}
     </EuiFormRow>
   );
 }


### PR DESCRIPTION
### Description

1. Add geo_shape type field support in geo_tile and geo_hash aggregation since OpenSearch has supported it.
2. Add centroid switch in geo_tile aggregation, which can't be switched before and is true by default.
3. In centroid editor, set value false and switch disabled when field type is geo_shape because currently OpenSearch only supports geo_shape aggregation without centroid.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3887

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
