### PR TITLE
[Dashboards listing] fix listing limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Console] Fix dev tool console autocomplete not loading issue ([#3775](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3775))
 - [Console] Fix dev tool console run command with query parameter error ([#3813](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3813))
 - Add clarifying tooltips to header navigation ([#3573](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3573))
+- [Dashboards Listing] Fix listing limit to utilize `savedObjects:listingLimit` instead of `savedObjects:perPage` ([#4021](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4021))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/dashboard/public/application/legacy_app.js
+++ b/src/plugins/dashboard/public/application/legacy_app.js
@@ -150,7 +150,7 @@ export function initDashboardApp(app, deps) {
               type: $scope.dashboardListTypes,
               search: search ? `${search}*` : undefined,
               fields: ['title', 'type', 'description', 'updated_at'],
-              perPage: $scope.initialPageSize,
+              perPage: $scope.listingLimit,
               page: 1,
               searchFields: ['title^3', 'type', 'description'],
               defaultSearchOperator: 'AND',


### PR DESCRIPTION
### Description

Initial page size was passed to the search function instead of the listing limit causing the max amount received to be significantly less than the previously implementation.

Saved objects per page is `20` by default and the listing limit per page is `1000` by default.

### Issues Resolved

resolves: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4017

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
