### PR TITLE
Add resource ID filtering in fetch `augment-vis` obj queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - New management overview page and rename stack management to dashboard management ([#4287](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4287))
 - [Vis Augmenter] Update base vis height in view events flyout ([#4535](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4535))
 - Optimize `augment-vis` saved obj searching by adding arg to saved obj client ([#4595](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4595))
+- Add resource ID filtering in fetch `augment-vis` obj queries ([#4608](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4608))
 
 
 ### 🐛 Bug Fixes

--- a/src/plugins/saved_objects/public/saved_object/saved_object_loader.ts
+++ b/src/plugins/saved_objects/public/saved_object/saved_object_loader.ts
@@ -132,7 +132,8 @@ export class SavedObjectLoader {
     search: string = '',
     size: number = 100,
     fields?: string[],
-    hasReference?: SavedObjectsFindOptions['hasReference']
+    hasReference?: SavedObjectsFindOptions['hasReference'],
+    searchFields: string[] = ['title^3', 'description']
   ) {
     return this.savedObjectsClient
       .find<Record<string, unknown>>({
@@ -140,7 +141,7 @@ export class SavedObjectLoader {
         search: search ? `${search}*` : undefined,
         perPage: size,
         page: 1,
-        searchFields: ['title^3', 'description'],
+        searchFields,
         defaultSearchOperator: 'AND',
         fields,
         hasReference,

--- a/src/plugins/saved_objects/public/saved_object/saved_object_loader.ts
+++ b/src/plugins/saved_objects/public/saved_object/saved_object_loader.ts
@@ -126,6 +126,8 @@ export class SavedObjectLoader {
    * @param search
    * @param size
    * @param fields
+   * @param hasReference Optional field to specify a reference
+   * @param searchFields Optional field to specify the search fields in the query
    * @returns {Promise}
    */
   findAll(

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
@@ -89,6 +89,8 @@ export class SavedObjectLoaderAugmentVis extends SavedObjectLoader {
    * @param search
    * @param size
    * @param fields
+   * @param hasReference Optional field to specify a reference
+   * @param searchFields Optional field to specify the search fields in the query
    * @returns {Promise}
    */
   findAll(

--- a/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
+++ b/src/plugins/vis_augmenter/public/saved_augment_vis/saved_augment_vis.ts
@@ -95,10 +95,11 @@ export class SavedObjectLoaderAugmentVis extends SavedObjectLoader {
     search: string = '',
     size: number = 100,
     fields?: string[],
-    hasReference?: SavedObjectsFindOptions['hasReference']
+    hasReference?: SavedObjectsFindOptions['hasReference'],
+    searchFields?: string[]
   ) {
     this.isAugmentationEnabled();
-    return super.findAll(search, size, fields, hasReference);
+    return super.findAll(search, size, fields, hasReference, searchFields);
   }
 
   find(search: string = '', size: number = 100) {

--- a/src/plugins/vis_augmenter/public/utils/utils.test.ts
+++ b/src/plugins/vis_augmenter/public/utils/utils.test.ts
@@ -349,6 +349,76 @@ describe('utils', () => {
       } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
       expect((await getAugmentVisSavedObjs(visId1, loader)).length).toEqual(2);
     });
+    it('undefined plugin resource list has no effect', async () => {
+      const loader = createSavedAugmentVisLoader({
+        savedObjectsClient: getMockAugmentVisSavedObjectClient([obj1, obj2]),
+      } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+      expect((await getAugmentVisSavedObjs(visId1, loader, undefined, undefined)).length).toEqual(
+        2
+      );
+    });
+    it('empty plugin resource list has no effect', async () => {
+      const loader = createSavedAugmentVisLoader({
+        savedObjectsClient: getMockAugmentVisSavedObjectClient([obj1, obj2]),
+      } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+      expect((await getAugmentVisSavedObjs(visId1, loader, undefined, [])).length).toEqual(2);
+    });
+    it('empty / undefined plugin resource list passes correct findAll() params', async () => {
+      const loader = createSavedAugmentVisLoader({
+        savedObjectsClient: getMockAugmentVisSavedObjectClient([obj1, obj2]),
+      } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+      loader.findAll = jest.fn().mockImplementation(loader.findAll);
+      expect((await getAugmentVisSavedObjs(visId1, loader, undefined, [])).length).toEqual(2);
+      expect(loader.findAll).toHaveBeenCalledWith(
+        '',
+        100,
+        [],
+        {
+          type: 'visualization',
+          id: visId1 as string,
+        },
+        []
+      );
+    });
+    it('single plugin resource is propagated to findAll()', async () => {
+      const loader = createSavedAugmentVisLoader({
+        savedObjectsClient: getMockAugmentVisSavedObjectClient([obj1, obj2]),
+      } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+      loader.findAll = jest.fn().mockImplementation(loader.findAll);
+      expect(
+        (await getAugmentVisSavedObjs(visId1, loader, undefined, ['resource-1'])).length
+      ).toEqual(2);
+      expect(loader.findAll).toHaveBeenCalledWith(
+        'resource-1',
+        100,
+        [],
+        {
+          type: 'visualization',
+          id: visId1 as string,
+        },
+        ['pluginResource.id']
+      );
+    });
+    it('multiple plugin resources are propagated to findAll()', async () => {
+      const loader = createSavedAugmentVisLoader({
+        savedObjectsClient: getMockAugmentVisSavedObjectClient([obj1, obj2]),
+      } as SavedObjectOpenSearchDashboardsServicesWithAugmentVis);
+      loader.findAll = jest.fn().mockImplementation(loader.findAll);
+      expect(
+        (await getAugmentVisSavedObjs(visId1, loader, undefined, ['resource-1', 'resource-2']))
+          .length
+      ).toEqual(2);
+      expect(loader.findAll).toHaveBeenCalledWith(
+        'resource-1|resource-2',
+        100,
+        [],
+        {
+          type: 'visualization',
+          id: visId1 as string,
+        },
+        ['pluginResource.id']
+      );
+    });
   });
 
   describe('buildPipelineFromAugmentVisSavedObjs', () => {

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -513,19 +513,14 @@ export class VisualizeEmbeddable
    * e.g., generating other vis embeddables in the view events flyout.
    */
   public async populateVisLayers(): Promise<void> {
-    const visLayers = await this.fetchVisLayers();
-    this.visLayers =
-      this.visAugmenterConfig?.visLayerResourceIds === undefined
-        ? visLayers
-        : visLayers.filter((visLayer) =>
-            this.visAugmenterConfig.visLayerResourceIds.includes(visLayer.pluginResource.id)
-          );
+    this.visLayers = await this.fetchVisLayers();
   }
 
   /**
    * Collects any VisLayers from plugin expressions functions
-   * by fetching all AugmentVisSavedObjects that match the vis
-   * saved object ID.
+   * by fetching all AugmentVisSavedObjects that meets below criteria:
+   * - includes a reference to the vis saved object id
+   * - includes any of the plugin resource IDs, if specified
    */
   fetchVisLayers = async (): Promise<VisLayers> => {
     try {
@@ -541,7 +536,9 @@ export class VisualizeEmbeddable
       const aborted = get(this.abortController, 'signal.aborted', false) as boolean;
       const augmentVisSavedObjs = await getAugmentVisSavedObjs(
         this.vis.id,
-        this.savedAugmentVisLoader
+        this.savedAugmentVisLoader,
+        undefined,
+        this.visAugmenterConfig?.visLayerResourceIds
       );
 
       if (!isEmpty(augmentVisSavedObjs) && !aborted && isEligibleForVisLayers(this.vis)) {


### PR DESCRIPTION
### Description

This PR provides optimizations to the saved object loader calls made in the vis embeddable. Specifically, when fetching the saved objects, it adds arguments to the query to filter by matching plugin resource IDs, when applicable. Before, all objects were returned and post-processing filtering was done. Now, we leverage OpenSearch to handle the filtering for us.

To make this change, a new optional argument has been added to the `findAll()` function to specify the search fields. Before, it was hardcoded to name and description. Now, we want to search on the `pluginResource.id` field such that we only return objects that match the input resource IDs.

This fix provides massive performance improvements when rendering the View Events flyout. Specifically, it prevents `n^2 - n` objects being returned, where `n` is the number of associations. This also means an equivalent amount of prevented plugin expression function runs, any queries ran within those expression functions, etc.

For example, suppose there are 10 associations to a visualization, and a user opens the View Events flyout.
Before, each visualization would be fetching all 10 `augment-vis` objects, executing all 10 expression functions (which would mean fetching all 10 resources, results for each of them, etc.). Each vis (10 executions) x 10 == 100 executions.
Now, each visualization only fetches the relevant `augment-vis` saved object, so only one expression function is ran. Each vis (1 execution) x 10 = 10 executions, a savings of 90%.

Before this change, the time to render the view events flyout as the number of visualizations/associations grew was exponential. Now, it is linear. Example of network request savings seen on my local:
Opening flyout with 5 associations = 98 requests (before) - 58 requests (after) = 40 requests prevented = ~41% less total requests.
10 associations = 288 requests (before) - 108 requests (after) = 180 requests prevented = ~63% less total requests

For more information on plugin resource IDs and how they are used, see "The VisAugmenterEmbeddableConfig" section in #3415 

Quick results on my local (top row is association count)
```
|        | 10   | 20   | 40   | 50   |
|--------|------|------|------|------|
| before | 1.7s | 3.4s | 5.4s | 9.3s |
| after  | 1.3s | 2.0s | 2.5s | 2.9s |
```

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
