### PR TITLE
[Feature Anywhere] Fix bug of charts in view events flyout not fetching vislayers

### DIFF
--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -418,10 +418,12 @@ export class VisualizeEmbeddable
     const abortController = this.abortController;
 
     // By waiting for this to complete, this.visLayers will be populated.
-    // Note we only fetch when in the context of a dashboard - we do not
-    // show events or have event functionality when in the vis edit view.
-    const isInDashboard = this.parent?.type === DASHBOARD_CONTAINER_TYPE;
-    if (isInDashboard) {
+    // Note we only fetch when in the context of a dashboard or in the view
+    // events flyout - we do not show events or have event functionality when
+    // in the vis edit view.
+    const shouldFetchVisLayers =
+      this.parent?.type === DASHBOARD_CONTAINER_TYPE || this.visAugmenterConfig?.inFlyout;
+    if (shouldFetchVisLayers) {
       await this.populateVisLayers();
     }
 


### PR DESCRIPTION
### Description

There was [some recent bug fixes](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4327) to prevent fetching vislayers in the context of the vis edit flow. This fix missed the scenario of rendering the charts in the view events flyout. This fixes that by checking the config that is passed to the visualize_embeddable, and checking if in the flyout context or not.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
