### PR TITLE
[Vis Augmenter] Fix bug of undefined tooltip when all plugin layers are empty

### DIFF
--- a/src/plugins/vis_augmenter/public/test_constants.ts
+++ b/src/plugins/vis_augmenter/public/test_constants.ts
@@ -171,6 +171,55 @@ const TEST_VALUES_MULTIPLE_VIS_LAYERS = [
   },
 ];
 
+const TEST_VALUES_MULTIPLE_VIS_LAYERS_ONE_EMPTY = [
+  {
+    [TEST_X_AXIS_ID]: 0,
+    [TEST_VALUE_AXIS_ID]: 5,
+    [TEST_PLUGIN_EVENT_TYPE]: 0,
+    [TEST_PLUGIN_EVENT_TYPE_2]: 0,
+  },
+  {
+    [TEST_X_AXIS_ID]: 5,
+    [TEST_VALUE_AXIS_ID]: 10,
+    [TEST_PLUGIN_EVENT_TYPE]: 2,
+    [TEST_PLUGIN_EVENT_TYPE_2]: 0,
+  },
+  {
+    [TEST_X_AXIS_ID]: 10,
+    [TEST_VALUE_AXIS_ID]: 6,
+    [TEST_PLUGIN_EVENT_TYPE]: 0,
+    [TEST_PLUGIN_EVENT_TYPE_2]: 0,
+  },
+  {
+    [TEST_X_AXIS_ID]: 15,
+    [TEST_VALUE_AXIS_ID]: 4,
+    [TEST_PLUGIN_EVENT_TYPE]: 0,
+    [TEST_PLUGIN_EVENT_TYPE_2]: 0,
+  },
+  {
+    [TEST_X_AXIS_ID]: 20,
+    [TEST_VALUE_AXIS_ID]: 5,
+    [TEST_PLUGIN_EVENT_TYPE]: 0,
+    [TEST_PLUGIN_EVENT_TYPE_2]: 0,
+  },
+  { [TEST_X_AXIS_ID]: 25, [TEST_PLUGIN_EVENT_TYPE]: 0, [TEST_PLUGIN_EVENT_TYPE_2]: 0 },
+  { [TEST_X_AXIS_ID]: 30, [TEST_PLUGIN_EVENT_TYPE]: 0, [TEST_PLUGIN_EVENT_TYPE_2]: 0 },
+  { [TEST_X_AXIS_ID]: 35, [TEST_PLUGIN_EVENT_TYPE]: 1, [TEST_PLUGIN_EVENT_TYPE_2]: 0 },
+  { [TEST_X_AXIS_ID]: 40, [TEST_PLUGIN_EVENT_TYPE]: 0, [TEST_PLUGIN_EVENT_TYPE_2]: 0 },
+  {
+    [TEST_X_AXIS_ID]: 45,
+    [TEST_VALUE_AXIS_ID]: 3,
+    [TEST_PLUGIN_EVENT_TYPE]: 0,
+    [TEST_PLUGIN_EVENT_TYPE_2]: 0,
+  },
+  {
+    [TEST_X_AXIS_ID]: 50,
+    [TEST_VALUE_AXIS_ID]: 5,
+    [TEST_PLUGIN_EVENT_TYPE]: 0,
+    [TEST_PLUGIN_EVENT_TYPE_2]: 0,
+  },
+];
+
 export const TEST_COLUMNS_NO_VIS_LAYERS = [
   {
     id: TEST_X_AXIS_ID,
@@ -267,6 +316,12 @@ export const TEST_DATATABLE_MULTIPLE_VIS_LAYERS = {
   type: 'opensearch_dashboards_datatable',
   columns: TEST_COLUMNS_MULTIPLE_VIS_LAYERS,
   rows: TEST_VALUES_MULTIPLE_VIS_LAYERS,
+} as OpenSearchDashboardsDatatable;
+
+export const TEST_DATATABLE_MULTIPLE_VIS_LAYERS_ONE_EMPTY = {
+  type: 'opensearch_dashboards_datatable',
+  columns: TEST_COLUMNS_MULTIPLE_VIS_LAYERS,
+  rows: TEST_VALUES_MULTIPLE_VIS_LAYERS_ONE_EMPTY,
 } as OpenSearchDashboardsDatatable;
 
 const TEST_BASE_CONFIG = {
@@ -507,6 +562,22 @@ export const TEST_VIS_LAYERS_MULTIPLE = [
         },
       },
     ],
+  },
+];
+
+export const TEST_VIS_LAYERS_MULTIPLE_ONE_EMPTY = [
+  ...TEST_VIS_LAYERS_SINGLE,
+  {
+    originPlugin: TEST_PLUGIN,
+    type: VisLayerTypes.PointInTimeEvents,
+    pluginResource: {
+      type: TEST_PLUGIN_RESOURCE_TYPE,
+      id: TEST_PLUGIN_RESOURCE_ID_2,
+      name: TEST_PLUGIN_RESOURCE_NAME_2,
+      urlPath: TEST_PLUGIN_RESOURCE_PATH_2,
+    },
+    pluginEventType: TEST_PLUGIN_EVENT_TYPE_2,
+    events: [],
   },
 ];
 

