### PR TITLE
[Feature Anywhere] Various bug fixes

### DIFF
--- a/src/plugins/vis_augmenter/public/view_events_flyout/actions/view_events_option_action.tsx
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/actions/view_events_option_action.tsx
@@ -23,7 +23,7 @@ export class ViewEventsOptionAction implements Action<EmbeddableContext> {
   constructor() {}
 
   public getIconType(): EuiIconType {
-    return 'apmTrace';
+    return 'inspect';
   }
 
   public getDisplayName() {

--- a/src/plugins/vis_augmenter/public/view_events_flyout/actions/view_events_option_action.tsx
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/actions/view_events_option_action.tsx
@@ -5,8 +5,7 @@
 
 import { i18n } from '@osd/i18n';
 import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
-import { get } from 'lodash';
-import { CoreStart } from 'opensearch-dashboards/public';
+import { get, isEmpty } from 'lodash';
 import { VisualizeEmbeddable } from '../../../../visualizations/public';
 import { EmbeddableContext } from '../../../../embeddable/public';
 import { Action, IncompatibleActionError } from '../../../../ui_actions/public';
@@ -35,7 +34,11 @@ export class ViewEventsOptionAction implements Action<EmbeddableContext> {
 
   public async isCompatible({ embeddable }: EmbeddableContext) {
     const vis = (embeddable as VisualizeEmbeddable).vis;
-    return vis !== undefined && isEligibleForVisLayers(vis);
+    return (
+      vis !== undefined &&
+      isEligibleForVisLayers(vis) &&
+      !isEmpty((embeddable as VisualizeEmbeddable).visLayers)
+    );
   }
 
   public async execute({ embeddable }: EmbeddableContext) {

--- a/src/plugins/vis_augmenter/public/view_events_flyout/components/event_vis_item.tsx
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/components/event_vis_item.tsx
@@ -32,7 +32,9 @@ export function EventVisItem(props: Props) {
         >
           <EuiFlexGroup alignItems="center">
             <EuiFlexItem>
-              <EuiLink href={`${baseUrl.prepend(`${urlPath}`)}`}>{name}</EuiLink>
+              <EuiLink href={`${baseUrl.prepend(`${urlPath}`)}`} target="_blank">
+                {name}
+              </EuiLink>
             </EuiFlexItem>
             <EventVisItemIcon visLayer={props.item.visLayer} />
           </EuiFlexGroup>

--- a/src/plugins/vis_augmenter/public/view_events_flyout/components/styles.scss
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/components/styles.scss
@@ -1,4 +1,4 @@
-$vis-description-width: 150px;
+$vis-description-width: 200px;
 $event-vis-height: 55px;
 $timeline-panel-height: 100px;
 $content-padding-top: 110px; // Padding needed within view events flyout content to sit comfortably below flyout header
@@ -22,6 +22,7 @@ $base-vis-min-height: 25vh; // Visualizations require the container to have a va
   &__visDescription {
     min-width: $vis-description-width;
     max-width: $vis-description-width;
+    word-break: break-word;
   }
 
   &__content {

--- a/src/plugins/vis_augmenter/server/capabilities_provider.ts
+++ b/src/plugins/vis_augmenter/server/capabilities_provider.ts
@@ -5,7 +5,7 @@
 
 export const capabilitiesProvider = () => ({
   visAugmenter: {
-    show: true,
+    show: false,
     delete: true,
     save: true,
     saveQuery: true,

--- a/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
+++ b/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { get } from 'lodash';
 import { SavedObjectsType } from 'opensearch-dashboards/server';
 
 export const augmentVisSavedObjectType: SavedObjectsType = {
@@ -13,7 +12,7 @@ export const augmentVisSavedObjectType: SavedObjectsType = {
   management: {
     importableAndExportable: true,
     getTitle(obj) {
-      return `augment-vis-${get(obj, 'attributes.originPlugin')}`;
+      return `augment-vis-${obj?.attributes?.originPlugin}`;
     },
     getEditUrl(obj) {
       return `/management/opensearch-dashboards/objects/savedAugmentVis/${encodeURIComponent(

--- a/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
+++ b/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { get } from 'lodash';
 import { SavedObjectsType } from 'opensearch-dashboards/server';
 
 export const augmentVisSavedObjectType: SavedObjectsType = {
@@ -12,7 +13,7 @@ export const augmentVisSavedObjectType: SavedObjectsType = {
   management: {
     importableAndExportable: true,
     getTitle(obj) {
-      return obj.attributes.title;
+      return `augment-vis-${get(obj, 'attributes.originPlugin')}`;
     },
     getEditUrl(obj) {
       return `/management/opensearch-dashboards/objects/savedAugmentVis/${encodeURIComponent(


### PR DESCRIPTION
### Description

Various bug fixes:
1. Hides 'view events' option on eligible charts, if there is no existing vislayers.
2. Fixes text wrapping of plugin resource names in view events flyout by adding [word-break styling](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break). Also expands width from 150px -> 200px to increase likelihood of the names fitting on one line and not looking too squished/compact
3. Adds external link to plugin resource names in view events flyout
4. Cleans up default saved obj title in the saved obj management plugin to be `augment-vis-<originPlugin>`
5. Disables/removes the 'View augment-vis' button in the saved obj details page in saved obj management plugin by updating the value in `capabilitiesProvider`.
6. Updates the view events icon to `inspect`


Screenshots of fixes:
Updated name:
![Screenshot 2023-06-05 at 3 27 27 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/62119629/dabcdcd8-94f3-478c-9851-f4285c1d3c8e)

Correct text wrapping:
![Screenshot 2023-06-05 at 2 43 45 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/62119629/a27affda-0a3c-4501-a35f-c4df9b2e4adf)

Removed 'View augment-vis' button:
![Screenshot 2023-06-05 at 3 42 16 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/62119629/2468223d-cb16-4aed-a527-d98e899352ee)


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
