### PR TITLE
Fix Node.js download link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Saved Objects Management] Fix relationships header overflow ([#4070](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4070))
 - Update main menu to display 'Dashboards' for consistency ([#4453](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4453))
 - [Multiple DataSource] Retain the original sample data API ([#4526](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4526))
+- Fix Node.js download link ([#4556](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4556))
 
 ### 🚞 Infrastructure
 

--- a/src/dev/build/tasks/nodejs/node_download_info.ts
+++ b/src/dev/build/tasks/nodejs/node_download_info.ts
@@ -46,7 +46,7 @@ export async function getNodeDownloadInfo(config: Config, platform: Platform) {
     ? `node-v${version}-win-x64.zip`
     : `node-v${version}-${arch}.tar.gz`;
 
-  const url = `https://mirrors.nodejs.org/dist/v${version}/${downloadName}`;
+  const url = `https://nodejs.org/dist/v${version}/${downloadName}`;
   const downloadPath = config.resolveFromRepo('.node_binaries', version, basename(downloadName));
   const extractDir = config.resolveFromRepo('.node_binaries', version, arch);
 
@@ -69,7 +69,7 @@ export async function getNodeVersionDownloadInfo(
     ? `node-v${version}-win-x64.zip`
     : `node-v${version}-${architecture}.tar.gz`;
 
-  const url = `https://mirrors.nodejs.org/dist/v${version}/${downloadName}`;
+  const url = `https://nodejs.org/dist/v${version}/${downloadName}`;
   const downloadPath = resolve(repoRoot, '.node_binaries', version, basename(downloadName));
   const extractDir = resolve(repoRoot, '.node_binaries', version, architecture);
 


### PR DESCRIPTION
### Description

Node.js has removed the domain `mirrors.nodejs.org` and their advertised download URL has been from `nodejs.org` for some time now.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
