### PR TITLE
Add configurable `defaults` and `overrides` to `uiSettings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add category option within groups for context menus ([#4144](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4144))
 - [Saved Object Service] Add Repository Factory Provider ([#4149](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4149))
 - [Multiple DataSource] Backend support for adding sample data ([#4268](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4268))
+- Add configurable defaults and overrides to uiSettings ([#4344](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4344))
 
 ### 🐛 Bug Fixes
 

--- a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
@@ -106,7 +106,7 @@ Object {
 }
 `;
 
-exports[`RenderingService setup() render() renders "core" page driven by settings 1`] = `
+exports[`RenderingService setup() render() renders "core" page driven by defaults 1`] = `
 Object {
   "anonymousStatusPage": false,
   "basePath": "/mock-server-basepath",
@@ -146,6 +146,59 @@ Object {
       "defaults": Object {
         "registered": Object {
           "name": "title",
+        },
+      },
+      "user": Object {},
+    },
+  },
+  "serverBasePath": "/mock-server-basepath",
+  "survey": "https://survey.opensearch.org",
+  "uiPlugins": Array [],
+  "vars": Object {},
+  "version": Any<String>,
+}
+`;
+
+exports[`RenderingService setup() render() renders "core" page driven by settings 1`] = `
+Object {
+  "anonymousStatusPage": false,
+  "basePath": "/mock-server-basepath",
+  "branch": Any<String>,
+  "branding": Object {
+    "applicationTitle": "OpenSearch Dashboards",
+    "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
+    "darkMode": true,
+    "loadingLogo": Object {},
+    "logo": Object {},
+    "mark": Object {},
+    "useExpandedHeader": true,
+  },
+  "buildNumber": Any<Number>,
+  "csp": Object {
+    "warnLegacyBrowsers": true,
+  },
+  "env": Object {
+    "mode": Object {
+      "dev": Any<Boolean>,
+      "name": Any<String>,
+      "prod": Any<Boolean>,
+    },
+    "packageInfo": Object {
+      "branch": Any<String>,
+      "buildNum": Any<Number>,
+      "buildSha": Any<String>,
+      "dist": Any<Boolean>,
+      "version": Any<String>,
+    },
+  },
+  "i18n": Object {
+    "translationsUrl": "/mock-server-basepath/translations/en.json",
+  },
+  "legacyMetadata": Object {
+    "uiSettings": Object {
+      "defaults": Object {
+        "theme:darkMode": Object {
+          "value": false,
         },
       },
       "user": Object {
@@ -197,6 +250,59 @@ Object {
   },
   "i18n": Object {
     "translationsUrl": "/translations/en.json",
+  },
+  "legacyMetadata": Object {
+    "uiSettings": Object {
+      "defaults": Object {
+        "registered": Object {
+          "name": "title",
+        },
+      },
+      "user": Object {},
+    },
+  },
+  "serverBasePath": "/mock-server-basepath",
+  "survey": "https://survey.opensearch.org",
+  "uiPlugins": Array [],
+  "vars": Object {},
+  "version": Any<String>,
+}
+`;
+
+exports[`RenderingService setup() render() renders "core" page with no defaults or overrides 1`] = `
+Object {
+  "anonymousStatusPage": false,
+  "basePath": "/mock-server-basepath",
+  "branch": Any<String>,
+  "branding": Object {
+    "applicationTitle": "OpenSearch Dashboards",
+    "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
+    "darkMode": false,
+    "loadingLogo": Object {},
+    "logo": Object {},
+    "mark": Object {},
+    "useExpandedHeader": true,
+  },
+  "buildNumber": Any<Number>,
+  "csp": Object {
+    "warnLegacyBrowsers": true,
+  },
+  "env": Object {
+    "mode": Object {
+      "dev": Any<Boolean>,
+      "name": Any<String>,
+      "prod": Any<Boolean>,
+    },
+    "packageInfo": Object {
+      "branch": Any<String>,
+      "buildNum": Any<Number>,
+      "buildSha": Any<String>,
+      "dist": Any<Boolean>,
+      "version": Any<String>,
+    },
+  },
+  "i18n": Object {
+    "translationsUrl": "/mock-server-basepath/translations/en.json",
   },
   "legacyMetadata": Object {
     "uiSettings": Object {

--- a/src/core/server/rendering/rendering_service.test.ts
+++ b/src/core/server/rendering/rendering_service.test.ts
@@ -106,12 +106,41 @@ describe('RenderingService', () => {
         expect(data).toMatchSnapshot(INJECTED_METADATA);
       });
 
+      it('renders "core" page driven by defaults', async () => {
+        uiSettings.getUserProvided.mockResolvedValue({ 'theme:darkMode': { userValue: false } });
+        uiSettings.getOverrideOrDefault.mockImplementation((name) => name === 'theme:darkMode');
+        const content = await render(createOpenSearchDashboardsRequest(), uiSettings, {
+          includeUserSettings: false,
+        });
+        const dom = load(content);
+        const data = JSON.parse(dom('osd-injected-metadata').attr('data') || '');
+
+        expect(uiSettings.getUserProvided).not.toHaveBeenCalled();
+        expect(data).toMatchSnapshot(INJECTED_METADATA);
+      });
+
       it('renders "core" page driven by settings', async () => {
         uiSettings.getUserProvided.mockResolvedValue({ 'theme:darkMode': { userValue: true } });
+        uiSettings.getRegistered.mockReturnValue({ 'theme:darkMode': { value: false } });
         const content = await render(createOpenSearchDashboardsRequest(), uiSettings);
         const dom = load(content);
         const data = JSON.parse(dom('osd-injected-metadata').attr('data') || '');
 
+        expect(data).toMatchSnapshot(INJECTED_METADATA);
+      });
+
+      it('renders "core" page with no defaults or overrides', async () => {
+        uiSettings.getUserProvided.mockResolvedValue({});
+        uiSettings.getOverrideOrDefault.mockImplementation((name) =>
+          name === 'theme:darkMode' ? undefined : false
+        );
+        const content = await render(createOpenSearchDashboardsRequest(), uiSettings, {
+          includeUserSettings: false,
+        });
+        const dom = load(content);
+        const data = JSON.parse(dom('osd-injected-metadata').attr('data') || '');
+
+        expect(uiSettings.getUserProvided).not.toHaveBeenCalled();
         expect(data).toMatchSnapshot(INJECTED_METADATA);
       });
 

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -95,9 +95,11 @@ export class RenderingService {
           defaults: uiSettings.getRegistered(),
           user: includeUserSettings ? await uiSettings.getUserProvided() : {},
         };
-        const darkMode = settings.user?.['theme:darkMode']?.userValue
-          ? Boolean(settings.user['theme:darkMode'].userValue)
-          : false;
+        // Cannot use `uiSettings.get()` since a user might not be authenticated
+        const darkMode =
+          (settings.user?.['theme:darkMode']?.userValue ??
+            uiSettings.getOverrideOrDefault('theme:darkMode')) ||
+          false;
 
         const brandingAssignment = await this.assignBrandingConfig(
           darkMode,

--- a/src/core/server/ui_settings/types.ts
+++ b/src/core/server/ui_settings/types.ts
@@ -52,9 +52,13 @@ export {
  */
 export interface IUiSettingsClient {
   /**
-   * Returns registered uiSettings values {@link UiSettingsParams}
+   * Returns all registered uiSettings values {@link UiSettingsParams}
    */
   getRegistered: () => Readonly<Record<string, PublicUiSettingsParams>>;
+  /**
+   * Returns the overridden uiSettings value if one exists, or the registered default if one exists {@link UiSettingsParams}
+   */
+  getOverrideOrDefault: (key: string) => unknown;
   /**
    * Retrieves uiSettings values set by the user with fallbacks to default values if not specified.
    */

--- a/src/core/server/ui_settings/ui_settings_client.test.ts
+++ b/src/core/server/ui_settings/ui_settings_client.test.ts
@@ -333,6 +333,25 @@ describe('ui settings', () => {
     });
   });
 
+  describe('#getOverrideOrDefault()', () => {
+    it('returns the non-overridden default settings passed within the constructor', () => {
+      const value = chance.word();
+      const defaults = { key: { value } };
+      const { uiSettings } = setup({ defaults });
+      expect(uiSettings.getOverrideOrDefault('key')).toEqual(value);
+      expect(uiSettings.getOverrideOrDefault('unknown')).toBeUndefined();
+    });
+
+    it('returns the overridden settings passed within the constructor', () => {
+      const value = chance.word();
+      const override = chance.word();
+      const defaults = { key: { value } };
+      const overrides = { key: { value: override } };
+      const { uiSettings } = setup({ defaults, overrides });
+      expect(uiSettings.getOverrideOrDefault('key')).toEqual(override);
+    });
+  });
+
   describe('#getUserProvided()', () => {
     it('pulls user configuration from OpenSearch', async () => {
       const { uiSettings, savedObjectsClient } = setup();

--- a/src/core/server/ui_settings/ui_settings_client.ts
+++ b/src/core/server/ui_settings/ui_settings_client.ts
@@ -91,6 +91,10 @@ export class UiSettingsClient implements IUiSettingsClient {
     return copiedDefaults;
   }
 
+  getOverrideOrDefault(key: string): unknown {
+    return this.isOverridden(key) ? this.overrides[key].value : this.defaults[key]?.value;
+  }
+
   async get<T = any>(key: string): Promise<T> {
     const all = await this.getAll();
     return all[key];

--- a/src/core/server/ui_settings/ui_settings_config.ts
+++ b/src/core/server/ui_settings/ui_settings_config.ts
@@ -37,13 +37,33 @@ const deprecations: ConfigDeprecationProvider = ({ unused, renameFromRoot }) => 
   renameFromRoot('server.defaultRoute', 'uiSettings.overrides.defaultRoute'),
 ];
 
+/* There are 4 levels of uiSettings:
+ *   1) defaults hardcoded in code
+ *   2) defaults provided in the opensearch_dashboards.yml
+ *   3) values selected by the user and received from savedObjects
+ *   4) overrides provided in the opensearch_dashboards.yml
+ *
+ * Each of these levels override the one above them.
+ *
+ * The schema below exposes only a limited set of settings to be set in the config file.
+ *
+ * ToDo: Remove overrides; these were added to force the lock down the theme version.
+ * The schema is temporarily relaxed to allow overriding the `darkMode` and setting
+ * `defaults`. An upcoming change would relax them further to allow setting them.
+ */
+
 const configSchema = schema.object({
   overrides: schema.object(
     {
+      'theme:darkMode': schema.maybe(schema.boolean({ defaultValue: true })),
       'theme:version': schema.string({ defaultValue: 'v7' }),
     },
     { unknowns: 'allow' }
   ),
+  defaults: schema.object({
+    'theme:darkMode': schema.maybe(schema.boolean({ defaultValue: false })),
+    'theme:version': schema.maybe(schema.string({ defaultValue: 'v7' })),
+  }),
 });
 
 export type UiSettingsConfigType = TypeOf<typeof configSchema>;

--- a/src/core/server/ui_settings/ui_settings_service.mock.ts
+++ b/src/core/server/ui_settings/ui_settings_service.mock.ts
@@ -39,6 +39,7 @@ import { UiSettingsService } from './ui_settings_service';
 const createClientMock = () => {
   const mocked: jest.Mocked<IUiSettingsClient> = {
     getRegistered: jest.fn(),
+    getOverrideOrDefault: jest.fn(),
     get: jest.fn(),
     getAll: jest.fn(),
     getUserProvided: jest.fn(),

--- a/src/legacy/ui/ui_render/ui_render_mixin.js
+++ b/src/legacy/ui/ui_render/ui_render_mixin.js
@@ -95,7 +95,7 @@ export function uiRenderMixin(osdServer, server, config) {
       const darkMode =
         !authEnabled || request.auth.isAuthenticated
           ? await uiSettings.get('theme:darkMode')
-          : false;
+          : uiSettings.getOverrideOrDefault('theme:darkMode');
 
       const themeVersion =
         !authEnabled || request.auth.isAuthenticated ? await uiSettings.get('theme:version') : 'v7';


### PR DESCRIPTION
### Description

Add configurable `defaults` and `overrides` to `uiSettings`

There are 4 levels of uiSettings:
1) defaults hardcoded in code
2) defaults provided in the opensearch_dashboards.yml
3) values selected by the user and received from savedObjects
4) overrides provided in the opensearch_dashboards.yml

Each of these levels override the one above them.

Also now:
* `theme:darkMode` and `theme:version` can be configured via `defaults`
* `theme:darkMode` can be configured via `overrides`
* unauthenticated users are no longer forced to light mode

Sample config:
```yml
uiSettings:
  overrides:
    "theme:darkMode": false
  defaults:
    "theme:darkMode": true # will be overridden by the above
    "theme:version": "v7"  # will have no effect due to the hard-coded override
```

Despite these changes, for now, `theme:version` override forces everyone to `v7`.

### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
