### PR TITLE
Fix (styles): Make ace code editor themes consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update main menu to display 'Dashboards' for consistency ([#4453](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4453))
 - [Multiple DataSource] Retain the original sample data API ([#4526](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4526))
 - Fix Node.js download link ([#4556](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4556))
+- [TSVB, Dashboards] Fix inconsistent dark mode code editor themes ([#4609](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4609))
 
 ### 🚞 Infrastructure
 

--- a/src/core/public/styles/_ace_overrides.scss
+++ b/src/core/public/styles/_ace_overrides.scss
@@ -6,7 +6,7 @@
 
 // In order to override the TM (Textmate) theme of Ace/Brace, everywhere,
 // it is being scoped by a known outer selector
-.application {
+.coreSystemRootDomElement {
   .ace-tm {
     $aceBackground: tintOrShade($euiColorLightShade, 50%, 0);
 

--- a/src/plugins/vis_default_editor/public/components/controls/raw_json.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/raw_json.tsx
@@ -100,7 +100,7 @@ function RawJsonParamEditor({
       <>
         <EuiCodeEditor
           mode="json"
-          theme="github"
+          theme="textmate"
           width="100%"
           height="250px"
           value={value}

--- a/src/plugins/vis_type_timeseries/public/application/components/markdown_editor.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/markdown_editor.js
@@ -126,7 +126,7 @@ export class MarkdownEditor extends Component {
           <EuiCodeEditor
             onLoad={this.handleOnLoad}
             mode="markdown"
-            theme="github"
+            theme="textmate"
             width="100%"
             height="100%"
             name={`ace-${model.id}`}

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config/markdown.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config/markdown.js
@@ -293,7 +293,7 @@ class MarkdownPanelConfigUi extends Component {
             <EuiSpacer size="s" />
             <EuiCodeEditor
               mode="less"
-              theme="github"
+              theme="textmate"
               width="100%"
               name={`ace-css-${model.id}`}
               setOptions={{ fontSize: '14px' }}


### PR DESCRIPTION
### Description

Fixes inconsistent code editor theming, particularly in dark mode. The vast majority of code editor components in OpenSearch Dashboards still use the deprecated `EuiCodeEditor` component, which is built around Ace editor. To enable dark mode theming, there are a series of ace editor SCSS style overrides, but these were only applied to children of the `application` class, which excluded editors in popovers or other portaled components. And TSVB used the `github` theme, which lacks dark mode overrides.

1. Use "textmate" theme everywhere
2. Update override selector to apply to root, to style portal-ed components, too (such as filter editor)

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

### Before

Data plugin edit filter DSL:
![Screenshot 2023-07-21 at 16-15-35 Visual Consistency Dashboard - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/1027b656-0454-40f9-ad4e-f59268553227)

Default editor advanced json field:
![Screenshot 2023-07-21 at 16-21-07 (Area) Stacked extensions over time - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/08d6571b-adb7-41ec-8d72-547bc01aaa19)

TSVB markdown editor:
![Screenshot 2023-07-21 at 16-17-42 Visualize - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/31fbdda0-af34-4e8e-9a8e-374438bb0225)

TSVB markdown custom CSS:
![Screenshot 2023-07-21 at 16-18-23 Visualize - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/a1e696e9-408a-499b-9319-9af6c8d1a6f5)

### After

These are all the views that use the `EuiCodeEditor` component in  OpenSearch Dashboards:

Vega vis editor:
![Screenshot 2023-07-21 at 15-49-55 Visualize - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/2161cebe-eb9f-49e5-a8e8-58eca2d74494)

TSVB vis markdown (CSS customization):
![Screenshot 2023-07-21 at 15-48-50 Visualize - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/df4fafae-fb40-4056-af8e-77666359d318)

TSVB vis markdown editor:
![Screenshot 2023-07-21 at 15-46-42 Visualize - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/f5721619-27f0-4c97-b770-4a4bafe9a206)

Vis default editor (used primarily in VisLib visualizations) advanced json fields:
![Screenshot 2023-07-21 at 15-45-14 Visualize - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/fbbc9ece-a325-47ec-ba8b-c29c056792e1)

Saved object management:
![Screenshot 2023-07-21 at 15-42-46 Saved Objects - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/fed10e88-e31b-496a-98a2-733c1c497c50)

Index pattern management, scripted fields editor:
![Screenshot 2023-07-21 at 15-40-03 hour_of_day - opensearch_dashboards_sample_data_logs - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/aca9484e-76a6-4af4-b7ae-35835d23a2b0)

Data plugin edit filter DSL:
![Screenshot 2023-07-21 at 15-38-40 Visual Consistency Dashboard - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/036971ee-47d9-4f82-a08d-484d6b1b2511)

Advanced settings:
![Screenshot 2023-07-21 at 15-37-36 OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/06246d5b-2902-44ae-868e-cf591203f83d)

Developer examples expression (dev mode only):
![Screenshot 2023-07-21 at 15-36-41 OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/c314da9b-c91a-4222-be06-ab0a72225d19)

Developer examples dashboard containers (dev mode only):
![Screenshot 2023-07-21 at 15-34-59 OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/940177c3-1d96-41ba-af8c-bbb25f6057f8)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
