### PR TITLE
Feat (Chrome): Update all collapsible nav groups to have the same sty…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Optimize `augment-vis` saved obj searching by adding arg to saved obj client ([#4595](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4595))
 - Add resource ID filtering in fetch `augment-vis` obj queries ([#4608](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4608))
 - [Discover] Update styles to compatible with OUI `next` theme ([#4644](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4644))
+- [Chrome] Unify background colors of all sections in side nav ([#4659](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4659))
 
 ### 🐛 Bug Fixes
 

--- a/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
@@ -435,7 +435,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                   className="euiCollapsibleNavGroup__children"
                 >
                   <EuiListGroup
-                    color="text"
+                    color="subdued"
                     gutterSize="none"
                     listItems={
                       Array [
@@ -463,7 +463,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                       }
                     >
                       <EuiListGroupItem
-                        color="text"
+                        color="subdued"
                         data-test-subj="collapsibleNavCustomNavLink"
                         href="Custom link"
                         isActive={false}
@@ -475,7 +475,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                         wrapText={false}
                       >
                         <li
-                          className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
                         >
                           <a
                             className="euiListGroupItem__button"
@@ -757,6 +757,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
             className="euiFlexItem eui-yScroll"
           >
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="/defaultModeLogo"
               data-test-subj="collapsibleNavGroup-opensearchDashboards"
               iconType="/defaultModeLogo"
@@ -797,7 +798,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="/defaultModeLogo"
                 data-test-subj="collapsibleNavGroup-opensearchDashboards"
                 id="mockId"
@@ -808,7 +809,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="/defaultModeLogo"
                   data-test-subj="collapsibleNavGroup-opensearchDashboards"
                   onToggle={[Function]}
@@ -1053,6 +1054,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
               </EuiAccordion>
             </EuiCollapsibleNavGroup>
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="logoObservability"
               data-test-subj="collapsibleNavGroup-observability"
               iconType="logoObservability"
@@ -1093,7 +1095,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="logoObservability"
                 data-test-subj="collapsibleNavGroup-observability"
                 id="mockId"
@@ -1104,7 +1106,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="logoObservability"
                   data-test-subj="collapsibleNavGroup-observability"
                   onToggle={[Function]}
@@ -1310,6 +1312,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
               </EuiAccordion>
             </EuiCollapsibleNavGroup>
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="logoSecurity"
               data-test-subj="collapsibleNavGroup-securitySolution"
               iconType="logoSecurity"
@@ -1350,7 +1353,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="logoSecurity"
                 data-test-subj="collapsibleNavGroup-securitySolution"
                 id="mockId"
@@ -1361,7 +1364,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="logoSecurity"
                   data-test-subj="collapsibleNavGroup-securitySolution"
                   onToggle={[Function]}
@@ -1528,6 +1531,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
               </EuiAccordion>
             </EuiCollapsibleNavGroup>
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="managementApp"
               data-test-subj="collapsibleNavGroup-management"
               iconType="managementApp"
@@ -1568,7 +1572,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="managementApp"
                 data-test-subj="collapsibleNavGroup-management"
                 id="mockId"
@@ -1579,7 +1583,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="managementApp"
                   data-test-subj="collapsibleNavGroup-management"
                   onToggle={[Function]}
@@ -1746,11 +1750,12 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
               </EuiAccordion>
             </EuiCollapsibleNavGroup>
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-subj="collapsibleNavGroup-noCategory"
               key="0"
             >
               <div
-                className="euiCollapsibleNavGroup"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
                 data-test-subj="collapsibleNavGroup-noCategory"
                 id="mockId"
               >
@@ -1764,7 +1769,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                       className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
                     >
                       <EuiListGroupItem
-                        color="text"
+                        color="subdued"
                         data-test-subj="collapsibleNavAppLink"
                         href="canvas"
                         isActive={false}
@@ -1773,7 +1778,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                         size="s"
                       >
                         <li
-                          className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                          className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
                         >
                           <a
                             className="euiListGroupItem__button"
@@ -1804,9 +1809,11 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 ]
               }
             >
-              <EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                background="light"
+              >
                 <div
-                  className="euiCollapsibleNavGroup"
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
                   id="mockId"
                 >
                   <div
@@ -2832,9 +2839,11 @@ exports[`CollapsibleNav renders the default nav 3`] = `
                 ]
               }
             >
-              <EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                background="light"
+              >
                 <div
-                  className="euiCollapsibleNavGroup"
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
                   id="mockId"
                 >
                   <div
@@ -3435,6 +3444,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 1`] = 
             className="euiFlexItem eui-yScroll"
           >
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="/darkModeLogo"
               data-test-subj="collapsibleNavGroup-opensearchDashboards"
               iconType="/darkModeLogo"
@@ -3475,7 +3485,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 1`] = 
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="/darkModeLogo"
                 data-test-subj="collapsibleNavGroup-opensearchDashboards"
                 id="mockId"
@@ -3486,7 +3496,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 1`] = 
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="/darkModeLogo"
                   data-test-subj="collapsibleNavGroup-opensearchDashboards"
                   onToggle={[Function]}
@@ -3653,6 +3663,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 1`] = 
               </EuiAccordion>
             </EuiCollapsibleNavGroup>
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="logoObservability"
               data-test-subj="collapsibleNavGroup-observability"
               iconType="logoObservability"
@@ -3693,7 +3704,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 1`] = 
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="logoObservability"
                 data-test-subj="collapsibleNavGroup-observability"
                 id="mockId"
@@ -3704,7 +3715,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 1`] = 
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="logoObservability"
                   data-test-subj="collapsibleNavGroup-observability"
                   onToggle={[Function]}
@@ -3878,9 +3889,11 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 1`] = 
                 ]
               }
             >
-              <EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                background="light"
+              >
                 <div
-                  className="euiCollapsibleNavGroup"
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
                   id="mockId"
                 >
                   <div
@@ -4480,6 +4493,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 2`] = 
             className="euiFlexItem eui-yScroll"
           >
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="/defaultModeLogo"
               data-test-subj="collapsibleNavGroup-opensearchDashboards"
               iconType="/defaultModeLogo"
@@ -4520,7 +4534,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 2`] = 
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="/defaultModeLogo"
                 data-test-subj="collapsibleNavGroup-opensearchDashboards"
                 id="mockId"
