### PR TITLE
Remove broken flot documentation link for Ruby API

### DIFF
--- a/packages/osd-ui-shared-deps/flot_charts/API.md
+++ b/packages/osd-ui-shared-deps/flot_charts/API.md
@@ -167,7 +167,7 @@ var options = {
         points: { show: true }
     }
 };
-	
+
 $.plot(placeholder, data, options);
 ```
 
@@ -254,10 +254,10 @@ xaxis, yaxis: {
     min: null or number
     max: null or number
     autoscaleMargin: null or number
-    
+
     transform: null or fn: number -> number
     inverseTransform: null or fn: number -> number
-    
+
     ticks: null or number or ticks array or (fn: axis -> ticks array)
     tickSize: number or array
     minTickSize: number or array
@@ -267,7 +267,7 @@ xaxis, yaxis: {
     labelWidth: null or number
     labelHeight: null or number
     reserveSpace: null or true
-    
+
     tickLength: null or number
 
     alignTicksWithAxis: null or number
@@ -415,7 +415,7 @@ ticks: [[0, "zero"], [1.2, "one mark"], [2.4, "two marks"]]
 ```
 
 You can mix the two if you like.
-  
+
 For extra flexibility you can specify a function as the "ticks"
 parameter. The function will be called with an object with the axis
 min and max and should return a ticks array. Here's a simplistic tick
@@ -575,7 +575,7 @@ In Python you can get it with something like:
 calendar.timegm(datetime_object.timetuple()) * 1000
 ```
 In Ruby you can get it using the `#to_i` method on the
-[`Time`](http://apidock.com/ruby/Time/to_i) object. If you're using the
+[`Time`] object. If you're using the
 `active_support` gem (default for Ruby on Rails applications) `#to_i` is also
 available on the `DateTime` and `ActiveSupport::TimeWithZone` objects. You
 simply need to multiply the result by 1000:
@@ -765,7 +765,7 @@ The options inside "series: {}" are copied to each of the series. So
 you can specify that all series should have bars by putting it in the
 global options, or override it for individual series by specifying
 bars in a particular the series object in the array of data.
-  
+
 The most important options are "lines", "points" and "bars" that
 specify whether and how lines, points and bars should be shown for
 each data series. In case you don't specify anything at all, Flot will
@@ -801,8 +801,8 @@ the y axis if "horizontal" is true), contrary to most other measures
 that are specified in pixels. For instance, for time series the unit
 is milliseconds so 24 * 60 * 60 * 1000 produces bars with the width of
 a day. "align" specifies whether a bar should be left-aligned
-(default), right-aligned or centered on top of the value it represents. 
-When "horizontal" is on, the bars are drawn horizontally, i.e. from the 
+(default), right-aligned or centered on top of the value it represents.
+When "horizontal" is on, the bars are drawn horizontally, i.e. from the
 y axis instead of the x axis; note that the bar end points are still
 defined in the same way so you'll probably want to swap the
 coordinates if you've been plotting vertical bars first.
@@ -1004,7 +1004,7 @@ item: {
 }
 ```
 
-For instance, if you have specified the data like this 
+For instance, if you have specified the data like this
 
 ```js
 $.plot($("#placeholder"), [ { label: "Foo", data: [[0, 10], [7, 3]] } ], ...);
@@ -1155,7 +1155,7 @@ can call:
 
     Returns the calculated offset of the data point at (x, y) in data
     space within the placeholder div. If you are working with multiple
