### PR TITLE
[Decouple] Allow plugin manifest config to define semver compatible OpenSearch plugin and verify if it is installed on the cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Discover] Update styles to compatible with OUI `next` theme ([#4644](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4644))
 - Remove visualization editor sidebar background ([#4719](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4719))
 - [Vis Colors] Remove customized colors from sample visualizations and dashboards ([#4741](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4741))
+- [Decouple] Allow plugin manifest config to define semver compatible OpenSearch plugin and verify if it is installed on the cluster([#4612](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4612))
 
 ### 🐛 Bug Fixes
 

--- a/src/core/public/plugins/plugins_service.test.ts
+++ b/src/core/public/plugins/plugins_service.test.ts
@@ -84,7 +84,7 @@ function createManifest(
     version: 'some-version',
     configPath: ['path'],
     requiredPlugins: required,
-    requiredOpenSearchPlugins: optional,
+    requiredEnginePlugins: optional,
     optionalPlugins: optional,
     requiredBundles: [],
   };

--- a/src/core/server/plugins/integration_tests/plugins_service.test.ts
+++ b/src/core/server/plugins/integration_tests/plugins_service.test.ts
@@ -42,7 +42,7 @@ import { config } from '../plugins_config';
 import { loggingSystemMock } from '../../logging/logging_system.mock';
 import { environmentServiceMock } from '../../environment/environment_service.mock';
 import { coreMock } from '../../mocks';
-import { Plugin } from '../types';
+import { Plugin, CompatibleEnginePluginVersions } from '../types';
 import { PluginWrapper } from '../plugin';
 
 describe('PluginsService', () => {
@@ -57,7 +57,7 @@ describe('PluginsService', () => {
       disabled = false,
       version = 'some-version',
       requiredPlugins = [],
-      requiredOpenSearchPlugins = [],
+      requiredEnginePlugins = {},
       requiredBundles = [],
       optionalPlugins = [],
       opensearchDashboardsVersion = '7.0.0',
@@ -69,7 +69,7 @@ describe('PluginsService', () => {
       disabled?: boolean;
       version?: string;
       requiredPlugins?: string[];
-      requiredOpenSearchPlugins?: string[];
+      requiredEnginePlugins?: CompatibleEnginePluginVersions;
       requiredBundles?: string[];
       optionalPlugins?: string[];
       opensearchDashboardsVersion?: string;
@@ -86,7 +86,7 @@ describe('PluginsService', () => {
         configPath: `${configPath}${disabled ? '-disabled' : ''}`,
         opensearchDashboardsVersion,
         requiredPlugins,
-        requiredOpenSearchPlugins,
+        requiredEnginePlugins,
         requiredBundles,
         optionalPlugins,
         server,

--- a/src/core/server/plugins/plugin.test.ts
+++ b/src/core/server/plugins/plugin.test.ts
@@ -69,7 +69,10 @@ function createPluginManifest(manifestProps: Partial<PluginManifest> = {}): Plug
     configPath: 'path',
     opensearchDashboardsVersion: '7.0.0',
     requiredPlugins: ['some-required-dep'],
-    requiredOpenSearchPlugins: ['some-os-plugins'],
+    requiredEnginePlugins: {
+      'test-os-plugin1': '^2.2.1',
+      'test-os-plugin2': '2.2.1 || 2.2.2',
+    },
     optionalPlugins: ['some-optional-dep'],
     requiredBundles: [],
     server: true,

--- a/src/core/server/plugins/plugin.ts
+++ b/src/core/server/plugins/plugin.ts
@@ -66,7 +66,7 @@ export class PluginWrapper<
   public readonly configPath: PluginManifest['configPath'];
   public readonly requiredPlugins: PluginManifest['requiredPlugins'];
   public readonly optionalPlugins: PluginManifest['optionalPlugins'];
-  public readonly requiredOpenSearchPlugins: PluginManifest['requiredOpenSearchPlugins'];
+  public readonly requiredEnginePlugins: PluginManifest['requiredEnginePlugins'];
   public readonly requiredBundles: PluginManifest['requiredBundles'];
   public readonly includesServerPlugin: PluginManifest['server'];
   public readonly includesUiPlugin: PluginManifest['ui'];
@@ -96,7 +96,7 @@ export class PluginWrapper<
     this.configPath = params.manifest.configPath;
     this.requiredPlugins = params.manifest.requiredPlugins;
     this.optionalPlugins = params.manifest.optionalPlugins;
-    this.requiredOpenSearchPlugins = params.manifest.requiredOpenSearchPlugins;
+    this.requiredEnginePlugins = params.manifest.requiredEnginePlugins;
     this.requiredBundles = params.manifest.requiredBundles;
     this.includesServerPlugin = params.manifest.server;
     this.includesUiPlugin = params.manifest.ui;

--- a/src/core/server/plugins/plugin_context.test.ts
+++ b/src/core/server/plugins/plugin_context.test.ts
@@ -56,7 +56,9 @@ function createPluginManifest(manifestProps: Partial<PluginManifest> = {}): Plug
     configPath: 'path',
     opensearchDashboardsVersion: '7.0.0',
     requiredPlugins: ['some-required-dep'],
-    requiredOpenSearchPlugins: ['some-backend-plugin'],
+    requiredEnginePlugins: {
+      'test-os-plugin1': '^2.2.1',
+    },
     requiredBundles: [],
     optionalPlugins: ['some-optional-dep'],
     server: true,

--- a/src/core/server/plugins/plugins_service.test.ts
+++ b/src/core/server/plugins/plugins_service.test.ts
@@ -47,7 +47,7 @@ import { PluginsService } from './plugins_service';
 import { PluginsSystem } from './plugins_system';
 import { config } from './plugins_config';
 import { take } from 'rxjs/operators';
-import { DiscoveredPlugin } from './types';
+import { DiscoveredPlugin, CompatibleEnginePluginVersions } from './types';
 
 const { join } = posix;
 const MockPluginsSystem: jest.Mock<PluginsSystem> = PluginsSystem as any;
@@ -78,7 +78,7 @@ const createPlugin = (
     disabled = false,
     version = 'some-version',
     requiredPlugins = [],
-    requiredOpenSearchPlugins = [],
+    requiredEnginePlugins = {},
     requiredBundles = [],
     optionalPlugins = [],
     opensearchDashboardsVersion = '7.0.0',
@@ -90,7 +90,7 @@ const createPlugin = (
     disabled?: boolean;
     version?: string;
     requiredPlugins?: string[];
-    requiredOpenSearchPlugins?: string[];
+    requiredEnginePlugins?: CompatibleEnginePluginVersions;
     requiredBundles?: string[];
     optionalPlugins?: string[];
     opensearchDashboardsVersion?: string;
@@ -107,7 +107,7 @@ const createPlugin = (
       configPath: `${configPath}${disabled ? '-disabled' : ''}`,
       opensearchDashboardsVersion,
       requiredPlugins,
-      requiredOpenSearchPlugins,
+      requiredEnginePlugins,
       requiredBundles,
       optionalPlugins,
       server,

--- a/src/core/server/plugins/plugins_system.test.ts
+++ b/src/core/server/plugins/plugins_system.test.ts
@@ -42,7 +42,7 @@ import { CoreContext } from '../core_context';
 import { loggingSystemMock } from '../logging/logging_system.mock';
 
 import { PluginWrapper } from './plugin';
-import { PluginName } from './types';
+import { PluginName, CompatibleEnginePluginVersions } from './types';
 import { PluginsSystem } from './plugins_system';
 import { coreMock } from '../mocks';
 import { Logger } from '../logging';
@@ -53,13 +53,13 @@ function createPlugin(
   {
     required = [],
     optional = [],
-    requiredOSPlugin = [],
+    requiredOSPlugin = {},
     server = true,
     ui = true,
   }: {
     required?: string[];
     optional?: string[];
-    requiredOSPlugin?: string[];
+    requiredOSPlugin?: CompatibleEnginePluginVersions;
     server?: boolean;
     ui?: boolean;
   } = {}
@@ -72,7 +72,7 @@ function createPlugin(
       configPath: 'path',
       opensearchDashboardsVersion: '7.0.0',
       requiredPlugins: required,
-      requiredOpenSearchPlugins: requiredOSPlugin,
+      requiredEnginePlugins: requiredOSPlugin,
       optionalPlugins: optional,
       requiredBundles: [],
       server,
@@ -195,7 +195,12 @@ test('correctly orders plugins and returns exposed values for "setup" and "start
   }
   const plugins = new Map([
     [
-      createPlugin('order-4', { required: ['order-2'], requiredOSPlugin: ['test-plugin'] }),
+      createPlugin('order-4', {
+        required: ['order-2'],
+        requiredOSPlugin: {
+          'test-plugin-1': '^1.1.1',
+        },
+      }),
       {
         setup: { 'order-2': 'added-as-2' },
         start: { 'order-2': 'started-as-2' },
@@ -253,12 +258,12 @@ test('correctly orders plugins and returns exposed values for "setup" and "start
   );
 
   const opensearch = startDeps.opensearch;
-  opensearch.client.asInternalUser.cat.plugins.mockResolvedValue({
+  opensearch.client.asInternalUser.cat.plugins.mockResolvedValueOnce({
     body: [
       {
         name: 'node-1',
-        component: 'test-plugin',
-        version: 'v1',
+        component: 'test-plugin-1',
+        version: '1.9.9',
       },
     ],
   } as any);
@@ -509,7 +514,7 @@ describe('start', () => {
       {
         name: 'node-1',
         component: 'test-plugin',
-        version: 'v1',
+        version: '2.1.0',
       },
     ],
   } as any);
@@ -549,8 +554,12 @@ describe('start', () => {
 
   it('validates opensearch plugin installation when dependency is fulfilled', async () => {
     [
-      createPlugin('order-1', { requiredOSPlugin: ['test-plugin'] }),
-      createPlugin('order-2'),
+      createPlugin('dependency-fulfilled-plugin', {
+        requiredOSPlugin: {
+          'test-plugin': '^2.0.0',
+        },
+      }),
+      createPlugin('no-dependency-plugin'),
     ].forEach((plugin, index) => {
       jest.spyOn(plugin, 'setup').mockResolvedValue(`setup-as-${index}`);
       jest.spyOn(plugin, 'start').mockResolvedValue(`started-as-${index}`);
@@ -561,12 +570,18 @@ describe('start', () => {
     const pluginsStart = await pluginsSystem.startPlugins(startDeps);
     expect(pluginsStart).toBeInstanceOf(Map);
     expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
+    const log = logger.get.mock.results[0].value as jest.Mocked<Logger>;
+    expect(log.warn).toHaveBeenCalledTimes(0);
   });
 
   it('validates opensearch plugin installation and does not error out when plugin is not installed', async () => {
     [
-      createPlugin('id-1', { requiredOSPlugin: ['missing-opensearch-dep'] }),
-      createPlugin('id-2'),
+      createPlugin('dependency-missing-plugin', {
+        requiredOSPlugin: {
+          'missing-opensearch-dep': '^2.0.0',
+        },
+      }),
+      createPlugin('no-dependency-plugin'),
     ].forEach((plugin, index) => {
       jest.spyOn(plugin, 'setup').mockResolvedValue(`setup-as-${index}`);
       jest.spyOn(plugin, 'start').mockResolvedValue(`started-as-${index}`);
@@ -577,17 +592,51 @@ describe('start', () => {
     const pluginsStart = await pluginsSystem.startPlugins(startDeps);
     expect(pluginsStart).toBeInstanceOf(Map);
     expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
+    const log = logger.get.mock.results[0].value as jest.Mocked<Logger>;
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      `OpenSearch plugin "missing-opensearch-dep" is not installed on the engine for the OpenSearch Dashboards plugin to function as expected.`
+    );
   });
 
-  it('validates opensearch plugin installation and does not error out when there is no dependency', async () => {
-    [createPlugin('id-1'), createPlugin('id-2')].forEach((plugin, index) => {
+  it('validates opensearch plugin installation and log warning when plugin exist but version is incompatible', async () => {
+    [
+      createPlugin('version-mismatch-plugin', {
+        requiredOSPlugin: {
+          'test-plugin-version-mismatch': '^1.0.0',
+        },
+      }),
+      createPlugin('no-dependency-plugin'),
+    ].forEach((plugin, index) => {
       jest.spyOn(plugin, 'setup').mockResolvedValue(`setup-as-${index}`);
       jest.spyOn(plugin, 'start').mockResolvedValue(`started-as-${index}`);
       pluginsSystem.addPlugin(plugin);
     });
+
     await pluginsSystem.setupPlugins(setupDeps);
     const pluginsStart = await pluginsSystem.startPlugins(startDeps);
     expect(pluginsStart).toBeInstanceOf(Map);
     expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
+    const log = logger.get.mock.results[0].value as jest.Mocked<Logger>;
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      `OpenSearch plugin "test-plugin-version-mismatch" is not installed on the engine for the OpenSearch Dashboards plugin to function as expected.`
+    );
+  });
+
+  it('validates opensearch plugin installation and does not warn when there is no dependency', async () => {
+    [createPlugin('no-dependency-plugin-1'), createPlugin('no-dependency-plugin-2')].forEach(
+      (plugin, index) => {
+        jest.spyOn(plugin, 'setup').mockResolvedValue(`setup-as-${index}`);
+        jest.spyOn(plugin, 'start').mockResolvedValue(`started-as-${index}`);
+        pluginsSystem.addPlugin(plugin);
+      }
+    );
+    await pluginsSystem.setupPlugins(setupDeps);
+    const pluginsStart = await pluginsSystem.startPlugins(startDeps);
+    expect(pluginsStart).toBeInstanceOf(Map);
+    expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
+    const log = logger.get.mock.results[0].value as jest.Mocked<Logger>;
+    expect(log.warn).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/core/server/plugins/types.ts
+++ b/src/core/server/plugins/types.ts
@@ -105,6 +105,9 @@ export type PluginName = string;
 /** @public */
 export type PluginOpaqueId = symbol;
 
+/** @public */
+export type CompatibleEnginePluginVersions = Record<string, string>;
+
 /** @internal */
 export interface PluginDependencies {
   asNames: ReadonlyMap<PluginName, PluginName[]>;
@@ -155,10 +158,10 @@ export interface PluginManifest {
   readonly requiredPlugins: readonly PluginName[];
 
   /**
-   * An optional list of component names of the backend OpenSearch plugins that **must be** installed on the cluster
+   * An optional list of the OpenSearch plugins that **must be** installed on the cluster
    * for this plugin to function properly.
    */
-  readonly requiredOpenSearchPlugins: readonly PluginName[];
+  readonly requiredEnginePlugins: CompatibleEnginePluginVersions;
 
   /**
    * List of plugin ids that this plugin's UI code imports modules from that are


### PR DESCRIPTION
### Description

This PR is an enhancement to the already existing plugin manifest ability to allow defining backend OpenSearch plugin dependencies. As part of decoupling Dashboards with OpenSearch Dashboards plugins and then with OpenSearch, we need a way to establish Dashboards plugin dependency with its counter part. 
This PR adds following changes -
* Modifying existing manifest config key `requiredOpenSearchPlugins` to define list of OpenSearch Plugin object and its version compatibility with that plugin.
* In the first iteration we can define version range in semver format only. 
* Compatible version defined in the manifest should be a valid version range.
* Validates if version compatible plugin is installed on the cluster or not.
* In this initial implementation, we are only logging the warning if plugin is not available and does not fail to start.

In the follow-up PRs,
* Add ability to disable Dashboards plugin when its counterpart is not installed on the cluster.
* Export function/API that plugins can extend to decide what they want to do when their OpenSearch counterpart plugin is not installed or is incompatible. 

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4611



### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
