### PR TITLE
[Table Visualization] Remove custom styling for text-align:center in favor of OUI utility class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Console] Remove unused ul element and its custom styling ([#3993](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3993))
 - Fix EUI/OUI type errors ([#3798](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3798))
 - Remove unused Sass in `tile_map` plugin ([#4110](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4110))
+- [Table Visualization] Remove custom styling for text-align:center in favor of OUI utility class. ([#4164](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4164))
 
 ### 🔩 Tests
 

--- a/src/plugins/vis_type_table/public/components/table_vis_app.scss
+++ b/src/plugins/vis_type_table/public/components/table_vis_app.scss
@@ -17,11 +17,6 @@
   flex: 0 0 auto;
 }
 
-// Style for table component title
-.visTable__component__title {
-  text-align: center;
-}
-
 // Modifier for visTables__group when displayed in columns
 .visTable__groupInColumns {
   flex-direction: row;

--- a/src/plugins/vis_type_table/public/components/table_vis_component.tsx
+++ b/src/plugins/vis_type_table/public/components/table_vis_component.tsx
@@ -104,7 +104,7 @@ export const TableVisComponent = ({
   return (
     <>
       {title && (
-        <EuiTitle size="xs" className="visTable__component__title">
+        <EuiTitle size="xs" className="eui-textCenter">
           <h3>{title}</h3>
         </EuiTitle>
       )}


### PR DESCRIPTION
### Description

Replaces usage of ```.visTable__component__title``` custom class with OUI utility class ```oui-textCenter```.

### Issues Resolved

Solves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4163

## Screenshot

<img width="1497" alt="image" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/67782303/351c6897-340f-4ade-bb99-b4bd2621f1db">

## Testing the changes

Go to table visualizations, use `Split table`. Now we have multiple tables and each one should have centered title as in the screenshot.

### Check List

- [ ] All tests pass
  - [X] `yarn test:jest`
  - [X] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
