### PR TITLE
[CI] setup Chrome and utilize binary path

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -25,6 +25,8 @@ env:
   TEST_OPENSEARCH_TRANSPORT_PORT: 9403
   TEST_OPENSEARCH_PORT: 9400
   OSD_SNAPSHOT_SKIP_VERIFY_CHECKSUM: true
+  # Version 112.0.5615.0
+  CHROME_VERSION: 1109208
 
 jobs:
   build-lint-test:
@@ -122,6 +124,7 @@ jobs:
   functional-tests:
     name: Run functional tests on ${{ matrix.name }} (ciGroup${{ matrix.group }})
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
@@ -133,6 +136,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - run: echo Running functional tests for ciGroup${{ matrix.group }}
+
+      - name: Setup Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: ${{ env.CHROME_VERSION }}
+
+      - name: Set Chrome Path
+        if: matrix.os != 'windows-latest'
+        run: |
+          echo "TEST_BROWSER_BINARY_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+
+      - name: Set Chrome Path (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo "TEST_BROWSER_BINARY_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $env:GITHUB_ENV
 
       - name: Configure git's autocrlf (Windows only)
         if: matrix.os == 'windows-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Upgrade yarn version to be compatible with @openearch-project/opensearch ([#3443](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3443))
 - [CI] Reduce redundancy by using matrix strategy on Windows and Linux workflows ([#3514](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3514))
 - Add an achievement badger to the PR ([#3721](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3721))
+- Install chrome driver for functional tests from path set by environment variable `TEST_BROWSER_BINARY_PATH`([#3997](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3997))
 
 ### 📝 Documentation
 

--- a/scripts/upgrade_chromedriver.js
+++ b/scripts/upgrade_chromedriver.js
@@ -25,17 +25,34 @@ const versionCheckCommands = [];
 switch (process.platform) {
   case 'win32':
     versionCheckCommands.push(
-      'powershell "(Get-Item \\"$Env:Programfiles/Google/Chrome/Application/chrome.exe\\").VersionInfo.FileVersion"'
+      ...[
+        ...(process.env.TEST_BROWSER_BINARY_PATH
+          ? [
+              `powershell "(Get-Item \\"${process.env.TEST_BROWSER_BINARY_PATH}\\").VersionInfo.FileVersion"`,
+            ]
+          : []),
+        'powershell "(Get-Item \\"$Env:Programfiles/Google/Chrome/Application/chrome.exe\\").VersionInfo.FileVersion"',
+      ]
     );
     break;
 
   case 'darwin':
     versionCheckCommands.push(
-      '/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --version'
+      ...[
+        ...(process.env.TEST_BROWSER_BINARY_PATH
+          ? [`${process.env.TEST_BROWSER_BINARY_PATH} --version`]
+          : []),
+        '/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --version',
+      ]
     );
     break;
 
   default:
+    versionCheckCommands.push(
+      ...(process.env.TEST_BROWSER_BINARY_PATH
+        ? [`${process.env.TEST_BROWSER_BINARY_PATH} --version`]
+        : [])
+    );
     versionCheckCommands.push(
       ...[
         '/usr/bin',


### PR DESCRIPTION
### Description

Within the CI, the virtual runner that we are utilizing has Chrome
installed already. The version of Chrome is installed periodically.

The most recent version of Chrome requires updates to dependencies
that drop support for Node 14.

This downloads chrome in the CI and then checks the chromedriver
from the environment variable `TEST_BROWSER_BINARY_PATH`.

### Issues Resolved

See failures here: 
https://github.com/opensearch-project/OpenSearch-Dashboards/actions/runs/4896112900/jobs/8742518044

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
