### PR TITLE
[Vis Augmenter] Fix stats API visualization ID bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update main menu to display 'Dashboards' for consistency ([#4453](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4453))
 - [Multiple DataSource] Retain the original sample data API ([#4526](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4526))
 - Fix Node.js download link ([#4556](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4556))
-- Fix stats API visualization ID bug ([#4565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4565))
 
 ### 🚞 Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update main menu to display 'Dashboards' for consistency ([#4453](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4453))
 - [Multiple DataSource] Retain the original sample data API ([#4526](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4526))
 - Fix Node.js download link ([#4556](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4556))
+- Fix stats API visualization ID bug ([#4565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4565))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/vis_augmenter/server/routes/stats_helpers.test.ts
+++ b/src/plugins/vis_augmenter/server/routes/stats_helpers.test.ts
@@ -14,6 +14,7 @@ const PLUGIN_RESOURCE_TYPE_2 = 'plugin-resource-type-2';
 const PLUGIN_RESOURCE_ID_1 = 'plugin-resource-id-1';
 const PLUGIN_RESOURCE_ID_2 = 'plugin-resource-id-2';
 const PLUGIN_RESOURCE_ID_3 = 'plugin-resource-id-3';
+const VIS_REF_NAME = 'visualization_0';
 const VIS_ID_1 = 'vis-id-1';
 const VIS_ID_2 = 'vis-id-2';
 const PER_PAGE = 4;
@@ -26,8 +27,14 @@ const SINGLE_SAVED_OBJ = [
         type: PLUGIN_RESOURCE_TYPE_1,
         id: PLUGIN_RESOURCE_ID_1,
       },
-      visId: VIS_ID_1,
+      visName: VIS_REF_NAME,
     },
+    references: [
+      {
+        name: VIS_REF_NAME,
+        id: VIS_ID_1,
+      },
+    ],
   },
 ] as Array<SavedObjectsFindResult<AugmentVisSavedObjectAttributes>>;
 
@@ -39,8 +46,14 @@ const MULTIPLE_SAVED_OBJS = [
         type: PLUGIN_RESOURCE_TYPE_1,
         id: PLUGIN_RESOURCE_ID_1,
       },
-      visId: VIS_ID_1,
+      visName: VIS_REF_NAME,
     },
+    references: [
+      {
+        name: VIS_REF_NAME,
+        id: VIS_ID_1,
+      },
+    ],
   },
   {
     attributes: {
@@ -49,8 +62,14 @@ const MULTIPLE_SAVED_OBJS = [
         type: PLUGIN_RESOURCE_TYPE_2,
         id: PLUGIN_RESOURCE_ID_2,
       },
-      visId: VIS_ID_1,
+      visName: VIS_REF_NAME,
     },
+    references: [
+      {
+        name: VIS_REF_NAME,
+        id: VIS_ID_1,
+      },
+    ],
   },
   {
     attributes: {
@@ -59,8 +78,14 @@ const MULTIPLE_SAVED_OBJS = [
         type: PLUGIN_RESOURCE_TYPE_2,
         id: PLUGIN_RESOURCE_ID_2,
       },
-      visId: VIS_ID_2,
+      visName: VIS_REF_NAME,
     },
+    references: [
+      {
+        name: VIS_REF_NAME,
+        id: VIS_ID_2,
+      },
+    ],
   },
   {
     attributes: {
@@ -69,8 +94,14 @@ const MULTIPLE_SAVED_OBJS = [
         type: PLUGIN_RESOURCE_TYPE_2,
         id: PLUGIN_RESOURCE_ID_3,
       },
-      visId: VIS_ID_1,
+      visName: VIS_REF_NAME,
     },
+    references: [
+      {
+        name: VIS_REF_NAME,
+        id: VIS_ID_1,
+      },
+    ],
   },
 ] as Array<SavedObjectsFindResult<AugmentVisSavedObjectAttributes>>;
 

--- a/src/plugins/vis_augmenter/server/routes/stats_helpers.ts
+++ b/src/plugins/vis_augmenter/server/routes/stats_helpers.ts
@@ -68,7 +68,7 @@ export const getStats = (
     const originPlugin = augmentVisObj.attributes.originPlugin;
     const pluginResourceType = augmentVisObj.attributes.pluginResource.type;
     const pluginResourceId = augmentVisObj.attributes.pluginResource.id;
-    const visualizationId = augmentVisObj.attributes.visId as string;
+    const visualizationId = augmentVisObj.references[0].id as string;
 
     originPluginMap[originPlugin] = (get(originPluginMap, originPlugin, 0) as number) + 1;
     pluginResourceTypeMap[pluginResourceType] =


### PR DESCRIPTION
### Description

After refactoring of `augment-vis` obj attributes, there was a miss when collecting the vis ID counts in the `stats` API. This updates it to fetch it properly from the `references` section of the saved obj.

Testing on a local cluster after adding some associations of anomaly detectors to 2 different visualizations:
Before:
```
curl localhost:5601/api/vis_augmenter/stats
{"total_objs":3,"obj_breakdown":{"origin_plugin":{"anomalyDetectionDashboards":3},"plugin_resource_type":{"Anomaly Detectors":3},"plugin_resource_id":{"S-RAUIkBCKX6lNDQOxH6":2,"U-RAUIkBCKX6lNDQUxGG":1},"visualization_id":{"undefined":3}}}
```

After:
```
curl localhost:5601/api/vis_augmenter/stats
{"total_objs":3,"obj_breakdown":{"origin_plugin":{"anomalyDetectionDashboards":3},"plugin_resource_type":{"Anomaly Detectors":3},"plugin_resource_id":{"S-RAUIkBCKX6lNDQOxH6":2,"U-RAUIkBCKX6lNDQUxGG":1},"visualization_id":{"da8669b0-21a0-11ee-818e-fba103081cb0":2,"f219dfd0-21a0-11ee-818e-fba103081cb0":1}}}
```

The reason for the miss is due to the loose type-safeness on the saved obj attributes, such that the tests still passed using test attributes that were correctly typed within the source code, but not strict enough such that it was incorrect when compared with the actual attributes returned from the API.

To be more specific, the attributes obj has the optional fields `visName` and `visId` depending on if before/after during the reference extraction. The test attributes had `visId` populated (post-reference-extraction), while the actual attributes had `visName` populated, and the ID was within `references` field (pre-reference-extraction)

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
