### PR TITLE
[Dashboard De-Angular] Enable time filter functionalities 

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
@@ -55,6 +55,7 @@ export const DashboardEditor = () => {
 
   console.log('savedDashboardInstance', savedDashboardInstance);
   console.log('appState', appState);
+  console.log('appStateData', appState?.getState());
   console.log('currentAppState', currentAppState);
   console.log('isEmbeddableRendered', isEmbeddableRendered);
   console.log('dashboardContainer', dashboardContainer);

--- a/src/plugins/dashboard/public/application/lib/update_saved_dashboard.ts
+++ b/src/plugins/dashboard/public/application/lib/update_saved_dashboard.ts
@@ -61,8 +61,11 @@ export function updateSavedDashboard(
   savedDashboard.refreshInterval = savedDashboard.timeRestore ? timeRestoreObj : undefined;
 
   // save only unpinned filters
-  const unpinnedFilters = savedDashboard
-    .getFilters()
-    .filter((filter) => !opensearchFilters.isFilterPinned(filter));
+  const unpinnedFilters = appState.filters.filter(
+    (filter) => !opensearchFilters.isFilterPinned(filter)
+  );
   savedDashboard.searchSource.setField('filter', unpinnedFilters);
+
+  // save the queries
+  savedDashboard.searchSource.setField('query', appState.query);
 }

--- a/src/plugins/dashboard/public/application/lib/update_saved_dashboard.ts
+++ b/src/plugins/dashboard/public/application/lib/update_saved_dashboard.ts
@@ -29,7 +29,7 @@
  */
 
 import _ from 'lodash';
-import { RefreshInterval, TimefilterContract } from 'src/plugins/data/public';
+import { Query, RefreshInterval, TimefilterContract } from 'src/plugins/data/public';
 import { FilterUtils } from './filter_utils';
 import { SavedObjectDashboard } from '../../saved_dashboards';
 import { DashboardAppState } from '../../types';
@@ -67,5 +67,5 @@ export function updateSavedDashboard(
   savedDashboard.searchSource.setField('filter', unpinnedFilters);
 
   // save the queries
-  savedDashboard.searchSource.setField('query', appState.query);
+  savedDashboard.searchSource.setField('query', appState.query as Query);
 }

--- a/src/plugins/dashboard/public/application/utils/use/use_saved_dashboard_instance.ts
+++ b/src/plugins/dashboard/public/application/utils/use/use_saved_dashboard_instance.ts
@@ -57,6 +57,23 @@ export const useSavedDashboardInstance = (
         } else if (dashboardIdFromUrl) {
           try {
             savedDashboard = await savedDashboards.get(dashboardIdFromUrl);
+
+            // Update time filter to match the saved dashboard if time restore has been set to true when saving the dashboard
+            // We should only set the time filter according to time restore once when we are loading the dashboard
+            if (savedDashboard && savedDashboard.timeRestore) {
+              if (savedDashboard.timeFrom && savedDashboard.timeTo) {
+                services.data.query.timefilter.timefilter.setTime({
+                  from: savedDashboard.timeFrom,
+                  to: savedDashboard.timeTo,
+                });
+              }
+              if (savedDashboard.refreshInterval) {
+                services.data.query.timefilter.timefilter.setRefreshInterval(
+                  savedDashboard.refreshInterval
+                );
+              }
+            }
+
             chrome.recentlyAccessed.add(
               savedDashboard.getFullPath(),
               savedDashboard.title,

--- a/src/plugins/dashboard/public/application/utils/use/use_saved_dashboard_instance.ts
+++ b/src/plugins/dashboard/public/application/utils/use/use_saved_dashboard_instance.ts
@@ -60,7 +60,7 @@ export const useSavedDashboardInstance = (
 
             // Update time filter to match the saved dashboard if time restore has been set to true when saving the dashboard
             // We should only set the time filter according to time restore once when we are loading the dashboard
-            if (savedDashboard && savedDashboard.timeRestore) {
+            if (savedDashboard.timeRestore) {
               if (savedDashboard.timeFrom && savedDashboard.timeTo) {
                 services.data.query.timefilter.timefilter.setTime({
                   from: savedDashboard.timeFrom,

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -444,8 +444,8 @@ export class DashboardPlugin
       },
     };
 
-    // TODO: need to add UI bootstrap
-    // initAngularBootstrap();
+    // TODO: delete this when discover de-angular is completed
+    initAngularBootstrap();
 
     core.application.register(app);
     urlForwarding.forwardApp(

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -123,7 +123,7 @@ export interface DashboardAppState {
     hidePanelTitles: boolean;
     useMargins: boolean;
   };
-  query: Query;
+  query: Query | string;
   filters: Filter[];
   viewMode: ViewMode;
   expandedPanelId?: string;

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -123,7 +123,7 @@ export interface DashboardAppState {
     hidePanelTitles: boolean;
     useMargins: boolean;
   };
-  query: Query | string;
+  query: Query;
   filters: Filter[];
   viewMode: ViewMode;
   expandedPanelId?: string;

--- a/test/functional/apps/dashboard/index.js
+++ b/test/functional/apps/dashboard/index.js
@@ -51,7 +51,7 @@ export default function ({ getService, loadTestFile }) {
     await opensearchArchiver.unload('logstash_functional');
   }
 
-  describe.skip('dashboard app', function () {
+  describe('dashboard app', function () {
     // This has to be first since the other tests create some embeddables as side affects and our counting assumes
     // a fresh index.
     describe('using current data', function () {


### PR DESCRIPTION
### Description

This PR fixes time filter related functionalities for dashboard plugin. 

1. Time filter are able to update the child visualization embeddables. They are part of the global states, thus they are not stored in state container/app state; however, we still need to pass the information to dashboard embeddable container because it needs the info to update the child visualization embeddables.

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/26f4b472-f037-4b96-a7c4-5d2d80b1f7d2



2. We need to be able to store dashboard with time filters/ without time filters by toggling the `Store time with dashboard` option on the save modal.


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/e19f68c0-c6cb-43a0-a361-36e1a2fc1d0d

3. Any query and filters should also be saved when saving dashboards.

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/8090c1c1-85d4-462c-9e1f-c3a607ad5fd3




### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
