### PR TITLE
[Dashboard De-Angular] Enable URL title param for initial filter on dashboard listing

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_listing.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing.tsx
@@ -59,15 +59,18 @@ export const DashboardListing = () => {
           if (matchingDashboards.length === 1) {
             history.replace(createDashboardEditUrl(matchingDashboards[0].id));
           } else {
-            history.push(`${DashboardConstants.LANDING_PAGE_PATH}?filter="${title}"`);
+            history.replace(`${DashboardConstants.LANDING_PAGE_PATH}?filter="${title}"`);
             setInitialFilter(title);
+            // Reload here is needed since we are using a URL param to render the table
+            // Previously, they called $route.reload() on angular routing
+            history.go(0);
           }
           return new Promise(() => {});
         }
       } catch (e) {
         notifications.toasts.addWarning(
           i18n.translate('dashboard.listing. savedObjectWarning', {
-            defaultMessage: 'Uble to filter by title',
+            defaultMessage: 'Unable to filter by title',
           })
         );
       }

--- a/src/plugins/dashboard/public/application/components/dashboard_listing.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing.tsx
@@ -3,15 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import { useMount } from 'react-use';
+import { useLocation } from 'react-router-dom';
 import {
   useOpenSearchDashboards,
   TableListView,
 } from '../../../../opensearch_dashboards_react/public';
 import { CreateButton } from '../listing/create_button';
-import { DashboardConstants } from '../../dashboard_constants';
+import { DashboardConstants, createDashboardEditUrl } from '../../dashboard_constants';
 import { DashboardServices } from '../../types';
 import { getTableColumns } from '../utils/get_table_columns';
 import { getNoItemsMessage } from '../utils/get_no_items_message';
@@ -33,6 +34,46 @@ export const DashboardListing = () => {
       dashboardProviders,
     },
   } = useOpenSearchDashboards<DashboardServices>();
+
+  const location = useLocation();
+  const queryParameters = new URLSearchParams(location.search);
+  const initialFiltersFromURL = queryParameters.get('filter');
+  const [initialFilter, setInitialFilter] = useState<string | null>(initialFiltersFromURL);
+
+  useEffect(() => {
+    const getDashboardsBasedOnUrl = async () => {
+      const title = queryParameters.get('title');
+
+      try {
+        if (title) {
+          const results = await savedObjectsClient.find<any>({
+            search: `"${title}"`,
+            searchFields: ['title'],
+            type: 'dashboard',
+          });
+
+          const matchingDashboards = results.savedObjects.filter(
+            (dashboard) => dashboard.attributes.title.toLowerCase() === title.toLowerCase()
+          );
+
+          if (matchingDashboards.length === 1) {
+            history.replace(createDashboardEditUrl(matchingDashboards[0].id));
+          } else {
+            history.push(`${DashboardConstants.LANDING_PAGE_PATH}?filter="${title}"`);
+            setInitialFilter(title);
+          }
+          return new Promise(() => {});
+        }
+      } catch (e) {
+        notifications.toasts.addWarning(
+          i18n.translate('dashboard.listing. savedObjectWarning', {
+            defaultMessage: 'Uble to filter by title',
+          })
+        );
+      }
+    };
+    getDashboardsBasedOnUrl();
+  }, [savedObjectsClient, history, notifications.toasts, queryParameters]);
 
   const hideWriteControls = dashboardConfig.getHideWriteControls();
 
@@ -143,7 +184,7 @@ export const DashboardListing = () => {
       editItem={hideWriteControls ? undefined : editItem}
       tableColumns={tableColumns}
       listingLimit={listingLimit}
-      initialFilter={''}
+      initialFilter={initialFilter ?? ''}
       initialPageSize={initialPageSize}
       noItemsFragment={noItemsFragment}
       entityName={i18n.translate('dashboard.listing.table.entityName', {


### PR DESCRIPTION
### Description
`title=xxx` can be append to dashboard listing URL and use as an initial filter.
1. when `title=xxx`, and xxx match exactly with one dashboard, the browser should navigate to that dashboard view page
2. If xxx does not have any exact match, then  all dashboards whose prefix that match will show
3. If xxx does not match any prefix, the listing will be empty

### Issues Resolved
#4356 

Fix the dashboard_listing related functional tests in test group 5.

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/71cb6138-42c8-407d-9b85-dc56f0255d33
