### PR TITLE
[Vis Augmenter] Update base vis height in view events flyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple DataSource] Frontend support for adding sample data ([#4412](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4412))
 - Enable plugins to augment visualizations with additional data and context ([#4361](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4361))
 - New management overview page and rename stack management to dashboard management ([#4287](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4287))
+- [Vis Augmenter] Update base vis height in view events flyout ([#4535](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4535))
 
 
 ### 🐛 Bug Fixes

--- a/src/plugins/vis_augmenter/public/view_events_flyout/components/styles.scss
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/components/styles.scss
@@ -1,6 +1,6 @@
 $vis-description-width: 200px;
 $event-vis-height: 55px;
-$timeline-panel-height: 100px;
+$timeline-panel-height: 90px;
 $content-padding-top: 110px; // Padding needed within view events flyout content to sit comfortably below flyout header
 $date-range-height: 45px; // Static height we want for the date range picker component
 $error-icon-padding-right: -8px; // This is so the error icon is aligned consistent with the event count icons

--- a/src/plugins/vis_augmenter/public/view_events_flyout/components/view_events_flyout.tsx
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/components/view_events_flyout.tsx
@@ -128,10 +128,14 @@ export function ViewEventsFlyout(props: Props) {
               >
                 <DateRangeItem timeRange={timeRange as TimeRange} reload={reload} />
               </EuiFlexItem>
-              <EuiFlexItem className="view-events-flyout__contentPanel" grow={5}>
+              <EuiFlexItem
+                className="view-events-flyout__contentPanel"
+                grow={7}
+                style={{ maxHeight: '40vh' }}
+              >
                 <BaseVisItem embeddable={visEmbeddable as VisualizeEmbeddable} />
               </EuiFlexItem>
-              <EuiFlexItem className="view-events-flyout__contentPanel show-y-scroll" grow={5}>
+              <EuiFlexItem className="view-events-flyout__contentPanel show-y-scroll" grow={3}>
                 <EventsPanel
                   eventVisEmbeddablesMap={eventVisEmbeddablesMap as EventVisEmbeddablesMap}
                 />


### PR DESCRIPTION
### Description

Update base vis height in view events flyout. Before, the base vis, when viewing the flyout on a normal laptop screen, would cut off the bottom part of the x-axis due to the styling and spacing params. This updates that a few ways:
1. Shrinks the bottom timeline vis by 10px to allocate more overall vertical space
2. Changes the ratio of the base vis and event vis panels from 5:5 to 7:3 so it can take up more vertical space when viewed in a smaller window
3. Sets the max height of the base vis panel to `40vh` so it doesn't grow too much when viewed in a bigger window.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
