### PR TITLE
[Backport 1.3][CVE-2022-1537] Bump grunt from 1.5.2 to 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 🛡 Security
 
+- [CVE-2022-1537] Bump grunt from `1.5.2` to `1.5.3` ([#4276](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4276))
 - [CVE-2022-25858] Bump terser from `4.8.0` to `4.8.1` ([#3726](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3726))
 - [CVE-2021-3765] Update `@microsoft/api-documenter` and `@microsoft/api-extractor` versions to bump validator from `8.2.0` to `13.9.0` ([#3725](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3725))
 

--- a/package.json
+++ b/package.json
@@ -417,7 +417,7 @@
     "fp-ts": "^2.3.1",
     "geckodriver": "^1.21.0",
     "getopts": "^2.2.5",
-    "grunt": "^1.5.2",
+    "grunt": "~1.5.3",
     "grunt-available-tasks": "^0.6.3",
     "grunt-cli": "^1.4.3",
     "grunt-contrib-watch": "^1.1.0",

--- a/packages/osd-ui-framework/package.json
+++ b/packages/osd-ui-framework/package.json
@@ -42,7 +42,7 @@
     "css-loader": "^3.4.2",
     "expose-loader": "^0.7.5",
     "file-loader": "^4.2.0",
-    "grunt": "^1.5.2",
+    "grunt": "~1.5.3",
     "grunt-babel": "^8.0.0",
     "grunt-contrib-clean": "^2.0.0",
     "grunt-contrib-copy": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10677,10 +10677,10 @@ grunt-run@^0.8.1:
   dependencies:
     strip-ansi "^3.0.0"
 
-grunt@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/grunt/-/grunt-1.5.2.tgz#46b014e28d17c85baac19d5e891bb3f04923c098"
-  integrity sha512-XCtfaIu72OyDqK24MjWiGC9SwlkuhkS1mrULr1xzuJ2XqAFhP3ZAchZGHJeSCY6mkaOXU4F7SbmmCF7xIVoC9w==
+grunt@~1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/grunt/-/grunt-1.5.3.tgz#3214101d11257b7e83cf2b38ea173b824deab76a"
+  integrity sha512-mKwmo4X2d8/4c/BmcOETHek675uOqw0RuA/zy12jaspWqvTp4+ZeQF1W+OTpcbncnaBsfbQJ6l0l4j+Sn/GmaQ==
   dependencies:
     dateformat "~3.0.3"
     eventemitter2 "~0.4.13"


### PR DESCRIPTION
### Description

* This one is to fix [CVE-2022-1537](https://github.com/advisories/GHSA-rm36-94g8-835r) in 1.3 branch targeting release 1.3.11
* This is a manual backport of
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3723 tailored for 1.3 as `Node 10` is in use for OSD 1.3
* Lock both major and minor as grunt 1.6 does requires `Node 16+`

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1579

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
