### PR TITLE
Add a `VisAugmenter` stats API

### DIFF
--- a/src/plugins/vis_augmenter/common/augment_vis_saved_object_attributes.ts
+++ b/src/plugins/vis_augmenter/common/augment_vis_saved_object_attributes.ts
@@ -6,6 +6,7 @@
 import { SavedObjectAttributes } from 'opensearch-dashboards/server';
 
 export interface AugmentVisSavedObjectAttributes extends SavedObjectAttributes {
+  id: string;
   title: string;
   description?: string;
   originPlugin: string;
@@ -13,10 +14,19 @@ export interface AugmentVisSavedObjectAttributes extends SavedObjectAttributes {
     type: string;
     id: string;
   };
-  visName: string;
   visLayerExpressionFn: {
     type: string;
     name: string;
   };
   version: number;
+  // Following fields are optional since they will get set/removed during the extraction/injection
+  // of the vis reference
+  visName?: string;
+  visId?: string;
+  visReference?: {
+    id: string;
+    name: string;
+  };
+  // Error may be populated if there is some issue when parsing the attribute values
+  error?: string;
 }

--- a/src/plugins/vis_augmenter/common/augment_vis_saved_object_attributes.ts
+++ b/src/plugins/vis_augmenter/common/augment_vis_saved_object_attributes.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectAttributes } from 'opensearch-dashboards/server';
+
+export interface AugmentVisSavedObjectAttributes extends SavedObjectAttributes {
+  title: string;
+  description?: string;
+  originPlugin: string;
+  pluginResource: {
+    type: string;
+    id: string;
+  };
+  visName: string;
+  visLayerExpressionFn: {
+    type: string;
+    name: string;
+  };
+  version: number;
+}

--- a/src/plugins/vis_augmenter/common/constants.ts
+++ b/src/plugins/vis_augmenter/common/constants.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const APP_PATH = {
+  STATS: '/stats',
+};
+export const APP_API = '/api/vis_augmenter';
+
+// used for limiting results received from the stats API
+export const PER_PAGE_REQUEST_NUMBER = 50;

