### PR TITLE
[BUG] [Vis Builder]  Fixes Sort order changes when editing a categorical value 

### DIFF
--- a/src/plugins/vis_default_editor/public/components/controls/utils/agg_utils.ts
+++ b/src/plugins/vis_default_editor/public/components/controls/utils/agg_utils.ts
@@ -71,6 +71,8 @@ function useFallbackMetric(
       if (!respAgg && value !== fallbackValue) {
         setValue(fallbackValue);
       }
+    } else {
+      setValue(DEFAULT_METRIC);
     }
   }, [setValue, isCompatibleAgg, metricAggs, value, fallbackValue]);
 }


### PR DESCRIPTION
I have reproduced the bug by following issue #2727, 

The expected behavior is "Edit" on X-axis set on default as "Custom", but it was set on "Metric: Unique count of Carrier" I have changed default behavior to Custom

<img width="1272" alt="Screenshot 2023-05-10 at 03 16 17" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/26738268/5bf97b98-601c-4f5e-886e-81bc5d88ce77">


fixes #2727
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
