### PR TITLE
Bundle Node 14 as a fallback for operating systems that cannot run Node 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Table Visualization] Move format table, consolidate types and add unit tests ([#3397](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3397))
 - [Multiple Datasource] Support Amazon OpenSearch Serverless ([#3957](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3957))
 - Add support for Node.js >=14.20.1 <19 ([#4071](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4071))
+- Bundle Node.js 14 as a fallback for operating systems that cannot run Node.js 18 ([#4151](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4151))
 
 ### 🐛 Bug Fixes
 

--- a/scripts/use_node
+++ b/scripts/use_node
@@ -57,11 +57,17 @@ elif [ ! -z "$NODE_HOME" ]; then
   NODE_ERROR_MSG="in NODE_HOME"
   NODE_ERROR_SHOW=true
 else
+  # Set these variables outside, as catchalls, to show meaningful errors if needed
   NODE="$OSD_HOME/node/bin/node"
   NODE_ERROR_MSG="bundled with OpenSearch Dashboards"
   # A bin folder at the root is only present in release builds that have a bundled Node.js binary
-  if [ -x "OSD_HOME/bin" ]; then
+  if [ -d "${OSD_HOME}/bin" ]; then
     NODE_ERROR_SHOW=true
+    # Not all operating systems can run the latest Node.js and the fallback is for them
+    "${NODE}" -v 2> /dev/null
+    if [ $? -ne 0 ] && [ -d "${OSD_HOME}/node/fallback" ]; then
+      NODE="$OSD_HOME/node/fallback/bin/node"
+    fi
   fi
 fi
 
@@ -75,7 +81,7 @@ else
 fi
 
 if [ ! -x "$NODE" ]; then
-  # Irrespective of NODE_ERROR_SHOW, show the error
+  # Irrespective of NODE_ERROR_SHOW, if NODE is not found or executable, show the error
   echo "Could not find a Node.js runtime binary $NODE_ERROR_MSG or on the system" >&2
   exit 1
 fi

--- a/src/dev/build/tasks/create_archives_sources_task.ts
+++ b/src/dev/build/tasks/create_archives_sources_task.ts
@@ -29,7 +29,7 @@
  */
 
 import { scanCopy, Task } from '../lib';
-import { getNodeDownloadInfo } from './nodejs';
+import { getNodeDownloadInfo, getNodeVersionDownloadInfo, NODE14_FALLBACK_VERSION } from './nodejs';
 
 export const CreateArchivesSources: Task = {
   description: 'Creating platform-specific archive source directories',
@@ -52,6 +52,20 @@ export const CreateArchivesSources: Task = {
         await scanCopy({
           source: (await getNodeDownloadInfo(config, platform)).extractDir,
           destination: build.resolvePathForPlatform(platform, 'node'),
+        });
+
+        // ToDo [NODE14]: Remove this Node.js 14 fallback download
+        // Copy the Node.js 14 binaries into node/fallback to be used by `use_node`
+        await scanCopy({
+          source: (
+            await getNodeVersionDownloadInfo(
+              NODE14_FALLBACK_VERSION,
+              platform.getNodeArch(),
+              platform.isWindows(),
+              config.resolveFromRepo()
+            )
+          ).extractDir,
+          destination: build.resolvePathForPlatform(platform, 'node', 'fallback'),
         });
 
         log.debug('Node.js copied into', platform.getNodeArch(), 'specific build directory');

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
@@ -44,7 +44,9 @@ jest.mock('../../lib/get_build_number');
 
 expect.addSnapshotSerializer(createAnyInstanceSerializer(ToolingLog));
 
-const { getNodeDownloadInfo } = jest.requireMock('./node_download_info');
+const { getNodeDownloadInfo, getNodeVersionDownloadInfo } = jest.requireMock(
+  './node_download_info'
+);
 const { getNodeShasums } = jest.requireMock('./node_shasums');
 const { download } = jest.requireMock('../../lib/download');
 
@@ -73,6 +75,16 @@ async function setup({ failOnUrl }: { failOnUrl?: string } = {}) {
       url: `${platform.getName()}:url`,
       downloadPath: `${platform.getName()}:downloadPath`,
       downloadName: `${platform.getName()}:downloadName`,
+    };
+  });
+
+  getNodeVersionDownloadInfo.mockImplementation((version, architecture, isWindows, repoRoot) => {
+    return {
+      url: `https://mirrors.nodejs.org/dist/v${version}/node-v${version}-${architecture}.tar.gz`,
+      downloadName: `node-v${version}-${architecture}.tar.gz`,
+      downloadPath: `/mocked/path/.node_binaries/${version}/node-v${version}-${architecture}.tar.gz`,
+      extractDir: `/mocked/path/.node_binaries/${version}/${architecture}`,
+      version,
     };
   });
 
@@ -132,6 +144,42 @@ it('downloads node builds for each platform', async () => {
           "retries": 3,
           "sha256": "win32:sha256",
           "url": "win32:url",
+        },
+      ],
+      Array [
+        Object {
+          "destination": "/mocked/path/.node_binaries/14.21.3/node-v14.21.3-linux-x64.tar.gz",
+          "log": <ToolingLog>,
+          "retries": 3,
+          "sha256": undefined,
+          "url": "https://mirrors.nodejs.org/dist/v14.21.3/node-v14.21.3-linux-x64.tar.gz",
+        },
+      ],
+      Array [
+        Object {
+          "destination": "/mocked/path/.node_binaries/14.21.3/node-v14.21.3-linux-arm64.tar.gz",
+          "log": <ToolingLog>,
+          "retries": 3,
+          "sha256": undefined,
+          "url": "https://mirrors.nodejs.org/dist/v14.21.3/node-v14.21.3-linux-arm64.tar.gz",
+        },
+      ],
+      Array [
+        Object {
+          "destination": "/mocked/path/.node_binaries/14.21.3/node-v14.21.3-darwin-x64.tar.gz",
+          "log": <ToolingLog>,
+          "retries": 3,
+          "sha256": undefined,
+          "url": "https://mirrors.nodejs.org/dist/v14.21.3/node-v14.21.3-darwin-x64.tar.gz",
+        },
+      ],
+      Array [
+        Object {
+          "destination": "/mocked/path/.node_binaries/14.21.3/node-v14.21.3-win32-x64.tar.gz",
+          "log": <ToolingLog>,
+          "retries": 3,
+          "sha256": undefined,
+          "url": "https://mirrors.nodejs.org/dist/v14.21.3/node-v14.21.3-win32-x64.tar.gz",
         },
       ],
     ]

--- a/src/dev/build/tasks/nodejs/extract_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/extract_node_builds_task.test.ts
@@ -123,11 +123,39 @@ it('runs expected fs operations', async () => {
             "strip": 1,
           },
         ],
+        Array [
+          <absolute path>/.node_binaries/14.21.3/node-v14.21.3-linux-x64.tar.gz,
+          <absolute path>/.node_binaries/14.21.3/linux-x64,
+          Object {
+            "strip": 1,
+          },
+        ],
+        Array [
+          <absolute path>/.node_binaries/14.21.3/node-v14.21.3-linux-arm64.tar.gz,
+          <absolute path>/.node_binaries/14.21.3/linux-arm64,
+          Object {
+            "strip": 1,
+          },
+        ],
+        Array [
+          <absolute path>/.node_binaries/14.21.3/node-v14.21.3-darwin-x64.tar.gz,
+          <absolute path>/.node_binaries/14.21.3/darwin-x64,
+          Object {
+            "strip": 1,
+          },
+        ],
       ],
       "unzip": Array [
         Array [
           <absolute path>/.node_binaries/<node version>/node-v<node version>-win-x64.zip,
           <absolute path>/.node_binaries/<node version>/win32-x64,
+          Object {
+            "strip": 1,
+          },
+        ],
+        Array [
+          <absolute path>/.node_binaries/14.21.3/node-v14.21.3-win-x64.zip,
+          <absolute path>/.node_binaries/14.21.3/win32-x64,
           Object {
             "strip": 1,
           },

--- a/src/dev/build/tasks/nodejs/node_download_info.ts
+++ b/src/dev/build/tasks/nodejs/node_download_info.ts
@@ -28,13 +28,15 @@
  * under the License.
  */
 
-import { basename } from 'path';
+import { basename, resolve } from 'path';
 import fetch from 'node-fetch';
 import semver from 'semver';
 
 import { Config, Platform } from '../../lib';
 
 const NODE_RANGE_CACHE: { [key: string]: string } = {};
+
+export const NODE14_FALLBACK_VERSION = '14.21.3';
 
 export async function getNodeDownloadInfo(config: Config, platform: Platform) {
   const version = getRequiredVersion(config);
@@ -47,6 +49,29 @@ export async function getNodeDownloadInfo(config: Config, platform: Platform) {
   const url = `https://mirrors.nodejs.org/dist/v${version}/${downloadName}`;
   const downloadPath = config.resolveFromRepo('.node_binaries', version, basename(downloadName));
   const extractDir = config.resolveFromRepo('.node_binaries', version, arch);
+
+  return {
+    url,
+    downloadName,
+    downloadPath,
+    extractDir,
+    version,
+  };
+}
+
+export async function getNodeVersionDownloadInfo(
+  version: string,
+  architecture: string,
+  isWindows: boolean,
+  repoRoot: string
+) {
+  const downloadName = isWindows
+    ? `node-v${version}-win-x64.zip`
+    : `node-v${version}-${architecture}.tar.gz`;
+
+  const url = `https://mirrors.nodejs.org/dist/v${version}/${downloadName}`;
+  const downloadPath = resolve(repoRoot, '.node_binaries', version, basename(downloadName));
+  const extractDir = resolve(repoRoot, '.node_binaries', version, architecture);
 
   return {
     url,


### PR DESCRIPTION
### Description

Not all operating systems can run Node 18. Hence, Node 14 is bundled as a fallback for them.


* getNodeVersionDownloadInfo is responsible for generating the download information for a specific version of Node.js given the version number, architecture (e.g., x64), and the operating system.
* Node.js 14 binaries are downloaded and copied to node/fallback directory in the build path specific to a platform.
* Check if the desired Node.js version is available and executable, and if it is not, falling back to the path where Node.js 14 is stored (the "fallback" directory).


Hold merging until #3955 is merged.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
