### PR TITLE
Bundle Node 14 and allow fallback to Node 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Vis Builder] Add persistence to visualizations inner state ([#3751](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3751))
 - [Table Visualization] Move format table, consolidate types and add unit tests ([#3397](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3397))
 - [Multiple Datasource] Support Amazon OpenSearch Serverless ([#3957](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3957))
+- Bundle Node 14 and allow fallback to Node 14 ([#4141](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4141))
+
 ### 🐛 Bug Fixes
 
 - [Vis Builder] Fixes auto bounds for timeseries bar chart visualization ([2401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2401))

--- a/scripts/use_node
+++ b/scripts/use_node
@@ -72,6 +72,15 @@ elif [ $OS = "freebsd" ]; then
   NODE="${LOCALBASE}/bin/node"
 else
   NODE="$(command -v node)"
+  if [ $? -ne 0 ]; then
+    NODE=""
+    for dir in "${OSD_HOME}/build/"*; do
+      if [[ -d "${dir}" && -f "${dir}/node/fallback/bin/node" ]]; then
+        NODE="${dir}/node/fallback/bin/node"
+        break
+      fi
+    done
+  fi
 fi
 
 if [ ! -x "$NODE" ]; then

--- a/src/dev/build/tasks/create_archives_sources_task.ts
+++ b/src/dev/build/tasks/create_archives_sources_task.ts
@@ -29,7 +29,7 @@
  */
 
 import { scanCopy, Task } from '../lib';
-import { getNodeDownloadInfo } from './nodejs';
+import { getNodeDownloadInfo, getNodeVersionDownloadInfo, NODE14_FALLBACK_VERSION } from './nodejs';
 
 export const CreateArchivesSources: Task = {
   description: 'Creating platform-specific archive source directories',
@@ -52,6 +52,20 @@ export const CreateArchivesSources: Task = {
         await scanCopy({
           source: (await getNodeDownloadInfo(config, platform)).extractDir,
           destination: build.resolvePathForPlatform(platform, 'node'),
+        });
+
+        // ToDo [NODE14]: Remove this Node.js 14 fallback download
+        // Copy the Node.js 14 binaries into node/fallback to be used by `use_node`
+        await scanCopy({
+          source: (
+            await getNodeVersionDownloadInfo(
+              NODE14_FALLBACK_VERSION,
+              platform.getNodeArch(),
+              platform.isWindows(),
+              config.resolveFromRepo()
+            )
+          ).extractDir,
+          destination: build.resolvePathForPlatform(platform, 'node', 'fallback'),
         });
 
         log.debug('Node.js copied into', platform.getNodeArch(), 'specific build directory');

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
@@ -44,7 +44,9 @@ jest.mock('../../lib/get_build_number');
 
 expect.addSnapshotSerializer(createAnyInstanceSerializer(ToolingLog));
 
-const { getNodeDownloadInfo } = jest.requireMock('./node_download_info');
+const { getNodeDownloadInfo, getNodeVersionDownloadInfo } = jest.requireMock(
+  './node_download_info'
+);
 const { getNodeShasums } = jest.requireMock('./node_shasums');
 const { download } = jest.requireMock('../../lib/download');
 
@@ -73,6 +75,16 @@ async function setup({ failOnUrl }: { failOnUrl?: string } = {}) {
       url: `${platform.getName()}:url`,
       downloadPath: `${platform.getName()}:downloadPath`,
       downloadName: `${platform.getName()}:downloadName`,
+    };
+  });
+
+  getNodeVersionDownloadInfo.mockImplementation((version, architecture, isWindows, repoRoot) => {
+    return {
+      url: `https://mirrors.nodejs.org/dist/v${version}/node-v${version}-${architecture}.tar.gz`,
+      downloadName: `node-v${version}-${architecture}.tar.gz`,
+      downloadPath: `/mocked/path/.node_binaries/${version}/node-v${version}-${architecture}.tar.gz`,
+      extractDir: `/mocked/path/.node_binaries/${version}/${architecture}`,
+      version,
     };
   });
 
@@ -132,6 +144,42 @@ it('downloads node builds for each platform', async () => {
           "retries": 3,
           "sha256": "win32:sha256",
           "url": "win32:url",
+        },
+      ],
+      Array [
+        Object {
+          "destination": "/mocked/path/.node_binaries/14.21.3/node-v14.21.3-linux-x64.tar.gz",
+          "log": <ToolingLog>,
+          "retries": 3,
+          "sha256": undefined,
+          "url": "https://mirrors.nodejs.org/dist/v14.21.3/node-v14.21.3-linux-x64.tar.gz",
+        },
+      ],
+      Array [
+        Object {
+          "destination": "/mocked/path/.node_binaries/14.21.3/node-v14.21.3-linux-arm64.tar.gz",
+          "log": <ToolingLog>,
+          "retries": 3,
+          "sha256": undefined,
+          "url": "https://mirrors.nodejs.org/dist/v14.21.3/node-v14.21.3-linux-arm64.tar.gz",
+        },
+      ],
+      Array [
+        Object {
+          "destination": "/mocked/path/.node_binaries/14.21.3/node-v14.21.3-darwin-x64.tar.gz",
+          "log": <ToolingLog>,
+          "retries": 3,
+          "sha256": undefined,
+          "url": "https://mirrors.nodejs.org/dist/v14.21.3/node-v14.21.3-darwin-x64.tar.gz",
+        },
+      ],
+      Array [
+        Object {
+          "destination": "/mocked/path/.node_binaries/14.21.3/node-v14.21.3-win32-x64.tar.gz",
+          "log": <ToolingLog>,
+          "retries": 3,
+          "sha256": undefined,
+          "url": "https://mirrors.nodejs.org/dist/v14.21.3/node-v14.21.3-win32-x64.tar.gz",
         },
       ],
     ]

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.ts
@@ -30,16 +30,25 @@
 
 import { download, GlobalTask } from '../../lib';
 import { getNodeShasums } from './node_shasums';
-import { getLatestNodeVersion, getNodeDownloadInfo } from './node_download_info';
+import {
+  getNodeDownloadInfo,
+  getNodeVersionDownloadInfo,
+  getRequiredVersion,
+  NODE14_FALLBACK_VERSION,
+} from './node_download_info';
 
 export const DownloadNodeBuilds: GlobalTask = {
   global: true,
   description: 'Downloading node.js builds for all platforms',
   async run(config, log) {
-    const latestNodeVersion = await getLatestNodeVersion(config);
-    const shasums = await getNodeShasums(log, latestNodeVersion);
-    await Promise.all(
-      config.getTargetPlatforms().map(async (platform) => {
+    const requiredNodeVersion = getRequiredVersion(config);
+    const shasums = await getNodeShasums(log, requiredNodeVersion);
+
+    // ToDo [NODE14]: Remove this Node.js 14 fallback download
+    const node14ShaSums = await getNodeShasums(log, NODE14_FALLBACK_VERSION);
+
+    await Promise.all([
+      ...config.getTargetPlatforms().map(async (platform) => {
         const { url, downloadPath, downloadName } = await getNodeDownloadInfo(config, platform);
         await download({
           log,
@@ -48,7 +57,23 @@ export const DownloadNodeBuilds: GlobalTask = {
           destination: downloadPath,
           retries: 3,
         });
-      })
-    );
+      }),
+      // ToDo [NODE14]: Remove this Node.js 14 fallback download
+      ...config.getTargetPlatforms().map(async (platform) => {
+        const { url, downloadPath, downloadName } = await getNodeVersionDownloadInfo(
+          NODE14_FALLBACK_VERSION,
+          platform.getNodeArch(),
+          platform.isWindows(),
+          config.resolveFromRepo()
+        );
+        await download({
+          log,
+          url,
+          sha256: node14ShaSums[downloadName],
+          destination: downloadPath,
+          retries: 3,
+        });
+      }),
+    ]);
   },
 };

--- a/src/dev/build/tasks/nodejs/extract_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/extract_node_builds_task.test.ts
@@ -123,11 +123,39 @@ it('runs expected fs operations', async () => {
             "strip": 1,
           },
         ],
+        Array [
+          <absolute path>/.node_binaries/14.21.3/node-v14.21.3-linux-x64.tar.gz,
+          <absolute path>/.node_binaries/14.21.3/linux-x64,
+          Object {
+            "strip": 1,
+          },
+        ],
+        Array [
+          <absolute path>/.node_binaries/14.21.3/node-v14.21.3-linux-arm64.tar.gz,
+          <absolute path>/.node_binaries/14.21.3/linux-arm64,
+          Object {
+            "strip": 1,
+          },
+        ],
+        Array [
+          <absolute path>/.node_binaries/14.21.3/node-v14.21.3-darwin-x64.tar.gz,
+          <absolute path>/.node_binaries/14.21.3/darwin-x64,
+          Object {
+            "strip": 1,
+          },
+        ],
       ],
       "unzip": Array [
         Array [
           <absolute path>/.node_binaries/<node version>/node-v<node version>-win-x64.zip,
           <absolute path>/.node_binaries/<node version>/win32-x64,
+          Object {
+            "strip": 1,
+          },
+        ],
+        Array [
+          <absolute path>/.node_binaries/14.21.3/node-v14.21.3-win-x64.zip,
+          <absolute path>/.node_binaries/14.21.3/win32-x64,
           Object {
             "strip": 1,
           },

--- a/src/dev/build/tasks/nodejs/node_download_info.ts
+++ b/src/dev/build/tasks/nodejs/node_download_info.ts
@@ -28,13 +28,15 @@
  * under the License.
  */
 
-import { basename } from 'path';
+import { basename, resolve } from 'path';
 import fetch from 'node-fetch';
 import semver from 'semver';
 
 import { Config, Platform } from '../../lib';
 
 const NODE_RANGE_CACHE: { [key: string]: string } = {};
+
+export const NODE14_FALLBACK_VERSION = '14.21.3';
 
 export async function getNodeDownloadInfo(config: Config, platform: Platform) {
   const version = await getLatestNodeVersion(config);
@@ -47,6 +49,29 @@ export async function getNodeDownloadInfo(config: Config, platform: Platform) {
   const url = `https://mirrors.nodejs.org/dist/v${version}/${downloadName}`;
   const downloadPath = config.resolveFromRepo('.node_binaries', version, basename(downloadName));
   const extractDir = config.resolveFromRepo('.node_binaries', version, arch);
+
+  return {
+    url,
+    downloadName,
+    downloadPath,
+    extractDir,
+    version,
+  };
+}
+
+export async function getNodeVersionDownloadInfo(
+  version: string,
+  architecture: string,
+  isWindows: boolean,
+  repoRoot: string
+) {
+  const downloadName = isWindows
+    ? `node-v${version}-win-x64.zip`
+    : `node-v${version}-${architecture}.tar.gz`;
+
+  const url = `https://mirrors.nodejs.org/dist/v${version}/${downloadName}`;
+  const downloadPath = resolve(repoRoot, '.node_binaries', version, basename(downloadName));
+  const extractDir = resolve(repoRoot, '.node_binaries', version, architecture);
 
   return {
     url,


### PR DESCRIPTION
### Description
Blocked by https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4071

This is resolving some backward issues to build on Node 18 for this PR https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4071 . The changes include:

* `getNodeVersionDownloadInfo` is responsible for generating the download information for a specific version of Node.js given the version number, architecture (e.g., x64), and the operating system.
* Node.js 14 binaries are downloaded and copied to node/fallback directory in the build path specific to a platform.
* Check if the desired Node.js version is available and executable, and if it is not, falling back to the path where Node.js 14 is stored (the "fallback" directory).

### Issues Resolved


### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
