### PR TITLE
Version increment from 2.9 to 2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dashboarding"
   ],
   "private": true,
-  "version": "2.9.0",
+  "version": "2.10.0",
   "branch": "2.x",
   "types": "./opensearch_dashboards.d.ts",
   "tsdocMetadata": "./build/tsdoc-metadata.json",


### PR DESCRIPTION
### Description

Increment the version on the parent branch (2.x) to the next development iteration (2.10) after 2.9 branch cut.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4486

