### PR TITLE
[Console] [CCI] Remove unused ul element and its custom styling.

### DIFF
--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
@@ -231,7 +231,6 @@ function EditorUI({ initialTextValue, dataSourceId }: EditorProps) {
   return (
     <div style={abs} className="conApp">
       <div className="conApp__editor">
-        <ul className="conApp__autoComplete" id="autocomplete" />
         <EuiFlexGroup
           className="conApp__editorActions"
           id="ConAppEditorActions"

--- a/src/plugins/console/public/styles/_app.scss
+++ b/src/plugins/console/public/styles/_app.scss
@@ -77,18 +77,6 @@
   z-index: $euiZLevel1;
 }
 
-// SASSTODO: This component seems to not be used anymore?
-// Possibly replaced by the Ace version
-.conApp__autoComplete {
-  position: absolute;
-  left: -1000px;
-  visibility: hidden;
-
-  /* by pass any other element in ace and resize bar, but not modal popups  */
-  z-index: $euiZLevel1 + 2;
-  margin-top: 22px;
-}
-
 .conApp__settingsModal {
   min-width: 460px;
 }


### PR DESCRIPTION
### Description
In the [OUI Usage Audit of ```console``` plugin](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3966) I found out that one \<ul> element and the custom styling related to it are no longer used. I have removed them, did visual tests before/after and didn't see any differences. It doesn't look like they are used in any tests so I believe that if all functional tests will pass ( after chromedriver issue resolution ), then it is safe to remove them.

### Issues Resolved

Solves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3992

### Check List

- [ ] All tests pass
  - [X] `yarn test:jest`
  - [X] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
