### PR TITLE
Allow plugins get vis embeddable to show in flyouts

### DIFF
--- a/src/plugins/vis_augmenter/public/index.ts
+++ b/src/plugins/vis_augmenter/public/index.ts
@@ -36,3 +36,5 @@ export * from './saved_augment_vis';
 export * from './test_constants';
 export * from './triggers';
 export * from './actions';
+export { fetchVisEmbeddable } from './view_events_flyout';
+export { setUISettings } from './services'; // Needed for plugin tests related to the CRUD saved object functions

--- a/src/plugins/vis_augmenter/public/view_events_flyout/components/index.ts
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/components/index.ts
@@ -5,3 +5,4 @@
 
 export { ViewEventsFlyout } from './view_events_flyout';
 export { EventVisEmbeddablesMap, EventVisEmbeddableItem } from './types';
+export { fetchVisEmbeddable } from './utils';

--- a/src/plugins/vis_augmenter/public/view_events_flyout/components/utils.tsx
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/components/utils.tsx
@@ -98,7 +98,7 @@ export async function fetchVisEmbeddableWithSetters(
 ): Promise<void> {
   try {
     const embeddable = await fetchVisEmbeddable(savedObjectId);
-    setTimeRange(embeddable.timeRange);
+    setTimeRange(getQueryService().timefilter.timefilter.getTime());
     setVisEmbeddable(embeddable);
   } catch (err: any) {
     setErrorMessage(String(err));

--- a/src/plugins/vis_augmenter/public/view_events_flyout/components/utils.tsx
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/components/utils.tsx
@@ -47,48 +47,58 @@ function getValueAxisPositions(embeddable: VisualizeEmbeddable): { left: boolean
  * Fetching the base vis to show in the flyout, based on the saved object ID. Add constraints
  * such that it is static and won't auto-refresh within the flyout.
  * @param savedObjectId the saved object id of the base vis
+ */
+export async function fetchVisEmbeddable(savedObjectId: string): Promise<VisualizeEmbeddable> {
+  const embeddableVisFactory = getEmbeddable().getEmbeddableFactory('visualization');
+  const contextInput = {
+    filters: getQueryService().filterManager.getFilters(),
+    query: getQueryService().queryString.getQuery(),
+    timeRange: getQueryService().timefilter.timefilter.getTime(),
+  };
+
+  const embeddable = (await embeddableVisFactory?.createFromSavedObject(savedObjectId, {
+    ...contextInput,
+    visAugmenterConfig: {
+      inFlyout: true,
+      flyoutContext: VisFlyoutContext.BASE_VIS,
+    },
+  } as VisualizeInput)) as VisualizeEmbeddable | ErrorEmbeddable;
+
+  if (embeddable instanceof ErrorEmbeddable) {
+    throw getErrorMessage(embeddable);
+  }
+
+  embeddable.updateInput({
+    // @ts-ignore
+    refreshConfig: {
+      value: 0,
+      pause: true,
+    },
+  });
+
+  // By waiting for this to complete, embeddable.visLayers will be populated
+  await embeddable.populateVisLayers();
+
+  return embeddable;
+}
+
+/**
+ * Fetching the base vis to show in the flyout, based on the saved object ID. Add constraints
+ * such that it is static and won't auto-refresh within the flyout.
+ * @param savedObjectId the saved object id of the base vis
  * @param setTimeRange custom hook used in base component
  * @param setVisEmbeddable custom hook used in base component
  * @param setErrorMessage custom hook used in base component
  */
-export async function fetchVisEmbeddable(
+export async function fetchVisEmbeddableWithSetters(
   savedObjectId: string,
   setTimeRange: Function,
   setVisEmbeddable: Function,
   setErrorMessage: Function
 ): Promise<void> {
-  const embeddableVisFactory = getEmbeddable().getEmbeddableFactory('visualization');
   try {
-    const contextInput = {
-      filters: getQueryService().filterManager.getFilters(),
-      query: getQueryService().queryString.getQuery(),
-      timeRange: getQueryService().timefilter.timefilter.getTime(),
-    };
-    setTimeRange(contextInput.timeRange);
-
-    const embeddable = (await embeddableVisFactory?.createFromSavedObject(savedObjectId, {
-      ...contextInput,
-      visAugmenterConfig: {
-        inFlyout: true,
-        flyoutContext: VisFlyoutContext.BASE_VIS,
-      },
-    } as VisualizeInput)) as VisualizeEmbeddable | ErrorEmbeddable;
-
-    if (embeddable instanceof ErrorEmbeddable) {
-      throw getErrorMessage(embeddable);
-    }
-
-    embeddable.updateInput({
-      // @ts-ignore
-      refreshConfig: {
-        value: 0,
-        pause: true,
-      },
-    });
-
-    // By waiting for this to complete, embeddable.visLayers will be populated
-    await embeddable.populateVisLayers();
-
+    const embeddable = await fetchVisEmbeddable(savedObjectId);
+    setTimeRange(embeddable.timeRange);
     setVisEmbeddable(embeddable);
   } catch (err: any) {
     setErrorMessage(String(err));

--- a/src/plugins/vis_augmenter/public/view_events_flyout/components/view_events_flyout.tsx
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/components/view_events_flyout.tsx
@@ -22,7 +22,11 @@ import { LoadingFlyoutBody } from './loading_flyout_body';
 import { ErrorFlyoutBody } from './error_flyout_body';
 import { EventsPanel } from './events_panel';
 import { TimelinePanel } from './timeline_panel';
-import { fetchVisEmbeddable, createEventEmbeddables, createTimelineEmbeddable } from './utils';
+import {
+  fetchVisEmbeddableWithSetters,
+  createEventEmbeddables,
+  createTimelineEmbeddable,
+} from './utils';
 import { EventVisEmbeddablesMap } from './types';
 
 interface Props {
@@ -56,7 +60,12 @@ export function ViewEventsFlyout(props: Props) {
   }
 
   useEffect(() => {
-    fetchVisEmbeddable(props.savedObjectId, setTimeRange, setVisEmbeddable, setErrorMessage);
+    fetchVisEmbeddableWithSetters(
+      props.savedObjectId,
+      setTimeRange,
+      setVisEmbeddable,
+      setErrorMessage
+    );
     // adding all of the values to the deps array cause a circular re-render. we don't want
     // to keep re-fetching the visEmbeddable after it is set.
     /* eslint-disable react-hooks/exhaustive-deps */

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -122,7 +122,7 @@ export class VisualizeEmbeddable
   implements ReferenceOrValueEmbeddable<VisualizeByValueInput, VisualizeByReferenceInput> {
   private handler?: ExpressionLoader;
   private timefilter: TimefilterContract;
-  public timeRange?: TimeRange;
+  private timeRange?: TimeRange;
   private query?: Query;
   private filters?: Filter[];
   private visCustomizations?: Pick<VisualizeInput, 'vis' | 'table'>;

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -122,7 +122,7 @@ export class VisualizeEmbeddable
   implements ReferenceOrValueEmbeddable<VisualizeByValueInput, VisualizeByReferenceInput> {
   private handler?: ExpressionLoader;
   private timefilter: TimefilterContract;
-  private timeRange?: TimeRange;
+  public timeRange?: TimeRange;
   private query?: Query;
   private filters?: Filter[];
   private visCustomizations?: Pick<VisualizeInput, 'vis' | 'table'>;


### PR DESCRIPTION
### Description

Allow plugins get vis embeddable to show in flyouts.
This prevents plugins from using the current embeddable object to show in the flyout as the breaks functionality in the main dashboard visualization.

### Issues Resolved

This prevents plugins from using the current embeddable object to show in the flyout as the breaks functionality in the main dashboard visualization.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
