### PR TITLE
[Dashboard De-Angular] Add additional routing configurations

### DIFF
--- a/src/plugins/dashboard/public/application/app.tsx
+++ b/src/plugins/dashboard/public/application/app.tsx
@@ -11,29 +11,47 @@
 
 import './app.scss';
 import { AppMountParameters } from 'opensearch-dashboards/public';
-import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { Route, Switch, useLocation } from 'react-router-dom';
 import { DashboardConstants, createDashboardEditUrl } from '../dashboard_constants';
 import { DashboardEditor, DashboardListing, DashboardNoMatch } from './components';
+import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
+import { DashboardServices } from '../types';
+import { syncQueryStateWithUrl } from '../../../data/public';
 
 export interface DashboardAppProps {
   onAppLeave: AppMountParameters['onAppLeave'];
 }
 
 export const DashboardApp = ({ onAppLeave }: DashboardAppProps) => {
+  const {
+    services: {
+      data: { query },
+      osdUrlStateStorage,
+    },
+  } = useOpenSearchDashboards<DashboardServices>();
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    // syncs `_g` portion of url with query services
+    const { stop } = syncQueryStateWithUrl(query, osdUrlStateStorage);
+
+    return () => stop();
+
+    // this effect should re-run when pathname is changed to preserve querystring part,
+    // so the global state is always preserved
+  }, [query, osdUrlStateStorage, pathname]);
+
   return (
     <Switch>
-      <Route exact path={['/', DashboardConstants.LANDING_PAGE_PATH]}>
-        <DashboardListing />
-      </Route>
-      <Route
-        exact
-        path={[DashboardConstants.CREATE_NEW_DASHBOARD_URL, createDashboardEditUrl(':id')]}
-      >
+      <Route path={[DashboardConstants.CREATE_NEW_DASHBOARD_URL, createDashboardEditUrl(':id')]}>
         <div className="app-container dshAppContainer">
           <DashboardEditor />
           <div id="dashboardViewport" />
         </div>
+      </Route>
+      <Route exact path={['/', DashboardConstants.LANDING_PAGE_PATH]}>
+        <DashboardListing />
       </Route>
       <DashboardNoMatch />
     </Switch>

--- a/src/plugins/dashboard/public/application/components/dashboard_listing.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing.tsx
@@ -31,7 +31,6 @@ export const DashboardListing = () => {
       notifications,
       savedDashboards,
       dashboardProviders,
-      addBasePath,
     },
   } = useOpenSearchDashboards<DashboardServices>();
 
@@ -90,22 +89,26 @@ export const DashboardListing = () => {
   };
 
   const editItem = useCallback(
-    ({ editUrl }: any) => {
-      if (addBasePath) {
-        history.push(addBasePath(editUrl));
+    ({ appId, editUrl }: any) => {
+      if (appId === 'dashboard') {
+        history.push(editUrl);
+      } else {
+        application.navigateToUrl(editUrl);
       }
     },
-    [history, addBasePath]
+    [history, application]
   );
 
-  const viewItem = useCallback(
-    ({ viewUrl }: any) => {
-      if (addBasePath) {
-        history.push(addBasePath(viewUrl));
-      }
-    },
-    [history, addBasePath]
-  );
+  // const viewItem = useCallback(
+  //   ({ appId, viewUrl }: any) => {
+  //     if (appId === 'dashboard') {
+  //       history.push(viewUrl);
+  //     } else {
+  //       application.navigateToUrl(viewUrl);
+  //     }
+  //   },
+  //   [history, application]
+  // );
 
   const deleteItems = useCallback(
     (dashboards: object[]) => {

--- a/src/plugins/dashboard/public/application/components/dashboard_no_match.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_no_match.tsx
@@ -3,8 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import { useEffect } from 'react';
+import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
+import { DashboardServices } from '../../types';
 
 export const DashboardNoMatch = () => {
-  return <div>Dashboard No Match</div>;
+  const { services } = useOpenSearchDashboards<DashboardServices>();
+  useEffect(() => {
+    const path = window.location.hash.substring(1);
+    services.restorePreviousUrl();
+
+    const { navigated } = services.navigateToLegacyOpenSearchDashboardsUrl(path);
+    if (!navigated) {
+      services.navigateToDefaultApp();
+    }
+  }, [services]);
+
+  return null;
 };

--- a/src/plugins/dashboard/public/application/utils/use/use_dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/utils/use/use_dashboard_container.tsx
@@ -86,7 +86,7 @@ export const useDashboardContainer = (
 
   useEffect(() => {
     const incomingEmbeddable = services.embeddable
-      .getStateTransfer(services.scopedHistory())
+      .getStateTransfer(services.scopedHistory)
       .getIncomingEmbeddablePackage();
 
     if (

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -270,7 +270,7 @@ export interface DashboardServices extends CoreStart {
   usageCollection?: UsageCollectionSetup;
   navigateToDefaultApp: UrlForwardingStart['navigateToDefaultApp'];
   navigateToLegacyOpenSearchDashboardsUrl: UrlForwardingStart['navigateToLegacyOpenSearchDashboardsUrl'];
-  scopedHistory: () => ScopedHistory;
+  scopedHistory: ScopedHistory;
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
   savedObjectsPublic: SavedObjectsStart;
   restorePreviousUrl: () => void;


### PR DESCRIPTION
### Description
This PR fix the following routing related issues:

1. The edit action should get to that dashboard in edit mode.
2. When there is no match for the route, should navigate to default app route.
3. Append '_g' param to URL both on the listing page and on the editor page.
4. When we click dashboard tab from the side menu, it should navigate back to the listing page without refreshing.

### Issues Resolved


## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/e8e417a4-86e4-4791-a1db-6aac948820d5



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
