### PR TITLE
[Dashboard De-Angular] Add embed mode and other URL param options

### DIFF
--- a/src/plugins/dashboard/public/application/utils/get_nav_actions.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_nav_actions.tsx
@@ -29,14 +29,7 @@ import { saveDashboard } from '../lib';
 import { DashboardContainer } from '../embeddable/dashboard_container';
 import { DashboardConstants, createDashboardEditUrl } from '../../dashboard_constants';
 import { unhashUrl } from '../../../../opensearch_dashboards_utils/public';
-
-enum UrlParams {
-  SHOW_TOP_MENU = 'show-top-menu',
-  SHOW_QUERY_INPUT = 'show-query-input',
-  SHOW_TIME_FILTER = 'show-time-filter',
-  SHOW_FILTER_BAR = 'show-filter-bar',
-  HIDE_FILTER_BAR = 'hide-filter-bar',
-}
+import { UrlParams } from '../components/dashboard_top_nav';
 
 interface UrlParamsSelectedMap {
   [UrlParams.SHOW_TOP_MENU]: boolean;

--- a/src/plugins/dashboard/public/application/utils/use/use_dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/utils/use/use_dashboard_container.tsx
@@ -223,7 +223,6 @@ const createDashboardEmbeddable = (
       viewMode: appStateData.viewMode,
       panels: embeddablesMap,
       isFullScreenMode: appStateData.fullScreenMode,
-      isEmbeddedExternally: false, // TODO
       isEmptyState:
         getShouldShowEditHelp(appStateData) ||
         getShouldShowViewHelp(appStateData) ||


### PR DESCRIPTION
### Description
UI should render based on URL param options. This PR should fix functional test: https://github.com/opensearch-project/OpenSearch-Dashboards/blob/70b3420fc18819f81fd8bf7efc4625f6ece77c63/test/functional/apps/dashboard/embed_mode.js

There are currently five URL param config options:
1. embed=true --> enter embed mode
 
once we enter embed mode:
1. show-top-menu=true --> show top menu 
2. show-query-input=true --> show query input
3. show-time-filter=true --> show time filter
4. hide-filter-bar=true --> hide filter bar

### Issues Resolved

This issue documented the some buggy behavior related to the embed mode: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4372#issuecomment-1605225746. However, since this is related to a common hook that is also used by other plugins, this PR still follows the old behavior for dashboard embed mode. And we can prob create a follow up issue to fix and enhance the embed mode URL param configs. 

## Screenshot

Uploading Screen Recording 2023-06-26 at 5.39.12 PM.mov…



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
