### PR TITLE
Set dashboard container functions and fix license headers

### DIFF
--- a/src/plugins/dashboard/public/application/app.tsx
+++ b/src/plugins/dashboard/public/application/app.tsx
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import './app.scss';

--- a/src/plugins/dashboard/public/application/components/dashboard_listing.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing.tsx
@@ -155,6 +155,12 @@ export const DashboardListing = () => {
     [history, application]
   );
 
+  // TODO: Currently, dashboard listing is using a href to view items.
+  // Dashboard listing should utilize a callback to take us away from using a href in favor
+  // of using onClick.
+  //
+  // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3365
+  //
   // const viewItem = useCallback(
   //   ({ appId, viewUrl }: any) => {
   //     if (appId === 'dashboard') {

--- a/src/plugins/dashboard/public/application/index.tsx
+++ b/src/plugins/dashboard/public/application/index.tsx
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/src/plugins/dashboard/public/application/utils/breadcrumbs.ts
+++ b/src/plugins/dashboard/public/application/utils/breadcrumbs.ts
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import { i18n } from '@osd/i18n';

--- a/src/plugins/dashboard/public/application/utils/create_dashboard_app_state.tsx
+++ b/src/plugins/dashboard/public/application/utils/create_dashboard_app_state.tsx
@@ -105,13 +105,18 @@ export const createDashboardGlobalAndAppState = ({
             ...state,
           });
         } else {
+          // TODO: This logic was ported over this but can be handled more gracefully and intentionally
+          // Sync from state url should be refactored within this application. The app is syncing from
+          // the query state and the dashboard in different locations which can be handled better.
+          // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3365
+          //
           // Do nothing in case when state from url is empty,
           // this fixes: https://github.com/elastic/kibana/issues/57789
           // There are not much cases when state in url could become empty:
           // 1. User manually removed `_a` from the url
           // 2. Browser is navigating away from the page and most likely there is no `_a` in the url.
           //    In this case we don't want to do any state updates
-          //    and just allow $scope.$on('destroy') fire later and clean up everything
+          //    and just unmount later and clean up everything
         }
       },
     },

--- a/src/plugins/dashboard/public/application/utils/get_dashboard_instance.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_dashboard_instance.tsx
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import { Dashboard, DashboardParams } from '../../dashboard';

--- a/src/plugins/dashboard/public/application/utils/use/use_chrome_visibility.ts
+++ b/src/plugins/dashboard/public/application/utils/use/use_chrome_visibility.ts
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import { useState, useEffect } from 'react';

--- a/src/plugins/dashboard/public/application/utils/use/use_dashboard_app_state.tsx
+++ b/src/plugins/dashboard/public/application/utils/use/use_dashboard_app_state.tsx
@@ -117,16 +117,15 @@ export const useDashboardAppAndGlobalState = ({
           savedDashboard: savedDashboardInstance,
           appState: stateContainer,
         });
-        // Ensure empty state is attached to current container being dispatched
-        dashboardContainer!.renderEmpty = () =>
-          renderEmpty(dashboardContainer!, stateContainer, services);
-
-        setCurrentContainer(dashboardContainer);
-
         if (!dashboardContainer) {
           return;
         }
 
+        // Ensure empty state is attached to current container being dispatched
+        dashboardContainer.renderEmpty = () =>
+          renderEmpty(dashboardContainer, stateContainer, services);
+
+        // Ensure update app state in url is attached to current container being dispatched
         dashboardContainer.updateAppStateUrl = ({
           replace,
           pathname,
@@ -147,6 +146,8 @@ export const useDashboardAppAndGlobalState = ({
             });
           }
         };
+
+        setCurrentContainer(dashboardContainer);
 
         const stopSyncingDashboardContainerOutputs = handleDashboardContainerOutputs(
           services,

--- a/src/plugins/dashboard/public/application/utils/use/use_dashboard_app_state.tsx
+++ b/src/plugins/dashboard/public/application/utils/use/use_dashboard_app_state.tsx
@@ -117,13 +117,15 @@ export const useDashboardAppAndGlobalState = ({
           savedDashboard: savedDashboardInstance,
           appState: stateContainer,
         });
+        // Ensure empty state is attached to current container being dispatched
+        dashboardContainer!.renderEmpty = () =>
+          renderEmpty(dashboardContainer!, stateContainer, services);
+
+        setCurrentContainer(dashboardContainer);
 
         if (!dashboardContainer) {
           return;
         }
-
-        dashboardContainer.renderEmpty = () =>
-          renderEmpty(dashboardContainer, stateContainer, services);
 
         dashboardContainer.updateAppStateUrl = ({
           replace,
@@ -195,8 +197,6 @@ export const useDashboardAppAndGlobalState = ({
           stopSyncingDashboardContainerOutputs();
           subscriptions.unsubscribe();
         };
-
-        setCurrentContainer(dashboardContainer);
       };
 
       getDashboardContainer();

--- a/src/plugins/dashboard/public/application/utils/use/use_dashboard_app_state.tsx
+++ b/src/plugins/dashboard/public/application/utils/use/use_dashboard_app_state.tsx
@@ -117,7 +117,6 @@ export const useDashboardAppAndGlobalState = ({
           savedDashboard: savedDashboardInstance,
           appState: stateContainer,
         });
-        setCurrentContainer(dashboardContainer);
 
         if (!dashboardContainer) {
           return;
@@ -196,6 +195,8 @@ export const useDashboardAppAndGlobalState = ({
           stopSyncingDashboardContainerOutputs();
           subscriptions.unsubscribe();
         };
+
+        setCurrentContainer(dashboardContainer);
       };
 
       getDashboardContainer();

--- a/src/plugins/dashboard/public/application/utils/use/use_saved_dashboard_instance.ts
+++ b/src/plugins/dashboard/public/application/utils/use/use_saved_dashboard_instance.ts
@@ -93,6 +93,8 @@ export const useSavedDashboardInstance = ({
       history.replace(DashboardConstants.LANDING_PAGE_PATH);
     };
 
+    // TODO: handle try/catch as expected workflows instead of catching as an error
+    // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3365
     const getSavedDashboardInstance = async () => {
       try {
         let dashboardInstance: {

--- a/src/plugins/dashboard/public/dashboard.ts
+++ b/src/plugins/dashboard/public/dashboard.ts
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 /**


### PR DESCRIPTION
`renderEmpty` was not being set prior to the current container was being dispatched. Moved the set state to after the functions are defined.

Also, clean up license headers for new files to use the correct license headers.
