### PR TITLE
Add saved objects service status api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Optimize `augment-vis` saved obj searching by adding arg to saved obj client ([#4595](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4595))
 - Add resource ID filtering in fetch `augment-vis` obj queries ([#4608](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4608))
 - Reduce the amount of comments in compiled CSS ([#4648](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4648))
+- [Saved Object Service] Customize saved objects service status ([#4696](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4696))
 - [Discover] Update styles to compatible with OUI `next` theme ([#4644](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4644))
 
 ### 🐛 Bug Fixes

--- a/src/core/server/legacy/legacy_service.ts
+++ b/src/core/server/legacy/legacy_service.ts
@@ -276,6 +276,9 @@ export class LegacyService implements CoreService {
         registerType: setupDeps.core.savedObjects.registerType,
         getImportExportObjectLimit: setupDeps.core.savedObjects.getImportExportObjectLimit,
         setRepositoryFactoryProvider: setupDeps.core.savedObjects.setRepositoryFactoryProvider,
+        setStatus: () => {
+          throw new Error(`core.savedObjects.setStatus is unsupported in legacy`);
+        },
       },
       status: {
         isStatusPageAnonymous: setupDeps.core.status.isStatusPageAnonymous,

--- a/src/core/server/plugins/plugin_context.ts
+++ b/src/core/server/plugins/plugin_context.ts
@@ -205,6 +205,7 @@ export function createPluginSetupContext<TPlugin, TPluginDependencies>(
       registerType: deps.savedObjects.registerType,
       getImportExportObjectLimit: deps.savedObjects.getImportExportObjectLimit,
       setRepositoryFactoryProvider: deps.savedObjects.setRepositoryFactoryProvider,
+      setStatus: deps.savedObjects.setStatus,
     },
     status: {
       core$: deps.status.core$,

--- a/src/core/server/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/server/saved_objects/saved_objects_service.mock.ts
@@ -80,6 +80,7 @@ const createSetupContractMock = () => {
     registerType: jest.fn(),
     getImportExportObjectLimit: jest.fn(),
     setRepositoryFactoryProvider: jest.fn(),
+    setStatus: jest.fn(),
   };
 
   setupContract.getImportExportObjectLimit.mockReturnValue(100);


### PR DESCRIPTION
### Description

Provides more flexible interface so that user can customize saved object service status based on their chosen storage option. 

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4655

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