@@ -4531,7 +4545,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 2`] = 
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="/defaultModeLogo"
                   data-test-subj="collapsibleNavGroup-opensearchDashboards"
                   onToggle={[Function]}
@@ -4698,6 +4712,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 2`] = 
               </EuiAccordion>
             </EuiCollapsibleNavGroup>
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="logoObservability"
               data-test-subj="collapsibleNavGroup-observability"
               iconType="logoObservability"
@@ -4738,7 +4753,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 2`] = 
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="logoObservability"
                 data-test-subj="collapsibleNavGroup-observability"
                 id="mockId"
@@ -4749,7 +4764,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 2`] = 
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="logoObservability"
                   data-test-subj="collapsibleNavGroup-observability"
                   onToggle={[Function]}
@@ -4923,9 +4938,11 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 2`] = 
                 ]
               }
             >
-              <EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                background="light"
+              >
                 <div
-                  className="euiCollapsibleNavGroup"
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
                   id="mockId"
                 >
                   <div
@@ -5523,6 +5540,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 3`] = 
             className="euiFlexItem eui-yScroll"
           >
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
               data-test-subj="collapsibleNavGroup-opensearchDashboards"
               iconType="undefined/opensearch_mark_default_mode.svg"
@@ -5563,7 +5581,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 3`] = 
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
                 data-test-subj="collapsibleNavGroup-opensearchDashboards"
                 id="mockId"
@@ -5574,7 +5592,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 3`] = 
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
                   data-test-subj="collapsibleNavGroup-opensearchDashboards"
                   onToggle={[Function]}
@@ -5741,6 +5759,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 3`] = 
               </EuiAccordion>
             </EuiCollapsibleNavGroup>
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="logoObservability"
               data-test-subj="collapsibleNavGroup-observability"
               iconType="logoObservability"
@@ -5781,7 +5800,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 3`] = 
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="logoObservability"
                 data-test-subj="collapsibleNavGroup-observability"
                 id="mockId"
@@ -5792,7 +5811,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 3`] = 
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="logoObservability"
                   data-test-subj="collapsibleNavGroup-observability"
                   onToggle={[Function]}
@@ -5966,9 +5985,11 @@ exports[`CollapsibleNav renders the nav bar with custom logo in dark mode 3`] = 
                 ]
               }
             >
-              <EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                background="light"
+              >
                 <div
-                  className="euiCollapsibleNavGroup"
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
                   id="mockId"
                 >
                   <div
@@ -6569,6 +6590,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 1`]
             className="euiFlexItem eui-yScroll"
           >
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="/defaultModeLogo"
               data-test-subj="collapsibleNavGroup-opensearchDashboards"
               iconType="/defaultModeLogo"
