### PR TITLE
Adding Tao and Zilong to MAINTAINERS

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,6 +17,8 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Kristen Tian              | [kristenTian](https://github.com/kristenTian)       | Amazon      |
 | Zhongnan Su               | [zhongnansu](https://github.com/zhongnansu)         | Amazon      |
 | Manasvini B Suryanarayana | [manasvinibs](https://github.com/manasvinibs)       | Amazon      |
+| Tao Liu                   | [Flyingliuhub](https://github.com/Flyingliuhub)     | Amazon      |
+| Zilong Xia                | [ZilongX](https://github.com/ZilongX)               | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
Adding Tao and Zilong to MAINTAINERS

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
