### PR TITLE
[Decouple] Add new core service to expose functionality to verify plugin compatibility with OpenSearch plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add support for read-only mode through tenants ([#4498](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4498))
 - [Workspace] Add core workspace service module to enable the implementation of workspace features within OSD plugins ([#5092](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5092))
 - [Workspace] Setup workspace skeleton and implement basic CRUD API ([#5075](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5075))
+- [Decouple] Add new cross compatibility check core service which export functionality for plugins to verify if their OpenSearch plugin counterpart is installed on the cluster or has incompatible version to configure the plugin behavior([#4710](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4710))
 
 ### 🐛 Bug Fixes
 

--- a/src/core/public/plugins/plugin.test.ts
+++ b/src/core/public/plugins/plugin.test.ts
@@ -45,7 +45,7 @@ function createManifest(
     requiredPlugins: required,
     optionalPlugins: optional,
     requiredBundles: [],
-    requiredEnginePlugins: { 'plugin-1': 'some-version' },
+    requiredEnginePlugins: {},
   } as DiscoveredPlugin;
 }
 

--- a/src/core/public/plugins/plugin.test.ts
+++ b/src/core/public/plugins/plugin.test.ts
@@ -45,6 +45,7 @@ function createManifest(
     requiredPlugins: required,
     optionalPlugins: optional,
     requiredBundles: [],
+    requiredEnginePlugins: { 'plugin-1': 'some-version' },
   } as DiscoveredPlugin;
 }
 

--- a/src/core/public/plugins/plugins_service.test.ts
+++ b/src/core/public/plugins/plugins_service.test.ts
@@ -85,7 +85,7 @@ function createManifest(
     version: 'some-version',
     configPath: ['path'],
     requiredPlugins: required,
-    requiredEnginePlugins: optional,
+    requiredEnginePlugins: {},
     optionalPlugins: optional,
     requiredBundles: [],
   };

--- a/src/core/server/cross_compatibility/README.md
+++ b/src/core/server/cross_compatibility/README.md
@@ -1,0 +1,78 @@
+## Cross Compatibility Service
+
+The cross compatibility service provides a way for OpenSearch Dashboards plugins to check if they are compatible with the installed OpenSearch plugins. This allows plugins to gracefully degrade their functionality or disable themselves if they are not compatible with the current OpenSearch plugin version.
+
+### Overview
+
+OpenSearch Dashboards plugins depend on specific versions of OpenSearch plugins. When a plugin is installed, OpenSearch Dashboards checks to make sure that the required OpenSearch plugins are installed and compatible. If a required plugin is not installed or is not compatible, OpenSearch Dashboards will log a warning but will still allow the plugin to start.
+
+The cross compatibility service provides a way for plugins to check for compatibility with their OpenSearch counterparts. This allows plugins to make informed decisions about how to behave when they are not compatible. For example, a plugin could disable itself, limit its functionality, or notify the user that they are using an incompatible plugin.
+
+### Usage
+
+To use the Cross Compatibility service, plugins can call the `verifyOpenSearchPluginsState()` API. This API checks the compatibility of the plugin with the installed OpenSearch plugins. The API returns a list of `CrossCompatibilityResult` objects, which contain information about the compatibility of each plugin.
+
+The `CrossCompatibilityResult` object has the following properties:
+
+`pluginName`: The OpenSearch Plugin name.
+`isCompatible`: A boolean indicating whether the plugin is compatible.
+`incompatibilityReason`: The reason the OpenSearch Plugin version is not compatible with the plugin.
+`installedVersions`: The version of the plugin that is installed.
+
+Plugins can use the information in the `CrossCompatibilityResult` object to decide how to behave. For example, a plugin could disable itself if the `isCompatible` property is false.
+
+The `verifyOpenSearchPluginsState()` API should be called from the `start()` lifecycle method. This allows plugins to check for compatibility before they start.
+
+### Example usage inside DashboardsSample Plugin
+
+```
+export class DashboardsSamplePlugin implements Plugin<DashboardsSamplePluginSetup, DashboardsSamplePluginStart> {
+
+    public setup(core: CoreSetup) {
+        this.logger.debug('Dashboard sample plugin setup');
+        this.capabilitiesService = core.capabilities;
+        return {};
+    }
+    public start(core: CoreStart) {
+        this.logger.debug('Dashboard sample plugin: Started');
+        exampleCompatibilityCheck(core);
+        return {};
+    }
+    ......
+
+    // Example capability provider
+    export const capabilitiesProvider = () => ({
+        exampleDashboardsPlugin: {
+            show: true,
+            createShortUrl: true,
+        },
+    });
+
+    function exampleCompatibilityCheck(core: CoreStart) {
+        const pluginName = 'exampleDashboardsPlugin';
+        const result = await core.versionCompatibility.verifyOpenSearchPluginsState(pluginName);
+        result.forEach((mustHavePlugin) => {
+            if (!mustHavePlugin.isCompatible) {
+                // use capabilities provider API to register plugin's capability to enable/disbale plugin
+                this.capabilitiesService.registerProvider(capabilitiesProvider);
+              }
+            else { // feature to enable when plugin has compatible version installed }
+        });
+        ......
+    }
+    .....
+}
+
+```
+The `exampleCompatibilityCheck()` function uses the `verifyOpenSearchPluginsState()` API to check for compatibility with the `DashboardsSample` plugin. If the plugin is compatible, the function enables the plugin's features. If the plugin is not compatible, the function gracefully degrades the plugin's functionality.
+
+### Use cases:
+
+The cross compatibility service can be used by plugins to:
+
+* Disable themselves if they are not compatible with the installed OpenSearch plugins.
+* Limit their functionality if they are not fully compatible with the installed OpenSearch plugins.
+* Notify users if they are using incompatible plugins.
+* Provide information to users about how to upgrade their plugins.
+
+The cross compatibility service is a valuable tool for developers who are building plugins for OpenSearch Dashboards. It allows plugins to be more resilient to changes in the OpenSearch ecosystem.

--- a/src/core/server/cross_compatibility/cross_compatibility.mock.ts
+++ b/src/core/server/cross_compatibility/cross_compatibility.mock.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CrossCompatibilityServiceStart } from './types';
+
+const createStartContractMock = () => {
+  const startContract: jest.Mocked<CrossCompatibilityServiceStart> = {
+    verifyOpenSearchPluginsState: jest.fn().mockReturnValue(Promise.resolve({})),
+  };
+  return startContract;
+};
+
+export const crossCompatibilityServiceMock = {
+  createStartContract: createStartContractMock,
+};

--- a/src/core/server/cross_compatibility/cross_compatibility_service.test.ts
+++ b/src/core/server/cross_compatibility/cross_compatibility_service.test.ts
@@ -26,7 +26,7 @@ describe('CrossCompatibilityService', () => {
     } as any);
 
     plugins?.set('foo', { 'os-plugin': '1.0.0 - 2.0.0' });
-    plugins?.set('bar', { 'os-plugin': '^3.0.0' });
+    plugins?.set('incompatiblePlugin', { 'os-plugin': '^3.0.0' });
     plugins?.set('test', {});
     service = new CrossCompatibilityService(mockCoreContext.create());
   });
@@ -48,8 +48,8 @@ describe('CrossCompatibilityService', () => {
     expect(results.length).toEqual(1);
     expect(results[0].pluginName).toEqual('os-plugin');
     expect(results[0].isCompatible).toEqual(true);
-    expect(results[0].incompatibleReason).toEqual('');
-    expect(results[0].installedVersions).toEqual(new Set(['1.1.0.0']));
+    expect(results[0].incompatibilityReason).toEqual('');
+    expect(results[0].installedVersions).toEqual(['1.1.0.0']);
     expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
   });
 
@@ -64,7 +64,7 @@ describe('CrossCompatibilityService', () => {
   });
 
   it('should return an array of CrossCompatibilityResult objects with the incompatible reason if the plugin is not installed', async () => {
-    const pluginName = 'bar';
+    const pluginName = 'incompatiblePlugin';
     const startDeps = { opensearch, plugins };
     const startResult = await service.start(startDeps);
     const results = await startResult.verifyOpenSearchPluginsState(pluginName);
@@ -72,10 +72,10 @@ describe('CrossCompatibilityService', () => {
     expect(results.length).toEqual(1);
     expect(results[0].pluginName).toEqual('os-plugin');
     expect(results[0].isCompatible).toEqual(false);
-    expect(results[0].incompatibleReason).toEqual(
+    expect(results[0].incompatibilityReason).toEqual(
       'OpenSearch plugin "os-plugin" in the version range "^3.0.0" is not installed on the OpenSearch for the OpenSearch Dashboards plugin to function as expected.'
     );
-    expect(results[0].installedVersions).toEqual(new Set(['1.1.0.0']));
+    expect(results[0].installedVersions).toEqual(['1.1.0.0']);
     expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/core/server/cross_compatibility/cross_compatibility_service.test.ts
+++ b/src/core/server/cross_compatibility/cross_compatibility_service.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CrossCompatibilityService } from './cross_compatibility_service';
+import { CompatibleEnginePluginVersions } from '../plugins/types';
+import { mockCoreContext } from '../core_context.mock';
+import { opensearchServiceMock } from '../opensearch/opensearch_service.mock';
+
+describe('CrossCompatibilityService', () => {
+  let service: CrossCompatibilityService;
+  let opensearch: any;
+  const plugins = new Map<string, CompatibleEnginePluginVersions>();
+
+  beforeEach(() => {
+    opensearch = opensearchServiceMock.createStart();
+    opensearch.client.asInternalUser.cat.plugins.mockResolvedValue({
+      body: [
+        {
+          name: 'node1',
+          component: 'os-plugin',
+          version: '1.1.0.0',
+        },
+      ],
+    } as any);
+
+    plugins?.set('foo', { 'os-plugin': '1.0.0 - 2.0.0' });
+    plugins?.set('bar', { 'os-plugin': '^3.0.0' });
+    plugins?.set('test', {});
+    service = new CrossCompatibilityService(mockCoreContext.create());
+  });
+
+  it('should start the cross compatibility service', async () => {
+    const startDeps = { opensearch, plugins };
+    const startResult = await service.start(startDeps);
+    expect(startResult).toEqual({
+      verifyOpenSearchPluginsState: expect.any(Function),
+    });
+  });
+
+  it('should return an array of CrossCompatibilityResult objects if plugin dependencies are specified', async () => {
+    const pluginName = 'foo';
+    const startDeps = { opensearch, plugins };
+    const startResult = await service.start(startDeps);
+    const results = await startResult.verifyOpenSearchPluginsState(pluginName);
+    expect(results).not.toBeUndefined();
+    expect(results.length).toEqual(1);
+    expect(results[0].pluginName).toEqual('os-plugin');
+    expect(results[0].isCompatible).toEqual(true);
+    expect(results[0].incompatibleReason).toEqual('');
+    expect(results[0].installedVersions).toEqual(new Set(['1.1.0.0']));
+    expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return an empty array if no plugin dependencies are specified', async () => {
+    const pluginName = 'test';
+    const startDeps = { opensearch, plugins };
+    const startResult = await service.start(startDeps);
+    const results = await startResult.verifyOpenSearchPluginsState(pluginName);
+    expect(results).not.toBeUndefined();
+    expect(results.length).toEqual(0);
+    expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return an array of CrossCompatibilityResult objects with the incompatible reason if the plugin is not installed', async () => {
+    const pluginName = 'bar';
+    const startDeps = { opensearch, plugins };
+    const startResult = await service.start(startDeps);
+    const results = await startResult.verifyOpenSearchPluginsState(pluginName);
+    expect(results).not.toBeUndefined();
+    expect(results.length).toEqual(1);
+    expect(results[0].pluginName).toEqual('os-plugin');
+    expect(results[0].isCompatible).toEqual(false);
+    expect(results[0].incompatibleReason).toEqual(
+      'OpenSearch plugin "os-plugin" in the version range "^3.0.0" is not installed on the OpenSearch for the OpenSearch Dashboards plugin to function as expected.'
+    );
+    expect(results[0].installedVersions).toEqual(new Set(['1.1.0.0']));
+    expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/server/cross_compatibility/cross_compatibility_service.ts
+++ b/src/core/server/cross_compatibility/cross_compatibility_service.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CatPluginsResponse } from '@opensearch-project/opensearch/api/types';
+import semver from 'semver';
+import { CrossCompatibilityResult, CrossCompatibilityServiceStart } from './types';
+import { CoreContext } from '../core_context';
+import { Logger } from '../logging';
+import { OpenSearchServiceStart } from '../opensearch';
+import { CompatibleEnginePluginVersions, PluginName } from '../plugins/types';
+
+export interface StartDeps {
+  opensearch: OpenSearchServiceStart;
+  plugins: Map<PluginName, CompatibleEnginePluginVersions>;
+}
+
+export class CrossCompatibilityService {
+  private readonly log: Logger;
+
+  constructor(coreContext: CoreContext) {
+    this.log = coreContext.logger.get('version-compatibility-service');
+  }
+
+  start({ opensearch, plugins }: StartDeps): CrossCompatibilityServiceStart {
+    this.log.warn('Starting version compatibility service');
+    return {
+      verifyOpenSearchPluginsState: (pluginName: string) => {
+        const pluginOpenSearchDeps = plugins.get(pluginName) || {};
+        return this.verifyOpenSearchPluginsState(opensearch, pluginOpenSearchDeps);
+      },
+    };
+  }
+
+  public async getOpenSearchPlugins(opensearch: OpenSearchServiceStart) {
+    // Makes cat.plugin api call to fetch list of OpenSearch plugins installed on the cluster
+    try {
+      const { body } = await opensearch.client.asInternalUser.cat.plugins<any[]>({
+        format: 'JSON',
+      });
+      return body;
+    } catch (error) {
+      this.log.warn(
+        `Cat API call to OpenSearch to get list of plugins installed on the cluster has failed: ${error}`
+      );
+      return [];
+    }
+  }
+
+  public async checkPluginVersionCompatibility(
+    pluginOpenSearchDeps: CompatibleEnginePluginVersions,
+    opensearchInstalledPlugins: CatPluginsResponse
+  ) {
+    const results: CrossCompatibilityResult[] = [];
+    for (const [pluginName, versionRange] of Object.entries(pluginOpenSearchDeps)) {
+      // add check to see if the Dashboards plugin version is compatible with installed OpenSearch plugin
+      const {
+        isCompatible,
+        installedPluginVersions,
+      } = await this.isVersionCompatibleOSPluginInstalled(
+        opensearchInstalledPlugins,
+        pluginName,
+        versionRange
+      );
+      results.push({
+        pluginName,
+        isCompatible: !isCompatible ? false : true,
+        incompatibleReason: !isCompatible
+          ? `OpenSearch plugin "${pluginName}" in the version range "${versionRange}" is not installed on the OpenSearch for the OpenSearch Dashboards plugin to function as expected.`
+          : '',
+        installedVersions: installedPluginVersions,
+      });
+
+      if (!isCompatible) {
+        this.log.warn(
+          `OpenSearch plugin "${pluginName}" is not installed on the cluster for the OpenSearch Dashboards plugin to function as expected.`
+        );
+      }
+    }
+    return results;
+  }
+
+  private async verifyOpenSearchPluginsState(
+    opensearch: OpenSearchServiceStart,
+    pluginOpenSearchDeps: CompatibleEnginePluginVersions
+  ): Promise<CrossCompatibilityResult[]> {
+    this.log.warn('Checking OpenSearch Plugin version compatibility');
+    // make _cat/plugins?format=json call to the OpenSearch instance
+    const opensearchInstalledPlugins = await this.getOpenSearchPlugins(opensearch);
+    const results = await this.checkPluginVersionCompatibility(
+      pluginOpenSearchDeps,
+      opensearchInstalledPlugins
+    );
+    return results;
+  }
+
+  private async isVersionCompatibleOSPluginInstalled(
+    opensearchInstalledPlugins: CatPluginsResponse,
+    depPluginName: string,
+    depPluginVersionRange: string
+  ) {
+    let isCompatible = false;
+    const installedPluginVersions = new Set<string>();
+    opensearchInstalledPlugins.forEach((obj) => {
+      if (obj.component === depPluginName && obj.version) {
+        installedPluginVersions.add(obj.version);
+        if (semver.satisfies(semver.coerce(obj.version)!.version, depPluginVersionRange)) {
+          isCompatible = true;
+        }
+      }
+    });
+    return { isCompatible, installedPluginVersions };
+  }
+}

--- a/src/core/server/cross_compatibility/index.ts
+++ b/src/core/server/cross_compatibility/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { CrossCompatibilityService } from './cross_compatibility_service';
+export { CrossCompatibilityResult, CrossCompatibilityServiceStart } from './types';

--- a/src/core/server/cross_compatibility/types.ts
+++ b/src/core/server/cross_compatibility/types.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CrossCompatibilityResult } from '../../types/cross_compatibility';
+
+/**
+ * API to check if the OpenSearch Dashboards plugin version is compatible with the installed OpenSearch plugin.
+ *
+ * @public
+ */
+export interface CrossCompatibilityServiceStart {
+  /**
+   * Checks if the OpenSearch Dashboards plugin version is compatible with the installed OpenSearch plugin.
+   *
+   * @returns {Promise<CrossCompatibilityResult[]>}
+   */
+  verifyOpenSearchPluginsState: (pluginName: string) => Promise<CrossCompatibilityResult[]>;
+}
+
+export { CrossCompatibilityResult };

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -77,6 +77,7 @@ import { Auditor, AuditTrailSetup, AuditTrailStart } from './audit_trail';
 import { AppenderConfigType, appendersSchema, LoggingServiceSetup } from './logging';
 import { CoreUsageDataStart } from './core_usage_data';
 import { SecurityServiceSetup } from './security/types';
+import { CrossCompatibilityServiceStart } from './cross_compatibility/types';
 
 // Because of #79265 we need to explicity import, then export these types for
 // scripts/telemetry_check.js to work as expected
@@ -485,6 +486,8 @@ export interface CoreStart {
   auditTrail: AuditTrailStart;
   /** @internal {@link CoreUsageDataStart} */
   coreUsageData: CoreUsageDataStart;
+  /** {@link CrossCompatibilityServiceStart} */
+  crossCompatibility: CrossCompatibilityServiceStart;
 }
 
 export {
@@ -496,6 +499,7 @@ export {
   PluginsServiceStart,
   PluginOpaqueId,
   AuditTrailStart,
+  CrossCompatibilityServiceStart,
 };
 
 /**

--- a/src/core/server/internal_types.ts
+++ b/src/core/server/internal_types.ts
@@ -49,6 +49,7 @@ import { AuditTrailSetup, AuditTrailStart } from './audit_trail';
 import { InternalLoggingServiceSetup } from './logging';
 import { CoreUsageDataStart } from './core_usage_data';
 import { InternalSecurityServiceSetup } from './security/types';
+import { CrossCompatibilityServiceStart } from './cross_compatibility';
 
 /** @internal */
 export interface InternalCoreSetup {
@@ -80,6 +81,7 @@ export interface InternalCoreStart {
   uiSettings: InternalUiSettingsServiceStart;
   auditTrail: AuditTrailStart;
   coreUsageData: CoreUsageDataStart;
+  crossCompatibility: CrossCompatibilityServiceStart;
 }
 
 /**

--- a/src/core/server/legacy/legacy_service.ts
+++ b/src/core/server/legacy/legacy_service.ts
@@ -233,6 +233,7 @@ export class LegacyService implements CoreService {
           throw new Error('core.start.coreUsageData.getCoreUsageData is unsupported in legacy');
         },
       },
+      crossCompatibility: startDeps.core.crossCompatibility,
     };
 
     const router = setupDeps.core.http.createRouter('', this.legacyId);

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -51,6 +51,7 @@ import { statusServiceMock } from './status/status_service.mock';
 import { auditTrailServiceMock } from './audit_trail/audit_trail_service.mock';
 import { coreUsageDataServiceMock } from './core_usage_data/core_usage_data_service.mock';
 import { securityServiceMock } from './security/security_service.mock';
+import { crossCompatibilityServiceMock } from './cross_compatibility/cross_compatibility.mock';
 
 export { configServiceMock } from './config/mocks';
 export { httpServerMock } from './http/http_server.mocks';
@@ -70,6 +71,7 @@ export { statusServiceMock } from './status/status_service.mock';
 export { contextServiceMock } from './context/context_service.mock';
 export { capabilitiesServiceMock } from './capabilities/capabilities_service.mock';
 export { coreUsageDataServiceMock } from './core_usage_data/core_usage_data_service.mock';
+export { crossCompatibilityServiceMock } from './cross_compatibility/cross_compatibility.mock';
 
 export function pluginInitializerContextConfigMock<T>(config: T) {
   const globalConfig: SharedGlobalConfig = {
@@ -174,6 +176,7 @@ function createCoreStartMock() {
     savedObjects: savedObjectsServiceMock.createStartContract(),
     uiSettings: uiSettingsServiceMock.createStartContract(),
     coreUsageData: coreUsageDataServiceMock.createStartContract(),
+    crossCompatibility: crossCompatibilityServiceMock.createStartContract(),
   };
 
   return mock;
@@ -209,6 +212,7 @@ function createInternalCoreStartMock() {
     uiSettings: uiSettingsServiceMock.createStartContract(),
     auditTrail: auditTrailServiceMock.createStartContract(),
     coreUsageData: coreUsageDataServiceMock.createStartContract(),
+    crossCompatibility: crossCompatibilityServiceMock.createStartContract(),
   };
   return startDeps;
 }

--- a/src/core/server/plugins/plugin_context.ts
+++ b/src/core/server/plugins/plugin_context.ts
@@ -271,5 +271,6 @@ export function createPluginStartContext<TPlugin, TPluginDependencies>(
     },
     auditTrail: deps.auditTrail,
     coreUsageData: deps.coreUsageData,
+    crossCompatibility: deps.crossCompatibility,
   };
 }

--- a/src/core/server/plugins/plugins_service.test.ts
+++ b/src/core/server/plugins/plugins_service.test.ts
@@ -491,6 +491,7 @@ describe('PluginsService', () => {
         requiredPlugins: [],
         requiredBundles: [],
         optionalPlugins: [],
+        requiredEnginePlugins: {},
       },
     ];
 

--- a/src/core/server/plugins/plugins_service.ts
+++ b/src/core/server/plugins/plugins_service.ts
@@ -38,7 +38,13 @@ import { CoreContext } from '../core_context';
 import { Logger } from '../logging';
 import { discover, PluginDiscoveryError, PluginDiscoveryErrorType } from './discovery';
 import { PluginWrapper } from './plugin';
-import { DiscoveredPlugin, PluginConfigDescriptor, PluginName, InternalPluginInfo } from './types';
+import {
+  DiscoveredPlugin,
+  PluginConfigDescriptor,
+  PluginName,
+  InternalPluginInfo,
+  CompatibleEnginePluginVersions,
+} from './types';
 import { PluginsConfig, PluginsConfigType } from './plugins_config';
 import { PluginsSystem } from './plugins_system';
 import { InternalCoreSetup, InternalCoreStart } from '../internal_types';
@@ -97,6 +103,7 @@ export class PluginsService implements CoreService<PluginsServiceSetup, PluginsS
   private readonly config$: Observable<PluginsConfig>;
   private readonly pluginConfigDescriptors = new Map<PluginName, PluginConfigDescriptor>();
   private readonly uiPluginInternalInfo = new Map<PluginName, InternalPluginInfo>();
+  private readonly openSearchPluginInfo = new Map<PluginName, CompatibleEnginePluginVersions>();
 
   constructor(private readonly coreContext: CoreContext) {
     this.log = coreContext.logger.get('plugins-service');
@@ -128,6 +135,7 @@ export class PluginsService implements CoreService<PluginsServiceSetup, PluginsS
         public: uiPlugins,
         browserConfigs: this.generateUiPluginsConfigs(uiPlugins),
       },
+      requiredEnginePlugins: this.openSearchPluginInfo,
     };
   }
 
@@ -252,6 +260,8 @@ export class PluginsService implements CoreService<PluginsServiceSetup, PluginsS
               publicAssetsDir: Path.resolve(plugin.path, 'public/assets'),
             });
           }
+
+          this.openSearchPluginInfo.set(plugin.name, plugin.requiredEnginePlugins);
 
           pluginEnableStatuses.set(plugin.name, { plugin, isEnabled });
         })

--- a/src/core/server/plugins/plugins_system.test.ts
+++ b/src/core/server/plugins/plugins_system.test.ts
@@ -552,7 +552,7 @@ describe('start', () => {
     expect(log.info).toHaveBeenCalledWith(`Starting [2] plugins: [order-1,order-0]`);
   });
 
-  it('validates opensearch plugin installation when dependency is fulfilled', async () => {
+  it('validates plugin start when opensearch dependency is fulfilled', async () => {
     [
       createPlugin('dependency-fulfilled-plugin', {
         requiredOSPlugin: {
@@ -569,12 +569,9 @@ describe('start', () => {
     await pluginsSystem.setupPlugins(setupDeps);
     const pluginsStart = await pluginsSystem.startPlugins(startDeps);
     expect(pluginsStart).toBeInstanceOf(Map);
-    expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
-    const log = logger.get.mock.results[0].value as jest.Mocked<Logger>;
-    expect(log.warn).toHaveBeenCalledTimes(0);
   });
 
-  it('validates opensearch plugin installation and does not error out when plugin is not installed', async () => {
+  it('validates plugin start when opensearch plugin dependency is not installed', async () => {
     [
       createPlugin('dependency-missing-plugin', {
         requiredOSPlugin: {
@@ -591,52 +588,5 @@ describe('start', () => {
     await pluginsSystem.setupPlugins(setupDeps);
     const pluginsStart = await pluginsSystem.startPlugins(startDeps);
     expect(pluginsStart).toBeInstanceOf(Map);
-    expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
-    const log = logger.get.mock.results[0].value as jest.Mocked<Logger>;
-    expect(log.warn).toHaveBeenCalledTimes(1);
-    expect(log.warn).toHaveBeenCalledWith(
-      `OpenSearch plugin "missing-opensearch-dep" is not installed on the engine for the OpenSearch Dashboards plugin to function as expected.`
-    );
-  });
-
-  it('validates opensearch plugin installation and log warning when plugin exist but version is incompatible', async () => {
-    [
-      createPlugin('version-mismatch-plugin', {
-        requiredOSPlugin: {
-          'test-plugin-version-mismatch': '^1.0.0',
-        },
-      }),
-      createPlugin('no-dependency-plugin'),
-    ].forEach((plugin, index) => {
-      jest.spyOn(plugin, 'setup').mockResolvedValue(`setup-as-${index}`);
-      jest.spyOn(plugin, 'start').mockResolvedValue(`started-as-${index}`);
-      pluginsSystem.addPlugin(plugin);
-    });
-
-    await pluginsSystem.setupPlugins(setupDeps);
-    const pluginsStart = await pluginsSystem.startPlugins(startDeps);
-    expect(pluginsStart).toBeInstanceOf(Map);
-    expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
-    const log = logger.get.mock.results[0].value as jest.Mocked<Logger>;
-    expect(log.warn).toHaveBeenCalledTimes(1);
-    expect(log.warn).toHaveBeenCalledWith(
-      `OpenSearch plugin "test-plugin-version-mismatch" is not installed on the engine for the OpenSearch Dashboards plugin to function as expected.`
-    );
-  });
-
-  it('validates opensearch plugin installation and does not warn when there is no dependency', async () => {
-    [createPlugin('no-dependency-plugin-1'), createPlugin('no-dependency-plugin-2')].forEach(
-      (plugin, index) => {
-        jest.spyOn(plugin, 'setup').mockResolvedValue(`setup-as-${index}`);
-        jest.spyOn(plugin, 'start').mockResolvedValue(`started-as-${index}`);
-        pluginsSystem.addPlugin(plugin);
-      }
-    );
-    await pluginsSystem.setupPlugins(setupDeps);
-    const pluginsStart = await pluginsSystem.startPlugins(startDeps);
-    expect(pluginsStart).toBeInstanceOf(Map);
-    expect(opensearch.client.asInternalUser.cat.plugins).toHaveBeenCalledTimes(1);
-    const log = logger.get.mock.results[0].value as jest.Mocked<Logger>;
-    expect(log.warn).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/core/server/plugins/plugins_system.ts
+++ b/src/core/server/plugins/plugins_system.ts
@@ -29,26 +29,27 @@
  */
 
 import { withTimeout } from '@osd/std';
-import semver from 'semver';
-import { CatPluginsResponse } from '@opensearch-project/opensearch/api/types';
 import { CoreContext } from '../core_context';
 import { Logger } from '../logging';
 import { PluginWrapper } from './plugin';
-import { DiscoveredPlugin, PluginName, CompatibleOpenSearchPluginVersions } from './types';
+import { DiscoveredPlugin, PluginName } from './types';
 import { createPluginSetupContext, createPluginStartContext } from './plugin_context';
 import { PluginsServiceSetupDeps, PluginsServiceStartDeps } from './plugins_service';
 import { PluginDependencies } from '.';
+import { CrossCompatibilityService } from '../cross_compatibility';
 
 const Sec = 1000;
 /** @internal */
 export class PluginsSystem {
   private readonly plugins = new Map<PluginName, PluginWrapper>();
   private readonly log: Logger;
+  private readonly crossCompatibilityService: CrossCompatibilityService;
   // `satup`, the past-tense version of the noun `setup`.
   private readonly satupPlugins: PluginName[] = [];
 
   constructor(private readonly coreContext: CoreContext) {
     this.log = coreContext.logger.get('plugins-system');
+    this.crossCompatibilityService = new CrossCompatibilityService(coreContext);
   }
 
   public addPlugin(plugin: PluginWrapper) {
@@ -167,54 +168,18 @@ export class PluginsSystem {
     return contracts;
   }
 
-  private async healthCheckOpenSearchPlugins(deps: PluginsServiceStartDeps) {
+  public async healthCheckOpenSearchPlugins(deps: PluginsServiceStartDeps) {
     // make _cat/plugins?format=json call to the OpenSearch instance
-    const opensearchInstalledPlugins = await this.getOpenSearchPlugins(deps);
+    const opensearchInstalledPlugins = await this.crossCompatibilityService.getOpenSearchPlugins(
+      deps.opensearch
+    );
     for (const pluginName of this.satupPlugins) {
       this.log.debug(`For plugin "${pluginName}"...`);
       const plugin = this.plugins.get(pluginName)!;
-      const pluginOpenSearchDeps = Object.entries(plugin.requiredEnginePlugins);
-      for (const [enginePluginName, versionRange] of pluginOpenSearchDeps) {
-        // add check to see if the installing Dashboards plugin version is compatible with installed OpenSearch plugin
-        if (
-          !this.isVersionCompatibleOSPluginInstalled(
-            opensearchInstalledPlugins,
-            enginePluginName,
-            versionRange
-          )
-        ) {
-          this.log.warn(
-            `OpenSearch plugin "${enginePluginName}" is not installed on the engine for the OpenSearch Dashboards plugin to function as expected.`
-          );
-        }
-      }
-    }
-  }
-
-  private isVersionCompatibleOSPluginInstalled(
-    opensearchInstalledPlugins: CatPluginsResponse,
-    depPlugin: string,
-    versionRange: string
-  ) {
-    return opensearchInstalledPlugins.find(
-      (obj) =>
-        obj.component === depPlugin &&
-        semver.satisfies(semver.coerce(obj.version)!.version, versionRange)
-    );
-  }
-
-  private async getOpenSearchPlugins(deps: PluginsServiceStartDeps) {
-    // Makes cat.plugin api call to fetch list of OpenSearch plugins installed on the cluster
-    try {
-      const { body } = await deps.opensearch.client.asInternalUser.cat.plugins<any[]>({
-        format: 'JSON',
-      });
-      return body;
-    } catch (error) {
-      this.log.warn(
-        `Cat API call to OpenSearch to get list of plugins installed on the cluster has failed: ${error}`
+      await this.crossCompatibilityService.checkPluginVersionCompatibility(
+        plugin.requiredEnginePlugins,
+        opensearchInstalledPlugins
       );
-      return [];
     }
   }
 
@@ -256,6 +221,7 @@ export class PluginsSystem {
               uiPluginNames.includes(p)
             ),
             requiredBundles: plugin.manifest.requiredBundles,
+            requiredEnginePlugins: plugin.manifest.requiredEnginePlugins,
           },
         ];
       })

--- a/src/core/server/plugins/plugins_system.ts
+++ b/src/core/server/plugins/plugins_system.ts
@@ -34,7 +34,7 @@ import { CatPluginsResponse } from '@opensearch-project/opensearch/api/types';
 import { CoreContext } from '../core_context';
 import { Logger } from '../logging';
 import { PluginWrapper } from './plugin';
-import { DiscoveredPlugin, PluginName } from './types';
+import { DiscoveredPlugin, PluginName, CompatibleOpenSearchPluginVersions } from './types';
 import { createPluginSetupContext, createPluginStartContext } from './plugin_context';
 import { PluginsServiceSetupDeps, PluginsServiceStartDeps } from './plugins_service';
 import { PluginDependencies } from '.';

--- a/src/core/server/plugins/plugins_system.ts
+++ b/src/core/server/plugins/plugins_system.ts
@@ -176,9 +176,10 @@ export class PluginsSystem {
     for (const pluginName of this.satupPlugins) {
       this.log.debug(`For plugin "${pluginName}"...`);
       const plugin = this.plugins.get(pluginName)!;
-      await this.crossCompatibilityService.checkPluginVersionCompatibility(
+      this.crossCompatibilityService.checkPluginVersionCompatibility(
         plugin.requiredEnginePlugins,
-        opensearchInstalledPlugins
+        opensearchInstalledPlugins,
+        pluginName
       );
     }
   }

--- a/src/core/server/plugins/types.ts
+++ b/src/core/server/plugins/types.ts
@@ -114,6 +114,33 @@ export interface PluginDependencies {
   asOpaqueIds: ReadonlyMap<PluginOpaqueId, PluginOpaqueId[]>;
 }
 
+// An interface defining OpenSearch plugin component name and semver compatible version range of
+// OpenSearch plugin to the plugin manifest.
+// This is used to check the compatibility of the plugin.
+// The plugin manifest is defined in the plugin's opensearch_dashboards.json file.
+//
+// @example
+//
+// "opensearch-dashboards-plugin-sample": {
+//   "opensearchDashboardsVersion": "2.0.0",
+//   "requiredPlugins": [
+//     "opensearch-dashboards-sample-data"
+//   ],
+//   "requiredOpenSearchPlugins": [
+//     {
+//       "id": "opensearch-dashboards-sample-data",
+//       "versionRange": "^2.0.0"
+//     }
+//   ],
+//   "requiredBundles": [
+//     "opensearch-dashboards-sample-data"
+//   ]
+// }
+export interface CompatibleOpenSearchPluginVersions {
+  id: PluginName;
+  versionRange: string;
+}
+
 /**
  * Describes the set of required and optional properties plugin can define in its
  * mandatory JSON manifest file.

--- a/src/core/server/plugins/types.ts
+++ b/src/core/server/plugins/types.ts
@@ -114,33 +114,6 @@ export interface PluginDependencies {
   asOpaqueIds: ReadonlyMap<PluginOpaqueId, PluginOpaqueId[]>;
 }
 
-// An interface defining OpenSearch plugin component name and semver compatible version range of
-// OpenSearch plugin to the plugin manifest.
-// This is used to check the compatibility of the plugin.
-// The plugin manifest is defined in the plugin's opensearch_dashboards.json file.
-//
-// @example
-//
-// "opensearch-dashboards-plugin-sample": {
-//   "opensearchDashboardsVersion": "2.0.0",
-//   "requiredPlugins": [
-//     "opensearch-dashboards-sample-data"
-//   ],
-//   "requiredOpenSearchPlugins": [
-//     {
-//       "id": "opensearch-dashboards-sample-data",
-//       "versionRange": "^2.0.0"
-//     }
-//   ],
-//   "requiredBundles": [
-//     "opensearch-dashboards-sample-data"
-//   ]
-// }
-export interface CompatibleOpenSearchPluginVersions {
-  id: PluginName;
-  versionRange: string;
-}
-
 /**
  * Describes the set of required and optional properties plugin can define in its
  * mandatory JSON manifest file.
@@ -257,6 +230,12 @@ export interface DiscoveredPlugin {
    * not required for this plugin to work properly.
    */
   readonly optionalPlugins: readonly PluginName[];
+
+  /**
+   * An optional list of the OpenSearch plugins that **must be** installed on the cluster
+   * for this plugin to function properly.
+   */
+  readonly requiredEnginePlugins: CompatibleEnginePluginVersions;
 
   /**
    * List of plugin ids that this plugin's UI code imports modules from that are

--- a/src/core/server/server.test.ts
+++ b/src/core/server/server.test.ts
@@ -62,6 +62,7 @@ beforeEach(() => {
   mockPluginsService.discover.mockResolvedValue({
     pluginTree: { asOpaqueIds: new Map(), asNames: new Map() },
     uiPlugins: { internal: new Map(), public: new Map(), browserConfigs: new Map() },
+    requiredEnginePlugins: new Map(),
   });
 });
 
@@ -111,6 +112,7 @@ test('injects legacy dependency to context#setup()', async () => {
   mockPluginsService.discover.mockResolvedValue({
     pluginTree: { asOpaqueIds: pluginDependencies, asNames: new Map() },
     uiPlugins: { internal: new Map(), public: new Map(), browserConfigs: new Map() },
+    requiredEnginePlugins: new Map(),
   });
 
   await server.setup();

--- a/src/core/types/cross_compatibility.ts
+++ b/src/core/types/cross_compatibility.ts
@@ -15,11 +15,11 @@ export interface CrossCompatibilityResult {
    * The reason the OpenSearch Plugin version is not compatible with the plugin.
    * This will be `undefined` if the OpenSearch Plugin version is compatible.
    */
-  incompatibleReason?: string;
+  incompatibilityReason?: string;
 
   /**
-   * The set of versions of dependency OpenSearch Plugin if any present on the cluster.
-   * This will be empty set if the OpenSearch Plugin is not present.
+   * The array of versions of dependency OpenSearch Plugin if any present on the cluster.
+   * This will be empty if the OpenSearch Plugin is not present.
    */
-  installedVersions: Set<string>;
+  installedVersions: string[];
 }

--- a/src/core/types/cross_compatibility.ts
+++ b/src/core/types/cross_compatibility.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @public */
+export interface CrossCompatibilityResult {
+  /** The OpenSearch Plugin name. */
+  pluginName: string;
+
+  /** Whether the current OpenSearch Plugin version is compatible with the dashboards plugin. */
+  isCompatible: boolean;
+
+  /**
+   * The reason the OpenSearch Plugin version is not compatible with the plugin.
+   * This will be `undefined` if the OpenSearch Plugin version is compatible.
+   */
+  incompatibleReason?: string;
+
+  /**
+   * The set of versions of dependency OpenSearch Plugin if any present on the cluster.
+   * This will be empty set if the OpenSearch Plugin is not present.
+   */
+  installedVersions: Set<string>;
+}

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -40,3 +40,4 @@ export * from './saved_objects';
 export * from './serializable';
 export * from './custom_branding';
 export * from './workspace';
+export * from './cross_compatibility';


### PR DESCRIPTION
### Description

* Adds new core server service `cross_compatibility_service` which export feature that plugins can extend to decide what they want to do if their OpenSearch plugin counterpart is not installed or has incompatible version. 

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4903
https://github.com/orgs/opensearch-project/projects/63/views/27?pane=issue&itemId=34093291

### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