--- a/src/plugins/vis_augmenter/public/vega/helpers.test.ts
+++ b/src/plugins/vis_augmenter/public/vega/helpers.test.ts
@@ -31,6 +31,7 @@ import {
 } from '../';
 import {
   TEST_DATATABLE_MULTIPLE_VIS_LAYERS,
+  TEST_DATATABLE_MULTIPLE_VIS_LAYERS_ONE_EMPTY,
   TEST_DATATABLE_NO_VIS_LAYERS,
   TEST_DATATABLE_ONLY_VIS_LAYERS,
   TEST_DATATABLE_SINGLE_ROW_NO_VIS_LAYERS,
@@ -48,6 +49,7 @@ import {
   TEST_SPEC_NO_VIS_LAYERS,
   TEST_SPEC_SINGLE_VIS_LAYER,
   TEST_VIS_LAYERS_MULTIPLE,
+  TEST_VIS_LAYERS_MULTIPLE_ONE_EMPTY,
   TEST_VIS_LAYERS_SINGLE,
   TEST_VIS_LAYERS_SINGLE_INVALID_BOUNDS,
   TEST_VIS_LAYERS_SINGLE_ON_BOUNDS,
@@ -409,6 +411,16 @@ describe('helpers', function () {
           TEST_VIS_LAYERS_SINGLE
         )
       ).toStrictEqual(TEST_DATATABLE_ONLY_VIS_LAYERS);
+    });
+    it('vis layers with one having events and the other empty are added correctly', function () {
+      expect(
+        addPointInTimeEventsLayersToTable(
+          TEST_DATATABLE_NO_VIS_LAYERS,
+
+          TEST_DIMENSIONS,
+          TEST_VIS_LAYERS_MULTIPLE_ONE_EMPTY
+        )
+      ).toStrictEqual(TEST_DATATABLE_MULTIPLE_VIS_LAYERS_ONE_EMPTY);
     });
     it('vis layer with out-of-bounds timestamps are not added', function () {
       expect(

--- a/src/plugins/vis_augmenter/public/vega/helpers.ts
+++ b/src/plugins/vis_augmenter/public/vega/helpers.ts
@@ -224,7 +224,6 @@ export const addPointInTimeEventsLayersToTable = (
   });
 
   visLayers.forEach((visLayer: PointInTimeEventsVisLayer) => {
-    if (isEmpty(visLayer.events)) return;
     const visLayerColumnId = `${visLayer.pluginEventType}`;
 
     // Add placeholder values of 0 for every event value. This is so the tooltip


### PR DESCRIPTION
### Description

Fix bug of undefined tooltip when all plugin layers are empty. There is a certain scenario where if one plugin has events (such that there is an event datapoint on a chart), but all VisLayers coming from a different plugin all have empty events, the tooltip will show as `undefined` for that plugin. This is because the existing logic blocks the population of `0` values into the source datatable. The fix is to remove that logic so it is always run. The original reason it had existed there was due to different ways of experimenting how to show the tooltips on the chart. With the final solution using default vega tooltip logic, the non-defined values in the source datatable unfortunately default to `undefined` using vega.


### Issues Resolved


## Screenshot

After:
<img width="433" alt="Screenshot 2023-07-14 at 3 26 39 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/62119629/dbc9dcd5-4862-45d5-b96d-5961fadcd5ee">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