@@ -6609,7 +6631,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 1`]
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="/defaultModeLogo"
                 data-test-subj="collapsibleNavGroup-opensearchDashboards"
                 id="mockId"
@@ -6620,7 +6642,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 1`]
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="/defaultModeLogo"
                   data-test-subj="collapsibleNavGroup-opensearchDashboards"
                   onToggle={[Function]}
@@ -6787,6 +6809,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 1`]
               </EuiAccordion>
             </EuiCollapsibleNavGroup>
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="logoObservability"
               data-test-subj="collapsibleNavGroup-observability"
               iconType="logoObservability"
@@ -6827,7 +6850,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 1`]
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="logoObservability"
                 data-test-subj="collapsibleNavGroup-observability"
                 id="mockId"
@@ -6838,7 +6861,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 1`]
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="logoObservability"
                   data-test-subj="collapsibleNavGroup-observability"
                   onToggle={[Function]}
@@ -7012,9 +7035,11 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 1`]
                 ]
               }
             >
-              <EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                background="light"
+              >
                 <div
-                  className="euiCollapsibleNavGroup"
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
                   id="mockId"
                 >
                   <div
@@ -7612,6 +7637,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 2`]
             className="euiFlexItem eui-yScroll"
           >
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
               data-test-subj="collapsibleNavGroup-opensearchDashboards"
               iconType="undefined/opensearch_mark_default_mode.svg"
@@ -7652,7 +7678,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 2`]
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
                 data-test-subj="collapsibleNavGroup-opensearchDashboards"
                 id="mockId"
@@ -7663,7 +7689,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 2`]
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="undefined/opensearch_mark_default_mode.svg"
                   data-test-subj="collapsibleNavGroup-opensearchDashboards"
                   onToggle={[Function]}
@@ -7830,6 +7856,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 2`]
               </EuiAccordion>
             </EuiCollapsibleNavGroup>
             <EuiCollapsibleNavGroup
+              background="light"
               data-test-opensearch-logo="logoObservability"
               data-test-subj="collapsibleNavGroup-observability"
               iconType="logoObservability"
@@ -7870,7 +7897,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 2`]
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                 data-test-opensearch-logo="logoObservability"
                 data-test-subj="collapsibleNavGroup-observability"
                 id="mockId"
@@ -7881,7 +7908,7 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 2`]
                 paddingSize="none"
               >
                 <div
-                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
                   data-test-opensearch-logo="logoObservability"
                   data-test-subj="collapsibleNavGroup-observability"
                   onToggle={[Function]}
@@ -8055,9 +8082,11 @@ exports[`CollapsibleNav renders the nav bar with custom logo in default mode 2`]
                 ]
               }
             >
-              <EuiCollapsibleNavGroup>
+              <EuiCollapsibleNavGroup
+                background="light"
+              >
                 <div
-                  className="euiCollapsibleNavGroup"
+                  className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
                   id="mockId"
                 >
                   <div

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -5955,7 +5955,7 @@ exports[`Header handles visibility and lock changes 1`] = `
                       className="euiCollapsibleNavGroup__children"
                     >
                       <EuiListGroup
-                        color="text"
+                        color="subdued"
                         gutterSize="none"
                         listItems={
                           Array [
@@ -5983,7 +5983,7 @@ exports[`Header handles visibility and lock changes 1`] = `
                           }
                         >
                           <EuiListGroupItem
-                            color="text"
+                            color="subdued"
                             data-test-subj="collapsibleNavCustomNavLink"
                             href=""
                             isActive={false}
@@ -5995,7 +5995,7 @@ exports[`Header handles visibility and lock changes 1`] = `
                             wrapText={false}
                           >
                             <li
-                              className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                              className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
                             >
                               <button
                                 className="euiListGroupItem__button"
@@ -6235,11 +6235,12 @@ exports[`Header handles visibility and lock changes 1`] = `
                 className="euiFlexItem eui-yScroll"
               >
                 <EuiCollapsibleNavGroup
+                  background="light"
                   data-test-subj="collapsibleNavGroup-noCategory"
                   key="0"
                 >
                   <div
-                    className="euiCollapsibleNavGroup"
+                    className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
                     data-test-subj="collapsibleNavGroup-noCategory"
                     id="mockId"
                   >
@@ -6253,7 +6254,7 @@ exports[`Header handles visibility and lock changes 1`] = `
                           className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
                         >
                           <EuiListGroupItem
-                            color="text"
+                            color="subdued"
                             data-test-subj="collapsibleNavAppLink"
                             href=""
                             isActive={false}
@@ -6262,7 +6263,7 @@ exports[`Header handles visibility and lock changes 1`] = `
                             size="s"
                           >
                             <li
