### PR TITLE
showing default tooltip on mark

### DIFF
--- a/src/plugins/vis_augmenter/public/constants.ts
+++ b/src/plugins/vis_augmenter/public/constants.ts
@@ -11,3 +11,4 @@ export const EVENT_MARK_SIZE = 100;
 export const EVENT_MARK_SIZE_ENLARGED = 140;
 export const EVENT_MARK_SHAPE = 'triangle-up';
 export const EVENT_TIMELINE_HEIGHT = 25;
+export const EVENT_TOOLTIP_CENTER_ON_MARK = 5;

--- a/src/plugins/vis_augmenter/public/vega/helpers.ts
+++ b/src/plugins/vis_augmenter/public/vega/helpers.ts
@@ -24,6 +24,7 @@ import {
   VisLayer,
   VisLayers,
   VisLayerTypes,
+  EVENT_TOOLTIP_CENTER_ON_MARK,
 } from '../';
 import { VisAnnotationType } from './constants';
 
@@ -70,6 +71,9 @@ export const addVisEventSignalsToSpecConfig = (spec: object) => {
     kibana: {
       ...config.kibana,
       signals,
+      tooltips: {
+        centerOnMark: EVENT_TOOLTIP_CENTER_ON_MARK,
+      },
     },
   };
 };
@@ -339,6 +343,7 @@ export const addPointInTimeEventsLayersToSpec = (
       color: EVENT_COLOR,
       filled: true,
       opacity: 1,
+      tooltip: true,
       // This style is only used to locate this mark when trying to add signals in the compiled vega spec.
       // @see @method vega_parser._compileVegaLite
       style: [`${VisAnnotationType.POINT_IN_TIME_ANNOTATION}`],


### PR DESCRIPTION
### Description
Show custom tooltip for point in time annotation mark in vega visualization

### Issues Resolved
Solves remaining part of #3317 

## Screenshot
<img width="480" alt="image" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/114732919/a38808fb-af1b-4435-92c3-a8d4c7e388b9">


## Testing the changes
N/A

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
