### PR TITLE
[CI] skip checksum verification for cypress tests

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -12,7 +12,10 @@ env:
   START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch'
   OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot'
   SPEC: 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js,'
-  CYPRESS_ENV: 'env CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=false'
+  CYPRESS_BROWSER: 'chromium'
+  CYPRESS_VISBUILDER_ENABLED: true
+  CYPRESS_DATASOURCE_MANAGEMENT_ENABLED: false
+  OSD_SNAPSHOT_SKIP_VERIFY_CHECKSUM: true
 
 jobs:
   cypress-tests:
@@ -76,7 +79,7 @@ jobs:
           working-directory: ${{ env.FTR_PATH }}
           start: ${{ env.OPENSEARCH_SNAPSHOT_CMD }}, ${{ env.START_CMD }}
           wait-on: 'http://localhost:9200, http://localhost:5601'
-          command: ${{ env.CYPRESS_ENV }} yarn cypress:run-without-security --browser chromium --spec ${{ env.SPEC }}
+          command: yarn cypress:run-without-security --browser ${{ env.CYPRESS_BROWSER }} --spec ${{ env.SPEC }}
 
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,6 +276,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Updating WS scans to ignore BWC artifacts in `cypress` ([#2408](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2408))
 - [CI] Run functional test repo as workflow ([#2503](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2503))
 - Add downgrade logic for branch in DocLinkService([#3483](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3483))
+- [CI] Skip checksum verification on OpenSearch snapshot for cypress tests ([#4188](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4188))
 
 ### 📝 Documentation
 


### PR DESCRIPTION
### Description

Snapshot checksum verification caused failure in test runs: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4187

Skipping the verification to enable the tests run as the snapshot of OpenSearch should not impact the tests.

### Issues Resolved

n/a

## Screenshot

<img width="718" alt="Screenshot 2023-05-31 at 12 30 31 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/12060704/f9372246-6f66-4182-bf53-f5f9166b2376">


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
