### PR TITLE
Fix --font-text CSS var usage and add more leaflet font overrides

### DIFF
--- a/packages/osd-ui-framework/src/global_styling/variables/_font.scss
+++ b/packages/osd-ui-framework/src/global_styling/variables/_font.scss
@@ -1,6 +1,6 @@
 // Font
 
-$kuiFontFamily: "var(--font-text)";
+$kuiFontFamily: var(--font-text);
 $kuiFontSize: $euiFontSize;
 $kuiLineHeight: $euiLineHeight;
 $kuiSubTextFontSize: $euiFontSizeS;

--- a/src/plugins/maps_legacy/public/map/_custom_button.scss
+++ b/src/plugins/maps_legacy/public/map/_custom_button.scss
@@ -1,0 +1,8 @@
+.mapButton {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome, sans-serif;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/src/plugins/maps_legacy/public/map/_leaflet_overrides.scss
+++ b/src/plugins/maps_legacy/public/map/_leaflet_overrides.scss
@@ -17,6 +17,7 @@ $visMapLeafletSprite: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/s
 
   .leaflet-container {
     background: $euiColorEmptyShade;
+    font-family: var(--font-text);
 
     // the heatmap layer plugin logs an error to the console when the map is in a 0-sized container
     min-width: 1px !important;
@@ -48,6 +49,10 @@ $visMapLeafletSprite: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/s
     }
   }
 
+  .leaflet-draw-actions a {
+    font-family: var(--font-text);
+  }
+
   .leaflet-touch .leaflet-bar a:first-child {
     border-top-left-radius: $euiBorderRadius;
     border-top-right-radius: $euiBorderRadius;
@@ -68,7 +73,7 @@ $visMapLeafletSprite: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/s
 
     @include fontSize(11px);
 
-    font-family: "var(--font-text)";
+    font-family: var(--font-text);
     font-weight: $euiFontWeightMedium;
     line-height: $euiLineHeight;
 

--- a/src/plugins/maps_legacy/public/map/_leaflet_overrides.scss
+++ b/src/plugins/maps_legacy/public/map/_leaflet_overrides.scss
@@ -68,7 +68,7 @@ $visMapLeafletSprite: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/s
 
     @include fontSize(11px);
 
-    font-family: var(--font-text);
+    font-family: "var(--font-text)";
     font-weight: $euiFontWeightMedium;
     line-height: $euiLineHeight;
 

--- a/src/plugins/maps_legacy/public/map/_legend.scss
+++ b/src/plugins/maps_legacy/public/map/_legend.scss
@@ -2,7 +2,7 @@
   @include fontSize(11px);
   @include euiBottomShadowMedium($color: $euiShadowColorLarge, $opacity: 0.1);
 
-  font-family: "var(--font-text)";
+  font-family: var(--font-text);
   font-weight: $euiFontWeightMedium;
   line-height: $euiLineHeight;
   color: $euiColorDarkShade;
@@ -32,13 +32,4 @@
   position: absolute;
   left: $euiSizeXXL;
   white-space: nowrap;
-}
-
-.mapButton {
-  display: inline-block;
-  font: normal normal normal 14px/1 FontAwesome, sans-serif;
-  font-size: inherit;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }

--- a/src/plugins/maps_legacy/public/map/_legend.scss
+++ b/src/plugins/maps_legacy/public/map/_legend.scss
@@ -2,7 +2,7 @@
   @include fontSize(11px);
   @include euiBottomShadowMedium($color: $euiShadowColorLarge, $opacity: 0.1);
 
-  font-family: var(--font-text);
+  font-family: "var(--font-text)";
   font-weight: $euiFontWeightMedium;
   line-height: $euiLineHeight;
   color: $euiColorDarkShade;

--- a/src/plugins/maps_legacy/public/map/index.scss
+++ b/src/plugins/maps_legacy/public/map/index.scss
@@ -1,2 +1,3 @@
+@import "./custom_button";
 @import "./leaflet_overrides";
 @import "./legend";


### PR DESCRIPTION
### Description

Follow-up from https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4658. We realized that there were usages of `--font-text` that included extraneous quotes. In addition to fixing, I added a couple additional overrides so that attribution, legend, and draw button text all use the correct theme font.

I was unable to reproduce any scenario where the `.leaflet-control-layers-expanded` class exists, so didn't verify that usage. Similarly, I searched but found no evidence that any components use a class that inherits the `$kuiFontFamily` SASS var, so I couldn't verify.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

The draw buttons, legend, and attribution label (bottom right) all are using the correct theme font:
<img width="1145" alt="Screen Shot 2023-08-04 at 2 48 31 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/4182590c-631d-4180-bc31-3c01c65fa198">

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