-                              className="euiListGroupItem euiListGroupItem--small euiListGroupItem--text euiListGroupItem-isClickable"
+                              className="euiListGroupItem euiListGroupItem--small euiListGroupItem--subdued euiListGroupItem-isClickable"
                             >
                               <button
                                 className="euiListGroupItem__button"
@@ -6293,9 +6294,11 @@ exports[`Header handles visibility and lock changes 1`] = `
                     ]
                   }
                 >
-                  <EuiCollapsibleNavGroup>
+                  <EuiCollapsibleNavGroup
+                    background="light"
+                  >
                     <div
-                      className="euiCollapsibleNavGroup"
+                      className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
                       id="mockId"
                     >
                       <div

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -206,7 +206,7 @@ export function CollapsibleNav({
                   }),
                 ]}
                 maxWidth="none"
-                color="text"
+                color="subdued"
                 gutterSize="none"
                 size="s"
               />
@@ -219,8 +219,8 @@ export function CollapsibleNav({
 
       {/* Recently viewed */}
       <EuiCollapsibleNavGroup
-        key="recentlyViewed"
         background="light"
+        key="recentlyViewed"
         title={i18n.translate('core.ui.recentlyViewed', { defaultMessage: 'Recently viewed' })}
         isCollapsible={true}
         initialIsOpen={getIsCategoryOpen('recentlyViewed', storage)}
@@ -281,6 +281,7 @@ export function CollapsibleNav({
 
           return (
             <EuiCollapsibleNavGroup
+              background="light"
               key={category.id}
               iconType={opensearchLinkLogo}
               title={category.label}
@@ -307,16 +308,20 @@ export function CollapsibleNav({
 
         {/* Things with no category (largely for custom plugins) */}
         {unknowns.map((link, i) => (
-          <EuiCollapsibleNavGroup data-test-subj={`collapsibleNavGroup-noCategory`} key={i}>
+          <EuiCollapsibleNavGroup
+            background="light"
+            data-test-subj={`collapsibleNavGroup-noCategory`}
+            key={i}
+          >
             <EuiListGroup flush>
-              <EuiListGroupItem color="text" size="s" {...readyForEUI(link, true)} />
+              <EuiListGroupItem color="subdued" size="s" {...readyForEUI(link, true)} />
             </EuiListGroup>
           </EuiCollapsibleNavGroup>
         ))}
 
         {/* Docking button only for larger screens that can support it*/}
         <EuiShowFor sizes={['l', 'xl']}>
-          <EuiCollapsibleNavGroup>
+          <EuiCollapsibleNavGroup background="light">
             <EuiListGroup flush>
               <EuiListGroupItem
                 data-test-subj="collapsible-nav-lock"


### PR DESCRIPTION
…ling

### Description

With light background and subdued link text

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

fixes https://github.com/opensearch-project/oui/issues/904

## Screenshot

Current themes, docked and undocked (note no more distinction between custom nav link and recent links and all subsequent sections):
<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
![Screenshot 2023-08-02 at 15-12-01 Dashboards - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/becd7927-cb05-4d0f-980d-b2a2c022cfc9)
![Screenshot 2023-08-02 at 15-12-29 Dashboards - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/80c330a7-f7d6-4c16-bbc8-950d184cf092)
![Screenshot 2023-08-02 at 15-13-24 Dashboards - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/8f9a33d3-b577-4999-b6f9-15ffba46b5b0)
![Screenshot 2023-08-02 at 15-13-05 Dashboards - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/161c4a5e-d829-4c8b-bb2c-85cdcbff1b0d)

next themes, docked and undocked:
![Screenshot 2023-08-02 at 15-14-03 Dashboards - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/6c90269e-e7c4-4189-aac6-97480be6410d)
![Screenshot 2023-08-02 at 15-14-31 Dashboards - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/bd6d72ba-d257-4052-8dca-4c65b22980e2)
![Screenshot 2023-08-02 at 15-15-24 Dashboards - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/78c05d9d-cbb5-497d-9900-97e33537c7b8)
![Screenshot 2023-08-02 at 15-15-09 Dashboards - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/0a4e9b1e-45a7-4770-95de-a53b9bcf31c7)

Additionally I standardized all sections to use subdued text color for the links - this demonstrates how the sidebar would look with both a custom nav link defined ("Manage cloud deployment") and an uncategorized nav link ("Uncategorized action").  Contrast with styling of "Manage cloud deployment" in screenshots above.
![Screenshot 2023-08-02 at 15-25-10 Dashboards - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/270f447a-a190-481b-a0e7-6b60223f6e62)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
