### PR TITLE
[Saved Object Service] Adds Repository Factory Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Support Amazon OpenSearch Serverless ([#3957](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3957))
 - Add support for Node.js >=14.20.1 <19 ([#4071](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4071))
 - Bundle Node.js 14 as a fallback for operating systems that cannot run Node.js 18 ([#4151](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4151))
+- [Saved Object Service] Add Repository Factory Provider ([#4149](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4149))
 - Enhance grouping for context menus ([#3924](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3924))
 
 ### 🐛 Bug Fixes

--- a/src/core/server/legacy/legacy_service.ts
+++ b/src/core/server/legacy/legacy_service.ts
@@ -275,6 +275,7 @@ export class LegacyService implements CoreService {
         addClientWrapper: setupDeps.core.savedObjects.addClientWrapper,
         registerType: setupDeps.core.savedObjects.registerType,
         getImportExportObjectLimit: setupDeps.core.savedObjects.getImportExportObjectLimit,
+        setRepositoryFactoryProvider: setupDeps.core.savedObjects.setRepositoryFactoryProvider,
       },
       status: {
         isStatusPageAnonymous: setupDeps.core.status.isStatusPageAnonymous,

--- a/src/core/server/plugins/plugin_context.ts
+++ b/src/core/server/plugins/plugin_context.ts
@@ -204,6 +204,7 @@ export function createPluginSetupContext<TPlugin, TPluginDependencies>(
       addClientWrapper: deps.savedObjects.addClientWrapper,
       registerType: deps.savedObjects.registerType,
       getImportExportObjectLimit: deps.savedObjects.getImportExportObjectLimit,
+      setRepositoryFactoryProvider: deps.savedObjects.setRepositoryFactoryProvider,
     },
     status: {
       core$: deps.status.core$,

--- a/src/core/server/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/server/saved_objects/saved_objects_service.mock.ts
@@ -79,6 +79,7 @@ const createSetupContractMock = () => {
     addClientWrapper: jest.fn(),
     registerType: jest.fn(),
     getImportExportObjectLimit: jest.fn(),
+    setRepositoryFactoryProvider: jest.fn(),
   };
 
   setupContract.getImportExportObjectLimit.mockReturnValue(100);

--- a/src/core/server/saved_objects/saved_objects_service.test.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.ts
@@ -41,7 +41,7 @@ import { errors as opensearchErrors } from '@opensearch-project/opensearch';
 import { SavedObjectsService } from './saved_objects_service';
 import { mockCoreContext } from '../core_context.mock';
 import { Env } from '../config';
-import { configServiceMock } from '../mocks';
+import { configServiceMock, savedObjectsRepositoryMock } from '../mocks';
 import { opensearchServiceMock } from '../opensearch/opensearch_service.mock';
 import { opensearchClientMock } from '../opensearch/client/mocks';
 import { httpServiceMock } from '../http/http_service.mock';
@@ -49,6 +49,7 @@ import { httpServerMock } from '../http/http_server.mocks';
 import { SavedObjectsClientFactoryProvider } from './service/lib';
 import { NodesVersionCompatibility } from '../opensearch/version_check/ensure_opensearch_version';
 import { SavedObjectsRepository } from './service/lib/repository';
+import { SavedObjectRepositoryFactoryProvider } from './service/lib/scoped_client_provider';
 
 jest.mock('./service/lib/repository');
 
@@ -169,6 +170,27 @@ describe('SavedObjectsService', () => {
         expect(typeRegistryInstanceMock.registerType).toHaveBeenCalledWith(type);
       });
     });
+
+    describe('#setRepositoryFactoryProvider', () => {
+      it('throws error if a repository is already registered', async () => {
+        const coreContext = createCoreContext();
+        const soService = new SavedObjectsService(coreContext);
+        const setup = await soService.setup(createSetupDeps());
+
+        const firstRepository: SavedObjectRepositoryFactoryProvider = () =>
+          savedObjectsRepositoryMock.create();
+        const secondRepository: SavedObjectRepositoryFactoryProvider = () =>
+          savedObjectsRepositoryMock.create();
+
+        setup.setRepositoryFactoryProvider(firstRepository);
+
+        expect(() => {
+          setup.setRepositoryFactoryProvider(secondRepository);
+        }).toThrowErrorMatchingInlineSnapshot(
+          `"custom repository factory is already set, and can only be set once"`
+        );
+      });
+    });
   });
 
   describe('#start()', () => {
@@ -281,6 +303,15 @@ describe('SavedObjectsService', () => {
       }).toThrowErrorMatchingInlineSnapshot(
         `"cannot call \`registerType\` after service startup."`
       );
+
+      const customRpository: SavedObjectRepositoryFactoryProvider = () =>
+        savedObjectsRepositoryMock.create();
+
+      expect(() => {
+        setup.setRepositoryFactoryProvider(customRpository);
+      }).toThrowErrorMatchingInlineSnapshot(
+        '"cannot call `setRepositoryFactoryProvider` after service startup."'
+      );
     });
 
     describe('#getTypeRegistry', () => {
@@ -367,6 +398,36 @@ describe('SavedObjectsService', () => {
         ] = (SavedObjectsRepository.createRepository as jest.Mocked<any>).mock.calls;
 
         expect(includedHiddenTypes).toEqual(['someHiddenType']);
+      });
+
+      it('Should not create SavedObjectsRepository when custom repository is registered ', async () => {
+        const coreContext = createCoreContext({ skipMigration: false });
+        const soService = new SavedObjectsService(coreContext);
+        const coreSetup = createSetupDeps();
+        const setup = await soService.setup(coreSetup);
+
+        const customRpository: SavedObjectRepositoryFactoryProvider = () =>
+          savedObjectsRepositoryMock.create();
+        setup.setRepositoryFactoryProvider(customRpository);
+
+        const coreStart = createStartDeps();
+        const { createInternalRepository } = await soService.start(coreStart);
+        createInternalRepository();
+
+        expect(SavedObjectsRepository.createRepository as jest.Mocked<any>).not.toHaveBeenCalled();
+      });
+
+      it('Should create SavedObjectsRepository when no custom repository is registered ', async () => {
+        const coreContext = createCoreContext({ skipMigration: false });
+        const soService = new SavedObjectsService(coreContext);
+        const coreSetup = createSetupDeps();
+        await soService.setup(coreSetup);
+
+        const coreStart = createStartDeps();
+        const { createInternalRepository } = await soService.start(coreStart);
+        createInternalRepository();
+
+        expect(SavedObjectsRepository.createRepository as jest.Mocked<any>).toHaveBeenCalled();
       });
     });
   });

--- a/src/core/server/saved_objects/service/lib/scoped_client_provider.ts
+++ b/src/core/server/saved_objects/service/lib/scoped_client_provider.ts
@@ -31,8 +31,33 @@
 import { PriorityCollection } from './priority_collection';
 import { SavedObjectsClientContract } from '../../types';
 import { SavedObjectsRepositoryFactory } from '../../saved_objects_service';
-import { ISavedObjectTypeRegistry } from '../../saved_objects_type_registry';
+import {
+  ISavedObjectTypeRegistry,
+  SavedObjectTypeRegistry,
+} from '../../saved_objects_type_registry';
 import { OpenSearchDashboardsRequest } from '../../../http';
+import { ISavedObjectsRepository } from './repository';
+import { OpenSearchClient } from '../../../opensearch';
+import { IOpenSearchDashboardsMigrator } from '../../migrations';
+
+/**
+ * Options passed to each SavedObjectRepositoryFactoryProvider to aid in creating the repository instance.
+ * @public
+ */
+export interface SavedObjectsRepositoryOptions {
+  migrator: IOpenSearchDashboardsMigrator;
+  typeRegistry: SavedObjectTypeRegistry;
+  includedHiddenTypes: string[];
+  client?: OpenSearchClient;
+}
+
+/**
+ * Provider to invoke to a factory function for creating ISavedObjectRepository {@link ISavedObjectRepository} instances.
+ * @public
+ */
+export type SavedObjectRepositoryFactoryProvider = (
+  options: SavedObjectsRepositoryOptions
+) => ISavedObjectsRepository;
 
 /**
  * Options passed to each SavedObjectsClientWrapperFactory to aid in creating the wrapper instance.

--- a/src/core/server/saved_objects/service/lib/scoped_client_provider.ts
+++ b/src/core/server/saved_objects/service/lib/scoped_client_provider.ts
@@ -37,7 +37,6 @@ import {
 } from '../../saved_objects_type_registry';
 import { OpenSearchDashboardsRequest } from '../../../http';
 import { ISavedObjectsRepository } from './repository';
-import { OpenSearchClient } from '../../../opensearch';
 import { IOpenSearchDashboardsMigrator } from '../../migrations';
 
 /**
@@ -48,7 +47,6 @@ export interface SavedObjectsRepositoryOptions {
   migrator: IOpenSearchDashboardsMigrator;
   typeRegistry: SavedObjectTypeRegistry;
   includedHiddenTypes: string[];
-  client?: OpenSearchClient;
 }
 
 /**


### PR DESCRIPTION
### Description

The **Repository Factory Provider** in OpenSearch-Dashboards will be responsible for creating and managing instances of the Repository (e.g. SavedObjectRepository, PostgresRepository, DynamoDBRepository etc.), which is used to interact with the metadata storage that stores the saved objects. Currently we have an repository interface named [ISavedObjectRepository](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/core/server/saved_objects/service/lib/repository.ts#L134), and the [SavedObjectRepository](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/core/server/saved_objects/service/lib/repository.ts#L139) is the implementation, which use an OpenSearch index as its data store. This approach would make the implementation of [ISavedObjectRepository](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/core/server/saved_objects/service/lib/repository.ts#L134) replaceable by plugin.

More details can be found in [this](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3954) PR.


### Check List

- [X] All tests pass
  - [X] `yarn test:jest`
  - [X] `yarn test:jest_integration`
  - [X] `yarn test:ftr`
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
