### PR TITLE
Hide any output from `use_node` checking for Node compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple DataSource] Add support for SigV4 authentication ([#3058](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3058)). Backwards-compatible feature included in v2.6.0 release.
 - Add plugin manifest config to define OpenSearch plugin dependency and verify if it is installed on the cluster ([#3116](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3116))
 - Replace re2 with RegExp in timeline and add unit tests ([#3908](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3908))
+- Hide any output from use_node checking for Node compatibility ([#4237](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4237))
 
 ### 🐛 Bug Fixes
 

--- a/scripts/use_node
+++ b/scripts/use_node
@@ -64,7 +64,7 @@ else
   if [ -d "${OSD_HOME}/bin" ]; then
     NODE_ERROR_SHOW=true
     # Not all operating systems can run the latest Node.js and the fallback is for them
-    "${NODE}" -v 2> /dev/null
+    "${NODE}" -v > /dev/null 2>&1
     if [ $? -ne 0 ] && [ -d "${OSD_HOME}/node/fallback" ]; then
       NODE="$OSD_HOME/node/fallback/bin/node"
     fi


### PR DESCRIPTION
The first time the `use_node` was executed in a session, while validating that the primary bundled Node binary was suitable for the OS, the version would be printed out in the case of success. This was a new bit of info with no labels to make it meaningful. The modified code supressed success or failure msgs.

resolves: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4241

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