--- a/src/plugins/vis_augmenter/common/index.ts
+++ b/src/plugins/vis_augmenter/common/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './constants';
+export { AugmentVisSavedObjectAttributes } from './augment_vis_saved_object_attributes';

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/_saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/_saved_augment_vis.ts
@@ -26,7 +26,8 @@ export function createSavedAugmentVisClass(services: SavedObjectOpenSearchDashbo
     public static type: string = name;
     public static mapping: Record<string, string> = {
       description: 'text',
-      pluginResourceId: 'text',
+      originPlugin: 'text',
+      pluginResource: 'text',
       visId: 'keyword',
       visLayerExpressionFn: 'text',
       version: 'integer',
@@ -45,7 +46,8 @@ export function createSavedAugmentVisClass(services: SavedObjectOpenSearchDashbo
         indexPattern: opts.indexPattern as IIndexPattern,
         defaults: {
           description: get(opts, 'description', ''),
-          pluginResourceId: get(opts, 'pluginResourceId', ''),
+          originPlugin: get(opts, 'originPlugin', ''),
+          pluginResource: get(opts, 'pluginResource', {}),
           visId: get(opts, 'visId', ''),
           visLayerExpressionFn: get(opts, 'visLayerExpressionFn', {}),
           version: 1,

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/_saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/_saved_augment_vis.ts
@@ -14,8 +14,8 @@ import {
   SavedObject,
   SavedObjectOpenSearchDashboardsServices,
 } from '../../../saved_objects/public';
-import { IIndexPattern } from '../../../data/public';
 import { extractReferences, injectReferences } from './saved_augment_vis_references';
+import { AugmentVisSavedObjectAttributes } from '../../common';
 
 const name = 'augment-vis';
 
@@ -24,26 +24,15 @@ export function createSavedAugmentVisClass(services: SavedObjectOpenSearchDashbo
 
   class SavedAugmentVis extends SavedObjectClass {
     public static type: string = name;
-    public static mapping: Record<string, string> = {
-      description: 'text',
-      originPlugin: 'text',
-      pluginResource: 'text',
-      visId: 'keyword',
-      visLayerExpressionFn: 'text',
-      version: 'integer',
-    };
+    public static mapping: AugmentVisSavedObjectAttributes;
 
-    constructor(opts: Record<string, unknown> | string = {}) {
-      if (typeof opts !== 'object') {
-        opts = { id: opts };
-      }
+    constructor(opts: AugmentVisSavedObjectAttributes) {
       super({
         type: SavedAugmentVis.type,
         mapping: SavedAugmentVis.mapping,
         extractReferences,
         injectReferences,
         id: (opts.id as string) || '',
-        indexPattern: opts.indexPattern as IIndexPattern,
         defaults: {
           description: get(opts, 'description', ''),
           originPlugin: get(opts, 'originPlugin', ''),
@@ -57,5 +46,5 @@ export function createSavedAugmentVisClass(services: SavedObjectOpenSearchDashbo
     }
   }
 
-  return SavedAugmentVis as new (opts: Record<string, unknown> | string) => SavedObject;
+  return SavedAugmentVis as new (opts: AugmentVisSavedObjectAttributes) => SavedObject;
 }

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
@@ -37,6 +37,18 @@ export function createSavedAugmentVisLoader(
         source.error = 'Unknown VisLayer expression function type';
         return source;
       }
+      if (get(source, 'originPlugin', undefined) === undefined) {
+        source.error = 'originPlugin is missing in augment-vis saved object';
+        return source;
+      }
+      if (get(source, 'pluginResource.type', undefined) === undefined) {
+        source.error = 'pluginResource.type is missing in augment-vis saved object';
+        return source;
+      }
+      if (get(source, 'pluginResource.id', undefined) === undefined) {
+        source.error = 'pluginResource.id is missing in augment-vis saved object';
+        return source;
+      }
       return source;
     };
 

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../saved_objects/public';
 import { createSavedAugmentVisClass } from './_saved_augment_vis';
 import { VisLayerTypes } from '../types';
+import { AugmentVisSavedObjectAttributes } from '../../common';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SavedObjectOpenSearchDashboardsServicesWithAugmentVis
@@ -21,9 +22,9 @@ export function createSavedAugmentVisLoader(
   const { savedObjectsClient } = services;
 
   class SavedObjectLoaderAugmentVis extends SavedObjectLoader {
-    mapHitSource = (source: Record<string, any>, id: string) => {
+    mapHitSource = (source: AugmentVisSavedObjectAttributes, id: string) => {
       source.id = id;
-      source.visId = get(source, 'visReference.id', '');
+      source.visId = get(source, 'visReference.id', '') as string;
 
       if (isEmpty(source.visReference)) {
         source.error = 'visReference is missing in augment-vis saved object';
@@ -33,7 +34,7 @@ export function createSavedAugmentVisLoader(
         source.error = 'visLayerExpressionFn is missing in augment-vis saved object';
         return source;
       }
-      if (!(get(source, 'visLayerExpressionFn.type', '') in VisLayerTypes)) {
+      if (!((get(source, 'visLayerExpressionFn.type', '') as string) in VisLayerTypes)) {
         source.error = 'Unknown VisLayer expression function type';
         return source;
       }
@@ -60,7 +61,7 @@ export function createSavedAugmentVisLoader(
      */
     mapSavedObjectApiHits(hit: {
       references: any[];
-      attributes: Record<string, unknown>;
+      attributes: AugmentVisSavedObjectAttributes;
       id: string;
     }) {
       // For now we are assuming only one vis reference per saved object.

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.test.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.test.ts
@@ -8,7 +8,7 @@ import {
   injectReferences,
   VIS_REFERENCE_NAME,
 } from './saved_augment_vis_references';
-import { AugmentVisSavedObject } from '../types';
+import { AugmentVisSavedObject } from './types';
 
 describe('extractReferences()', () => {
   test('extracts nothing if visId is null', () => {

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.ts
@@ -4,6 +4,7 @@
  */
 
 import { SavedObjectAttributes, SavedObjectReference } from '../../../../core/public';
+import { AugmentVisSavedObjectAttributes } from '../../common';
 import { AugmentVisSavedObject } from './types';
 
 /**
@@ -35,7 +36,7 @@ export function extractReferences({
   attributes: SavedObjectAttributes;
   references: SavedObjectReference[];
 }) {
-  const updatedAttributes = { ...attributes };
+  const updatedAttributes = { ...attributes } as AugmentVisSavedObjectAttributes;
   const updatedReferences = [...references];
 
   // Extract saved object

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis_references.ts
@@ -4,7 +4,7 @@
  */
 
 import { SavedObjectAttributes, SavedObjectReference } from '../../../../core/public';
-import { AugmentVisSavedObject } from '../types';
+import { AugmentVisSavedObject } from './types';
 
 /**
  * Note that references aren't stored in the object's client-side interface (AugmentVisSavedObject).

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/types.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/types.ts
@@ -6,11 +6,17 @@
 import { SavedObject } from '../../../saved_objects/public';
 import { VisLayerExpressionFn } from '../expressions';
 
+export interface ISavedPluginResource {
+  type: string;
+  id: string;
+}
+
 export interface ISavedAugmentVis {
   id?: string;
   title: string;
   description?: string;
-  pluginResourceId: string;
+  originPlugin: string;
+  pluginResource: ISavedPluginResource;
   visName?: string;
   visId?: string;
   visLayerExpressionFn: VisLayerExpressionFn;

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/utils/helpers.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/utils/helpers.ts
@@ -4,7 +4,7 @@
  */
 
 import { getSavedAugmentVisLoader } from '../../services';
-import { ISavedAugmentVis } from '../../types';
+import { ISavedAugmentVis } from '../types';
 
 /**
  * Create an augment vis saved object given an object that

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/utils/test_helpers.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/utils/test_helpers.ts
@@ -4,22 +4,24 @@
  */
 
 import { cloneDeep } from 'lodash';
-import { VisLayerExpressionFn, ISavedAugmentVis } from '../../';
+import { VisLayerExpressionFn, ISavedAugmentVis, ISavedPluginResource } from '../../';
 import { VIS_REFERENCE_NAME } from '../saved_augment_vis_references';
 
-const pluginResourceId = 'test-plugin-resource-id';
 const title = 'test-title';
 const version = 1;
 
 export const generateAugmentVisSavedObject = (
   idArg: string,
   exprFnArg: VisLayerExpressionFn,
-  visIdArg: string
+  visIdArg: string,
+  originPluginArg: string,
+  pluginResourceArg: ISavedPluginResource
 ) => {
   return {
     id: idArg,
     title,
-    pluginResourceId,
+    originPlugin: originPluginArg,
+    pluginResource: pluginResourceArg,
     visLayerExpressionFn: exprFnArg,
     VIS_REFERENCE_NAME,
     visId: visIdArg,

--- a/src/plugins/vis_augmenter/public/utils/utils.test.ts
+++ b/src/plugins/vis_augmenter/public/utils/utils.test.ts
@@ -51,12 +51,35 @@ describe('utils', () => {
         testArg: 'test-value',
       },
     } as VisLayerExpressionFn;
+    const originPlugin = 'test-plugin';
+    const pluginResource = {
+      type: 'test-plugin',
+      id: 'test-plugin-resource-id',
+    };
     const visId1 = 'test-vis-id-1';
     const visId2 = 'test-vis-id-2';
     const visId3 = 'test-vis-id-3';
-    const obj1 = generateAugmentVisSavedObject('valid-obj-id-1', fn, visId1);
-    const obj2 = generateAugmentVisSavedObject('valid-obj-id-2', fn, visId1);
-    const obj3 = generateAugmentVisSavedObject('valid-obj-id-3', fn, visId2);
+    const obj1 = generateAugmentVisSavedObject(
+      'valid-obj-id-1',
+      fn,
+      visId1,
+      originPlugin,
+      pluginResource
+    );
+    const obj2 = generateAugmentVisSavedObject(
+      'valid-obj-id-2',
+      fn,
+      visId1,
+      originPlugin,
+      pluginResource
+    );
+    const obj3 = generateAugmentVisSavedObject(
+      'valid-obj-id-3',
+      fn,
+      visId2,
+      originPlugin,
+      pluginResource
+    );
 
     it('returns no matching saved objs with filtering', async () => {
       const loader = createSavedAugmentVisLoader({
@@ -93,7 +116,11 @@ describe('utils', () => {
   describe('buildPipelineFromAugmentVisSavedObjs', () => {
     const obj1 = {
       title: 'obj1',
-      pluginResourceId: 'obj-1-resource-id',
+      originPlugin: 'test-plugin',
+      pluginResource: {
+        type: 'test-resource-type',
+        id: 'obj-1-resource-id',
+      },
       visLayerExpressionFn: {
         type: VisLayerTypes.PointInTimeEvents,
         name: 'fn-1',
@@ -104,7 +131,11 @@ describe('utils', () => {
     } as ISavedAugmentVis;
     const obj2 = {
       title: 'obj2',
-      pluginResourceId: 'obj-2-resource-id',
+      originPlugin: 'test-plugin',
+      pluginResource: {
+        type: 'test-resource-type',
+        id: 'obj-2-resource-id',
+      },
       visLayerExpressionFn: {
         type: VisLayerTypes.PointInTimeEvents,
         name: 'fn-2',

--- a/src/plugins/vis_augmenter/server/plugin.ts
+++ b/src/plugins/vis_augmenter/server/plugin.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../core/server';
 import { augmentVisSavedObjectType } from './saved_objects';
 import { capabilitiesProvider } from './capabilities_provider';
+import { registerStatsRoute } from './routes/stats';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface VisAugmenterPluginSetup {}
@@ -30,6 +31,11 @@ export class VisAugmenterPlugin
     this.logger.debug('VisAugmenter: Setup');
     core.savedObjects.registerType(augmentVisSavedObjectType);
     core.capabilities.registerProvider(capabilitiesProvider);
+
+    // Register server-side APIs
+    const router = core.http.createRouter();
+    registerStatsRoute(router, this.logger);
+
     return {};
   }
 

--- a/src/plugins/vis_augmenter/server/routes/stats.ts
+++ b/src/plugins/vis_augmenter/server/routes/stats.ts
@@ -30,7 +30,6 @@ export const registerStatsRoute = (router: IRouter, logger: Logger) => {
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
       try {
-        // console.log('--------running api-----------');
         const savedObjectsClient = context.core.savedObjects.client;
         const augmentVisSavedObjects: SavedObjectsFindResponse<AugmentVisSavedObjectAttributes> = await getAugmentVisSavedObjects(
           savedObjectsClient,

--- a/src/plugins/vis_augmenter/server/routes/stats.ts
+++ b/src/plugins/vis_augmenter/server/routes/stats.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger } from '@osd/logging';
+import { ResponseError } from '@opensearch-project/opensearch/lib/errors';
+import {
+  IOpenSearchDashboardsResponse,
+  IRouter,
+  SavedObjectsFindResponse,
+} from '../../../../core/server';
+import {
+  APP_API,
+  APP_PATH,
+  PER_PAGE_REQUEST_NUMBER,
+  AugmentVisSavedObjectAttributes,
+} from '../../common';
+import { getAugmentVisSavedObjects, getStats } from './stats_helpers';
+
+export const registerStatsRoute = (router: IRouter, logger: Logger) => {
+  router.get(
+    {
+      path: `${APP_API}${APP_PATH.STATS}`,
+      validate: {},
+    },
+    async (
+      context,
+      request,
+      response
+    ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
+      try {
+        // console.log('--------running api-----------');
+        const savedObjectsClient = context.core.savedObjects.client;
+        const augmentVisSavedObjects: SavedObjectsFindResponse<AugmentVisSavedObjectAttributes> = await getAugmentVisSavedObjects(
+          savedObjectsClient,
+          PER_PAGE_REQUEST_NUMBER
+        );
+        const stats = getStats(augmentVisSavedObjects);
+        return response.ok({
+          body: stats,
+        });
+      } catch (error: any) {
+        logger.error(error);
+        return response.customError({
+          statusCode: error.statusCode || 500,
+          body: {
+            message: error.message,
+            attributes: {
+              error: error.body?.error || error.message,
+            },
+          },
+        });
+      }
+    }
+  );
+};

--- a/src/plugins/vis_augmenter/server/routes/stats_helpers.test.ts
+++ b/src/plugins/vis_augmenter/server/routes/stats_helpers.test.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsFindResult } from '../../../../../src/core/server';
+import { AugmentVisSavedObjectAttributes } from '../../common';
+import { getAugmentVisSavedObjects, getStats } from './stats_helpers';
+
+const ORIGIN_PLUGIN_1 = 'origin-plugin-1';
+const ORIGIN_PLUGIN_2 = 'origin-plugin-2';
+const PLUGIN_RESOURCE_TYPE_1 = 'plugin-resource-type-1';
+const PLUGIN_RESOURCE_TYPE_2 = 'plugin-resource-type-2';
+const PLUGIN_RESOURCE_ID_1 = 'plugin-resource-id-1';
+const PLUGIN_RESOURCE_ID_2 = 'plugin-resource-id-2';
+const PLUGIN_RESOURCE_ID_3 = 'plugin-resource-id-3';
+const VIS_ID_1 = 'vis-id-1';
+const VIS_ID_2 = 'vis-id-2';
+const PER_PAGE = 4;
+
+const SINGLE_SAVED_OBJ = [
+  {
+    attributes: {
+      originPlugin: ORIGIN_PLUGIN_1,
+      pluginResource: {
+        type: PLUGIN_RESOURCE_TYPE_1,
+        id: PLUGIN_RESOURCE_ID_1,
+      },
+      visId: VIS_ID_1,
+    },
+  },
+] as Array<SavedObjectsFindResult<AugmentVisSavedObjectAttributes>>;
+
+const MULTIPLE_SAVED_OBJS = [
+  {
+    attributes: {
+      originPlugin: ORIGIN_PLUGIN_1,
+      pluginResource: {
+        type: PLUGIN_RESOURCE_TYPE_1,
+        id: PLUGIN_RESOURCE_ID_1,
+      },
+      visId: VIS_ID_1,
+    },
+  },
+  {
+    attributes: {
+      originPlugin: ORIGIN_PLUGIN_2,
+      pluginResource: {
+        type: PLUGIN_RESOURCE_TYPE_2,
+        id: PLUGIN_RESOURCE_ID_2,
+      },
+      visId: VIS_ID_1,
+    },
+  },
+  {
+    attributes: {
+      originPlugin: ORIGIN_PLUGIN_2,
+      pluginResource: {
+        type: PLUGIN_RESOURCE_TYPE_2,
+        id: PLUGIN_RESOURCE_ID_2,
+      },
+      visId: VIS_ID_2,
+    },
+  },
+  {
+    attributes: {
+      originPlugin: ORIGIN_PLUGIN_2,
+      pluginResource: {
+        type: PLUGIN_RESOURCE_TYPE_2,
+        id: PLUGIN_RESOURCE_ID_3,
+      },
+      visId: VIS_ID_1,
+    },
+  },
+] as Array<SavedObjectsFindResult<AugmentVisSavedObjectAttributes>>;
+
+describe('getAugmentVisSavedObjs()', function () {
+  const mockClient = {
+    find: jest.fn(),
+  };
+  it('should return empty arr if no objs found', async function () {
+    mockClient.find.mockResolvedValueOnce({
+      total: 0,
+      page: 1,
+      per_page: PER_PAGE,
+      saved_objects: [],
+    });
+
+    // @ts-ignore
+    const response = await getAugmentVisSavedObjects(mockClient, PER_PAGE);
+    expect(response.total).toEqual(0);
+    expect(response.saved_objects).toHaveLength(0);
+  });
+
+  it('should return all augment-vis saved objects', async function () {
+    mockClient.find.mockResolvedValueOnce({
+      total: 4,
+      page: 1,
+      per_page: PER_PAGE,
+      saved_objects: MULTIPLE_SAVED_OBJS,
+    });
+
+    // @ts-ignore
+    const response = await getAugmentVisSavedObjects(mockClient, PER_PAGE);
+    expect(response.total).toEqual(4);
+    expect(response.saved_objects).toHaveLength(4);
+    expect(response.saved_objects[0].attributes.originPlugin).toEqual(ORIGIN_PLUGIN_1);
+    expect(response.saved_objects[1].attributes.originPlugin).toEqual(ORIGIN_PLUGIN_2);
+    expect(response.saved_objects[2].attributes.originPlugin).toEqual(ORIGIN_PLUGIN_2);
+    expect(response.saved_objects[3].attributes.originPlugin).toEqual(ORIGIN_PLUGIN_2);
+  });
+
+  it('should correctly perform pagination', async function () {
+    mockClient.find
+      .mockResolvedValueOnce({
+        total: 5,
+        page: 1,
+        per_page: PER_PAGE,
+        saved_objects: MULTIPLE_SAVED_OBJS,
+      })
+      .mockResolvedValueOnce({
+        total: 5,
+        page: 2,
+        per_page: PER_PAGE,
+        saved_objects: SINGLE_SAVED_OBJ,
+      });
+
+    // @ts-ignore
+    const response = await getAugmentVisSavedObjects(mockClient, PER_PAGE);
+    expect(response.total).toEqual(5);
+    expect(response.saved_objects).toHaveLength(5);
+    expect(response.saved_objects[0].attributes.originPlugin).toEqual(ORIGIN_PLUGIN_1);
+    expect(response.saved_objects[1].attributes.originPlugin).toEqual(ORIGIN_PLUGIN_2);
+    expect(response.saved_objects[2].attributes.originPlugin).toEqual(ORIGIN_PLUGIN_2);
+    expect(response.saved_objects[3].attributes.originPlugin).toEqual(ORIGIN_PLUGIN_2);
+    expect(response.saved_objects[4].attributes.originPlugin).toEqual(ORIGIN_PLUGIN_1);
+  });
+});
+
+describe('getStats()', function () {
+  it('should return total of 0 and empty mappings on empty response', function () {
+    const response = getStats({
+      total: 0,
+      page: 1,
+      per_page: PER_PAGE,
+      saved_objects: [],
+    });
+    expect(response.total_objs).toEqual(0);
+    expect(response.obj_breakdown.origin_plugin).toEqual({});
+    expect(response.obj_breakdown.plugin_resource_type).toEqual({});
+    expect(response.obj_breakdown.plugin_resource_id).toEqual({});
+    expect(response.obj_breakdown.visualization_id).toEqual({});
+  });
+
+  it('should return correct count and mappings on single-obj response', function () {
+    const response = getStats({
+      total: 1,
+      page: 1,
+      per_page: PER_PAGE,
+      saved_objects: SINGLE_SAVED_OBJ,
+    });
+    expect(response.total_objs).toEqual(1);
+    expect(response.obj_breakdown.origin_plugin).toEqual({
+      [ORIGIN_PLUGIN_1]: 1,
+    });
+    expect(response.obj_breakdown.plugin_resource_type).toEqual({
+      [PLUGIN_RESOURCE_TYPE_1]: 1,
+    });
+    expect(response.obj_breakdown.plugin_resource_id).toEqual({
+      [PLUGIN_RESOURCE_ID_1]: 1,
+    });
+    expect(response.obj_breakdown.visualization_id).toEqual({
+      [VIS_ID_1]: 1,
+    });
+  });
+
+  it('should return correct count and mappings on multiple-obj response', function () {
+    const response = getStats({
+      total: MULTIPLE_SAVED_OBJS.length,
+      page: 1,
+      per_page: PER_PAGE,
+      saved_objects: MULTIPLE_SAVED_OBJS,
+    });
+    expect(response.total_objs).toEqual(4);
+    expect(response.obj_breakdown.origin_plugin).toEqual({
+      [ORIGIN_PLUGIN_1]: 1,
+      [ORIGIN_PLUGIN_2]: 3,
+    });
+    expect(response.obj_breakdown.plugin_resource_type).toEqual({
+      [PLUGIN_RESOURCE_TYPE_1]: 1,
+      [PLUGIN_RESOURCE_TYPE_2]: 3,
+    });
+    expect(response.obj_breakdown.plugin_resource_id).toEqual({
+      [PLUGIN_RESOURCE_ID_1]: 1,
+      [PLUGIN_RESOURCE_ID_2]: 2,
+      [PLUGIN_RESOURCE_ID_3]: 1,
+    });
+    expect(response.obj_breakdown.visualization_id).toEqual({
+      [VIS_ID_1]: 3,
+      [VIS_ID_2]: 1,
+    });
+  });
+});

--- a/src/plugins/vis_augmenter/server/routes/stats_helpers.ts
+++ b/src/plugins/vis_augmenter/server/routes/stats_helpers.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  SavedObjectsFindResponse,
+  SavedObjectsClientContract,
+} from '../../../../../src/core/server';
+import { AugmentVisSavedObjectAttributes } from '../../common';
+
+interface ObjectBreakdown {
+  origin_plugin: { [key: string]: number };
+  plugin_resource_type: { [key: string]: number };
+  plugin_resource_id: { [key: string]: number };
+  visualization_id: { [key: string]: number };
+}
+
+interface VisAugmenterStats {
+  total_objs: number;
+  obj_breakdown: ObjectBreakdown;
+}
+
+export const getAugmentVisSavedObjects = async (
+  savedObjectsClient: SavedObjectsClientContract,
+  perPage: number
+): Promise<SavedObjectsFindResponse<AugmentVisSavedObjectAttributes>> => {
+  const augmentVisSavedObjects: SavedObjectsFindResponse<AugmentVisSavedObjectAttributes> = await savedObjectsClient?.find(
+    {
+      type: 'augment-vis',
+      perPage,
+    }
+  );
+  // If there are more than perPage of objs, we need to make additional requests
+  if (augmentVisSavedObjects.total > perPage) {
+    const iterations = Math.ceil(augmentVisSavedObjects.total / perPage);
+    for (let i = 1; i < iterations; i++) {
+      const augmentVisSavedObjectsPage: SavedObjectsFindResponse<AugmentVisSavedObjectAttributes> = await savedObjectsClient?.find(
+        {
+          type: 'augment-vis',
+          perPage,
+          page: i + 1,
+        }
+      );
+      augmentVisSavedObjects.saved_objects = [
+        ...augmentVisSavedObjects.saved_objects,
+        ...augmentVisSavedObjectsPage.saved_objects,
+      ];
+    }
+  }
+  return augmentVisSavedObjects;
+};
+
+export const getStats = (
+  augmentVisSavedObjects: SavedObjectsFindResponse<AugmentVisSavedObjectAttributes>
+): VisAugmenterStats => {
+  // TODO: instantiate count/agg maps here
+  augmentVisSavedObjects.saved_objects.forEach((augmentVisObj) => {
+    // TODO: extract/populate maps here
+  });
+
+  return {
+    total_objs: augmentVisSavedObjects.total,
+    obj_breakdown: {
+      origin_plugin: {
+        test: 1,
+      },
+      plugin_resource_type: {
+        test: 1,
+      },
+      plugin_resource_id: {
+        test: 1,
+      },
+      visualization_id: {
+        test: 1,
+      },
+    },
+  };
+};

--- a/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
+++ b/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
@@ -24,7 +24,13 @@ export const augmentVisSavedObjectType: SavedObjectsType = {
     properties: {
       title: { type: 'text' },
       description: { type: 'text' },
-      pluginResourceId: { type: 'text' },
+      originPlugin: { type: 'text' },
+      pluginResource: {
+        properties: {
+          type: { type: 'text' },
+          id: { type: 'text' },
+        },
+      },
       visName: { type: 'keyword', index: false, doc_values: false },
       visLayerExpressionFn: {
         properties: {


### PR DESCRIPTION
### Description

Adds a server-side API `/api/vis-augmenter/stats` to track usage of the feature. It does this by collecting all `augment-vis` saved objects, and aggregating values within them. Specifically:
- total number of saved objects
- breakdown and count of unique origin plugins
- breakdown and count of unique plugin resource types
- breakdown and count of plugin resource IDs
- breakdown and count of visualization IDs

This allows us to track what plugins and plugin resource types are being used (e.g., how many anomaly detectors are associated), as well as the individual IDs of the plugin resources and visualizations, to see if there are any unique patterns in how the feature is being used (e.g., many plugin resources to one visualization compared to roughly 1:1 mapping).

To collect these values, this PR also changes the `augment-vis` saved object interface to include all of these fields. 

Additionally, there's some small type optimizations to the saved object loader to process the individual attributes, by introducing `AugmentVisSavedObjectAttributes`. Many of the functions are updated to include this interface.

Existing tests are updated and new tests are added for the functions used in the API call.

### Issues Resolved

closes #3836 

### Check List
- [X] Commits are signed per the DCO using --signoff