-    axes, you can specify the x and y axis references, e.g. 
+    axes, you can specify the x and y axis references, e.g.
 
     ```js
       o = pointOffset({ x: xpos, y: ypos, xaxis: 2, yaxis: 3 })
@@ -1215,8 +1215,8 @@ Flot to keep track of its state, so be careful.
     With multiple axes, the extra axes are returned as x2axis, x3axis,
     etc., e.g. getAxes().y2axis is the second y axis. You can check
     y2axis.used to see whether the axis is associated with any data
-    points and y2axis.show to see if it is currently shown. 
- 
+    points and y2axis.show to see if it is currently shown.
+
   - getPlaceholder()
 
     Returns placeholder that the plot was put into. This can be useful
@@ -1226,7 +1226,7 @@ Flot to keep track of its state, so be careful.
 
     Returns the canvas used for drawing in case you need to hack on it
     yourself. You'll probably need to get the plot offset too.
-  
+
   - getPlotOffset()
 
     Gets the offset that the grid has within the canvas as an object
@@ -1242,7 +1242,7 @@ Flot to keep track of its state, so be careful.
     if you modify the values in here, Flot will use the new values.
     If you change something, you probably have to call draw() or
     setupGrid() or triggerRedrawOverlay() to see the change.
-    
+
 
 ## Hooks ##
 
@@ -1254,7 +1254,7 @@ gets access to the internal data structures in Flot.
 Here's an overview of the phases Flot goes through:
 
   1. Plugin initialization, parsing options
-  
+
   2. Constructing the canvases used for drawing
 
   3. Set data: parsing data specification, calculating colors,
@@ -1270,7 +1270,7 @@ Here's an overview of the phases Flot goes through:
 
   7. Responding to events, if any
 
-  8. Shutdown: this mostly happens in case a plot is overwritten 
+  8. Shutdown: this mostly happens in case a plot is overwritten
 
 Each hook is simply a function which is put in the appropriate array.
 You can add them through the "hooks" option, and they are also available
@@ -1295,22 +1295,22 @@ hooks in the plugins bundled with Flot.
  - processOptions  [phase 1]
 
     ```function(plot, options)```
-   
+
     Called after Flot has parsed and merged options. Useful in the
     instance where customizations beyond simple merging of default
     values is needed. A plugin might use it to detect that it has been
     enabled and then turn on or off other options.
 
- 
+
  - processRawData  [phase 3]
 
     ```function(plot, series, data, datapoints)```
- 
+
     Called before Flot copies and normalizes the raw data for the given
     series. If the function fills in datapoints.points with normalized
     points and sets datapoints.pointsize to the size of the points,
     Flot will skip the copying/normalization step for this series.
-   
+
     In any case, you might be interested in setting datapoints.format,
     an array of objects for specifying how a point is normalized and
     how it interferes with axis scaling. It accepts the following options:
@@ -1430,7 +1430,7 @@ hooks in the plugins bundled with Flot.
     state by drawing something (add a drawOverlay hook and call
     triggerRedrawOverlay) or firing an externally visible event for
     user code. See the crosshair plugin for an example.
-     
+
     Currently, eventHolder actually contains both the static canvas
     used for the plot itself and the overlay canvas used for
     interactive features because some versions of IE get the stacking
@@ -1469,7 +1469,7 @@ hooks in the plugins bundled with Flot.
     add a callback to clean up after you. Take a look at the section in
     the [PLUGINS](PLUGINS.md) document for more info.
 
-   
+
 ## Plugins ##
 
 Plugins extend the functionality of Flot. To use a plugin, simply

--- a/packages/osd-ui-shared-deps/flot_charts/API.md
+++ b/packages/osd-ui-shared-deps/flot_charts/API.md
@@ -575,7 +575,7 @@ In Python you can get it with something like:
 calendar.timegm(datetime_object.timetuple()) * 1000
 ```
 In Ruby you can get it using the `#to_i` method on the
-[`Time`] object. If you're using the
+`Time` object. If you're using the
 `active_support` gem (default for Ruby on Rails applications) `#to_i` is also
 available on the `DateTime` and `ActiveSupport::TimeWithZone` objects. You
 simply need to multiply the result by 1000:


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
The link https://apidock.com/ruby/Time/to_i is currently down for maintenance, which is causing the link checker automation to fail on all PRs.

But we don't need this link anyway, because it's developer docs talking about standard methods in various languages. And we plan to deprecate flot_charts altogether: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4267

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
