### PR TITLE
[Dashboard De-Angular] Render empty dashboard screen when creating new dashboards

### DIFF
--- a/src/plugins/dashboard/public/application/app.scss
+++ b/src/plugins/dashboard/public/application/app.scss
@@ -1,0 +1,11 @@
+.dshAppContainer {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+#dashboardViewport {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}

--- a/src/plugins/dashboard/public/application/app.tsx
+++ b/src/plugins/dashboard/public/application/app.tsx
@@ -9,6 +9,7 @@
  * GitHub history for details.
  */
 
+import './app.scss';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';

--- a/src/plugins/dashboard/public/application/dashboard_empty_screen.scss
+++ b/src/plugins/dashboard/public/application/dashboard_empty_screen.scss
@@ -1,9 +1,3 @@
-.dshAppContainer {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-}
-
 .dshStartScreen {
   text-align: center;
 }

--- a/src/plugins/dashboard/public/application/dashboard_empty_screen.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_empty_screen.tsx
@@ -28,6 +28,7 @@
  * under the License.
  */
 
+import './dashboard_empty_screen.scss';
 import React from 'react';
 import { I18nProvider } from '@osd/i18n/react';
 import {


### PR DESCRIPTION
### Description
Render empty dashboard screen when creating a new dashboard. 

1. When clicking `Create New`, show the correct empty new dashboard page and the view mode should be default to `Edit` mode.
![Screenshot 2023-06-20 at 10 33 21 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/8b2a3583-0238-40b8-9868-e1fb34582127)

2. When clicking `Add an existing` button, the add panel will be triggered
3. When clicking `Create new` button, the create new visualization panel should be shown
4. When existing out of edit mode, view mode should correctly render the empty view page.
![Screenshot 2023-06-20 at 10 35 00 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/c637eaa1-7e93-4e04-9671-fb9642395d51)
5. When clicking `Edit` button in the box, it should automatically switch to edit view mode.


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/be2933fb-c9b0-43c5-8658-615e7030fe17



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
