### PR TITLE
[Vis colors] Replace vis_type_timeline colors with `ouiPaletteColorBlind()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Table Visualization] Remove custom styling for text-align:center in favor of OUI utility class. ([#4164](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4164))
 - Replace the use of `bluebird` in `saved_objects` plugin ([#4026](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4026))
 - [Vis Colors] Update default color in TSVB to use `ouiPaletteColorBlind()[0]`([#4363](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4363))
+- [Vis Colors] Replace vis_type_timeline colors with `ouiPaletteColorBlind()` ([#4366](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4366))
 
 ### 🔩 Tests
 

--- a/src/plugins/vis_type_timeline/public/helpers/panel_utils.ts
+++ b/src/plugins/vis_type_timeline/public/helpers/panel_utils.ts
@@ -32,6 +32,7 @@ import { cloneDeep, defaults, mergeWith, compact } from 'lodash';
 import $ from 'jquery';
 import moment, { Moment } from 'moment-timezone';
 
+import { euiPaletteColorBlind } from '@elastic/eui';
 import { TimefilterContract } from 'src/plugins/data/public';
 import { IUiSettingsClient } from 'opensearch-dashboards/public';
 
@@ -65,18 +66,7 @@ interface TimeRangeBounds {
 export const ACTIVE_CURSOR = 'ACTIVE_CURSOR_TIMELINE';
 export const eventBus = $({});
 
-const colors = [
-  '#01A4A4',
-  '#C66',
-  '#D0D102',
-  '#616161',
-  '#00A1CB',
-  '#32742C',
-  '#F18D05',
-  '#113F8C',
-  '#61AE24',
-  '#D70060',
-];
+const colors = euiPaletteColorBlind();
 
 const SERIES_ID_ATTR = 'data-series-id';
 


### PR DESCRIPTION
### Description

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4318

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4322

## Screenshot

Before:
![Screenshot 2023-06-22 at 4 27 20 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/105884062/7f362062-729c-4847-9537-ef9fe4244035)

After:
![Screenshot 2023-06-22 at 4 27 30 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/105884062/0f2a4c02-0598-43ac-a89e-587ebd3210eb)


### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
