### PR TITLE
[Vis Colors] Update default color in TSVB to use `ouiPaletteColorBlind()[0]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Remove unused Sass in `tile_map` plugin ([#4110](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4110))
 - [Table Visualization] Remove custom styling for text-align:center in favor of OUI utility class. ([#4164](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4164))
 - Replace the use of `bluebird` in `saved_objects` plugin ([#4026](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4026))
+- [Vis Colors] Update default color in TSVB to use `ouiPaletteColorBlind()[0]`([#4363](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4363))
 
 ### 🔩 Tests
 

--- a/src/plugins/vis_type_timeseries/public/metrics_type.ts
+++ b/src/plugins/vis_type_timeseries/public/metrics_type.ts
@@ -30,6 +30,7 @@
 
 import { i18n } from '@osd/i18n';
 
+import { euiPaletteColorBlind } from '@elastic/eui';
 // @ts-ignore
 import { metricsRequestHandler } from './request_handler';
 import { EditorController } from './application';
@@ -53,7 +54,7 @@ export const metricsVisDefinition = {
       series: [
         {
           id: '61ca57f1-469d-11e7-af02-69e470af7417',
-          color: '#68BC00',
+          color: euiPaletteColorBlind()[0],
           split_mode: 'everything',
           split_color_mode: 'opensearchDashboards',
           metrics: [


### PR DESCRIPTION
### Description

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4318

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4324

## Screenshot
Before:
![Screenshot 2023-06-22 at 11 35 18 AM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/105884062/228cb47c-cec1-47bb-a7cf-439f193e9241)

After:
![Screenshot 2023-06-22 at 11 35 29 AM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/105884062/89c0ce06-f21a-4591-9aca-bcac2a158822)



### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
