### PR TITLE
Reduce the amount of comments in compiled CSS and bundled CSS-in-JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Enable theme-switching via Advanced Settings to preview the Next theme ([#4475](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4475))
 - Optimize `augment-vis` saved obj searching by adding arg to saved obj client ([#4595](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4595))
 - Add resource ID filtering in fetch `augment-vis` obj queries ([#4608](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4608))
+- Reduce the amount of comments in compiled CSS ([#4648](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4648))
 - [Discover] Update styles to compatible with OUI `next` theme ([#4644](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4644))
 
 ### 🐛 Bug Fixes

--- a/packages/osd-optimizer/package.json
+++ b/packages/osd-optimizer/package.json
@@ -48,6 +48,7 @@
     "@types/watchpack": "^1.1.6",
     "@types/webpack": "^4.41.31",
     "babel-loader": "^8.2.3",
+    "comment-stripper": "^0.0.4",
     "css-loader": "^5.2.7",
     "file-loader": "^6.2.0",
     "loader-utils": "^2.0.4",

--- a/packages/osd-optimizer/src/worker/webpack.config.ts
+++ b/packages/osd-optimizer/src/worker/webpack.config.ts
@@ -137,6 +137,12 @@ export function getWebpackConfig(bundle: Bundle, bundleRefs: BundleRefs, worker:
                 sourceMap: !worker.dist,
               },
             },
+            {
+              loader: 'comment-stripper',
+              options: {
+                language: 'css',
+              },
+            },
           ],
         },
         {
@@ -162,6 +168,12 @@ export function getWebpackConfig(bundle: Bundle, bundleRefs: BundleRefs, worker:
                     postcssOptions: {
                       config: require.resolve('@osd/optimizer/postcss.config.js'),
                     },
+                  },
+                },
+                {
+                  loader: 'comment-stripper',
+                  options: {
+                    language: 'css',
                   },
                 },
                 {

--- a/packages/osd-ui-framework/Gruntfile.js
+++ b/packages/osd-ui-framework/Gruntfile.js
@@ -28,6 +28,7 @@
  * under the License.
  */
 
+const { strip } = require('comment-stripper');
 const sass = require('node-sass');
 const postcss = require('postcss');
 const postcssConfig = require('@osd/optimizer/postcss.config.js');
@@ -91,7 +92,10 @@ module.exports = function (grunt) {
           }
 
           postcss([postcssConfig])
-            .process(result.css, { from: src, to: dest })
+            .process(strip(result.css.toString('utf8'), { language: 'css' }), {
+              from: src,
+              to: dest,
+            })
             .then((result) => {
               grunt.file.write(dest, result.css);
 

--- a/packages/osd-ui-framework/dist/kui_dark.css
+++ b/packages/osd-ui-framework/dist/kui_dark.css
@@ -8,577 +8,17 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/**
- * 1. Focus rings shouldn't be visible on scrollable regions, but a11y requires them to be focusable.
- *    Browser's supporting `:focus-visible` will still show outline on keyboard focus only.
- *    Others like Safari, won't show anything at all.
- * 2. Force the `:focus-visible` when the `tabindex=0` (is tabbable)
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/**
- * 1. Enforce pointer when there's no href.
- * 2. Allow these styles to be applied to a button element.
- */
-/**
- * 1. Override Bootstrap styles.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :disabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * Nothing fancy, just the basics so we can use this for both regular and static controls.
- */
-/**
- * 1. Prevent Firefox users from being able to resize textareas to smaller than the min-height.
- */
-/**
- * We specifically don't include Angular's ng-${state} classes here because we don't want to be tightly
- * coupled with Angular.
- */
-/**
- * 1. Embedded SVG of fa-caret-down
- *    (https://github.com/encharm/Font-Awesome-SVG-PNG/blob/master/black/svg/caret-down.svg).
- * 2. Make room on right side for the caret.
- * 3. Prevent Firefox from showing dotted line around text on focus.
- */
-/**
- * 1. Setting to inline-block guarantees the same height when applied to both
- *    button elements and anchor tags.
- * 2. Fit MicroButton inside of Table rows without pushing them taller.
- */
-/**
- * 1. Give Bar a consistent height for when it contains shorter children, and therefore can't
- *    depend on them to give it the desired height.
- */
-/**
- * 1. Put 10px of space between each child.
- * 2. If there is only one section, align it to the right. If you wanted it aligned right, you
- *    wouldn't use the Bar in the first place.
- * 3. Children in the middle should center their content.
- * 4. Fix an IE bug which causes the last child to overflow the container.
- * 5. Fixing this bug means we now need to align the children to the right.
- */
-/**
- * 1. Required for IE11.
- */
+
 main {
   display: block;
-  /* 1 */ }
+   }
 
 .kuiBar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */ }
+   }
 
 .kuiBarSection {
   display: flex;
@@ -588,33 +28,25 @@ main {
   margin-right: 25px; }
   .kuiBarSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiBarSection:first-child {
     margin-left: 0; }
   .kuiBarSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiBarSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiBarSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Setting to inline-block guarantees the same height when applied to both
- *    button elements and anchor tags.
- * 2. Links can be focused when they're "disabled" (since we're just faking this with a class), but
- *    at least make them look like they're not focused.
- */
 .kuiButton {
   display: inline-block;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
+    -webkit-appearance: none;
+            appearance: none;
   cursor: pointer;
   padding: 4px 12px 5px;
   font-size: 16px;
@@ -634,18 +66,13 @@ main {
     -webkit-transform: translateY(1px);
             transform: translateY(1px); }
   a.kuiButton:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    -webkit-transform: translateY(1px);
-            transform: translateY(1px); }
+        -webkit-transform: translateY(1px);
+                transform: translateY(1px); }
 
-/**
-   * 1. Solves whitespace problems introduced by inline elements.
-   */
 .kuiButton__inner {
   display: flex;
-  /* 1 */
-  align-items: center;
-  /* 1 */ }
+    align-items: center;
+   }
 
 .kuiButton--small {
   font-size: 12px;
@@ -668,122 +95,85 @@ main {
 .kuiButton--iconText.kuiButton--small .kuiButton__icon:last-child:not(:only-child) {
   margin-left: 4px; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--basic {
   color: #DFE5EF;
   background-color: #25262E; }
   .kuiButton--basic:not(a):enabled:focus {
     color: #DFE5EF; }
   a.kuiButton--basic:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #DFE5EF; }
+        color: #DFE5EF; }
   .kuiButton--basic:enabled:hover {
     background-color: #0e0f12 !important;
-    /* 1 */ }
+     }
   a.kuiButton--basic:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    background-color: #0e0f12 !important;
-    /* 1 */ }
+        background-color: #0e0f12 !important;
+     }
   .kuiButton--basic:enabled:active {
     background-color: #0e0f12 !important;
-    /* 1 */ }
+     }
   a.kuiButton--basic:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    background-color: #0e0f12 !important;
-    /* 1 */ }
+        background-color: #0e0f12 !important;
+     }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--primary {
   color: #FFF;
   background-color: #1BA9F5; }
   .kuiButton--primary:not(a):enabled:focus {
     color: #FFF; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #FFF; }
+        color: #FFF; }
   .kuiButton--primary:enabled:hover {
     color: #FFF !important;
-    /* 1 */
-    background-color: #098dd4; }
+        background-color: #098dd4; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #098dd4; }
+        color: #FFF !important;
+        background-color: #098dd4; }
   .kuiButton--primary:enabled:active {
     color: #FFF !important;
-    /* 1 */
-    background-color: #098dd4; }
+        background-color: #098dd4; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #098dd4; }
+        color: #FFF !important;
+        background-color: #098dd4; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--success {
   color: #FFF;
   background-color: #7DE2D1; }
   .kuiButton--success:not(a):enabled:focus {
     color: #FFF; }
   a.kuiButton--success:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #FFF; }
+        color: #FFF; }
   .kuiButton--success:enabled:hover {
     color: #FFF !important;
-    /* 1 */
-    background-color: #53d9c2; }
+        background-color: #53d9c2; }
   a.kuiButton--success:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #53d9c2; }
+        color: #FFF !important;
+        background-color: #53d9c2; }
   .kuiButton--success:enabled:active {
     color: #FFF !important;
-    /* 1 */
-    background-color: #53d9c2; }
+        background-color: #53d9c2; }
   a.kuiButton--success:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #53d9c2; }
+        color: #FFF !important;
+        background-color: #53d9c2; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--danger {
   color: #F66;
   border: solid 1px #F66; }
   .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #1D1E24, 0 0 0 2px #F66;
-    /* 3 */
-    color: #F66; }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #1D1E24, 0 0 0 2px #F66;
+        color: #F66; }
   a.kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #1D1E24, 0 0 0 2px #F66;
-    /* 3 */
-    color: #F66; }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #1D1E24, 0 0 0 2px #F66;
+        color: #F66; }
   .kuiButton--danger:enabled:hover {
     color: #ff3333 !important;
     border: solid 1px #ff3333;
     background-color: rgba(255, 102, 102, 0.1); }
   a.kuiButton--danger:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #ff3333 !important;
+        color: #ff3333 !important;
     border: solid 1px #ff3333;
     background-color: rgba(255, 102, 102, 0.1); }
   .kuiButton--danger:enabled:active {
@@ -791,112 +181,77 @@ main {
     border: solid 1px #ff3333;
     background-color: rgba(255, 102, 102, 0.1); }
   a.kuiButton--danger:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #ff3333 !important;
+        color: #ff3333 !important;
     border: solid 1px #ff3333;
     background-color: rgba(255, 102, 102, 0.1); }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--warning {
   color: #FFF;
   background-color: #FFCE7A; }
   .kuiButton--warning:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #1D1E24, 0 0 0 2px #FFCE7A;
-    /* 3 */
-    color: #FFF; }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #1D1E24, 0 0 0 2px #FFCE7A;
+        color: #FFF; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #1D1E24, 0 0 0 2px #FFCE7A;
-    /* 3 */
-    color: #FFF; }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #1D1E24, 0 0 0 2px #FFCE7A;
+        color: #FFF; }
   .kuiButton--warning:enabled:hover {
     color: #FFF !important;
-    /* 1 */
-    background-color: #ffbb47; }
+        background-color: #ffbb47; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #ffbb47; }
+        color: #FFF !important;
+        background-color: #ffbb47; }
   .kuiButton--warning:enabled:active {
     color: #FFF !important;
-    /* 1 */
-    background-color: #ffbb47; }
+        background-color: #ffbb47; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #ffbb47; }
+        color: #FFF !important;
+        background-color: #ffbb47; }
   .kuiButton--warning:disabled {
     background-color: #ffe1ad; }
   a.kuiButton--warning.kuiButton-isDisabled {
     background-color: #ffe1ad; }
 
-/**
- * 1. Override Bootstrap.
- * 2. Override either Bootstrap or Timeline styles.
- */
 .kuiButton--hollow {
   color: #1BA9F5 !important;
-  /* 2 */
-  background-color: transparent; }
+    background-color: transparent; }
   .kuiButton--hollow:enabled:hover {
     color: #098dd4 !important;
-    /* 1 */
-    text-decoration: underline; }
+        text-decoration: underline; }
   a.kuiButton--hollow:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #098dd4 !important;
-    /* 1 */
-    text-decoration: underline; }
+        color: #098dd4 !important;
+        text-decoration: underline; }
   .kuiButton--hollow:enabled:active {
     color: #098dd4 !important;
-    /* 1 */
-    text-decoration: underline; }
+        text-decoration: underline; }
   a.kuiButton--hollow:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #098dd4 !important;
-    /* 1 */
-    text-decoration: underline; }
+        color: #098dd4 !important;
+        text-decoration: underline; }
 
 .kuiButton--secondary {
   color: #1BA9F5 !important;
-  /* 2 */
-  border: solid 1px #1BA9F5; }
+    border: solid 1px #1BA9F5; }
   .kuiButton--secondary:enabled:hover {
     color: #098dd4 !important;
-    /* 1 */
-    border: solid 1px #098dd4;
+        border: solid 1px #098dd4;
     background-color: rgba(27, 169, 245, 0.1);
     text-decoration: underline; }
   a.kuiButton--secondary:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #098dd4 !important;
-    /* 1 */
-    border: solid 1px #098dd4;
+        color: #098dd4 !important;
+        border: solid 1px #098dd4;
     background-color: rgba(27, 169, 245, 0.1);
     text-decoration: underline; }
   .kuiButton--secondary:enabled:active {
     color: #098dd4 !important;
-    /* 1 */
-    border: solid 1px #098dd4;
+        border: solid 1px #098dd4;
     background-color: rgba(27, 169, 245, 0.1);
     text-decoration: underline; }
   a.kuiButton--secondary:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #098dd4 !important;
-    /* 1 */
-    border: solid 1px #098dd4;
+        color: #098dd4 !important;
+        border: solid 1px #098dd4;
     background-color: rgba(27, 169, 245, 0.1);
     text-decoration: underline; }
 
@@ -942,58 +297,37 @@ main {
   line-height: 1;
   font-size: 16px;
   color: #DFE5EF !important;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   opacity: 0.35; }
   .kuiCollapseButton:hover {
     opacity: 1; }
 
-/**
- * 1. Set inline-block so this wrapper shrinks to fit the input.
- */
 .kuiAssistedInput {
   display: inline-block;
-  /* 1 */
-  position: relative; }
+    position: relative; }
 
-/**
-   * 1. Vertically center the assistance, regardless of its height.
-   */
 .kuiAssistedInput__assistance {
   position: absolute;
   right: 12px;
   top: 50%;
-  /* 1 */
-  -webkit-transform: translateY(-50%);
-          transform: translateY(-50%);
-  /* 1 */ }
+    -webkit-transform: translateY(-50%);
+            transform: translateY(-50%);
+   }
 
-/**
- * 1. Deliberately disable only webkit appearance. If we disable it in Firefox, we get a really
- *    ugly default appearance which we can't customize, so our best option is to give Firefox
- *    control over the checkbox's appearance.
- * 2. Override default styles (possibly from Bootstrap).
- */
 .kuiCheckBox {
   -webkit-appearance: none;
           appearance: none;
-  /* 1 */
-  background-color: #16171c;
+    background-color: #16171c;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 4px;
   width: 16px;
   height: 16px;
   font: "var(--font-text)" !important;
-  /* 2 */
-  line-height: 1.5 !important;
-  /* 2 */
-  margin: 0 !important;
-  /* 2 */
-  font-family: "var(--font-text)" !important;
-  /* 2 */
-  font-size: 10px !important;
-  /* 2 */
-  transition: background-color 0.1s linear; }
+    line-height: 1.5 !important;
+    margin: 0 !important;
+    font-family: "var(--font-text)" !important;
+    font-size: 10px !important;
+    transition: background-color 0.1s linear; }
   .kuiCheckBox::before {
     position: relative;
     left: 0.25em;
@@ -1010,11 +344,9 @@ main {
       opacity: 1; }
   .kuiCheckBox:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #1D1E24, 0 0 0 2px #1BA9F5;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #1D1E24, 0 0 0 2px #1BA9F5;
+     }
   .kuiCheckBox:disabled {
     background-color: #202128 !important;
     border-color: #202128 !important;
@@ -1030,15 +362,12 @@ main {
   font-size: 16px;
   margin-left: 8px; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiLabel {
   font-size: 16px;
   line-height: 1.5;
   font-weight: bold;
   margin-bottom: 0;
-  /* 1 */ }
+   }
 
 .kuiSearchInput {
   width: 180px;
@@ -1056,10 +385,6 @@ main {
   font-size: 1em;
   color: #535966; }
 
-/**
-   * 1. Make space for search icon.
-   * 2. Expand to fill container.
-   */
 .kuiSearchInput__input {
   -webkit-appearance: none;
           appearance: none;
@@ -1074,11 +399,9 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-left: 28px;
-  /* 1 */
-  width: 100%;
-  /* 2 */ }
+    padding-left: 28px;
+    width: 100%;
+   }
   .kuiSearchInput__input:invalid {
     border-color: #F66; }
   .kuiSearchInput__input:focus {
@@ -1094,9 +417,6 @@ main {
 .kuiSearchInput--large {
   width: 400px; }
 
-/**
- * Avoid setting a width here, so that the width of the options can dynamically set the width.
- */
 .kuiSelect {
   -webkit-appearance: none;
           appearance: none;
@@ -1111,15 +431,12 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-right: 30px;
-  /* 2 */
-  background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
-  /* 1 */
-  background-size: 14px;
+    padding-right: 30px;
+    background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
+    background-size: 14px;
   background-repeat: no-repeat;
   background-position: calc(100% - 8px);
-  /* 2 */ }
+   }
   .kuiSelect:invalid {
     border-color: #F66; }
   .kuiSelect:focus {
@@ -1130,7 +447,7 @@ main {
     cursor: not-allowed; }
   .kuiSelect:-moz-focusring {
     text-shadow: 0 0 0;
-    /* 3 */ }
+     }
   .kuiSelect.kuiSelect-isInvalid {
     border-color: #F66; }
   .kuiSelect:focus {
@@ -1147,9 +464,6 @@ main {
 .kuiSelect--large {
   width: 400px; }
 
-/**
- * 1. Have the same spatial footprint as the regular input.
- */
 .kuiStaticInput {
   width: 180px;
   -webkit-appearance: none;
@@ -1161,8 +475,7 @@ main {
   line-height: 1.5;
   color: #DFE5EF;
   border: 1px solid transparent;
-  /* 1 */
-  background-color: transparent; }
+    background-color: transparent; }
 
 .kuiTextArea {
   width: 180px;
@@ -1179,7 +492,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */ }
+   }
   .kuiTextArea:invalid {
     border-color: #F66; }
   .kuiTextArea:focus {
@@ -1219,7 +532,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */ }
+   }
   .kuiTextInput:invalid {
     border-color: #F66; }
   .kuiTextInput:focus {
@@ -1237,13 +550,10 @@ main {
 .kuiTextInput--large {
   width: 400px; }
 
-/**
- * 1. We may want to put elements in here which have different heights.
- */
 .kuiFieldGroup {
   display: flex;
   align-items: center;
-  /* 1 */ }
+   }
 
 .kuiFieldGroup--alignTop {
   align-items: flex-start; }
@@ -1258,23 +568,14 @@ main {
   .kuiFieldGroupSection--wide > * {
     width: 100%; }
 
-/**
- * 1. Copied from FontAwesome's .fa class. We use a custom class to make it easier to migrate away
- *    from FontAwesome someday. When we do migrate away, we can just update this definition.
- */
 .kuiIcon {
   display: inline-block;
-  /* 1 */
-  font: normal normal normal 14px/1 FontAwesome, sans-serif;
-  /* 1 */
-  font-size: inherit;
-  /* 1 */
-  text-rendering: auto;
-  /* 1 */
-  -webkit-font-smoothing: antialiased;
-  /* 1 */
-  -moz-osx-font-smoothing: grayscale;
-  /* 1 */ }
+    font: normal normal normal 14px/1 FontAwesome, sans-serif;
+    font-size: inherit;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+   }
 
 .kuiIcon--info {
   color: #1BA9F5; }
@@ -1299,41 +600,26 @@ main {
   line-height: 1.5;
   border: 2px solid; }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--info {
   border-color: rgba(27, 169, 245, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--success {
   border-color: rgba(125, 226, 209, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--warning {
   border-color: rgba(255, 206, 122, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--error {
   border-color: rgba(255, 102, 102, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. Align with first line of title text if it wraps.
- */
 .kuiInfoPanelHeader {
   display: flex;
   align-items: baseline;
-  /* 1 */ }
+   }
 
 .kuiInfoPanelHeader__icon {
   margin-right: 10px;
@@ -1358,34 +644,24 @@ main {
   color: #1BA9F5;
   text-decoration: none;
   cursor: pointer;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: none;
-  /* 2 */
-  font-size: inherit;
-  /* 2 */
-  line-height: inherit;
-  /* 2 */ }
+    -webkit-appearance: none;
+            appearance: none;
+    background-color: transparent;
+    border: none;
+    font-size: inherit;
+    line-height: inherit;
+   }
   .kuiLink:visited, .kuiLink:active {
     color: #1BA9F5; }
   .kuiLink:hover {
     color: #098dd4;
     text-decoration: underline; }
 
-/**
- * 1. Breadcrumbs are placed in the top-left corner and need to be bumped over
- *    a bit.
- */
 .kuiLocalBreadcrumbs {
   display: flex;
   align-items: center;
   padding: 12px 8px;
-  /* 1 */
-  border-bottom: 1px solid #343741;
+    border-bottom: 1px solid #343741;
   flex-grow: 1;
   flex-basis: 100%;
   background-color: #1D1E24; }
@@ -1403,28 +679,18 @@ main {
       margin-right: 4px;
       color: #343741; }
 
-/**
- * 1. Make it a bit darker to contrast with the gray background.
- */
 .kuiLocalBreadcrumb__link {
   color: #1BA9F5;
   text-decoration: none;
   cursor: pointer;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: none;
-  /* 2 */
-  font-size: inherit;
-  /* 2 */
-  line-height: inherit;
-  /* 2 */
-  color: #1BA9F5;
-  /* 1 */
-  font-size: 16px; }
+    -webkit-appearance: none;
+            appearance: none;
+    background-color: transparent;
+    border: none;
+    font-size: inherit;
+    line-height: inherit;
+    color: #1BA9F5;
+    font-size: 16px; }
   .kuiLocalBreadcrumb__link:visited, .kuiLocalBreadcrumb__link:active {
     color: #1BA9F5; }
   .kuiLocalBreadcrumb__link:hover {
@@ -1449,9 +715,6 @@ main {
   justify-content: space-between;
   margin-bottom: 4px; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiDatePickerNavigationButton {
   -webkit-appearance: none;
           appearance: none;
@@ -1467,13 +730,10 @@ main {
     background-color: #1BA9F5; }
   .kuiDatePickerNavigationButton:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px transparent, 0 0 0 2px #1BA9F5;
-    /* 3 */
-    color: #DFE5EF;
-    /* 1 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px transparent, 0 0 0 2px #1BA9F5;
+        color: #DFE5EF;
+     }
 
 .kuiDatePickerHeaderCell {
   padding: 9px 0;
@@ -1486,19 +746,12 @@ main {
 .kuiDatePickerRowCell {
   padding: 0;
   text-align: center;
-  /**
-   * This state class exists to support weird angular-bootstrap datepicker functionality,
-   * in which you can't select a day on the "From" calendar if it falls after the selected day in
-   * the "To" calendar (and vice versa, you can't select a "To" day if it is before the "From" day).
-   */ }
+   }
   .kuiDatePickerRowCell.kuiDatePickerRowCell-isBlocked {
     cursor: not-allowed; }
     .kuiDatePickerRowCell.kuiDatePickerRowCell-isBlocked .kuiDatePickerRowCellContent {
       pointer-events: none; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiDatePickerRowCellContent {
   -webkit-appearance: none;
           appearance: none;
@@ -1512,13 +765,10 @@ main {
   line-height: 1.2; }
   .kuiDatePickerRowCellContent:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px transparent, 0 0 0 2px #1BA9F5;
-    /* 3 */
-    color: #DFE5EF;
-    /* 1 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px transparent, 0 0 0 2px #1BA9F5;
+        color: #DFE5EF;
+     }
   .kuiDatePickerRowCellContent:disabled {
     pointer-events: none;
     opacity: 0.5; }
@@ -1551,8 +801,7 @@ main {
   line-height: 1;
   font-size: 16px;
   color: #DFE5EF !important;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   opacity: 0.35;
   position: absolute;
   top: 1px;
@@ -1572,13 +821,9 @@ main {
 .kuiLocalDropdownPanel--right {
   margin-left: 30px; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiLocalDropdownTitle {
   margin-top: 0;
-  /* 1 */
-  margin-bottom: 12px;
+    margin-bottom: 12px;
   font-size: 18px;
   color: #DFE5EF; }
 
@@ -1593,15 +838,11 @@ main {
   justify-content: space-between;
   margin-bottom: 6px; }
 
-/**
-   * 1. Override inherited styles.
-   */
 .kuiLocalDropdownHeader__label {
   font-size: 14px;
   font-weight: 700;
   margin-bottom: 0;
-  /* 1 */
-  color: #DFE5EF; }
+    color: #DFE5EF; }
 
 .kuiLocalDropdownHeader__actions {
   display: flex; }
@@ -1683,24 +924,16 @@ main {
   margin-right: 5px;
   margin-bottom: -1px; }
 
-/**
- * 1. Match height of logo in side bar, but allow it to expand to accommodate
- *    dropdown.
- */
 .kuiLocalNav {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   min-height: 69px;
-  /* 1 */
-  color: #DFE5EF;
+    color: #DFE5EF;
   background-color: #1D1E24;
   line-height: 1.5;
   border-bottom: solid 1px #343741; }
 
-/**
- * 1. Allow row to expand if the content is so long that it wraps.
- */
 .kuiLocalNavRow {
   display: flex;
   align-items: stretch;
@@ -1710,18 +943,10 @@ main {
   display: flex;
   align-items: stretch; }
 
-/**
- * 1. We make this row flex-start because it usually contains a search input, which may expand
- *    beyond the height of this container. We can't use `align-items: center`, because this would
- *    cause the search input to overflow both on the top and bottom; `align-items: flex-start`
- *    makes it only overflow on the bottom. But this means we need to manually center the content
- *    of this container using padding.
- */
 .kuiLocalNavRow--secondary {
   padding: 0 8px;
-  /* 1 */
-  align-items: flex-start;
-  /* 1 */ }
+    align-items: flex-start;
+   }
 
 .kuiLocalSearch {
   display: flex;
@@ -1742,8 +967,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  flex: 1 1 100%;
+    flex: 1 1 100%;
   border-color: #FFF;
   border-color: #343741;
   border-radius: 4px 0 0 4px; }
@@ -1766,28 +990,19 @@ main {
   border-radius: 0;
   border-left-width: 0; }
 
-/**
- * 1. em used for right padding so documentation link and query string
- *    won't overlap if the user increases their default browser font size
- *    This is sized for the 'Options' link
- */
 .kuiLocalSearchInput,
 .kuiLocalSearchAssistedInput__input {
   padding-right: 6em;
-  /* 1 */ }
+   }
 
-/**
- * 1. Vertically center the assistance, regardless of its height.
- */
 .kuiLocalSearchAssistedInput__assistance {
   position: absolute;
   right: 6px;
   top: 50%;
-  /* 1 */
-  z-index: 2;
+    z-index: 2;
   -webkit-transform: translateY(-50%);
           transform: translateY(-50%);
-  /* 1 */ }
+   }
 
 .kuiLocalSearchSelect {
   -webkit-appearance: none;
@@ -1803,16 +1018,12 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-right: 30px;
-  /* 2 */
-  background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
-  /* 1 */
-  background-size: 14px;
+    padding-right: 30px;
+    background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
+    background-size: 14px;
   background-repeat: no-repeat;
   background-position: calc(100% - 8px);
-  /* 2 */
-  border-left-width: 0;
+    border-left-width: 0;
   border-radius: 0; }
   .kuiLocalSearchSelect:invalid {
     border-color: #F66; }
@@ -1824,40 +1035,28 @@ main {
     cursor: not-allowed; }
   .kuiLocalSearchSelect:-moz-focusring {
     text-shadow: 0 0 0;
-    /* 3 */ }
+     }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiLocalSearchButton {
   width: 43px;
   height: 32px;
   font-size: 16px;
   line-height: 0;
-  /* 1 */
-  color: #FFF;
+    color: #FFF;
   background-color: #1BA9F5;
   border: 0;
   border-radius: 0 4px 4px 0; }
   .kuiLocalSearchButton:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #343741, 0 0 0 2px #1BA9F5;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #343741, 0 0 0 2px #1BA9F5;
+     }
 
-/**
- * 1. We want the bottom border on selected tabs to be flush with the bottom of the container.
- */
 .kuiLocalTabs {
   display: flex;
   align-items: flex-end;
   height: 100%; }
 
-/**
-   * 1. Override inherited typographic styles.
-   */
 .kuiLocalTab {
   padding: 5px 0 6px;
   font-size: 18px;
@@ -1866,13 +1065,8 @@ main {
   text-decoration: none;
   cursor: pointer;
   margin-top: 0 !important;
-  /* 1 */
-  margin-bottom: 0 !important;
-  /* 1 */
-  /**
-     * 1. We may want to show a tooltip to explain why the tab is disabled, so we will just show
-     *    a regular cursor instead of setting pointer-events: none.
-     */ }
+    margin-bottom: 0 !important;
+     }
   .kuiLocalTab:hover:not(.kuiLocalTab-isDisabled), .kuiLocalTab:active:not(.kuiLocalTab-isDisabled) {
     color: #1BA9F5; }
   .kuiLocalTab.kuiLocalTab-isSelected {
@@ -1882,7 +1076,7 @@ main {
   .kuiLocalTab.kuiLocalTab-isDisabled {
     opacity: 0.5;
     cursor: default;
-    /* 1 */ }
+     }
   .kuiLocalTab + .kuiLocalTab {
     margin-left: 15px; }
 
@@ -1900,22 +1094,19 @@ main {
     padding: 0;
     display: none; }
 
-/**
- * 1. Put 10px of space between each child.
- */
 .kuiPager {
   display: flex;
   align-items: center; }
   .kuiPager > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
 .kuiPagerText {
   font-size: 16px;
   line-height: 1.5;
   color: #98A2B3;
   white-space: nowrap;
-  /* 1 */ }
+   }
 
 .kuiPanel {
   box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.3), 0 1px 5px -2px rgba(0, 0, 0, 0.3);
@@ -1951,62 +1142,44 @@ main {
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 50px;
   border-bottom: 1px solid #343741; }
   .kuiPanelHeader .kuiButton:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #343741, 0 0 0 2px #1BA9F5;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #343741, 0 0 0 2px #1BA9F5;
+     }
   a.kuiPanelHeader .kuiButton:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #343741, 0 0 0 2px #1BA9F5;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #343741, 0 0 0 2px #1BA9F5;
+     }
   .kuiPanelHeader .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #343741, 0 0 0 2px #F66;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #343741, 0 0 0 2px #F66;
+     }
   a.kuiPanelHeader .kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #343741, 0 0 0 2px #F66;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #343741, 0 0 0 2px #F66;
+     }
   .kuiPanelHeader .kuiSelect {
     border-color: #16171c; }
     .kuiPanelHeader .kuiSelect:not(a):enabled:focus {
       outline: none;
       border-color: #1BA9F5; }
     a.kuiPanelHeader .kuiSelect:not(.kuiButton-isDisabled):focus {
-      /* 1 */
-      outline: none;
+            outline: none;
       border-color: #1BA9F5; }
 
-/**
-   * 1. This way we can use h1, h2, etc.
-   */
 .kuiPanelHeader__title {
   font-size: 20px;
   line-height: 1.5;
   margin: 0;
-  /* 1 */ }
+   }
 
-/**
- * 1. Undo what barSection mixin does.
- */
 .kuiPanelHeaderSection {
   display: flex;
   align-items: center;
@@ -2015,26 +1188,24 @@ main {
   margin-right: 25px; }
   .kuiPanelHeaderSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiPanelHeaderSection:first-child {
     margin-left: 0; }
   .kuiPanelHeaderSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiPanelHeaderSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiPanelHeaderSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
   .kuiPanelHeaderSection:only-child {
     margin-left: 0;
-    /* 1 */
-    margin-right: auto;
-    /* 1 */ }
+        margin-right: auto;
+     }
 
 .kuiPanelBody {
   padding: 10px; }
@@ -2069,98 +1240,65 @@ main {
 .kuiStatusText--error {
   color: #F66; }
 
-/**
- * 1. Set the image to be the same size as a font icon at 14px.
- * 2. We need to cap the height too, in case the icon was designed thin and tall.
- */
 .kuiStatusText__icon {
   margin-right: 6px;
   width: 1.15em;
-  /* 1 */
-  max-height: 1.15em;
-  /* 2 */ }
+    max-height: 1.15em;
+   }
 
-/**
- * 1. Make seamless transition from ToolBar to Table header and contained Menu.
- * 1. Make seamless transition from Table to ToolBarFooter header.
- */
 .kuiControlledTable {
   background: #1D1E24; }
   .kuiControlledTable .kuiTable {
     border-top: none;
-    /* 1 */ }
+     }
   .kuiControlledTable .kuiToolBarFooter {
     border-top: none;
-    /* 2 */ }
+     }
   .kuiControlledTable .kuiMenu--contained {
     border-top: none;
-    /* 1 */ }
+     }
 
-/**
- * 1. Prevent cells from expanding based on content size. This substitutes for table-layout: fixed.
- */
-/**
- * NOTE: table-layout: fixed causes a bug in IE11 and Edge (see #9929). It also prevents us from
- * specifying a column width, e.g. the checkbox column.
- */
 .kuiTable {
   width: 100%;
   border: 1px solid #343741;
   border-collapse: collapse;
   background-color: #1D1E24; }
 
-/**
- * 1. Allow contents of cells to determine table's width.
- */
 .kuiTable--fluid {
   width: auto;
-  /* 1 */ }
+   }
   .kuiTable--fluid .kuiTableHeaderCell,
   .kuiTable--fluid .kuiTableRowCell {
     max-width: none;
-    /* 1 */ }
+     }
 
 .kuiTableHeaderCell {
   font-size: 16px;
   font-weight: 400;
   text-align: left;
   max-width: 20px;
-  /* 1 */
-  line-height: 1.5;
+    line-height: 1.5;
   color: #98A2B3; }
 
 .kuiTableHeaderCell__liner {
   display: inline-block;
   padding: 7px 8px 8px; }
 
-/**
- * 1. Prevent rapid clicking from selecting text.
- * 2. Remove native button element styles.
- * 3. Make buttons look and behave like table header cells.
- */
 .kuiTableHeaderCellButton {
   -webkit-user-select: none;
           user-select: none;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   width: 100%;
   -webkit-appearance: none;
           appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: 0;
-  /* 2 */
-  padding: 0;
-  /* 2 */
-  color: inherit;
-  /* 3 */
-  line-height: inherit;
-  /* 3 */
-  font-size: inherit;
-  /* 3 */
-  text-align: inherit;
-  /* 3 */ }
+    background-color: transparent;
+    border: 0;
+    padding: 0;
+    color: inherit;
+    line-height: inherit;
+    font-size: inherit;
+    text-align: inherit;
+   }
   .kuiTableHeaderCellButton:hover .kuiTableSortIcon {
     display: block;
     opacity: 1; }
@@ -2190,31 +1328,20 @@ main {
   font-weight: 400;
   text-align: left;
   max-width: 20px;
-  /* 1 */
-  color: #DFE5EF;
+    color: #DFE5EF;
   border-top: 1px solid #343741;
   vertical-align: middle; }
 
-/**
-   * 1. Vertically align all children.
-   * 2. The padding on this div allows the ellipsis to show if the content is truncated. If
-   *    the padding was on the cell, the ellipsis would be cropped.
-   * 3. Truncate content with an ellipsis.
-   */
 .kuiTableRowCell__liner {
   padding: 7px 8px 8px;
-  /* 2 */
-  line-height: 1.5;
-  /* 1 */
-  overflow: hidden;
-  /* 3 */
-  text-overflow: ellipsis;
-  /* 3 */
-  white-space: nowrap;
-  /* 3 */ }
+    line-height: 1.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+   }
   .kuiTableRowCell__liner > * {
     vertical-align: middle;
-    /* 1 */ }
+     }
 
 .kuiTableRowCell--wrap .kuiTableRowCell__liner {
   white-space: normal; }
@@ -2223,34 +1350,24 @@ main {
   overflow: visible;
   white-space: normal; }
 
-/**
- * 1. We don't want to create too strong a disconnect between the original row and the row
- *    that contains its expanded details.
- */
 .kuiTableRowCell--expanded {
   border-top-color: #1D1E24;
-  /* 1 */ }
+   }
 
 .kuiTableRowCell--alignRight {
   text-align: right; }
   .kuiTableRowCell--alignRight .kuiTableRowCell__liner {
     text-align: right; }
 
-/**
- * 1. Rendered width of cell with checkbox inside of it.
- * 2. Align checkbox with text in other cells.
- * 3. Show the checkbox in Edge; otherwise it gets cropped.
- */
 .kuiTableHeaderCell--checkBox,
 .kuiTableRowCell--checkBox {
   width: 28px;
-  /* 1 */
-  line-height: 1;
-  /* 2 */ }
+    line-height: 1;
+   }
   .kuiTableHeaderCell--checkBox .kuiTableRowCell__liner,
   .kuiTableRowCell--checkBox .kuiTableRowCell__liner {
     overflow: visible;
-    /* 3 */ }
+     }
   .kuiTableHeaderCell--checkBox .kuiTableHeaderCell__liner,
   .kuiTableHeaderCell--checkBox .kuiTableRowCell__liner,
   .kuiTableRowCell--checkBox .kuiTableHeaderCell__liner,
@@ -2267,41 +1384,30 @@ main {
   display: flex;
   border-bottom: 1px solid #343741; }
 
-/**
- * 1. Override button styles (some of which are from Bootstrap).
- * 2. Adding a border shifts tabs right by 1px, so we need to shift them back.
- * 3. Move the tab down so that its bottom border covers the container's bottom border.
- * 4. When the tab is focused, its bottom border changes to be 1px, so we need to add 1px more
- *    of padding to make sure the text doesn't shift down.
- */
 .kuiTab {
   -webkit-appearance: none;
           appearance: none;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   padding: 10px 30px;
   font-size: 16px;
   color: #98A2B3;
   background-color: transparent;
-  /* 1 */
-  border: 1px solid #343741;
+    border: 1px solid #343741;
   border-radius: 0;
-  /* 1 */
-  margin-bottom: -1px;
-  /* 3 */ }
+    margin-bottom: -1px;
+   }
   .kuiTab + .kuiTab {
     border-left: none; }
     .kuiTab + .kuiTab:focus:not(.kuiTab-isSelected):not(:active) {
       margin-left: -1px;
-      /* 2 */ }
+       }
   .kuiTab:active {
     outline: none !important;
-    /* 1 */
-    box-shadow: none;
-    /* 1 */ }
+        box-shadow: none;
+     }
   .kuiTab:focus {
     outline: none;
-    /* 1 */ }
+     }
   .kuiTab:focus:not(.kuiTab-isSelected):not(:active) {
     z-index: 1;
     color: #1BA9F5;
@@ -2320,49 +1426,37 @@ main {
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 50px;
   background-color: transparent;
   border: solid 1px #343741; }
   .kuiToolBar .kuiButton:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #343741, 0 0 0 2px #1BA9F5;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #343741, 0 0 0 2px #1BA9F5;
+     }
   a.kuiToolBar .kuiButton:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #343741, 0 0 0 2px #1BA9F5;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #343741, 0 0 0 2px #1BA9F5;
+     }
   .kuiToolBar .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #343741, 0 0 0 2px #F66;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #343741, 0 0 0 2px #F66;
+     }
   a.kuiToolBar .kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #343741, 0 0 0 2px #F66;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #343741, 0 0 0 2px #F66;
+     }
   .kuiToolBar .kuiSelect {
     border-color: #16171c; }
     .kuiToolBar .kuiSelect:not(a):enabled:focus {
       outline: none;
       border-color: #1BA9F5; }
     a.kuiToolBar .kuiSelect:not(.kuiButton-isDisabled):focus {
-      /* 1 */
-      outline: none;
+            outline: none;
       border-color: #1BA9F5; }
 
 .kuiToolBarSection {
@@ -2373,36 +1467,31 @@ main {
   margin-right: 25px; }
   .kuiToolBarSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiToolBarSection:first-child {
     margin-left: 0; }
   .kuiToolBarSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiToolBarSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiToolBarSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Override Bar styles and put Search on the left side.
- */
 .kuiToolBar--searchOnly .kuiToolBarSearch {
   margin-left: 0 !important;
-  /* 1 */ }
+   }
 
 .kuiToolBarFooter {
   display: flex;
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 40px;
   background-color: #1D1E24; }
 
@@ -2414,27 +1503,21 @@ main {
   margin-right: 25px; }
   .kuiToolBarFooterSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiToolBarFooterSection:first-child {
     margin-left: 0; }
   .kuiToolBarFooterSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiToolBarFooterSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiToolBarFooterSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Put 10px of space between each child.
- * 2. Fix IE11 bug which causes this item to grow too wide when there is only a single
- *    kuiToolBarSection sibling.
- */
 .kuiToolBarSearch {
   display: flex;
   align-items: center;
@@ -2442,15 +1525,14 @@ main {
   margin-right: 25px;
   flex: 1 1 auto;
   max-width: 100%;
-  /* 2 */
-  line-height: 1.5; }
+    line-height: 1.5; }
   .kuiToolBarSearch:first-child {
     margin-left: 0; }
   .kuiToolBarSearch:last-child {
     margin-right: 0; }
   .kuiToolBarSearch > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
 .kuiToolBarSearchBox {
   flex: 1 1 auto;
@@ -2465,85 +1547,55 @@ main {
   font-size: 1em;
   color: #acacac; }
 
-/**
-   * 1. Fix inherited styles (possibly from Bootstrap).
-   */
 .kuiToolBarSearchBox__input {
   width: 100%;
   min-width: 200px;
   padding: 4px 12px 5px 28px;
   font-family: "var(--font-text)";
-  /* 1 */
-  background-color: #1D1E24;
+    background-color: #1D1E24;
   color: #DFE5EF;
   border-radius: 4px;
   font-size: 1em;
   border: 1px solid #343741;
   line-height: normal;
-  /* 1 */
-  transition: border-color 0.1s linear; }
+    transition: border-color 0.1s linear; }
   .kuiToolBarSearchBox__input:focus {
     outline: none;
     border-color: #1BA9F5; }
 
-/*
- * 1. We don't want the text to take up two lines and overflow the ToolBar.
- */
 .kuiToolBarText {
   font-size: 16px;
   line-height: 1.5;
   color: #98A2B3;
   white-space: nowrap;
-  /* 1 */ }
+   }
 
-/**
- * 1. Override h1.
- */
 .kuiTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  font-size: 24px; }
+    font-weight: 400;
+    font-size: 24px; }
 
-/**
- * 1. Override h2, h3, etc.
- */
 .kuiSubTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  font-size: 20px; }
+    font-weight: 400;
+    font-size: 20px; }
 
-/**
- * 1. Override p.
- */
 .kuiTextTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 700;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 700;
+    line-height: 1.5;
   font-size: 16px; }
 
-/**
- * 1. Override p.
- */
 .kuiText {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 400;
+    line-height: 1.5;
   font-size: 16px; }
 
 .kuiSubText {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 400;
+    line-height: 1.5;
   font-size: 14px; }
 
 .kuiSubduedText {

--- a/packages/osd-ui-framework/dist/kui_light.css
+++ b/packages/osd-ui-framework/dist/kui_light.css
@@ -8,543 +8,17 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/**
- * 1. Focus rings shouldn't be visible on scrollable regions, but a11y requires them to be focusable.
- *    Browser's supporting `:focus-visible` will still show outline on keyboard focus only.
- *    Others like Safari, won't show anything at all.
- * 2. Force the `:focus-visible` when the `tabindex=0` (is tabbable)
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/**
- * 1. Enforce pointer when there's no href.
- * 2. Allow these styles to be applied to a button element.
- */
-/**
- * 1. Override Bootstrap styles.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :disabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * Nothing fancy, just the basics so we can use this for both regular and static controls.
- */
-/**
- * 1. Prevent Firefox users from being able to resize textareas to smaller than the min-height.
- */
-/**
- * We specifically don't include Angular's ng-${state} classes here because we don't want to be tightly
- * coupled with Angular.
- */
-/**
- * 1. Embedded SVG of fa-caret-down
- *    (https://github.com/encharm/Font-Awesome-SVG-PNG/blob/master/black/svg/caret-down.svg).
- * 2. Make room on right side for the caret.
- * 3. Prevent Firefox from showing dotted line around text on focus.
- */
-/**
- * 1. Setting to inline-block guarantees the same height when applied to both
- *    button elements and anchor tags.
- * 2. Fit MicroButton inside of Table rows without pushing them taller.
- */
-/**
- * 1. Give Bar a consistent height for when it contains shorter children, and therefore can't
- *    depend on them to give it the desired height.
- */
-/**
- * 1. Put 10px of space between each child.
- * 2. If there is only one section, align it to the right. If you wanted it aligned right, you
- *    wouldn't use the Bar in the first place.
- * 3. Children in the middle should center their content.
- * 4. Fix an IE bug which causes the last child to overflow the container.
- * 5. Fixing this bug means we now need to align the children to the right.
- */
-/**
- * 1. Required for IE11.
- */
+
 main {
   display: block;
-  /* 1 */ }
+   }
 
 .kuiBar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */ }
+   }
 
 .kuiBarSection {
   display: flex;
@@ -554,33 +28,25 @@ main {
   margin-right: 25px; }
   .kuiBarSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiBarSection:first-child {
     margin-left: 0; }
   .kuiBarSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiBarSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiBarSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Setting to inline-block guarantees the same height when applied to both
- *    button elements and anchor tags.
- * 2. Links can be focused when they're "disabled" (since we're just faking this with a class), but
- *    at least make them look like they're not focused.
- */
 .kuiButton {
   display: inline-block;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
+    -webkit-appearance: none;
+            appearance: none;
   cursor: pointer;
   padding: 4px 12px 5px;
   font-size: 16px;
@@ -600,18 +66,13 @@ main {
     -webkit-transform: translateY(1px);
             transform: translateY(1px); }
   a.kuiButton:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    -webkit-transform: translateY(1px);
-            transform: translateY(1px); }
+        -webkit-transform: translateY(1px);
+                transform: translateY(1px); }
 
-/**
-   * 1. Solves whitespace problems introduced by inline elements.
-   */
 .kuiButton__inner {
   display: flex;
-  /* 1 */
-  align-items: center;
-  /* 1 */ }
+    align-items: center;
+   }
 
 .kuiButton--small {
   font-size: 12px;
@@ -634,122 +95,85 @@ main {
 .kuiButton--iconText.kuiButton--small .kuiButton__icon:last-child:not(:only-child) {
   margin-left: 4px; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--basic {
   color: #343741;
   background-color: #F5F7FA; }
   .kuiButton--basic:not(a):enabled:focus {
     color: #343741; }
   a.kuiButton--basic:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #343741; }
+        color: #343741; }
   .kuiButton--basic:enabled:hover {
     background-color: #d3dce9 !important;
-    /* 1 */ }
+     }
   a.kuiButton--basic:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    background-color: #d3dce9 !important;
-    /* 1 */ }
+        background-color: #d3dce9 !important;
+     }
   .kuiButton--basic:enabled:active {
     background-color: #d3dce9 !important;
-    /* 1 */ }
+     }
   a.kuiButton--basic:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    background-color: #d3dce9 !important;
-    /* 1 */ }
+        background-color: #d3dce9 !important;
+     }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--primary {
   color: #FFF;
   background-color: #006BB4; }
   .kuiButton--primary:not(a):enabled:focus {
     color: #FFF; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #FFF; }
+        color: #FFF; }
   .kuiButton--primary:enabled:hover {
     color: #FFF !important;
-    /* 1 */
-    background-color: #004d81; }
+        background-color: #004d81; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #004d81; }
+        color: #FFF !important;
+        background-color: #004d81; }
   .kuiButton--primary:enabled:active {
     color: #FFF !important;
-    /* 1 */
-    background-color: #004d81; }
+        background-color: #004d81; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #004d81; }
+        color: #FFF !important;
+        background-color: #004d81; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--success {
   color: #FFF;
   background-color: #017D73; }
   .kuiButton--success:not(a):enabled:focus {
     color: #FFF; }
   a.kuiButton--success:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #FFF; }
+        color: #FFF; }
   .kuiButton--success:enabled:hover {
     color: #FFF !important;
-    /* 1 */
-    background-color: #014a44; }
+        background-color: #014a44; }
   a.kuiButton--success:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #014a44; }
+        color: #FFF !important;
+        background-color: #014a44; }
   .kuiButton--success:enabled:active {
     color: #FFF !important;
-    /* 1 */
-    background-color: #014a44; }
+        background-color: #014a44; }
   a.kuiButton--success:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #014a44; }
+        color: #FFF !important;
+        background-color: #014a44; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--danger {
   color: #BD271E;
   border: solid 1px #BD271E; }
   .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #BD271E;
-    /* 3 */
-    color: #BD271E; }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #BD271E;
+        color: #BD271E; }
   a.kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #BD271E;
-    /* 3 */
-    color: #BD271E; }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #BD271E;
+        color: #BD271E; }
   .kuiButton--danger:enabled:hover {
     color: #911e17 !important;
     border: solid 1px #911e17;
     background-color: rgba(189, 39, 30, 0.1); }
   a.kuiButton--danger:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #911e17 !important;
+        color: #911e17 !important;
     border: solid 1px #911e17;
     background-color: rgba(189, 39, 30, 0.1); }
   .kuiButton--danger:enabled:active {
@@ -757,112 +181,77 @@ main {
     border: solid 1px #911e17;
     background-color: rgba(189, 39, 30, 0.1); }
   a.kuiButton--danger:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #911e17 !important;
+        color: #911e17 !important;
     border: solid 1px #911e17;
     background-color: rgba(189, 39, 30, 0.1); }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--warning {
   color: #FFF;
   background-color: #F5A700; }
   .kuiButton--warning:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #F5A700;
-    /* 3 */
-    color: #FFF; }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #F5A700;
+        color: #FFF; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #F5A700;
-    /* 3 */
-    color: #FFF; }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #F5A700;
+        color: #FFF; }
   .kuiButton--warning:enabled:hover {
     color: #FFF !important;
-    /* 1 */
-    background-color: #c28400; }
+        background-color: #c28400; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #c28400; }
+        color: #FFF !important;
+        background-color: #c28400; }
   .kuiButton--warning:enabled:active {
     color: #FFF !important;
-    /* 1 */
-    background-color: #c28400; }
+        background-color: #c28400; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #c28400; }
+        color: #FFF !important;
+        background-color: #c28400; }
   .kuiButton--warning:disabled {
     background-color: #ffbb29; }
   a.kuiButton--warning.kuiButton-isDisabled {
     background-color: #ffbb29; }
 
-/**
- * 1. Override Bootstrap.
- * 2. Override either Bootstrap or Timeline styles.
- */
 .kuiButton--hollow {
   color: #006BB4 !important;
-  /* 2 */
-  background-color: transparent; }
+    background-color: transparent; }
   .kuiButton--hollow:enabled:hover {
     color: #004d81 !important;
-    /* 1 */
-    text-decoration: underline; }
+        text-decoration: underline; }
   a.kuiButton--hollow:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #004d81 !important;
-    /* 1 */
-    text-decoration: underline; }
+        color: #004d81 !important;
+        text-decoration: underline; }
   .kuiButton--hollow:enabled:active {
     color: #004d81 !important;
-    /* 1 */
-    text-decoration: underline; }
+        text-decoration: underline; }
   a.kuiButton--hollow:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #004d81 !important;
-    /* 1 */
-    text-decoration: underline; }
+        color: #004d81 !important;
+        text-decoration: underline; }
 
 .kuiButton--secondary {
   color: #006BB4 !important;
-  /* 2 */
-  border: solid 1px #006BB4; }
+    border: solid 1px #006BB4; }
   .kuiButton--secondary:enabled:hover {
     color: #004d81 !important;
-    /* 1 */
-    border: solid 1px #004d81;
+        border: solid 1px #004d81;
     background-color: rgba(0, 107, 180, 0.1);
     text-decoration: underline; }
   a.kuiButton--secondary:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #004d81 !important;
-    /* 1 */
-    border: solid 1px #004d81;
+        color: #004d81 !important;
+        border: solid 1px #004d81;
     background-color: rgba(0, 107, 180, 0.1);
     text-decoration: underline; }
   .kuiButton--secondary:enabled:active {
     color: #004d81 !important;
-    /* 1 */
-    border: solid 1px #004d81;
+        border: solid 1px #004d81;
     background-color: rgba(0, 107, 180, 0.1);
     text-decoration: underline; }
   a.kuiButton--secondary:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #004d81 !important;
-    /* 1 */
-    border: solid 1px #004d81;
+        color: #004d81 !important;
+        border: solid 1px #004d81;
     background-color: rgba(0, 107, 180, 0.1);
     text-decoration: underline; }
 
@@ -908,58 +297,37 @@ main {
   line-height: 1;
   font-size: 16px;
   color: #343741 !important;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   opacity: 0.35; }
   .kuiCollapseButton:hover {
     opacity: 1; }
 
-/**
- * 1. Set inline-block so this wrapper shrinks to fit the input.
- */
 .kuiAssistedInput {
   display: inline-block;
-  /* 1 */
-  position: relative; }
+    position: relative; }
 
-/**
-   * 1. Vertically center the assistance, regardless of its height.
-   */
 .kuiAssistedInput__assistance {
   position: absolute;
   right: 12px;
   top: 50%;
-  /* 1 */
-  -webkit-transform: translateY(-50%);
-          transform: translateY(-50%);
-  /* 1 */ }
+    -webkit-transform: translateY(-50%);
+            transform: translateY(-50%);
+   }
 
-/**
- * 1. Deliberately disable only webkit appearance. If we disable it in Firefox, we get a really
- *    ugly default appearance which we can't customize, so our best option is to give Firefox
- *    control over the checkbox's appearance.
- * 2. Override default styles (possibly from Bootstrap).
- */
 .kuiCheckBox {
   -webkit-appearance: none;
           appearance: none;
-  /* 1 */
-  background-color: #fbfcfd;
+    background-color: #fbfcfd;
   border: 1px solid rgba(15, 39, 118, 0.1);
   border-radius: 4px;
   width: 16px;
   height: 16px;
   font: "var(--font-text)" !important;
-  /* 2 */
-  line-height: 1.5 !important;
-  /* 2 */
-  margin: 0 !important;
-  /* 2 */
-  font-family: "var(--font-text)" !important;
-  /* 2 */
-  font-size: 10px !important;
-  /* 2 */
-  transition: background-color 0.1s linear; }
+    line-height: 1.5 !important;
+    margin: 0 !important;
+    font-family: "var(--font-text)" !important;
+    font-size: 10px !important;
+    transition: background-color 0.1s linear; }
   .kuiCheckBox::before {
     position: relative;
     left: 0.25em;
@@ -976,11 +344,9 @@ main {
       opacity: 1; }
   .kuiCheckBox:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #006BB4;
+     }
   .kuiCheckBox:disabled {
     background-color: #eef2f7 !important;
     border-color: #eef2f7 !important;
@@ -996,15 +362,12 @@ main {
   font-size: 16px;
   margin-left: 8px; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiLabel {
   font-size: 16px;
   line-height: 1.5;
   font-weight: bold;
   margin-bottom: 0;
-  /* 1 */ }
+   }
 
 .kuiSearchInput {
   width: 180px;
@@ -1022,10 +385,6 @@ main {
   font-size: 1em;
   color: #98A2B3; }
 
-/**
-   * 1. Make space for search icon.
-   * 2. Expand to fill container.
-   */
 .kuiSearchInput__input {
   -webkit-appearance: none;
           appearance: none;
@@ -1040,11 +399,9 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-left: 28px;
-  /* 1 */
-  width: 100%;
-  /* 2 */ }
+    padding-left: 28px;
+    width: 100%;
+   }
   .kuiSearchInput__input:invalid {
     border-color: #BD271E; }
   .kuiSearchInput__input:focus {
@@ -1060,9 +417,6 @@ main {
 .kuiSearchInput--large {
   width: 400px; }
 
-/**
- * Avoid setting a width here, so that the width of the options can dynamically set the width.
- */
 .kuiSelect {
   -webkit-appearance: none;
           appearance: none;
@@ -1077,15 +431,12 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-right: 30px;
-  /* 2 */
-  background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
-  /* 1 */
-  background-size: 14px;
+    padding-right: 30px;
+    background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
+    background-size: 14px;
   background-repeat: no-repeat;
   background-position: calc(100% - 8px);
-  /* 2 */ }
+   }
   .kuiSelect:invalid {
     border-color: #BD271E; }
   .kuiSelect:focus {
@@ -1096,7 +447,7 @@ main {
     cursor: not-allowed; }
   .kuiSelect:-moz-focusring {
     text-shadow: 0 0 0;
-    /* 3 */ }
+     }
   .kuiSelect.kuiSelect-isInvalid {
     border-color: #BD271E; }
   .kuiSelect:focus {
@@ -1113,9 +464,6 @@ main {
 .kuiSelect--large {
   width: 400px; }
 
-/**
- * 1. Have the same spatial footprint as the regular input.
- */
 .kuiStaticInput {
   width: 180px;
   -webkit-appearance: none;
@@ -1127,8 +475,7 @@ main {
   line-height: 1.5;
   color: #343741;
   border: 1px solid transparent;
-  /* 1 */
-  background-color: transparent; }
+    background-color: transparent; }
 
 .kuiTextArea {
   width: 180px;
@@ -1145,7 +492,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */ }
+   }
   .kuiTextArea:invalid {
     border-color: #BD271E; }
   .kuiTextArea:focus {
@@ -1185,7 +532,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */ }
+   }
   .kuiTextInput:invalid {
     border-color: #BD271E; }
   .kuiTextInput:focus {
@@ -1203,13 +550,10 @@ main {
 .kuiTextInput--large {
   width: 400px; }
 
-/**
- * 1. We may want to put elements in here which have different heights.
- */
 .kuiFieldGroup {
   display: flex;
   align-items: center;
-  /* 1 */ }
+   }
 
 .kuiFieldGroup--alignTop {
   align-items: flex-start; }
@@ -1224,23 +568,14 @@ main {
   .kuiFieldGroupSection--wide > * {
     width: 100%; }
 
-/**
- * 1. Copied from FontAwesome's .fa class. We use a custom class to make it easier to migrate away
- *    from FontAwesome someday. When we do migrate away, we can just update this definition.
- */
 .kuiIcon {
   display: inline-block;
-  /* 1 */
-  font: normal normal normal 14px/1 FontAwesome, sans-serif;
-  /* 1 */
-  font-size: inherit;
-  /* 1 */
-  text-rendering: auto;
-  /* 1 */
-  -webkit-font-smoothing: antialiased;
-  /* 1 */
-  -moz-osx-font-smoothing: grayscale;
-  /* 1 */ }
+    font: normal normal normal 14px/1 FontAwesome, sans-serif;
+    font-size: inherit;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+   }
 
 .kuiIcon--info {
   color: #006BB4; }
@@ -1265,41 +600,26 @@ main {
   line-height: 1.5;
   border: 2px solid; }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--info {
   border-color: rgba(0, 107, 180, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--success {
   border-color: rgba(1, 125, 115, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--warning {
   border-color: rgba(245, 167, 0, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--error {
   border-color: rgba(189, 39, 30, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. Align with first line of title text if it wraps.
- */
 .kuiInfoPanelHeader {
   display: flex;
   align-items: baseline;
-  /* 1 */ }
+   }
 
 .kuiInfoPanelHeader__icon {
   margin-right: 10px;
@@ -1324,34 +644,24 @@ main {
   color: #006BB4;
   text-decoration: none;
   cursor: pointer;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: none;
-  /* 2 */
-  font-size: inherit;
-  /* 2 */
-  line-height: inherit;
-  /* 2 */ }
+    -webkit-appearance: none;
+            appearance: none;
+    background-color: transparent;
+    border: none;
+    font-size: inherit;
+    line-height: inherit;
+   }
   .kuiLink:visited, .kuiLink:active {
     color: #006BB4; }
   .kuiLink:hover {
     color: #004d81;
     text-decoration: underline; }
 
-/**
- * 1. Breadcrumbs are placed in the top-left corner and need to be bumped over
- *    a bit.
- */
 .kuiLocalBreadcrumbs {
   display: flex;
   align-items: center;
   padding: 12px 8px;
-  /* 1 */
-  border-bottom: 1px solid #D3DAE6;
+    border-bottom: 1px solid #D3DAE6;
   flex-grow: 1;
   flex-basis: 100%;
   background-color: #FFF; }
@@ -1369,28 +679,18 @@ main {
       margin-right: 4px;
       color: #D3DAE6; }
 
-/**
- * 1. Make it a bit darker to contrast with the gray background.
- */
 .kuiLocalBreadcrumb__link {
   color: #006BB4;
   text-decoration: none;
   cursor: pointer;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: none;
-  /* 2 */
-  font-size: inherit;
-  /* 2 */
-  line-height: inherit;
-  /* 2 */
-  color: #006BB4;
-  /* 1 */
-  font-size: 16px; }
+    -webkit-appearance: none;
+            appearance: none;
+    background-color: transparent;
+    border: none;
+    font-size: inherit;
+    line-height: inherit;
+    color: #006BB4;
+    font-size: 16px; }
   .kuiLocalBreadcrumb__link:visited, .kuiLocalBreadcrumb__link:active {
     color: #006BB4; }
   .kuiLocalBreadcrumb__link:hover {
@@ -1415,9 +715,6 @@ main {
   justify-content: space-between;
   margin-bottom: 4px; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiDatePickerNavigationButton {
   -webkit-appearance: none;
           appearance: none;
@@ -1433,13 +730,10 @@ main {
     background-color: #006BB4; }
   .kuiDatePickerNavigationButton:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px transparent, 0 0 0 2px #006BB4;
-    /* 3 */
-    color: #343741;
-    /* 1 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px transparent, 0 0 0 2px #006BB4;
+        color: #343741;
+     }
 
 .kuiDatePickerHeaderCell {
   padding: 9px 0;
@@ -1452,19 +746,12 @@ main {
 .kuiDatePickerRowCell {
   padding: 0;
   text-align: center;
-  /**
-   * This state class exists to support weird angular-bootstrap datepicker functionality,
-   * in which you can't select a day on the "From" calendar if it falls after the selected day in
-   * the "To" calendar (and vice versa, you can't select a "To" day if it is before the "From" day).
-   */ }
+   }
   .kuiDatePickerRowCell.kuiDatePickerRowCell-isBlocked {
     cursor: not-allowed; }
     .kuiDatePickerRowCell.kuiDatePickerRowCell-isBlocked .kuiDatePickerRowCellContent {
       pointer-events: none; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiDatePickerRowCellContent {
   -webkit-appearance: none;
           appearance: none;
@@ -1478,13 +765,10 @@ main {
   line-height: 1.2; }
   .kuiDatePickerRowCellContent:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px transparent, 0 0 0 2px #006BB4;
-    /* 3 */
-    color: #343741;
-    /* 1 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px transparent, 0 0 0 2px #006BB4;
+        color: #343741;
+     }
   .kuiDatePickerRowCellContent:disabled {
     pointer-events: none;
     opacity: 0.5; }
@@ -1517,8 +801,7 @@ main {
   line-height: 1;
   font-size: 16px;
   color: #343741 !important;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   opacity: 0.35;
   position: absolute;
   top: 1px;
@@ -1538,13 +821,9 @@ main {
 .kuiLocalDropdownPanel--right {
   margin-left: 30px; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiLocalDropdownTitle {
   margin-top: 0;
-  /* 1 */
-  margin-bottom: 12px;
+    margin-bottom: 12px;
   font-size: 18px;
   color: #343741; }
 
@@ -1559,15 +838,11 @@ main {
   justify-content: space-between;
   margin-bottom: 6px; }
 
-/**
-   * 1. Override inherited styles.
-   */
 .kuiLocalDropdownHeader__label {
   font-size: 14px;
   font-weight: 700;
   margin-bottom: 0;
-  /* 1 */
-  color: #343741; }
+    color: #343741; }
 
 .kuiLocalDropdownHeader__actions {
   display: flex; }
@@ -1649,24 +924,16 @@ main {
   margin-right: 5px;
   margin-bottom: -1px; }
 
-/**
- * 1. Match height of logo in side bar, but allow it to expand to accommodate
- *    dropdown.
- */
 .kuiLocalNav {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   min-height: 69px;
-  /* 1 */
-  color: #343741;
+    color: #343741;
   background-color: #FFF;
   line-height: 1.5;
   border-bottom: solid 1px #D3DAE6; }
 
-/**
- * 1. Allow row to expand if the content is so long that it wraps.
- */
 .kuiLocalNavRow {
   display: flex;
   align-items: stretch;
@@ -1676,18 +943,10 @@ main {
   display: flex;
   align-items: stretch; }
 
-/**
- * 1. We make this row flex-start because it usually contains a search input, which may expand
- *    beyond the height of this container. We can't use `align-items: center`, because this would
- *    cause the search input to overflow both on the top and bottom; `align-items: flex-start`
- *    makes it only overflow on the bottom. But this means we need to manually center the content
- *    of this container using padding.
- */
 .kuiLocalNavRow--secondary {
   padding: 0 8px;
-  /* 1 */
-  align-items: flex-start;
-  /* 1 */ }
+    align-items: flex-start;
+   }
 
 .kuiLocalSearch {
   display: flex;
@@ -1708,8 +967,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  flex: 1 1 100%;
+    flex: 1 1 100%;
   border-color: #FFF;
   border-color: #D3DAE6;
   border-radius: 4px 0 0 4px; }
@@ -1732,28 +990,19 @@ main {
   border-radius: 0;
   border-left-width: 0; }
 
-/**
- * 1. em used for right padding so documentation link and query string
- *    won't overlap if the user increases their default browser font size
- *    This is sized for the 'Options' link
- */
 .kuiLocalSearchInput,
 .kuiLocalSearchAssistedInput__input {
   padding-right: 6em;
-  /* 1 */ }
+   }
 
-/**
- * 1. Vertically center the assistance, regardless of its height.
- */
 .kuiLocalSearchAssistedInput__assistance {
   position: absolute;
   right: 6px;
   top: 50%;
-  /* 1 */
-  z-index: 2;
+    z-index: 2;
   -webkit-transform: translateY(-50%);
           transform: translateY(-50%);
-  /* 1 */ }
+   }
 
 .kuiLocalSearchSelect {
   -webkit-appearance: none;
@@ -1769,16 +1018,12 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-right: 30px;
-  /* 2 */
-  background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
-  /* 1 */
-  background-size: 14px;
+    padding-right: 30px;
+    background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
+    background-size: 14px;
   background-repeat: no-repeat;
   background-position: calc(100% - 8px);
-  /* 2 */
-  border-left-width: 0;
+    border-left-width: 0;
   border-radius: 0; }
   .kuiLocalSearchSelect:invalid {
     border-color: #BD271E; }
@@ -1790,40 +1035,28 @@ main {
     cursor: not-allowed; }
   .kuiLocalSearchSelect:-moz-focusring {
     text-shadow: 0 0 0;
-    /* 3 */ }
+     }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiLocalSearchButton {
   width: 43px;
   height: 32px;
   font-size: 16px;
   line-height: 0;
-  /* 1 */
-  color: #FFF;
+    color: #FFF;
   background-color: #006BB4;
   border: 0;
   border-radius: 0 4px 4px 0; }
   .kuiLocalSearchButton:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
+     }
 
-/**
- * 1. We want the bottom border on selected tabs to be flush with the bottom of the container.
- */
 .kuiLocalTabs {
   display: flex;
   align-items: flex-end;
   height: 100%; }
 
-/**
-   * 1. Override inherited typographic styles.
-   */
 .kuiLocalTab {
   padding: 5px 0 6px;
   font-size: 18px;
@@ -1832,13 +1065,8 @@ main {
   text-decoration: none;
   cursor: pointer;
   margin-top: 0 !important;
-  /* 1 */
-  margin-bottom: 0 !important;
-  /* 1 */
-  /**
-     * 1. We may want to show a tooltip to explain why the tab is disabled, so we will just show
-     *    a regular cursor instead of setting pointer-events: none.
-     */ }
+    margin-bottom: 0 !important;
+     }
   .kuiLocalTab:hover:not(.kuiLocalTab-isDisabled), .kuiLocalTab:active:not(.kuiLocalTab-isDisabled) {
     color: #006BB4; }
   .kuiLocalTab.kuiLocalTab-isSelected {
@@ -1848,7 +1076,7 @@ main {
   .kuiLocalTab.kuiLocalTab-isDisabled {
     opacity: 0.5;
     cursor: default;
-    /* 1 */ }
+     }
   .kuiLocalTab + .kuiLocalTab {
     margin-left: 15px; }
 
@@ -1866,22 +1094,19 @@ main {
     padding: 0;
     display: none; }
 
-/**
- * 1. Put 10px of space between each child.
- */
 .kuiPager {
   display: flex;
   align-items: center; }
   .kuiPager > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
 .kuiPagerText {
   font-size: 16px;
   line-height: 1.5;
   color: #69707D;
   white-space: nowrap;
-  /* 1 */ }
+   }
 
 .kuiPanel {
   box-shadow: 0 2px 2px -1px rgba(152, 162, 179, 0.3), 0 1px 5px -2px rgba(152, 162, 179, 0.3);
@@ -1917,62 +1142,44 @@ main {
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 50px;
   border-bottom: 1px solid #D3DAE6; }
   .kuiPanelHeader .kuiButton:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
+     }
   a.kuiPanelHeader .kuiButton:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
+     }
   .kuiPanelHeader .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
+     }
   a.kuiPanelHeader .kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
+     }
   .kuiPanelHeader .kuiSelect {
     border-color: #fbfcfd; }
     .kuiPanelHeader .kuiSelect:not(a):enabled:focus {
       outline: none;
       border-color: #006BB4; }
     a.kuiPanelHeader .kuiSelect:not(.kuiButton-isDisabled):focus {
-      /* 1 */
-      outline: none;
+            outline: none;
       border-color: #006BB4; }
 
-/**
-   * 1. This way we can use h1, h2, etc.
-   */
 .kuiPanelHeader__title {
   font-size: 20px;
   line-height: 1.5;
   margin: 0;
-  /* 1 */ }
+   }
 
-/**
- * 1. Undo what barSection mixin does.
- */
 .kuiPanelHeaderSection {
   display: flex;
   align-items: center;
@@ -1981,26 +1188,24 @@ main {
   margin-right: 25px; }
   .kuiPanelHeaderSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiPanelHeaderSection:first-child {
     margin-left: 0; }
   .kuiPanelHeaderSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiPanelHeaderSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiPanelHeaderSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
   .kuiPanelHeaderSection:only-child {
     margin-left: 0;
-    /* 1 */
-    margin-right: auto;
-    /* 1 */ }
+        margin-right: auto;
+     }
 
 .kuiPanelBody {
   padding: 10px; }
@@ -2035,98 +1240,65 @@ main {
 .kuiStatusText--error {
   color: #BD271E; }
 
-/**
- * 1. Set the image to be the same size as a font icon at 14px.
- * 2. We need to cap the height too, in case the icon was designed thin and tall.
- */
 .kuiStatusText__icon {
   margin-right: 6px;
   width: 1.15em;
-  /* 1 */
-  max-height: 1.15em;
-  /* 2 */ }
+    max-height: 1.15em;
+   }
 
-/**
- * 1. Make seamless transition from ToolBar to Table header and contained Menu.
- * 1. Make seamless transition from Table to ToolBarFooter header.
- */
 .kuiControlledTable {
   background: #FFF; }
   .kuiControlledTable .kuiTable {
     border-top: none;
-    /* 1 */ }
+     }
   .kuiControlledTable .kuiToolBarFooter {
     border-top: none;
-    /* 2 */ }
+     }
   .kuiControlledTable .kuiMenu--contained {
     border-top: none;
-    /* 1 */ }
+     }
 
-/**
- * 1. Prevent cells from expanding based on content size. This substitutes for table-layout: fixed.
- */
-/**
- * NOTE: table-layout: fixed causes a bug in IE11 and Edge (see #9929). It also prevents us from
- * specifying a column width, e.g. the checkbox column.
- */
 .kuiTable {
   width: 100%;
   border: 1px solid #D3DAE6;
   border-collapse: collapse;
   background-color: #FFF; }
 
-/**
- * 1. Allow contents of cells to determine table's width.
- */
 .kuiTable--fluid {
   width: auto;
-  /* 1 */ }
+   }
   .kuiTable--fluid .kuiTableHeaderCell,
   .kuiTable--fluid .kuiTableRowCell {
     max-width: none;
-    /* 1 */ }
+     }
 
 .kuiTableHeaderCell {
   font-size: 16px;
   font-weight: 400;
   text-align: left;
   max-width: 20px;
-  /* 1 */
-  line-height: 1.5;
+    line-height: 1.5;
   color: #69707D; }
 
 .kuiTableHeaderCell__liner {
   display: inline-block;
   padding: 7px 8px 8px; }
 
-/**
- * 1. Prevent rapid clicking from selecting text.
- * 2. Remove native button element styles.
- * 3. Make buttons look and behave like table header cells.
- */
 .kuiTableHeaderCellButton {
   -webkit-user-select: none;
           user-select: none;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   width: 100%;
   -webkit-appearance: none;
           appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: 0;
-  /* 2 */
-  padding: 0;
-  /* 2 */
-  color: inherit;
-  /* 3 */
-  line-height: inherit;
-  /* 3 */
-  font-size: inherit;
-  /* 3 */
-  text-align: inherit;
-  /* 3 */ }
+    background-color: transparent;
+    border: 0;
+    padding: 0;
+    color: inherit;
+    line-height: inherit;
+    font-size: inherit;
+    text-align: inherit;
+   }
   .kuiTableHeaderCellButton:hover .kuiTableSortIcon {
     display: block;
     opacity: 1; }
@@ -2156,31 +1328,20 @@ main {
   font-weight: 400;
   text-align: left;
   max-width: 20px;
-  /* 1 */
-  color: #343741;
+    color: #343741;
   border-top: 1px solid #D3DAE6;
   vertical-align: middle; }
 
-/**
-   * 1. Vertically align all children.
-   * 2. The padding on this div allows the ellipsis to show if the content is truncated. If
-   *    the padding was on the cell, the ellipsis would be cropped.
-   * 3. Truncate content with an ellipsis.
-   */
 .kuiTableRowCell__liner {
   padding: 7px 8px 8px;
-  /* 2 */
-  line-height: 1.5;
-  /* 1 */
-  overflow: hidden;
-  /* 3 */
-  text-overflow: ellipsis;
-  /* 3 */
-  white-space: nowrap;
-  /* 3 */ }
+    line-height: 1.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+   }
   .kuiTableRowCell__liner > * {
     vertical-align: middle;
-    /* 1 */ }
+     }
 
 .kuiTableRowCell--wrap .kuiTableRowCell__liner {
   white-space: normal; }
@@ -2189,34 +1350,24 @@ main {
   overflow: visible;
   white-space: normal; }
 
-/**
- * 1. We don't want to create too strong a disconnect between the original row and the row
- *    that contains its expanded details.
- */
 .kuiTableRowCell--expanded {
   border-top-color: #FFF;
-  /* 1 */ }
+   }
 
 .kuiTableRowCell--alignRight {
   text-align: right; }
   .kuiTableRowCell--alignRight .kuiTableRowCell__liner {
     text-align: right; }
 
-/**
- * 1. Rendered width of cell with checkbox inside of it.
- * 2. Align checkbox with text in other cells.
- * 3. Show the checkbox in Edge; otherwise it gets cropped.
- */
 .kuiTableHeaderCell--checkBox,
 .kuiTableRowCell--checkBox {
   width: 28px;
-  /* 1 */
-  line-height: 1;
-  /* 2 */ }
+    line-height: 1;
+   }
   .kuiTableHeaderCell--checkBox .kuiTableRowCell__liner,
   .kuiTableRowCell--checkBox .kuiTableRowCell__liner {
     overflow: visible;
-    /* 3 */ }
+     }
   .kuiTableHeaderCell--checkBox .kuiTableHeaderCell__liner,
   .kuiTableHeaderCell--checkBox .kuiTableRowCell__liner,
   .kuiTableRowCell--checkBox .kuiTableHeaderCell__liner,
@@ -2233,41 +1384,30 @@ main {
   display: flex;
   border-bottom: 1px solid #D3DAE6; }
 
-/**
- * 1. Override button styles (some of which are from Bootstrap).
- * 2. Adding a border shifts tabs right by 1px, so we need to shift them back.
- * 3. Move the tab down so that its bottom border covers the container's bottom border.
- * 4. When the tab is focused, its bottom border changes to be 1px, so we need to add 1px more
- *    of padding to make sure the text doesn't shift down.
- */
 .kuiTab {
   -webkit-appearance: none;
           appearance: none;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   padding: 10px 30px;
   font-size: 16px;
   color: #69707D;
   background-color: transparent;
-  /* 1 */
-  border: 1px solid #D3DAE6;
+    border: 1px solid #D3DAE6;
   border-radius: 0;
-  /* 1 */
-  margin-bottom: -1px;
-  /* 3 */ }
+    margin-bottom: -1px;
+   }
   .kuiTab + .kuiTab {
     border-left: none; }
     .kuiTab + .kuiTab:focus:not(.kuiTab-isSelected):not(:active) {
       margin-left: -1px;
-      /* 2 */ }
+       }
   .kuiTab:active {
     outline: none !important;
-    /* 1 */
-    box-shadow: none;
-    /* 1 */ }
+        box-shadow: none;
+     }
   .kuiTab:focus {
     outline: none;
-    /* 1 */ }
+     }
   .kuiTab:focus:not(.kuiTab-isSelected):not(:active) {
     z-index: 1;
     color: #006BB4;
@@ -2286,49 +1426,37 @@ main {
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 50px;
   background-color: transparent;
   border: solid 1px #D3DAE6; }
   .kuiToolBar .kuiButton:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
+     }
   a.kuiToolBar .kuiButton:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
+     }
   .kuiToolBar .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
+     }
   a.kuiToolBar .kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
+     }
   .kuiToolBar .kuiSelect {
     border-color: #fbfcfd; }
     .kuiToolBar .kuiSelect:not(a):enabled:focus {
       outline: none;
       border-color: #006BB4; }
     a.kuiToolBar .kuiSelect:not(.kuiButton-isDisabled):focus {
-      /* 1 */
-      outline: none;
+            outline: none;
       border-color: #006BB4; }
 
 .kuiToolBarSection {
@@ -2339,36 +1467,31 @@ main {
   margin-right: 25px; }
   .kuiToolBarSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiToolBarSection:first-child {
     margin-left: 0; }
   .kuiToolBarSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiToolBarSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiToolBarSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Override Bar styles and put Search on the left side.
- */
 .kuiToolBar--searchOnly .kuiToolBarSearch {
   margin-left: 0 !important;
-  /* 1 */ }
+   }
 
 .kuiToolBarFooter {
   display: flex;
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 40px;
   background-color: #FFF; }
 
@@ -2380,27 +1503,21 @@ main {
   margin-right: 25px; }
   .kuiToolBarFooterSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiToolBarFooterSection:first-child {
     margin-left: 0; }
   .kuiToolBarFooterSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiToolBarFooterSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiToolBarFooterSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Put 10px of space between each child.
- * 2. Fix IE11 bug which causes this item to grow too wide when there is only a single
- *    kuiToolBarSection sibling.
- */
 .kuiToolBarSearch {
   display: flex;
   align-items: center;
@@ -2408,15 +1525,14 @@ main {
   margin-right: 25px;
   flex: 1 1 auto;
   max-width: 100%;
-  /* 2 */
-  line-height: 1.5; }
+    line-height: 1.5; }
   .kuiToolBarSearch:first-child {
     margin-left: 0; }
   .kuiToolBarSearch:last-child {
     margin-right: 0; }
   .kuiToolBarSearch > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
 .kuiToolBarSearchBox {
   flex: 1 1 auto;
@@ -2431,85 +1547,55 @@ main {
   font-size: 1em;
   color: #acacac; }
 
-/**
-   * 1. Fix inherited styles (possibly from Bootstrap).
-   */
 .kuiToolBarSearchBox__input {
   width: 100%;
   min-width: 200px;
   padding: 4px 12px 5px 28px;
   font-family: "var(--font-text)";
-  /* 1 */
-  background-color: #FFF;
+    background-color: #FFF;
   color: #343741;
   border-radius: 4px;
   font-size: 1em;
   border: 1px solid #D3DAE6;
   line-height: normal;
-  /* 1 */
-  transition: border-color 0.1s linear; }
+    transition: border-color 0.1s linear; }
   .kuiToolBarSearchBox__input:focus {
     outline: none;
     border-color: #006BB4; }
 
-/*
- * 1. We don't want the text to take up two lines and overflow the ToolBar.
- */
 .kuiToolBarText {
   font-size: 16px;
   line-height: 1.5;
   color: #69707D;
   white-space: nowrap;
-  /* 1 */ }
+   }
 
-/**
- * 1. Override h1.
- */
 .kuiTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  font-size: 24px; }
+    font-weight: 400;
+    font-size: 24px; }
 
-/**
- * 1. Override h2, h3, etc.
- */
 .kuiSubTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  font-size: 20px; }
+    font-weight: 400;
+    font-size: 20px; }
 
-/**
- * 1. Override p.
- */
 .kuiTextTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 700;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 700;
+    line-height: 1.5;
   font-size: 16px; }
 
-/**
- * 1. Override p.
- */
 .kuiText {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 400;
+    line-height: 1.5;
   font-size: 16px; }
 
 .kuiSubText {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 400;
+    line-height: 1.5;
   font-size: 14px; }
 
 .kuiSubduedText {

--- a/packages/osd-ui-framework/dist/kui_next_dark.css
+++ b/packages/osd-ui-framework/dist/kui_next_dark.css
@@ -8,577 +8,17 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/**
- * 1. Focus rings shouldn't be visible on scrollable regions, but a11y requires them to be focusable.
- *    Browser's supporting `:focus-visible` will still show outline on keyboard focus only.
- *    Others like Safari, won't show anything at all.
- * 2. Force the `:focus-visible` when the `tabindex=0` (is tabbable)
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/**
- * 1. Enforce pointer when there's no href.
- * 2. Allow these styles to be applied to a button element.
- */
-/**
- * 1. Override Bootstrap styles.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :disabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * Nothing fancy, just the basics so we can use this for both regular and static controls.
- */
-/**
- * 1. Prevent Firefox users from being able to resize textareas to smaller than the min-height.
- */
-/**
- * We specifically don't include Angular's ng-${state} classes here because we don't want to be tightly
- * coupled with Angular.
- */
-/**
- * 1. Embedded SVG of fa-caret-down
- *    (https://github.com/encharm/Font-Awesome-SVG-PNG/blob/master/black/svg/caret-down.svg).
- * 2. Make room on right side for the caret.
- * 3. Prevent Firefox from showing dotted line around text on focus.
- */
-/**
- * 1. Setting to inline-block guarantees the same height when applied to both
- *    button elements and anchor tags.
- * 2. Fit MicroButton inside of Table rows without pushing them taller.
- */
-/**
- * 1. Give Bar a consistent height for when it contains shorter children, and therefore can't
- *    depend on them to give it the desired height.
- */
-/**
- * 1. Put 10px of space between each child.
- * 2. If there is only one section, align it to the right. If you wanted it aligned right, you
- *    wouldn't use the Bar in the first place.
- * 3. Children in the middle should center their content.
- * 4. Fix an IE bug which causes the last child to overflow the container.
- * 5. Fixing this bug means we now need to align the children to the right.
- */
-/**
- * 1. Required for IE11.
- */
+
 main {
   display: block;
-  /* 1 */ }
+   }
 
 .kuiBar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */ }
+   }
 
 .kuiBarSection {
   display: flex;
@@ -588,33 +28,25 @@ main {
   margin-right: 25px; }
   .kuiBarSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiBarSection:first-child {
     margin-left: 0; }
   .kuiBarSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiBarSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiBarSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Setting to inline-block guarantees the same height when applied to both
- *    button elements and anchor tags.
- * 2. Links can be focused when they're "disabled" (since we're just faking this with a class), but
- *    at least make them look like they're not focused.
- */
 .kuiButton {
   display: inline-block;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
+    -webkit-appearance: none;
+            appearance: none;
   cursor: pointer;
   padding: 4px 12px 5px;
   font-size: 16px;
@@ -634,18 +66,13 @@ main {
     -webkit-transform: translateY(1px);
             transform: translateY(1px); }
   a.kuiButton:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    -webkit-transform: translateY(1px);
-            transform: translateY(1px); }
+        -webkit-transform: translateY(1px);
+                transform: translateY(1px); }
 
-/**
-   * 1. Solves whitespace problems introduced by inline elements.
-   */
 .kuiButton__inner {
   display: flex;
-  /* 1 */
-  align-items: center;
-  /* 1 */ }
+    align-items: center;
+   }
 
 .kuiButton--small {
   font-size: 12px;
@@ -668,122 +95,85 @@ main {
 .kuiButton--iconText.kuiButton--small .kuiButton__icon:last-child:not(:only-child) {
   margin-left: 4px; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--basic {
   color: #DFE5EF;
   background-color: #101B25; }
   .kuiButton--basic:not(a):enabled:focus {
     color: #DFE5EF; }
   a.kuiButton--basic:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #DFE5EF; }
+        color: #DFE5EF; }
   .kuiButton--basic:enabled:hover {
     background-color: #010101 !important;
-    /* 1 */ }
+     }
   a.kuiButton--basic:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    background-color: #010101 !important;
-    /* 1 */ }
+        background-color: #010101 !important;
+     }
   .kuiButton--basic:enabled:active {
     background-color: #010101 !important;
-    /* 1 */ }
+     }
   a.kuiButton--basic:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    background-color: #010101 !important;
-    /* 1 */ }
+        background-color: #010101 !important;
+     }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--primary {
   color: #FCFEFF;
   background-color: #159D8D; }
   .kuiButton--primary:not(a):enabled:focus {
     color: #FCFEFF; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #FCFEFF; }
+        color: #FCFEFF; }
   .kuiButton--primary:enabled:hover {
     color: #FCFEFF !important;
-    /* 1 */
-    background-color: #0f7065; }
+        background-color: #0f7065; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FCFEFF !important;
-    /* 1 */
-    background-color: #0f7065; }
+        color: #FCFEFF !important;
+        background-color: #0f7065; }
   .kuiButton--primary:enabled:active {
     color: #FCFEFF !important;
-    /* 1 */
-    background-color: #0f7065; }
+        background-color: #0f7065; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FCFEFF !important;
-    /* 1 */
-    background-color: #0f7065; }
+        color: #FCFEFF !important;
+        background-color: #0f7065; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--success {
   color: #FCFEFF;
   background-color: #7DE2D1; }
   .kuiButton--success:not(a):enabled:focus {
     color: #FCFEFF; }
   a.kuiButton--success:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #FCFEFF; }
+        color: #FCFEFF; }
   .kuiButton--success:enabled:hover {
     color: #FCFEFF !important;
-    /* 1 */
-    background-color: #53d9c2; }
+        background-color: #53d9c2; }
   a.kuiButton--success:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FCFEFF !important;
-    /* 1 */
-    background-color: #53d9c2; }
+        color: #FCFEFF !important;
+        background-color: #53d9c2; }
   .kuiButton--success:enabled:active {
     color: #FCFEFF !important;
-    /* 1 */
-    background-color: #53d9c2; }
+        background-color: #53d9c2; }
   a.kuiButton--success:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FCFEFF !important;
-    /* 1 */
-    background-color: #53d9c2; }
+        color: #FCFEFF !important;
+        background-color: #53d9c2; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--danger {
   color: #F66;
   border: solid 1px #F66; }
   .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #0A121A, 0 0 0 2px #F66;
-    /* 3 */
-    color: #F66; }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #0A121A, 0 0 0 2px #F66;
+        color: #F66; }
   a.kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #0A121A, 0 0 0 2px #F66;
-    /* 3 */
-    color: #F66; }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #0A121A, 0 0 0 2px #F66;
+        color: #F66; }
   .kuiButton--danger:enabled:hover {
     color: #ff3333 !important;
     border: solid 1px #ff3333;
     background-color: rgba(255, 102, 102, 0.1); }
   a.kuiButton--danger:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #ff3333 !important;
+        color: #ff3333 !important;
     border: solid 1px #ff3333;
     background-color: rgba(255, 102, 102, 0.1); }
   .kuiButton--danger:enabled:active {
@@ -791,112 +181,77 @@ main {
     border: solid 1px #ff3333;
     background-color: rgba(255, 102, 102, 0.1); }
   a.kuiButton--danger:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #ff3333 !important;
+        color: #ff3333 !important;
     border: solid 1px #ff3333;
     background-color: rgba(255, 102, 102, 0.1); }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--warning {
   color: #FCFEFF;
   background-color: #FFCE7A; }
   .kuiButton--warning:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #0A121A, 0 0 0 2px #FFCE7A;
-    /* 3 */
-    color: #FCFEFF; }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #0A121A, 0 0 0 2px #FFCE7A;
+        color: #FCFEFF; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #0A121A, 0 0 0 2px #FFCE7A;
-    /* 3 */
-    color: #FCFEFF; }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #0A121A, 0 0 0 2px #FFCE7A;
+        color: #FCFEFF; }
   .kuiButton--warning:enabled:hover {
     color: #FCFEFF !important;
-    /* 1 */
-    background-color: #ffbb47; }
+        background-color: #ffbb47; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FCFEFF !important;
-    /* 1 */
-    background-color: #ffbb47; }
+        color: #FCFEFF !important;
+        background-color: #ffbb47; }
   .kuiButton--warning:enabled:active {
     color: #FCFEFF !important;
-    /* 1 */
-    background-color: #ffbb47; }
+        background-color: #ffbb47; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FCFEFF !important;
-    /* 1 */
-    background-color: #ffbb47; }
+        color: #FCFEFF !important;
+        background-color: #ffbb47; }
   .kuiButton--warning:disabled {
     background-color: #ffe1ad; }
   a.kuiButton--warning.kuiButton-isDisabled {
     background-color: #ffe1ad; }
 
-/**
- * 1. Override Bootstrap.
- * 2. Override either Bootstrap or Timeline styles.
- */
 .kuiButton--hollow {
   color: #159D8D !important;
-  /* 2 */
-  background-color: transparent; }
+    background-color: transparent; }
   .kuiButton--hollow:enabled:hover {
     color: #0f7065 !important;
-    /* 1 */
-    text-decoration: underline; }
+        text-decoration: underline; }
   a.kuiButton--hollow:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #0f7065 !important;
-    /* 1 */
-    text-decoration: underline; }
+        color: #0f7065 !important;
+        text-decoration: underline; }
   .kuiButton--hollow:enabled:active {
     color: #0f7065 !important;
-    /* 1 */
-    text-decoration: underline; }
+        text-decoration: underline; }
   a.kuiButton--hollow:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #0f7065 !important;
-    /* 1 */
-    text-decoration: underline; }
+        color: #0f7065 !important;
+        text-decoration: underline; }
 
 .kuiButton--secondary {
   color: #159D8D !important;
-  /* 2 */
-  border: solid 1px #159D8D; }
+    border: solid 1px #159D8D; }
   .kuiButton--secondary:enabled:hover {
     color: #0f7065 !important;
-    /* 1 */
-    border: solid 1px #0f7065;
+        border: solid 1px #0f7065;
     background-color: rgba(21, 157, 141, 0.1);
     text-decoration: underline; }
   a.kuiButton--secondary:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #0f7065 !important;
-    /* 1 */
-    border: solid 1px #0f7065;
+        color: #0f7065 !important;
+        border: solid 1px #0f7065;
     background-color: rgba(21, 157, 141, 0.1);
     text-decoration: underline; }
   .kuiButton--secondary:enabled:active {
     color: #0f7065 !important;
-    /* 1 */
-    border: solid 1px #0f7065;
+        border: solid 1px #0f7065;
     background-color: rgba(21, 157, 141, 0.1);
     text-decoration: underline; }
   a.kuiButton--secondary:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #0f7065 !important;
-    /* 1 */
-    border: solid 1px #0f7065;
+        color: #0f7065 !important;
+        border: solid 1px #0f7065;
     background-color: rgba(21, 157, 141, 0.1);
     text-decoration: underline; }
 
@@ -942,58 +297,37 @@ main {
   line-height: 1;
   font-size: 16px;
   color: #DFE5EF !important;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   opacity: 0.35; }
   .kuiCollapseButton:hover {
     opacity: 1; }
 
-/**
- * 1. Set inline-block so this wrapper shrinks to fit the input.
- */
 .kuiAssistedInput {
   display: inline-block;
-  /* 1 */
-  position: relative; }
+    position: relative; }
 
-/**
-   * 1. Vertically center the assistance, regardless of its height.
-   */
 .kuiAssistedInput__assistance {
   position: absolute;
   right: 12px;
   top: 50%;
-  /* 1 */
-  -webkit-transform: translateY(-50%);
-          transform: translateY(-50%);
-  /* 1 */ }
+    -webkit-transform: translateY(-50%);
+            transform: translateY(-50%);
+   }
 
-/**
- * 1. Deliberately disable only webkit appearance. If we disable it in Firefox, we get a really
- *    ugly default appearance which we can't customize, so our best option is to give Firefox
- *    control over the checkbox's appearance.
- * 2. Override default styles (possibly from Bootstrap).
- */
 .kuiCheckBox {
   -webkit-appearance: none;
           appearance: none;
-  /* 1 */
-  background-color: #0e1721;
+    background-color: #0e1721;
   border: 1px solid rgba(252, 254, 255, 0.1);
   border-radius: 4px;
   width: 16px;
   height: 16px;
   font: "var(--font-text)" !important;
-  /* 2 */
-  line-height: 1.5 !important;
-  /* 2 */
-  margin: 0 !important;
-  /* 2 */
-  font-family: "var(--font-text)" !important;
-  /* 2 */
-  font-size: 10px !important;
-  /* 2 */
-  transition: background-color 0.1s linear; }
+    line-height: 1.5 !important;
+    margin: 0 !important;
+    font-family: "var(--font-text)" !important;
+    font-size: 10px !important;
+    transition: background-color 0.1s linear; }
   .kuiCheckBox::before {
     position: relative;
     left: 0.25em;
@@ -1010,11 +344,9 @@ main {
       opacity: 1; }
   .kuiCheckBox:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #0A121A, 0 0 0 2px #159D8D;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #0A121A, 0 0 0 2px #159D8D;
+     }
   .kuiCheckBox:disabled {
     background-color: #0d161e !important;
     border-color: #0d161e !important;
@@ -1030,15 +362,12 @@ main {
   font-size: 16px;
   margin-left: 8px; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiLabel {
   font-size: 16px;
   line-height: 1.5;
   font-weight: bold;
   margin-bottom: 0;
-  /* 1 */ }
+   }
 
 .kuiSearchInput {
   width: 180px;
@@ -1056,10 +385,6 @@ main {
   font-size: 1em;
   color: #5B6875; }
 
-/**
-   * 1. Make space for search icon.
-   * 2. Expand to fill container.
-   */
 .kuiSearchInput__input {
   -webkit-appearance: none;
           appearance: none;
@@ -1074,11 +399,9 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-left: 28px;
-  /* 1 */
-  width: 100%;
-  /* 2 */ }
+    padding-left: 28px;
+    width: 100%;
+   }
   .kuiSearchInput__input:invalid {
     border-color: #F66; }
   .kuiSearchInput__input:focus {
@@ -1094,9 +417,6 @@ main {
 .kuiSearchInput--large {
   width: 400px; }
 
-/**
- * Avoid setting a width here, so that the width of the options can dynamically set the width.
- */
 .kuiSelect {
   -webkit-appearance: none;
           appearance: none;
@@ -1111,15 +431,12 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-right: 30px;
-  /* 2 */
-  background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
-  /* 1 */
-  background-size: 14px;
+    padding-right: 30px;
+    background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
+    background-size: 14px;
   background-repeat: no-repeat;
   background-position: calc(100% - 8px);
-  /* 2 */ }
+   }
   .kuiSelect:invalid {
     border-color: #F66; }
   .kuiSelect:focus {
@@ -1130,7 +447,7 @@ main {
     cursor: not-allowed; }
   .kuiSelect:-moz-focusring {
     text-shadow: 0 0 0;
-    /* 3 */ }
+     }
   .kuiSelect.kuiSelect-isInvalid {
     border-color: #F66; }
   .kuiSelect:focus {
@@ -1147,9 +464,6 @@ main {
 .kuiSelect--large {
   width: 400px; }
 
-/**
- * 1. Have the same spatial footprint as the regular input.
- */
 .kuiStaticInput {
   width: 180px;
   -webkit-appearance: none;
@@ -1161,8 +475,7 @@ main {
   line-height: 1.5;
   color: #DFE5EF;
   border: 1px solid transparent;
-  /* 1 */
-  background-color: transparent; }
+    background-color: transparent; }
 
 .kuiTextArea {
   width: 180px;
@@ -1179,7 +492,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */ }
+   }
   .kuiTextArea:invalid {
     border-color: #F66; }
   .kuiTextArea:focus {
@@ -1219,7 +532,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */ }
+   }
   .kuiTextInput:invalid {
     border-color: #F66; }
   .kuiTextInput:focus {
@@ -1237,13 +550,10 @@ main {
 .kuiTextInput--large {
   width: 400px; }
 
-/**
- * 1. We may want to put elements in here which have different heights.
- */
 .kuiFieldGroup {
   display: flex;
   align-items: center;
-  /* 1 */ }
+   }
 
 .kuiFieldGroup--alignTop {
   align-items: flex-start; }
@@ -1258,23 +568,14 @@ main {
   .kuiFieldGroupSection--wide > * {
     width: 100%; }
 
-/**
- * 1. Copied from FontAwesome's .fa class. We use a custom class to make it easier to migrate away
- *    from FontAwesome someday. When we do migrate away, we can just update this definition.
- */
 .kuiIcon {
   display: inline-block;
-  /* 1 */
-  font: normal normal normal 14px/1 FontAwesome, sans-serif;
-  /* 1 */
-  font-size: inherit;
-  /* 1 */
-  text-rendering: auto;
-  /* 1 */
-  -webkit-font-smoothing: antialiased;
-  /* 1 */
-  -moz-osx-font-smoothing: grayscale;
-  /* 1 */ }
+    font: normal normal normal 14px/1 FontAwesome, sans-serif;
+    font-size: inherit;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+   }
 
 .kuiIcon--info {
   color: #159D8D; }
@@ -1299,41 +600,26 @@ main {
   line-height: 1.5;
   border: 2px solid; }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--info {
   border-color: rgba(21, 157, 141, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--success {
   border-color: rgba(125, 226, 209, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--warning {
   border-color: rgba(255, 206, 122, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--error {
   border-color: rgba(255, 102, 102, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. Align with first line of title text if it wraps.
- */
 .kuiInfoPanelHeader {
   display: flex;
   align-items: baseline;
-  /* 1 */ }
+   }
 
 .kuiInfoPanelHeader__icon {
   margin-right: 10px;
@@ -1358,34 +644,24 @@ main {
   color: #159D8D;
   text-decoration: none;
   cursor: pointer;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: none;
-  /* 2 */
-  font-size: inherit;
-  /* 2 */
-  line-height: inherit;
-  /* 2 */ }
+    -webkit-appearance: none;
+            appearance: none;
+    background-color: transparent;
+    border: none;
+    font-size: inherit;
+    line-height: inherit;
+   }
   .kuiLink:visited, .kuiLink:active {
     color: #159D8D; }
   .kuiLink:hover {
     color: #0f7065;
     text-decoration: underline; }
 
-/**
- * 1. Breadcrumbs are placed in the top-left corner and need to be bumped over
- *    a bit.
- */
 .kuiLocalBreadcrumbs {
   display: flex;
   align-items: center;
   padding: 12px 8px;
-  /* 1 */
-  border-bottom: 1px solid #293847;
+    border-bottom: 1px solid #293847;
   flex-grow: 1;
   flex-basis: 100%;
   background-color: #0A121A; }
@@ -1403,28 +679,18 @@ main {
       margin-right: 4px;
       color: #293847; }
 
-/**
- * 1. Make it a bit darker to contrast with the gray background.
- */
 .kuiLocalBreadcrumb__link {
   color: #159D8D;
   text-decoration: none;
   cursor: pointer;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: none;
-  /* 2 */
-  font-size: inherit;
-  /* 2 */
-  line-height: inherit;
-  /* 2 */
-  color: #159D8D;
-  /* 1 */
-  font-size: 16px; }
+    -webkit-appearance: none;
+            appearance: none;
+    background-color: transparent;
+    border: none;
+    font-size: inherit;
+    line-height: inherit;
+    color: #159D8D;
+    font-size: 16px; }
   .kuiLocalBreadcrumb__link:visited, .kuiLocalBreadcrumb__link:active {
     color: #159D8D; }
   .kuiLocalBreadcrumb__link:hover {
@@ -1449,9 +715,6 @@ main {
   justify-content: space-between;
   margin-bottom: 4px; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiDatePickerNavigationButton {
   -webkit-appearance: none;
           appearance: none;
@@ -1467,13 +730,10 @@ main {
     background-color: #159D8D; }
   .kuiDatePickerNavigationButton:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px transparent, 0 0 0 2px #159D8D;
-    /* 3 */
-    color: #DFE5EF;
-    /* 1 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px transparent, 0 0 0 2px #159D8D;
+        color: #DFE5EF;
+     }
 
 .kuiDatePickerHeaderCell {
   padding: 9px 0;
@@ -1486,19 +746,12 @@ main {
 .kuiDatePickerRowCell {
   padding: 0;
   text-align: center;
-  /**
-   * This state class exists to support weird angular-bootstrap datepicker functionality,
-   * in which you can't select a day on the "From" calendar if it falls after the selected day in
-   * the "To" calendar (and vice versa, you can't select a "To" day if it is before the "From" day).
-   */ }
+   }
   .kuiDatePickerRowCell.kuiDatePickerRowCell-isBlocked {
     cursor: not-allowed; }
     .kuiDatePickerRowCell.kuiDatePickerRowCell-isBlocked .kuiDatePickerRowCellContent {
       pointer-events: none; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiDatePickerRowCellContent {
   -webkit-appearance: none;
           appearance: none;
@@ -1512,13 +765,10 @@ main {
   line-height: 1.2; }
   .kuiDatePickerRowCellContent:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px transparent, 0 0 0 2px #159D8D;
-    /* 3 */
-    color: #DFE5EF;
-    /* 1 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px transparent, 0 0 0 2px #159D8D;
+        color: #DFE5EF;
+     }
   .kuiDatePickerRowCellContent:disabled {
     pointer-events: none;
     opacity: 0.5; }
@@ -1551,8 +801,7 @@ main {
   line-height: 1;
   font-size: 16px;
   color: #DFE5EF !important;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   opacity: 0.35;
   position: absolute;
   top: 1px;
@@ -1572,13 +821,9 @@ main {
 .kuiLocalDropdownPanel--right {
   margin-left: 30px; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiLocalDropdownTitle {
   margin-top: 0;
-  /* 1 */
-  margin-bottom: 12px;
+    margin-bottom: 12px;
   font-size: 18px;
   color: #DFE5EF; }
 
@@ -1593,15 +838,11 @@ main {
   justify-content: space-between;
   margin-bottom: 6px; }
 
-/**
-   * 1. Override inherited styles.
-   */
 .kuiLocalDropdownHeader__label {
   font-size: 14px;
   font-weight: 700;
   margin-bottom: 0;
-  /* 1 */
-  color: #DFE5EF; }
+    color: #DFE5EF; }
 
 .kuiLocalDropdownHeader__actions {
   display: flex; }
@@ -1683,24 +924,16 @@ main {
   margin-right: 5px;
   margin-bottom: -1px; }
 
-/**
- * 1. Match height of logo in side bar, but allow it to expand to accommodate
- *    dropdown.
- */
 .kuiLocalNav {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   min-height: 69px;
-  /* 1 */
-  color: #DFE5EF;
+    color: #DFE5EF;
   background-color: #0A121A;
   line-height: 1.5;
   border-bottom: solid 1px #293847; }
 
-/**
- * 1. Allow row to expand if the content is so long that it wraps.
- */
 .kuiLocalNavRow {
   display: flex;
   align-items: stretch;
@@ -1710,18 +943,10 @@ main {
   display: flex;
   align-items: stretch; }
 
-/**
- * 1. We make this row flex-start because it usually contains a search input, which may expand
- *    beyond the height of this container. We can't use `align-items: center`, because this would
- *    cause the search input to overflow both on the top and bottom; `align-items: flex-start`
- *    makes it only overflow on the bottom. But this means we need to manually center the content
- *    of this container using padding.
- */
 .kuiLocalNavRow--secondary {
   padding: 0 8px;
-  /* 1 */
-  align-items: flex-start;
-  /* 1 */ }
+    align-items: flex-start;
+   }
 
 .kuiLocalSearch {
   display: flex;
@@ -1742,8 +967,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  flex: 1 1 100%;
+    flex: 1 1 100%;
   border-color: #FCFEFF;
   border-color: #293847;
   border-radius: 4px 0 0 4px; }
@@ -1766,28 +990,19 @@ main {
   border-radius: 0;
   border-left-width: 0; }
 
-/**
- * 1. em used for right padding so documentation link and query string
- *    won't overlap if the user increases their default browser font size
- *    This is sized for the 'Options' link
- */
 .kuiLocalSearchInput,
 .kuiLocalSearchAssistedInput__input {
   padding-right: 6em;
-  /* 1 */ }
+   }
 
-/**
- * 1. Vertically center the assistance, regardless of its height.
- */
 .kuiLocalSearchAssistedInput__assistance {
   position: absolute;
   right: 6px;
   top: 50%;
-  /* 1 */
-  z-index: 2;
+    z-index: 2;
   -webkit-transform: translateY(-50%);
           transform: translateY(-50%);
-  /* 1 */ }
+   }
 
 .kuiLocalSearchSelect {
   -webkit-appearance: none;
@@ -1803,16 +1018,12 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-right: 30px;
-  /* 2 */
-  background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
-  /* 1 */
-  background-size: 14px;
+    padding-right: 30px;
+    background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
+    background-size: 14px;
   background-repeat: no-repeat;
   background-position: calc(100% - 8px);
-  /* 2 */
-  border-left-width: 0;
+    border-left-width: 0;
   border-radius: 0; }
   .kuiLocalSearchSelect:invalid {
     border-color: #F66; }
@@ -1824,40 +1035,28 @@ main {
     cursor: not-allowed; }
   .kuiLocalSearchSelect:-moz-focusring {
     text-shadow: 0 0 0;
-    /* 3 */ }
+     }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiLocalSearchButton {
   width: 43px;
   height: 32px;
   font-size: 16px;
   line-height: 0;
-  /* 1 */
-  color: #FCFEFF;
+    color: #FCFEFF;
   background-color: #159D8D;
   border: 0;
   border-radius: 0 4px 4px 0; }
   .kuiLocalSearchButton:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #293847, 0 0 0 2px #159D8D;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #293847, 0 0 0 2px #159D8D;
+     }
 
-/**
- * 1. We want the bottom border on selected tabs to be flush with the bottom of the container.
- */
 .kuiLocalTabs {
   display: flex;
   align-items: flex-end;
   height: 100%; }
 
-/**
-   * 1. Override inherited typographic styles.
-   */
 .kuiLocalTab {
   padding: 5px 0 6px;
   font-size: 18px;
@@ -1866,13 +1065,8 @@ main {
   text-decoration: none;
   cursor: pointer;
   margin-top: 0 !important;
-  /* 1 */
-  margin-bottom: 0 !important;
-  /* 1 */
-  /**
-     * 1. We may want to show a tooltip to explain why the tab is disabled, so we will just show
-     *    a regular cursor instead of setting pointer-events: none.
-     */ }
+    margin-bottom: 0 !important;
+     }
   .kuiLocalTab:hover:not(.kuiLocalTab-isDisabled), .kuiLocalTab:active:not(.kuiLocalTab-isDisabled) {
     color: #159D8D; }
   .kuiLocalTab.kuiLocalTab-isSelected {
@@ -1882,7 +1076,7 @@ main {
   .kuiLocalTab.kuiLocalTab-isDisabled {
     opacity: 0.5;
     cursor: default;
-    /* 1 */ }
+     }
   .kuiLocalTab + .kuiLocalTab {
     margin-left: 15px; }
 
@@ -1900,22 +1094,19 @@ main {
     padding: 0;
     display: none; }
 
-/**
- * 1. Put 10px of space between each child.
- */
 .kuiPager {
   display: flex;
   align-items: center; }
   .kuiPager > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
 .kuiPagerText {
   font-size: 16px;
   line-height: 1.5;
   color: #8D98A3;
   white-space: nowrap;
-  /* 1 */ }
+   }
 
 .kuiPanel {
   box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.3), 0 1px 5px -2px rgba(0, 0, 0, 0.3);
@@ -1951,62 +1142,44 @@ main {
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 50px;
   border-bottom: 1px solid #293847; }
   .kuiPanelHeader .kuiButton:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #293847, 0 0 0 2px #159D8D;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #293847, 0 0 0 2px #159D8D;
+     }
   a.kuiPanelHeader .kuiButton:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #293847, 0 0 0 2px #159D8D;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #293847, 0 0 0 2px #159D8D;
+     }
   .kuiPanelHeader .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #293847, 0 0 0 2px #F66;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #293847, 0 0 0 2px #F66;
+     }
   a.kuiPanelHeader .kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #293847, 0 0 0 2px #F66;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #293847, 0 0 0 2px #F66;
+     }
   .kuiPanelHeader .kuiSelect {
     border-color: #0e1721; }
     .kuiPanelHeader .kuiSelect:not(a):enabled:focus {
       outline: none;
       border-color: #159D8D; }
     a.kuiPanelHeader .kuiSelect:not(.kuiButton-isDisabled):focus {
-      /* 1 */
-      outline: none;
+            outline: none;
       border-color: #159D8D; }
 
-/**
-   * 1. This way we can use h1, h2, etc.
-   */
 .kuiPanelHeader__title {
   font-size: 20px;
   line-height: 1.5;
   margin: 0;
-  /* 1 */ }
+   }
 
-/**
- * 1. Undo what barSection mixin does.
- */
 .kuiPanelHeaderSection {
   display: flex;
   align-items: center;
@@ -2015,26 +1188,24 @@ main {
   margin-right: 25px; }
   .kuiPanelHeaderSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiPanelHeaderSection:first-child {
     margin-left: 0; }
   .kuiPanelHeaderSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiPanelHeaderSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiPanelHeaderSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
   .kuiPanelHeaderSection:only-child {
     margin-left: 0;
-    /* 1 */
-    margin-right: auto;
-    /* 1 */ }
+        margin-right: auto;
+     }
 
 .kuiPanelBody {
   padding: 10px; }
@@ -2069,98 +1240,65 @@ main {
 .kuiStatusText--error {
   color: #F66; }
 
-/**
- * 1. Set the image to be the same size as a font icon at 14px.
- * 2. We need to cap the height too, in case the icon was designed thin and tall.
- */
 .kuiStatusText__icon {
   margin-right: 6px;
   width: 1.15em;
-  /* 1 */
-  max-height: 1.15em;
-  /* 2 */ }
+    max-height: 1.15em;
+   }
 
-/**
- * 1. Make seamless transition from ToolBar to Table header and contained Menu.
- * 1. Make seamless transition from Table to ToolBarFooter header.
- */
 .kuiControlledTable {
   background: #0A121A; }
   .kuiControlledTable .kuiTable {
     border-top: none;
-    /* 1 */ }
+     }
   .kuiControlledTable .kuiToolBarFooter {
     border-top: none;
-    /* 2 */ }
+     }
   .kuiControlledTable .kuiMenu--contained {
     border-top: none;
-    /* 1 */ }
+     }
 
-/**
- * 1. Prevent cells from expanding based on content size. This substitutes for table-layout: fixed.
- */
-/**
- * NOTE: table-layout: fixed causes a bug in IE11 and Edge (see #9929). It also prevents us from
- * specifying a column width, e.g. the checkbox column.
- */
 .kuiTable {
   width: 100%;
   border: 1px solid #293847;
   border-collapse: collapse;
   background-color: #0A121A; }
 
-/**
- * 1. Allow contents of cells to determine table's width.
- */
 .kuiTable--fluid {
   width: auto;
-  /* 1 */ }
+   }
   .kuiTable--fluid .kuiTableHeaderCell,
   .kuiTable--fluid .kuiTableRowCell {
     max-width: none;
-    /* 1 */ }
+     }
 
 .kuiTableHeaderCell {
   font-size: 16px;
   font-weight: 400;
   text-align: left;
   max-width: 20px;
-  /* 1 */
-  line-height: 1.5;
+    line-height: 1.5;
   color: #8D98A3; }
 
 .kuiTableHeaderCell__liner {
   display: inline-block;
   padding: 7px 8px 8px; }
 
-/**
- * 1. Prevent rapid clicking from selecting text.
- * 2. Remove native button element styles.
- * 3. Make buttons look and behave like table header cells.
- */
 .kuiTableHeaderCellButton {
   -webkit-user-select: none;
           user-select: none;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   width: 100%;
   -webkit-appearance: none;
           appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: 0;
-  /* 2 */
-  padding: 0;
-  /* 2 */
-  color: inherit;
-  /* 3 */
-  line-height: inherit;
-  /* 3 */
-  font-size: inherit;
-  /* 3 */
-  text-align: inherit;
-  /* 3 */ }
+    background-color: transparent;
+    border: 0;
+    padding: 0;
+    color: inherit;
+    line-height: inherit;
+    font-size: inherit;
+    text-align: inherit;
+   }
   .kuiTableHeaderCellButton:hover .kuiTableSortIcon {
     display: block;
     opacity: 1; }
@@ -2190,31 +1328,20 @@ main {
   font-weight: 400;
   text-align: left;
   max-width: 20px;
-  /* 1 */
-  color: #DFE5EF;
+    color: #DFE5EF;
   border-top: 1px solid #293847;
   vertical-align: middle; }
 
-/**
-   * 1. Vertically align all children.
-   * 2. The padding on this div allows the ellipsis to show if the content is truncated. If
-   *    the padding was on the cell, the ellipsis would be cropped.
-   * 3. Truncate content with an ellipsis.
-   */
 .kuiTableRowCell__liner {
   padding: 7px 8px 8px;
-  /* 2 */
-  line-height: 1.5;
-  /* 1 */
-  overflow: hidden;
-  /* 3 */
-  text-overflow: ellipsis;
-  /* 3 */
-  white-space: nowrap;
-  /* 3 */ }
+    line-height: 1.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+   }
   .kuiTableRowCell__liner > * {
     vertical-align: middle;
-    /* 1 */ }
+     }
 
 .kuiTableRowCell--wrap .kuiTableRowCell__liner {
   white-space: normal; }
@@ -2223,34 +1350,24 @@ main {
   overflow: visible;
   white-space: normal; }
 
-/**
- * 1. We don't want to create too strong a disconnect between the original row and the row
- *    that contains its expanded details.
- */
 .kuiTableRowCell--expanded {
   border-top-color: #0A121A;
-  /* 1 */ }
+   }
 
 .kuiTableRowCell--alignRight {
   text-align: right; }
   .kuiTableRowCell--alignRight .kuiTableRowCell__liner {
     text-align: right; }
 
-/**
- * 1. Rendered width of cell with checkbox inside of it.
- * 2. Align checkbox with text in other cells.
- * 3. Show the checkbox in Edge; otherwise it gets cropped.
- */
 .kuiTableHeaderCell--checkBox,
 .kuiTableRowCell--checkBox {
   width: 28px;
-  /* 1 */
-  line-height: 1;
-  /* 2 */ }
+    line-height: 1;
+   }
   .kuiTableHeaderCell--checkBox .kuiTableRowCell__liner,
   .kuiTableRowCell--checkBox .kuiTableRowCell__liner {
     overflow: visible;
-    /* 3 */ }
+     }
   .kuiTableHeaderCell--checkBox .kuiTableHeaderCell__liner,
   .kuiTableHeaderCell--checkBox .kuiTableRowCell__liner,
   .kuiTableRowCell--checkBox .kuiTableHeaderCell__liner,
@@ -2267,41 +1384,30 @@ main {
   display: flex;
   border-bottom: 1px solid #293847; }
 
-/**
- * 1. Override button styles (some of which are from Bootstrap).
- * 2. Adding a border shifts tabs right by 1px, so we need to shift them back.
- * 3. Move the tab down so that its bottom border covers the container's bottom border.
- * 4. When the tab is focused, its bottom border changes to be 1px, so we need to add 1px more
- *    of padding to make sure the text doesn't shift down.
- */
 .kuiTab {
   -webkit-appearance: none;
           appearance: none;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   padding: 10px 30px;
   font-size: 16px;
   color: #8D98A3;
   background-color: transparent;
-  /* 1 */
-  border: 1px solid #293847;
+    border: 1px solid #293847;
   border-radius: 0;
-  /* 1 */
-  margin-bottom: -1px;
-  /* 3 */ }
+    margin-bottom: -1px;
+   }
   .kuiTab + .kuiTab {
     border-left: none; }
     .kuiTab + .kuiTab:focus:not(.kuiTab-isSelected):not(:active) {
       margin-left: -1px;
-      /* 2 */ }
+       }
   .kuiTab:active {
     outline: none !important;
-    /* 1 */
-    box-shadow: none;
-    /* 1 */ }
+        box-shadow: none;
+     }
   .kuiTab:focus {
     outline: none;
-    /* 1 */ }
+     }
   .kuiTab:focus:not(.kuiTab-isSelected):not(:active) {
     z-index: 1;
     color: #159D8D;
@@ -2320,49 +1426,37 @@ main {
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 50px;
   background-color: transparent;
   border: solid 1px #293847; }
   .kuiToolBar .kuiButton:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #293847, 0 0 0 2px #159D8D;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #293847, 0 0 0 2px #159D8D;
+     }
   a.kuiToolBar .kuiButton:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #293847, 0 0 0 2px #159D8D;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #293847, 0 0 0 2px #159D8D;
+     }
   .kuiToolBar .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #293847, 0 0 0 2px #F66;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #293847, 0 0 0 2px #F66;
+     }
   a.kuiToolBar .kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #293847, 0 0 0 2px #F66;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #293847, 0 0 0 2px #F66;
+     }
   .kuiToolBar .kuiSelect {
     border-color: #0e1721; }
     .kuiToolBar .kuiSelect:not(a):enabled:focus {
       outline: none;
       border-color: #159D8D; }
     a.kuiToolBar .kuiSelect:not(.kuiButton-isDisabled):focus {
-      /* 1 */
-      outline: none;
+            outline: none;
       border-color: #159D8D; }
 
 .kuiToolBarSection {
@@ -2373,36 +1467,31 @@ main {
   margin-right: 25px; }
   .kuiToolBarSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiToolBarSection:first-child {
     margin-left: 0; }
   .kuiToolBarSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiToolBarSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiToolBarSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Override Bar styles and put Search on the left side.
- */
 .kuiToolBar--searchOnly .kuiToolBarSearch {
   margin-left: 0 !important;
-  /* 1 */ }
+   }
 
 .kuiToolBarFooter {
   display: flex;
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 40px;
   background-color: #0A121A; }
 
@@ -2414,27 +1503,21 @@ main {
   margin-right: 25px; }
   .kuiToolBarFooterSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiToolBarFooterSection:first-child {
     margin-left: 0; }
   .kuiToolBarFooterSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiToolBarFooterSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiToolBarFooterSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Put 10px of space between each child.
- * 2. Fix IE11 bug which causes this item to grow too wide when there is only a single
- *    kuiToolBarSection sibling.
- */
 .kuiToolBarSearch {
   display: flex;
   align-items: center;
@@ -2442,15 +1525,14 @@ main {
   margin-right: 25px;
   flex: 1 1 auto;
   max-width: 100%;
-  /* 2 */
-  line-height: 1.5; }
+    line-height: 1.5; }
   .kuiToolBarSearch:first-child {
     margin-left: 0; }
   .kuiToolBarSearch:last-child {
     margin-right: 0; }
   .kuiToolBarSearch > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
 .kuiToolBarSearchBox {
   flex: 1 1 auto;
@@ -2465,85 +1547,55 @@ main {
   font-size: 1em;
   color: #acacac; }
 
-/**
-   * 1. Fix inherited styles (possibly from Bootstrap).
-   */
 .kuiToolBarSearchBox__input {
   width: 100%;
   min-width: 200px;
   padding: 4px 12px 5px 28px;
   font-family: "var(--font-text)";
-  /* 1 */
-  background-color: #0A121A;
+    background-color: #0A121A;
   color: #DFE5EF;
   border-radius: 4px;
   font-size: 1em;
   border: 1px solid #293847;
   line-height: normal;
-  /* 1 */
-  transition: border-color 0.1s linear; }
+    transition: border-color 0.1s linear; }
   .kuiToolBarSearchBox__input:focus {
     outline: none;
     border-color: #159D8D; }
 
-/*
- * 1. We don't want the text to take up two lines and overflow the ToolBar.
- */
 .kuiToolBarText {
   font-size: 16px;
   line-height: 1.5;
   color: #8D98A3;
   white-space: nowrap;
-  /* 1 */ }
+   }
 
-/**
- * 1. Override h1.
- */
 .kuiTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  font-size: 24px; }
+    font-weight: 400;
+    font-size: 24px; }
 
-/**
- * 1. Override h2, h3, etc.
- */
 .kuiSubTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  font-size: 20px; }
+    font-weight: 400;
+    font-size: 20px; }
 
-/**
- * 1. Override p.
- */
 .kuiTextTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 700;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 700;
+    line-height: 1.5;
   font-size: 16px; }
 
-/**
- * 1. Override p.
- */
 .kuiText {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 400;
+    line-height: 1.5;
   font-size: 16px; }
 
 .kuiSubText {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 400;
+    line-height: 1.5;
   font-size: 14px; }
 
 .kuiSubduedText {

--- a/packages/osd-ui-framework/dist/kui_next_light.css
+++ b/packages/osd-ui-framework/dist/kui_next_light.css
@@ -8,543 +8,17 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/**
- * 1. Focus rings shouldn't be visible on scrollable regions, but a11y requires them to be focusable.
- *    Browser's supporting `:focus-visible` will still show outline on keyboard focus only.
- *    Others like Safari, won't show anything at all.
- * 2. Force the `:focus-visible` when the `tabindex=0` (is tabbable)
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/*!
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-/* OUI -> EUI Aliases */
-/* End of Aliases */
-/**
- * 1. Enforce pointer when there's no href.
- * 2. Allow these styles to be applied to a button element.
- */
-/**
- * 1. Override Bootstrap styles.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :disabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * 1. Links can't have a disabled attribute, so they can't support :enabled.
- */
-/**
- * Nothing fancy, just the basics so we can use this for both regular and static controls.
- */
-/**
- * 1. Prevent Firefox users from being able to resize textareas to smaller than the min-height.
- */
-/**
- * We specifically don't include Angular's ng-${state} classes here because we don't want to be tightly
- * coupled with Angular.
- */
-/**
- * 1. Embedded SVG of fa-caret-down
- *    (https://github.com/encharm/Font-Awesome-SVG-PNG/blob/master/black/svg/caret-down.svg).
- * 2. Make room on right side for the caret.
- * 3. Prevent Firefox from showing dotted line around text on focus.
- */
-/**
- * 1. Setting to inline-block guarantees the same height when applied to both
- *    button elements and anchor tags.
- * 2. Fit MicroButton inside of Table rows without pushing them taller.
- */
-/**
- * 1. Give Bar a consistent height for when it contains shorter children, and therefore can't
- *    depend on them to give it the desired height.
- */
-/**
- * 1. Put 10px of space between each child.
- * 2. If there is only one section, align it to the right. If you wanted it aligned right, you
- *    wouldn't use the Bar in the first place.
- * 3. Children in the middle should center their content.
- * 4. Fix an IE bug which causes the last child to overflow the container.
- * 5. Fixing this bug means we now need to align the children to the right.
- */
-/**
- * 1. Required for IE11.
- */
+
 main {
   display: block;
-  /* 1 */ }
+   }
 
 .kuiBar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */ }
+   }
 
 .kuiBarSection {
   display: flex;
@@ -554,33 +28,25 @@ main {
   margin-right: 25px; }
   .kuiBarSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiBarSection:first-child {
     margin-left: 0; }
   .kuiBarSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiBarSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiBarSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Setting to inline-block guarantees the same height when applied to both
- *    button elements and anchor tags.
- * 2. Links can be focused when they're "disabled" (since we're just faking this with a class), but
- *    at least make them look like they're not focused.
- */
 .kuiButton {
   display: inline-block;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
+    -webkit-appearance: none;
+            appearance: none;
   cursor: pointer;
   padding: 4px 12px 5px;
   font-size: 16px;
@@ -600,18 +66,13 @@ main {
     -webkit-transform: translateY(1px);
             transform: translateY(1px); }
   a.kuiButton:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    -webkit-transform: translateY(1px);
-            transform: translateY(1px); }
+        -webkit-transform: translateY(1px);
+                transform: translateY(1px); }
 
-/**
-   * 1. Solves whitespace problems introduced by inline elements.
-   */
 .kuiButton__inner {
   display: flex;
-  /* 1 */
-  align-items: center;
-  /* 1 */ }
+    align-items: center;
+   }
 
 .kuiButton--small {
   font-size: 12px;
@@ -634,122 +95,85 @@ main {
 .kuiButton--iconText.kuiButton--small .kuiButton__icon:last-child:not(:only-child) {
   margin-left: 4px; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--basic {
   color: #343741;
   background-color: #F5F7FA; }
   .kuiButton--basic:not(a):enabled:focus {
     color: #343741; }
   a.kuiButton--basic:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #343741; }
+        color: #343741; }
   .kuiButton--basic:enabled:hover {
     background-color: #d3dce9 !important;
-    /* 1 */ }
+     }
   a.kuiButton--basic:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    background-color: #d3dce9 !important;
-    /* 1 */ }
+        background-color: #d3dce9 !important;
+     }
   .kuiButton--basic:enabled:active {
     background-color: #d3dce9 !important;
-    /* 1 */ }
+     }
   a.kuiButton--basic:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    background-color: #d3dce9 !important;
-    /* 1 */ }
+        background-color: #d3dce9 !important;
+     }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--primary {
   color: #FFF;
   background-color: #006BB4; }
   .kuiButton--primary:not(a):enabled:focus {
     color: #FFF; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #FFF; }
+        color: #FFF; }
   .kuiButton--primary:enabled:hover {
     color: #FFF !important;
-    /* 1 */
-    background-color: #004d81; }
+        background-color: #004d81; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #004d81; }
+        color: #FFF !important;
+        background-color: #004d81; }
   .kuiButton--primary:enabled:active {
     color: #FFF !important;
-    /* 1 */
-    background-color: #004d81; }
+        background-color: #004d81; }
   a.kuiButton--primary:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #004d81; }
+        color: #FFF !important;
+        background-color: #004d81; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--success {
   color: #FFF;
   background-color: #017D73; }
   .kuiButton--success:not(a):enabled:focus {
     color: #FFF; }
   a.kuiButton--success:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    color: #FFF; }
+        color: #FFF; }
   .kuiButton--success:enabled:hover {
     color: #FFF !important;
-    /* 1 */
-    background-color: #014a44; }
+        background-color: #014a44; }
   a.kuiButton--success:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #014a44; }
+        color: #FFF !important;
+        background-color: #014a44; }
   .kuiButton--success:enabled:active {
     color: #FFF !important;
-    /* 1 */
-    background-color: #014a44; }
+        background-color: #014a44; }
   a.kuiButton--success:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #014a44; }
+        color: #FFF !important;
+        background-color: #014a44; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--danger {
   color: #BD271E;
   border: solid 1px #BD271E; }
   .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #BD271E;
-    /* 3 */
-    color: #BD271E; }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #BD271E;
+        color: #BD271E; }
   a.kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #BD271E;
-    /* 3 */
-    color: #BD271E; }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #BD271E;
+        color: #BD271E; }
   .kuiButton--danger:enabled:hover {
     color: #911e17 !important;
     border: solid 1px #911e17;
     background-color: rgba(189, 39, 30, 0.1); }
   a.kuiButton--danger:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #911e17 !important;
+        color: #911e17 !important;
     border: solid 1px #911e17;
     background-color: rgba(189, 39, 30, 0.1); }
   .kuiButton--danger:enabled:active {
@@ -757,112 +181,77 @@ main {
     border: solid 1px #911e17;
     background-color: rgba(189, 39, 30, 0.1); }
   a.kuiButton--danger:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #911e17 !important;
+        color: #911e17 !important;
     border: solid 1px #911e17;
     background-color: rgba(189, 39, 30, 0.1); }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiButton--warning {
   color: #FFF;
   background-color: #F5A700; }
   .kuiButton--warning:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #F5A700;
-    /* 3 */
-    color: #FFF; }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #F5A700;
+        color: #FFF; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #F5A700;
-    /* 3 */
-    color: #FFF; }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #F5A700;
+        color: #FFF; }
   .kuiButton--warning:enabled:hover {
     color: #FFF !important;
-    /* 1 */
-    background-color: #c28400; }
+        background-color: #c28400; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #c28400; }
+        color: #FFF !important;
+        background-color: #c28400; }
   .kuiButton--warning:enabled:active {
     color: #FFF !important;
-    /* 1 */
-    background-color: #c28400; }
+        background-color: #c28400; }
   a.kuiButton--warning:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #FFF !important;
-    /* 1 */
-    background-color: #c28400; }
+        color: #FFF !important;
+        background-color: #c28400; }
   .kuiButton--warning:disabled {
     background-color: #ffbb29; }
   a.kuiButton--warning.kuiButton-isDisabled {
     background-color: #ffbb29; }
 
-/**
- * 1. Override Bootstrap.
- * 2. Override either Bootstrap or Timeline styles.
- */
 .kuiButton--hollow {
   color: #006BB4 !important;
-  /* 2 */
-  background-color: transparent; }
+    background-color: transparent; }
   .kuiButton--hollow:enabled:hover {
     color: #004d81 !important;
-    /* 1 */
-    text-decoration: underline; }
+        text-decoration: underline; }
   a.kuiButton--hollow:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #004d81 !important;
-    /* 1 */
-    text-decoration: underline; }
+        color: #004d81 !important;
+        text-decoration: underline; }
   .kuiButton--hollow:enabled:active {
     color: #004d81 !important;
-    /* 1 */
-    text-decoration: underline; }
+        text-decoration: underline; }
   a.kuiButton--hollow:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #004d81 !important;
-    /* 1 */
-    text-decoration: underline; }
+        color: #004d81 !important;
+        text-decoration: underline; }
 
 .kuiButton--secondary {
   color: #006BB4 !important;
-  /* 2 */
-  border: solid 1px #006BB4; }
+    border: solid 1px #006BB4; }
   .kuiButton--secondary:enabled:hover {
     color: #004d81 !important;
-    /* 1 */
-    border: solid 1px #004d81;
+        border: solid 1px #004d81;
     background-color: rgba(0, 107, 180, 0.1);
     text-decoration: underline; }
   a.kuiButton--secondary:not(.kuiButton-isDisabled):hover {
-    /* 1 */
-    color: #004d81 !important;
-    /* 1 */
-    border: solid 1px #004d81;
+        color: #004d81 !important;
+        border: solid 1px #004d81;
     background-color: rgba(0, 107, 180, 0.1);
     text-decoration: underline; }
   .kuiButton--secondary:enabled:active {
     color: #004d81 !important;
-    /* 1 */
-    border: solid 1px #004d81;
+        border: solid 1px #004d81;
     background-color: rgba(0, 107, 180, 0.1);
     text-decoration: underline; }
   a.kuiButton--secondary:not(.kuiButton-isDisabled):active {
-    /* 1 */
-    color: #004d81 !important;
-    /* 1 */
-    border: solid 1px #004d81;
+        color: #004d81 !important;
+        border: solid 1px #004d81;
     background-color: rgba(0, 107, 180, 0.1);
     text-decoration: underline; }
 
@@ -908,58 +297,37 @@ main {
   line-height: 1;
   font-size: 16px;
   color: #343741 !important;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   opacity: 0.35; }
   .kuiCollapseButton:hover {
     opacity: 1; }
 
-/**
- * 1. Set inline-block so this wrapper shrinks to fit the input.
- */
 .kuiAssistedInput {
   display: inline-block;
-  /* 1 */
-  position: relative; }
+    position: relative; }
 
-/**
-   * 1. Vertically center the assistance, regardless of its height.
-   */
 .kuiAssistedInput__assistance {
   position: absolute;
   right: 12px;
   top: 50%;
-  /* 1 */
-  -webkit-transform: translateY(-50%);
-          transform: translateY(-50%);
-  /* 1 */ }
+    -webkit-transform: translateY(-50%);
+            transform: translateY(-50%);
+   }
 
-/**
- * 1. Deliberately disable only webkit appearance. If we disable it in Firefox, we get a really
- *    ugly default appearance which we can't customize, so our best option is to give Firefox
- *    control over the checkbox's appearance.
- * 2. Override default styles (possibly from Bootstrap).
- */
 .kuiCheckBox {
   -webkit-appearance: none;
           appearance: none;
-  /* 1 */
-  background-color: #fbfcfd;
+    background-color: #fbfcfd;
   border: 1px solid rgba(15, 39, 118, 0.1);
   border-radius: 4px;
   width: 16px;
   height: 16px;
   font: "var(--font-text)" !important;
-  /* 2 */
-  line-height: 1.5 !important;
-  /* 2 */
-  margin: 0 !important;
-  /* 2 */
-  font-family: "var(--font-text)" !important;
-  /* 2 */
-  font-size: 10px !important;
-  /* 2 */
-  transition: background-color 0.1s linear; }
+    line-height: 1.5 !important;
+    margin: 0 !important;
+    font-family: "var(--font-text)" !important;
+    font-size: 10px !important;
+    transition: background-color 0.1s linear; }
   .kuiCheckBox::before {
     position: relative;
     left: 0.25em;
@@ -976,11 +344,9 @@ main {
       opacity: 1; }
   .kuiCheckBox:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #FFF, 0 0 0 2px #006BB4;
+     }
   .kuiCheckBox:disabled {
     background-color: #eef2f7 !important;
     border-color: #eef2f7 !important;
@@ -996,15 +362,12 @@ main {
   font-size: 16px;
   margin-left: 8px; }
 
-/**
- * 1. Override Bootstrap.
- */
 .kuiLabel {
   font-size: 16px;
   line-height: 1.5;
   font-weight: bold;
   margin-bottom: 0;
-  /* 1 */ }
+   }
 
 .kuiSearchInput {
   width: 180px;
@@ -1022,10 +385,6 @@ main {
   font-size: 1em;
   color: #98A2B3; }
 
-/**
-   * 1. Make space for search icon.
-   * 2. Expand to fill container.
-   */
 .kuiSearchInput__input {
   -webkit-appearance: none;
           appearance: none;
@@ -1040,11 +399,9 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-left: 28px;
-  /* 1 */
-  width: 100%;
-  /* 2 */ }
+    padding-left: 28px;
+    width: 100%;
+   }
   .kuiSearchInput__input:invalid {
     border-color: #BD271E; }
   .kuiSearchInput__input:focus {
@@ -1060,9 +417,6 @@ main {
 .kuiSearchInput--large {
   width: 400px; }
 
-/**
- * Avoid setting a width here, so that the width of the options can dynamically set the width.
- */
 .kuiSelect {
   -webkit-appearance: none;
           appearance: none;
@@ -1077,15 +431,12 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-right: 30px;
-  /* 2 */
-  background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
-  /* 1 */
-  background-size: 14px;
+    padding-right: 30px;
+    background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
+    background-size: 14px;
   background-repeat: no-repeat;
   background-position: calc(100% - 8px);
-  /* 2 */ }
+   }
   .kuiSelect:invalid {
     border-color: #BD271E; }
   .kuiSelect:focus {
@@ -1096,7 +447,7 @@ main {
     cursor: not-allowed; }
   .kuiSelect:-moz-focusring {
     text-shadow: 0 0 0;
-    /* 3 */ }
+     }
   .kuiSelect.kuiSelect-isInvalid {
     border-color: #BD271E; }
   .kuiSelect:focus {
@@ -1113,9 +464,6 @@ main {
 .kuiSelect--large {
   width: 400px; }
 
-/**
- * 1. Have the same spatial footprint as the regular input.
- */
 .kuiStaticInput {
   width: 180px;
   -webkit-appearance: none;
@@ -1127,8 +475,7 @@ main {
   line-height: 1.5;
   color: #343741;
   border: 1px solid transparent;
-  /* 1 */
-  background-color: transparent; }
+    background-color: transparent; }
 
 .kuiTextArea {
   width: 180px;
@@ -1145,7 +492,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */ }
+   }
   .kuiTextArea:invalid {
     border-color: #BD271E; }
   .kuiTextArea:focus {
@@ -1185,7 +532,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */ }
+   }
   .kuiTextInput:invalid {
     border-color: #BD271E; }
   .kuiTextInput:focus {
@@ -1203,13 +550,10 @@ main {
 .kuiTextInput--large {
   width: 400px; }
 
-/**
- * 1. We may want to put elements in here which have different heights.
- */
 .kuiFieldGroup {
   display: flex;
   align-items: center;
-  /* 1 */ }
+   }
 
 .kuiFieldGroup--alignTop {
   align-items: flex-start; }
@@ -1224,23 +568,14 @@ main {
   .kuiFieldGroupSection--wide > * {
     width: 100%; }
 
-/**
- * 1. Copied from FontAwesome's .fa class. We use a custom class to make it easier to migrate away
- *    from FontAwesome someday. When we do migrate away, we can just update this definition.
- */
 .kuiIcon {
   display: inline-block;
-  /* 1 */
-  font: normal normal normal 14px/1 FontAwesome, sans-serif;
-  /* 1 */
-  font-size: inherit;
-  /* 1 */
-  text-rendering: auto;
-  /* 1 */
-  -webkit-font-smoothing: antialiased;
-  /* 1 */
-  -moz-osx-font-smoothing: grayscale;
-  /* 1 */ }
+    font: normal normal normal 14px/1 FontAwesome, sans-serif;
+    font-size: inherit;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+   }
 
 .kuiIcon--info {
   color: #006BB4; }
@@ -1265,41 +600,26 @@ main {
   line-height: 1.5;
   border: 2px solid; }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--info {
   border-color: rgba(0, 107, 180, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--success {
   border-color: rgba(1, 125, 115, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--warning {
   border-color: rgba(245, 167, 0, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. TODO: Pick a hex value instead of making these colors translucent.
- */
 .kuiInfoPanel--error {
   border-color: rgba(189, 39, 30, 0.25);
-  /* 1 */ }
+   }
 
-/**
- * 1. Align with first line of title text if it wraps.
- */
 .kuiInfoPanelHeader {
   display: flex;
   align-items: baseline;
-  /* 1 */ }
+   }
 
 .kuiInfoPanelHeader__icon {
   margin-right: 10px;
@@ -1324,34 +644,24 @@ main {
   color: #006BB4;
   text-decoration: none;
   cursor: pointer;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: none;
-  /* 2 */
-  font-size: inherit;
-  /* 2 */
-  line-height: inherit;
-  /* 2 */ }
+    -webkit-appearance: none;
+            appearance: none;
+    background-color: transparent;
+    border: none;
+    font-size: inherit;
+    line-height: inherit;
+   }
   .kuiLink:visited, .kuiLink:active {
     color: #006BB4; }
   .kuiLink:hover {
     color: #004d81;
     text-decoration: underline; }
 
-/**
- * 1. Breadcrumbs are placed in the top-left corner and need to be bumped over
- *    a bit.
- */
 .kuiLocalBreadcrumbs {
   display: flex;
   align-items: center;
   padding: 12px 8px;
-  /* 1 */
-  border-bottom: 1px solid #D3DAE6;
+    border-bottom: 1px solid #D3DAE6;
   flex-grow: 1;
   flex-basis: 100%;
   background-color: #FFF; }
@@ -1369,28 +679,18 @@ main {
       margin-right: 4px;
       color: #D3DAE6; }
 
-/**
- * 1. Make it a bit darker to contrast with the gray background.
- */
 .kuiLocalBreadcrumb__link {
   color: #006BB4;
   text-decoration: none;
   cursor: pointer;
-  /* 1 */
-  -webkit-appearance: none;
-          appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: none;
-  /* 2 */
-  font-size: inherit;
-  /* 2 */
-  line-height: inherit;
-  /* 2 */
-  color: #006BB4;
-  /* 1 */
-  font-size: 16px; }
+    -webkit-appearance: none;
+            appearance: none;
+    background-color: transparent;
+    border: none;
+    font-size: inherit;
+    line-height: inherit;
+    color: #006BB4;
+    font-size: 16px; }
   .kuiLocalBreadcrumb__link:visited, .kuiLocalBreadcrumb__link:active {
     color: #006BB4; }
   .kuiLocalBreadcrumb__link:hover {
@@ -1415,9 +715,6 @@ main {
   justify-content: space-between;
   margin-bottom: 4px; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiDatePickerNavigationButton {
   -webkit-appearance: none;
           appearance: none;
@@ -1433,13 +730,10 @@ main {
     background-color: #006BB4; }
   .kuiDatePickerNavigationButton:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px transparent, 0 0 0 2px #006BB4;
-    /* 3 */
-    color: #343741;
-    /* 1 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px transparent, 0 0 0 2px #006BB4;
+        color: #343741;
+     }
 
 .kuiDatePickerHeaderCell {
   padding: 9px 0;
@@ -1452,19 +746,12 @@ main {
 .kuiDatePickerRowCell {
   padding: 0;
   text-align: center;
-  /**
-   * This state class exists to support weird angular-bootstrap datepicker functionality,
-   * in which you can't select a day on the "From" calendar if it falls after the selected day in
-   * the "To" calendar (and vice versa, you can't select a "To" day if it is before the "From" day).
-   */ }
+   }
   .kuiDatePickerRowCell.kuiDatePickerRowCell-isBlocked {
     cursor: not-allowed; }
     .kuiDatePickerRowCell.kuiDatePickerRowCell-isBlocked .kuiDatePickerRowCellContent {
       pointer-events: none; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiDatePickerRowCellContent {
   -webkit-appearance: none;
           appearance: none;
@@ -1478,13 +765,10 @@ main {
   line-height: 1.2; }
   .kuiDatePickerRowCellContent:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px transparent, 0 0 0 2px #006BB4;
-    /* 3 */
-    color: #343741;
-    /* 1 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px transparent, 0 0 0 2px #006BB4;
+        color: #343741;
+     }
   .kuiDatePickerRowCellContent:disabled {
     pointer-events: none;
     opacity: 0.5; }
@@ -1517,8 +801,7 @@ main {
   line-height: 1;
   font-size: 16px;
   color: #343741 !important;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   opacity: 0.35;
   position: absolute;
   top: 1px;
@@ -1538,13 +821,9 @@ main {
 .kuiLocalDropdownPanel--right {
   margin-left: 30px; }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiLocalDropdownTitle {
   margin-top: 0;
-  /* 1 */
-  margin-bottom: 12px;
+    margin-bottom: 12px;
   font-size: 18px;
   color: #343741; }
 
@@ -1559,15 +838,11 @@ main {
   justify-content: space-between;
   margin-bottom: 6px; }
 
-/**
-   * 1. Override inherited styles.
-   */
 .kuiLocalDropdownHeader__label {
   font-size: 14px;
   font-weight: 700;
   margin-bottom: 0;
-  /* 1 */
-  color: #343741; }
+    color: #343741; }
 
 .kuiLocalDropdownHeader__actions {
   display: flex; }
@@ -1649,24 +924,16 @@ main {
   margin-right: 5px;
   margin-bottom: -1px; }
 
-/**
- * 1. Match height of logo in side bar, but allow it to expand to accommodate
- *    dropdown.
- */
 .kuiLocalNav {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   min-height: 69px;
-  /* 1 */
-  color: #343741;
+    color: #343741;
   background-color: #FFF;
   line-height: 1.5;
   border-bottom: solid 1px #D3DAE6; }
 
-/**
- * 1. Allow row to expand if the content is so long that it wraps.
- */
 .kuiLocalNavRow {
   display: flex;
   align-items: stretch;
@@ -1676,18 +943,10 @@ main {
   display: flex;
   align-items: stretch; }
 
-/**
- * 1. We make this row flex-start because it usually contains a search input, which may expand
- *    beyond the height of this container. We can't use `align-items: center`, because this would
- *    cause the search input to overflow both on the top and bottom; `align-items: flex-start`
- *    makes it only overflow on the bottom. But this means we need to manually center the content
- *    of this container using padding.
- */
 .kuiLocalNavRow--secondary {
   padding: 0 8px;
-  /* 1 */
-  align-items: flex-start;
-  /* 1 */ }
+    align-items: flex-start;
+   }
 
 .kuiLocalSearch {
   display: flex;
@@ -1708,8 +967,7 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  flex: 1 1 100%;
+    flex: 1 1 100%;
   border-color: #FFF;
   border-color: #D3DAE6;
   border-radius: 4px 0 0 4px; }
@@ -1732,28 +990,19 @@ main {
   border-radius: 0;
   border-left-width: 0; }
 
-/**
- * 1. em used for right padding so documentation link and query string
- *    won't overlap if the user increases their default browser font size
- *    This is sized for the 'Options' link
- */
 .kuiLocalSearchInput,
 .kuiLocalSearchAssistedInput__input {
   padding-right: 6em;
-  /* 1 */ }
+   }
 
-/**
- * 1. Vertically center the assistance, regardless of its height.
- */
 .kuiLocalSearchAssistedInput__assistance {
   position: absolute;
   right: 6px;
   top: 50%;
-  /* 1 */
-  z-index: 2;
+    z-index: 2;
   -webkit-transform: translateY(-50%);
           transform: translateY(-50%);
-  /* 1 */ }
+   }
 
 .kuiLocalSearchSelect {
   -webkit-appearance: none;
@@ -1769,16 +1018,12 @@ main {
   border-radius: 4px;
   transition: border-color 0.1s linear;
   min-height: 32px;
-  /* 1 */
-  padding-right: 30px;
-  /* 2 */
-  background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
-  /* 1 */
-  background-size: 14px;
+    padding-right: 30px;
+    background-image: url('data:image/svg+xml;utf8,<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z"/></svg>');
+    background-size: 14px;
   background-repeat: no-repeat;
   background-position: calc(100% - 8px);
-  /* 2 */
-  border-left-width: 0;
+    border-left-width: 0;
   border-radius: 0; }
   .kuiLocalSearchSelect:invalid {
     border-color: #BD271E; }
@@ -1790,40 +1035,28 @@ main {
     cursor: not-allowed; }
   .kuiLocalSearchSelect:-moz-focusring {
     text-shadow: 0 0 0;
-    /* 3 */ }
+     }
 
-/**
- * 1. Override inherited styles.
- */
 .kuiLocalSearchButton {
   width: 43px;
   height: 32px;
   font-size: 16px;
   line-height: 0;
-  /* 1 */
-  color: #FFF;
+    color: #FFF;
   background-color: #006BB4;
   border: 0;
   border-radius: 0 4px 4px 0; }
   .kuiLocalSearchButton:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
+     }
 
-/**
- * 1. We want the bottom border on selected tabs to be flush with the bottom of the container.
- */
 .kuiLocalTabs {
   display: flex;
   align-items: flex-end;
   height: 100%; }
 
-/**
-   * 1. Override inherited typographic styles.
-   */
 .kuiLocalTab {
   padding: 5px 0 6px;
   font-size: 18px;
@@ -1832,13 +1065,8 @@ main {
   text-decoration: none;
   cursor: pointer;
   margin-top: 0 !important;
-  /* 1 */
-  margin-bottom: 0 !important;
-  /* 1 */
-  /**
-     * 1. We may want to show a tooltip to explain why the tab is disabled, so we will just show
-     *    a regular cursor instead of setting pointer-events: none.
-     */ }
+    margin-bottom: 0 !important;
+     }
   .kuiLocalTab:hover:not(.kuiLocalTab-isDisabled), .kuiLocalTab:active:not(.kuiLocalTab-isDisabled) {
     color: #006BB4; }
   .kuiLocalTab.kuiLocalTab-isSelected {
@@ -1848,7 +1076,7 @@ main {
   .kuiLocalTab.kuiLocalTab-isDisabled {
     opacity: 0.5;
     cursor: default;
-    /* 1 */ }
+     }
   .kuiLocalTab + .kuiLocalTab {
     margin-left: 15px; }
 
@@ -1866,22 +1094,19 @@ main {
     padding: 0;
     display: none; }
 
-/**
- * 1. Put 10px of space between each child.
- */
 .kuiPager {
   display: flex;
   align-items: center; }
   .kuiPager > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
 .kuiPagerText {
   font-size: 16px;
   line-height: 1.5;
   color: #69707D;
   white-space: nowrap;
-  /* 1 */ }
+   }
 
 .kuiPanel {
   box-shadow: 0 2px 2px -1px rgba(152, 162, 179, 0.3), 0 1px 5px -2px rgba(152, 162, 179, 0.3);
@@ -1917,62 +1142,44 @@ main {
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 50px;
   border-bottom: 1px solid #D3DAE6; }
   .kuiPanelHeader .kuiButton:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
+     }
   a.kuiPanelHeader .kuiButton:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
+     }
   .kuiPanelHeader .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
+     }
   a.kuiPanelHeader .kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
+     }
   .kuiPanelHeader .kuiSelect {
     border-color: #fbfcfd; }
     .kuiPanelHeader .kuiSelect:not(a):enabled:focus {
       outline: none;
       border-color: #006BB4; }
     a.kuiPanelHeader .kuiSelect:not(.kuiButton-isDisabled):focus {
-      /* 1 */
-      outline: none;
+            outline: none;
       border-color: #006BB4; }
 
-/**
-   * 1. This way we can use h1, h2, etc.
-   */
 .kuiPanelHeader__title {
   font-size: 20px;
   line-height: 1.5;
   margin: 0;
-  /* 1 */ }
+   }
 
-/**
- * 1. Undo what barSection mixin does.
- */
 .kuiPanelHeaderSection {
   display: flex;
   align-items: center;
@@ -1981,26 +1188,24 @@ main {
   margin-right: 25px; }
   .kuiPanelHeaderSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiPanelHeaderSection:first-child {
     margin-left: 0; }
   .kuiPanelHeaderSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiPanelHeaderSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiPanelHeaderSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
   .kuiPanelHeaderSection:only-child {
     margin-left: 0;
-    /* 1 */
-    margin-right: auto;
-    /* 1 */ }
+        margin-right: auto;
+     }
 
 .kuiPanelBody {
   padding: 10px; }
@@ -2035,98 +1240,65 @@ main {
 .kuiStatusText--error {
   color: #BD271E; }
 
-/**
- * 1. Set the image to be the same size as a font icon at 14px.
- * 2. We need to cap the height too, in case the icon was designed thin and tall.
- */
 .kuiStatusText__icon {
   margin-right: 6px;
   width: 1.15em;
-  /* 1 */
-  max-height: 1.15em;
-  /* 2 */ }
+    max-height: 1.15em;
+   }
 
-/**
- * 1. Make seamless transition from ToolBar to Table header and contained Menu.
- * 1. Make seamless transition from Table to ToolBarFooter header.
- */
 .kuiControlledTable {
   background: #FFF; }
   .kuiControlledTable .kuiTable {
     border-top: none;
-    /* 1 */ }
+     }
   .kuiControlledTable .kuiToolBarFooter {
     border-top: none;
-    /* 2 */ }
+     }
   .kuiControlledTable .kuiMenu--contained {
     border-top: none;
-    /* 1 */ }
+     }
 
-/**
- * 1. Prevent cells from expanding based on content size. This substitutes for table-layout: fixed.
- */
-/**
- * NOTE: table-layout: fixed causes a bug in IE11 and Edge (see #9929). It also prevents us from
- * specifying a column width, e.g. the checkbox column.
- */
 .kuiTable {
   width: 100%;
   border: 1px solid #D3DAE6;
   border-collapse: collapse;
   background-color: #FFF; }
 
-/**
- * 1. Allow contents of cells to determine table's width.
- */
 .kuiTable--fluid {
   width: auto;
-  /* 1 */ }
+   }
   .kuiTable--fluid .kuiTableHeaderCell,
   .kuiTable--fluid .kuiTableRowCell {
     max-width: none;
-    /* 1 */ }
+     }
 
 .kuiTableHeaderCell {
   font-size: 16px;
   font-weight: 400;
   text-align: left;
   max-width: 20px;
-  /* 1 */
-  line-height: 1.5;
+    line-height: 1.5;
   color: #69707D; }
 
 .kuiTableHeaderCell__liner {
   display: inline-block;
   padding: 7px 8px 8px; }
 
-/**
- * 1. Prevent rapid clicking from selecting text.
- * 2. Remove native button element styles.
- * 3. Make buttons look and behave like table header cells.
- */
 .kuiTableHeaderCellButton {
   -webkit-user-select: none;
           user-select: none;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   width: 100%;
   -webkit-appearance: none;
           appearance: none;
-  /* 2 */
-  background-color: transparent;
-  /* 2 */
-  border: 0;
-  /* 2 */
-  padding: 0;
-  /* 2 */
-  color: inherit;
-  /* 3 */
-  line-height: inherit;
-  /* 3 */
-  font-size: inherit;
-  /* 3 */
-  text-align: inherit;
-  /* 3 */ }
+    background-color: transparent;
+    border: 0;
+    padding: 0;
+    color: inherit;
+    line-height: inherit;
+    font-size: inherit;
+    text-align: inherit;
+   }
   .kuiTableHeaderCellButton:hover .kuiTableSortIcon {
     display: block;
     opacity: 1; }
@@ -2156,31 +1328,20 @@ main {
   font-weight: 400;
   text-align: left;
   max-width: 20px;
-  /* 1 */
-  color: #343741;
+    color: #343741;
   border-top: 1px solid #D3DAE6;
   vertical-align: middle; }
 
-/**
-   * 1. Vertically align all children.
-   * 2. The padding on this div allows the ellipsis to show if the content is truncated. If
-   *    the padding was on the cell, the ellipsis would be cropped.
-   * 3. Truncate content with an ellipsis.
-   */
 .kuiTableRowCell__liner {
   padding: 7px 8px 8px;
-  /* 2 */
-  line-height: 1.5;
-  /* 1 */
-  overflow: hidden;
-  /* 3 */
-  text-overflow: ellipsis;
-  /* 3 */
-  white-space: nowrap;
-  /* 3 */ }
+    line-height: 1.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+   }
   .kuiTableRowCell__liner > * {
     vertical-align: middle;
-    /* 1 */ }
+     }
 
 .kuiTableRowCell--wrap .kuiTableRowCell__liner {
   white-space: normal; }
@@ -2189,34 +1350,24 @@ main {
   overflow: visible;
   white-space: normal; }
 
-/**
- * 1. We don't want to create too strong a disconnect between the original row and the row
- *    that contains its expanded details.
- */
 .kuiTableRowCell--expanded {
   border-top-color: #FFF;
-  /* 1 */ }
+   }
 
 .kuiTableRowCell--alignRight {
   text-align: right; }
   .kuiTableRowCell--alignRight .kuiTableRowCell__liner {
     text-align: right; }
 
-/**
- * 1. Rendered width of cell with checkbox inside of it.
- * 2. Align checkbox with text in other cells.
- * 3. Show the checkbox in Edge; otherwise it gets cropped.
- */
 .kuiTableHeaderCell--checkBox,
 .kuiTableRowCell--checkBox {
   width: 28px;
-  /* 1 */
-  line-height: 1;
-  /* 2 */ }
+    line-height: 1;
+   }
   .kuiTableHeaderCell--checkBox .kuiTableRowCell__liner,
   .kuiTableRowCell--checkBox .kuiTableRowCell__liner {
     overflow: visible;
-    /* 3 */ }
+     }
   .kuiTableHeaderCell--checkBox .kuiTableHeaderCell__liner,
   .kuiTableHeaderCell--checkBox .kuiTableRowCell__liner,
   .kuiTableRowCell--checkBox .kuiTableHeaderCell__liner,
@@ -2233,41 +1384,30 @@ main {
   display: flex;
   border-bottom: 1px solid #D3DAE6; }
 
-/**
- * 1. Override button styles (some of which are from Bootstrap).
- * 2. Adding a border shifts tabs right by 1px, so we need to shift them back.
- * 3. Move the tab down so that its bottom border covers the container's bottom border.
- * 4. When the tab is focused, its bottom border changes to be 1px, so we need to add 1px more
- *    of padding to make sure the text doesn't shift down.
- */
 .kuiTab {
   -webkit-appearance: none;
           appearance: none;
-  /* 1 */
-  cursor: pointer;
+    cursor: pointer;
   padding: 10px 30px;
   font-size: 16px;
   color: #69707D;
   background-color: transparent;
-  /* 1 */
-  border: 1px solid #D3DAE6;
+    border: 1px solid #D3DAE6;
   border-radius: 0;
-  /* 1 */
-  margin-bottom: -1px;
-  /* 3 */ }
+    margin-bottom: -1px;
+   }
   .kuiTab + .kuiTab {
     border-left: none; }
     .kuiTab + .kuiTab:focus:not(.kuiTab-isSelected):not(:active) {
       margin-left: -1px;
-      /* 2 */ }
+       }
   .kuiTab:active {
     outline: none !important;
-    /* 1 */
-    box-shadow: none;
-    /* 1 */ }
+        box-shadow: none;
+     }
   .kuiTab:focus {
     outline: none;
-    /* 1 */ }
+     }
   .kuiTab:focus:not(.kuiTab-isSelected):not(:active) {
     z-index: 1;
     color: #006BB4;
@@ -2286,49 +1426,37 @@ main {
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 50px;
   background-color: transparent;
   border: solid 1px #D3DAE6; }
   .kuiToolBar .kuiButton:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
+     }
   a.kuiToolBar .kuiButton:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #006BB4;
+     }
   .kuiToolBar .kuiButton--danger:not(a):enabled:focus {
     z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
-    /* 3 */ }
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
+     }
   a.kuiToolBar .kuiButton--danger:not(.kuiButton-isDisabled):focus {
-    /* 1 */
-    z-index: 1;
-    /* 1 */
-    outline: none !important;
-    /* 2 */
-    box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
-    /* 3 */ }
+        z-index: 1;
+        outline: none !important;
+        box-shadow: 0 0 0 1px #D3DAE6, 0 0 0 2px #BD271E;
+     }
   .kuiToolBar .kuiSelect {
     border-color: #fbfcfd; }
     .kuiToolBar .kuiSelect:not(a):enabled:focus {
       outline: none;
       border-color: #006BB4; }
     a.kuiToolBar .kuiSelect:not(.kuiButton-isDisabled):focus {
-      /* 1 */
-      outline: none;
+            outline: none;
       border-color: #006BB4; }
 
 .kuiToolBarSection {
@@ -2339,36 +1467,31 @@ main {
   margin-right: 25px; }
   .kuiToolBarSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiToolBarSection:first-child {
     margin-left: 0; }
   .kuiToolBarSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiToolBarSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiToolBarSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Override Bar styles and put Search on the left side.
- */
 .kuiToolBar--searchOnly .kuiToolBarSearch {
   margin-left: 0 !important;
-  /* 1 */ }
+   }
 
 .kuiToolBarFooter {
   display: flex;
   align-items: center;
   justify-content: space-between;
   min-height: 30px;
-  /* 1 */
-  padding: 10px;
+    padding: 10px;
   height: 40px;
   background-color: #FFF; }
 
@@ -2380,27 +1503,21 @@ main {
   margin-right: 25px; }
   .kuiToolBarFooterSection:not(:first-child):not(:last-child):not(:only-child) {
     justify-content: center;
-    /* 3 */ }
+     }
   .kuiToolBarFooterSection:first-child {
     margin-left: 0; }
   .kuiToolBarFooterSection:last-child {
     margin-right: 0;
     flex: 0 1 auto;
-    /* 4 */
-    justify-content: flex-end;
-    /* 5 */ }
+        justify-content: flex-end;
+     }
   .kuiToolBarFooterSection:only-child {
     margin-left: auto;
-    /* 2 */ }
+     }
   .kuiToolBarFooterSection > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
-/**
- * 1. Put 10px of space between each child.
- * 2. Fix IE11 bug which causes this item to grow too wide when there is only a single
- *    kuiToolBarSection sibling.
- */
 .kuiToolBarSearch {
   display: flex;
   align-items: center;
@@ -2408,15 +1525,14 @@ main {
   margin-right: 25px;
   flex: 1 1 auto;
   max-width: 100%;
-  /* 2 */
-  line-height: 1.5; }
+    line-height: 1.5; }
   .kuiToolBarSearch:first-child {
     margin-left: 0; }
   .kuiToolBarSearch:last-child {
     margin-right: 0; }
   .kuiToolBarSearch > * + * {
     margin-left: 10px;
-    /* 1 */ }
+     }
 
 .kuiToolBarSearchBox {
   flex: 1 1 auto;
@@ -2431,85 +1547,55 @@ main {
   font-size: 1em;
   color: #acacac; }
 
-/**
-   * 1. Fix inherited styles (possibly from Bootstrap).
-   */
 .kuiToolBarSearchBox__input {
   width: 100%;
   min-width: 200px;
   padding: 4px 12px 5px 28px;
   font-family: "var(--font-text)";
-  /* 1 */
-  background-color: #FFF;
+    background-color: #FFF;
   color: #343741;
   border-radius: 4px;
   font-size: 1em;
   border: 1px solid #D3DAE6;
   line-height: normal;
-  /* 1 */
-  transition: border-color 0.1s linear; }
+    transition: border-color 0.1s linear; }
   .kuiToolBarSearchBox__input:focus {
     outline: none;
     border-color: #006BB4; }
 
-/*
- * 1. We don't want the text to take up two lines and overflow the ToolBar.
- */
 .kuiToolBarText {
   font-size: 16px;
   line-height: 1.5;
   color: #69707D;
   white-space: nowrap;
-  /* 1 */ }
+   }
 
-/**
- * 1. Override h1.
- */
 .kuiTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  font-size: 24px; }
+    font-weight: 400;
+    font-size: 24px; }
 
-/**
- * 1. Override h2, h3, etc.
- */
 .kuiSubTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  font-size: 20px; }
+    font-weight: 400;
+    font-size: 20px; }
 
-/**
- * 1. Override p.
- */
 .kuiTextTitle {
   margin: 0;
-  /* 1 */
-  font-weight: 700;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 700;
+    line-height: 1.5;
   font-size: 16px; }
 
-/**
- * 1. Override p.
- */
 .kuiText {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 400;
+    line-height: 1.5;
   font-size: 16px; }
 
 .kuiSubText {
   margin: 0;
-  /* 1 */
-  font-weight: 400;
-  /* 1 */
-  line-height: 1.5;
+    font-weight: 400;
+    line-height: 1.5;
   font-size: 14px; }
 
 .kuiSubduedText {

--- a/packages/osd-ui-framework/package.json
+++ b/packages/osd-ui-framework/package.json
@@ -26,6 +26,7 @@
     "@elastic/eui": "npm:@opensearch-project/oui@1.3.0-alpha.2",
     "@osd/babel-preset": "1.0.0",
     "@osd/optimizer": "1.0.0",
+    "comment-stripper": "^0.0.4",
     "grunt": "^1.5.2",
     "grunt-babel": "^8.0.0",
     "grunt-contrib-clean": "^2.0.0",

--- a/packages/osd-ui-shared-deps/package.json
+++ b/packages/osd-ui-shared-deps/package.json
@@ -42,10 +42,12 @@
     "@osd/babel-preset": "1.0.0",
     "@osd/dev-utils": "1.0.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+    "comment-stripper": "^0.0.4",
     "css-loader": "^5.2.7",
     "del": "^6.1.1",
     "loader-utils": "^2.0.4",
     "node-sass": "npm:@amoo-miki/node-sass@9.0.0-libsass-3.6.5",
+    "sass-loader": "npm:@amoo-miki/sass-loader@10.4.1-node-sass-9.0.0-libsass-3.6.5",
     "val-loader": "^2.1.2",
     "webpack": "npm:@amoo-miki/webpack@4.46.0-rc.2"
   }

--- a/packages/osd-ui-shared-deps/webpack.config.js
+++ b/packages/osd-ui-shared-deps/webpack.config.js
@@ -76,7 +76,30 @@ exports.getWebpackConfig = ({ dev = false } = {}) => ({
       },
       {
         test: /\.css$/,
-        use: [MiniCssExtractPlugin.loader, 'css-loader'],
+        use: [
+          MiniCssExtractPlugin.loader,
+          'css-loader',
+          {
+            loader: 'comment-stripper',
+            options: {
+              language: 'css',
+            },
+          },
+        ],
+      },
+      {
+        test: /\.scss$/,
+        use: [
+          MiniCssExtractPlugin.loader,
+          'css-loader',
+          {
+            loader: 'comment-stripper',
+            options: {
+              language: 'css',
+            },
+          },
+          'sass-loader',
+        ],
       },
       {
         include: [require.resolve('./theme.ts')],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6100,6 +6100,13 @@ commander@^5.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+comment-stripper@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/comment-stripper/-/comment-stripper-0.0.4.tgz#e8d61366d362779ea225c764f05cca6c950f8a2c"
+  integrity sha512-4K87KyAmZtZmAUznIJuVsBB7v328V4GBL2wVhno71aunUymMfYBVaAWITH4jrH6uI7NbxpczSdl7NysHx+XfYg==
+  dependencies:
+    loader-utils "^2.0.0"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"


### PR DESCRIPTION
### Description

When CSS and SCSS files are combined in OSD, all of the copyright headers are retained. This ends up creating artifacts that are riddled with numerous duplicate copyright headers. `comment-stripper` is employed to ethically hoist a single copy of all copyright headers used in an artifact, resulting in smaller payloads.


### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
