### PR TITLE
Feature/data explorer surroundings

### DIFF
--- a/src/plugins/data_explorer/public/services/view_service/types.ts
+++ b/src/plugins/data_explorer/public/services/view_service/types.ts
@@ -19,7 +19,7 @@ export interface ViewDefinition<T = any> {
   readonly title: string;
   readonly ui?: {
     defaults: T | (() => T) | (() => Promise<T>);
-    slice: Slice<T>;
+    slices: Slice[];
   };
   readonly Canvas: LazyExoticComponent<(props: ViewProps) => React.ReactElement>;
   readonly Panel: LazyExoticComponent<(props: ViewProps) => React.ReactElement>;

--- a/src/plugins/data_explorer/public/utils/state_management/preload.ts
+++ b/src/plugins/data_explorer/public/utils/state_management/preload.ts
@@ -26,7 +26,21 @@ export const getPreloadedState = async (
 
     // defaults can be a function or an object
     if (typeof defaults === 'function') {
-      rootState[view.id] = await defaults();
+      const defaultResult = await defaults();
+
+      // Check if the result contains the view's ID key.
+      // This is used to distinguish between a single registered state and multiple states.
+      // Multiple registered states should return an object with multiple key-value pairs with one key always equal to view.id.
+      if (view.id in defaultResult) {
+        for (const key in defaultResult) {
+          // The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype
+          if (defaultResult.hasOwnProperty(key)) {
+            rootState[key] = defaultResult[key];
+          }
+        }
+      } else {
+        rootState[view.id] = defaultResult;
+      }
     } else {
       rootState[view.id] = defaults;
     }

--- a/src/plugins/data_explorer/public/utils/state_management/store.ts
+++ b/src/plugins/data_explorer/public/utils/state_management/store.ts
@@ -33,13 +33,14 @@ export const configurePreloadedStore = (preloadedState: PreloadedState<RootState
 };
 
 export const getPreloadedStore = async (services: DataExplorerServices) => {
-  // For each view preload the data and register the slice
+  // For each view preload the data and register the slices
   const views = services.viewRegistry.all();
   views.forEach((view) => {
     if (!view.ui) return;
 
-    const { slice } = view.ui;
-    registerSlice(slice);
+    view.ui.slices.forEach((slice) => {
+      registerSlice(slice);
+    });
   });
 
   const preloadedState = await loadReduxState(services);

--- a/src/plugins/discover/public/application/components/context/api/anchor.ts
+++ b/src/plugins/discover/public/application/components/context/api/anchor.ts
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { i18n } from '@osd/i18n';
+
+import {
+  ISearchSource,
+  OpenSearchQuerySortValue,
+  IndexPattern,
+} from '../../../../../../data/public';
+import { OpenSearchHitRecord } from './context';
+
+export async function fetchAnchor(
+  anchorId: string,
+  indexPattern: IndexPattern,
+  searchSource: ISearchSource,
+  sort: OpenSearchQuerySortValue[]
+): Promise<OpenSearchHitRecord> {
+  updateSearchSource(searchSource, anchorId, sort, indexPattern);
+
+  const response = await searchSource.fetch();
+  const doc = response.hits?.hits?.[0];
+
+  if (!doc) {
+    throw new Error(
+      i18n.translate('discover.context.failedToLoadAnchorDocumentErrorDescription', {
+        defaultMessage: 'Failed to load anchor document.',
+      })
+    );
+  }
+
+  return {
+    ...doc,
+    isAnchor: true,
+  } as OpenSearchHitRecord;
+}
+
+export function updateSearchSource(
+  searchSource: ISearchSource,
+  anchorId: string,
+  sort: OpenSearchQuerySortValue[],
+  indexPattern: IndexPattern
+) {
+  searchSource
+    .setParent(undefined)
+    .setField('index', indexPattern)
+    .setField('version', true)
+    .setField('size', 1)
+    .setField('query', {
+      query: {
+        constant_score: {
+          filter: {
+            ids: {
+              values: [anchorId],
+            },
+          },
+        },
+      },
+      language: 'lucene',
+    })
+    .setField('sort', sort);
+
+  return searchSource;
+}

--- a/src/plugins/discover/public/application/components/context/api/context.ts
+++ b/src/plugins/discover/public/application/components/context/api/context.ts
@@ -1,0 +1,133 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Filter, IndexPattern } from 'src/plugins/data/public';
+import { reverseSortDir, SortDirection } from './utils/sorting';
+import { extractNanos, convertIsoToMillis } from './utils/date_conversion';
+import { fetchHitsInInterval } from './utils/fetch_hits_in_interval';
+import { generateIntervals } from './utils/generate_intervals';
+import { getOpenSearchQuerySearchAfter } from './utils/get_opensearch_query_search_after';
+import { getOpenSearchQuerySort } from './utils/get_opensearch_query_sort';
+import { getServices } from '../../../../opensearch_dashboards_services';
+
+export enum SurrDocType {
+  SUCCESSORS = 'successors',
+  PREDECESSORS = 'predecessors',
+}
+export interface OpenSearchHitRecord {
+  fields: Record<string, any>;
+  sort: number[];
+  _source: Record<string, any>;
+  _id: string;
+  isAnchor?: boolean;
+}
+export type OpenSearchHitRecordList = OpenSearchHitRecord[];
+
+const DAY_MILLIS = 24 * 60 * 60 * 1000;
+
+// look from 1 day up to 10000 days into the past and future
+const LOOKUP_OFFSETS = [0, 1, 7, 30, 365, 10000].map((days) => days * DAY_MILLIS);
+
+/**
+ * Fetch successor or predecessor documents of a given anchor document
+ *
+ * @param {SurrDocType} type - `successors` or `predecessors`
+ * @param {string} indexPatternId
+ * @param {OpenSearchHitRecord} anchor - anchor record
+ * @param {string} timeField - name of the timefield, that's sorted on
+ * @param {string} tieBreakerField - name of the tie breaker, the 2nd sort field
+ * @param {SortDirection} sortDir - direction of sorting
+ * @param {number} size - number of records to retrieve
+ * @param {Filter[]} filters - to apply in the query
+ * @returns {Promise<object[]>}
+ */
+
+export async function fetchSurroundingDocs(
+  type: SurrDocType,
+  indexPattern: IndexPattern,
+  anchor: OpenSearchHitRecord,
+  tieBreakerField: string,
+  sortDir: SortDirection,
+  size: number,
+  filters: Filter[]
+) {
+  if (typeof anchor !== 'object' || anchor === null || !size) {
+    return [];
+  }
+  const timeField = indexPattern.timeFieldName!;
+  const searchSource = await createSearchSource(indexPattern, filters);
+  const sortDirToApply = type === 'successors' ? sortDir : reverseSortDir(sortDir);
+
+  const nanos = indexPattern.isTimeNanosBased() ? extractNanos(anchor._source[timeField]) : '';
+  const timeValueMillis =
+    nanos !== '' ? convertIsoToMillis(anchor._source[timeField]) : anchor.sort[0];
+
+  const intervals = generateIntervals(LOOKUP_OFFSETS, timeValueMillis, type, sortDir);
+  let documents: OpenSearchHitRecordList = [];
+
+  for (const interval of intervals) {
+    const remainingSize = size - documents.length;
+
+    if (remainingSize <= 0) {
+      break;
+    }
+
+    const searchAfter = getOpenSearchQuerySearchAfter(type, documents, timeField, anchor, nanos);
+
+    const sort = getOpenSearchQuerySort(timeField, tieBreakerField, sortDirToApply);
+
+    const hits = await fetchHitsInInterval(
+      searchSource,
+      timeField,
+      sort,
+      sortDirToApply,
+      interval,
+      searchAfter,
+      remainingSize,
+      nanos,
+      anchor._id
+    );
+
+    documents =
+      type === 'successors' ? [...documents, ...hits] : [...hits.slice().reverse(), ...documents];
+  }
+
+  return documents;
+}
+
+export async function createSearchSource(indexPattern: IndexPattern, filters: Filter[]) {
+  const { data } = getServices();
+
+  const searchSource = await data.search.searchSource.create();
+  return searchSource
+    .setParent(undefined)
+    .setField('index', indexPattern)
+    .setField('filter', filters);
+}

--- a/src/plugins/discover/public/application/components/context/api/utils/date_conversion.test.ts
+++ b/src/plugins/discover/public/application/components/context/api/utils/date_conversion.test.ts
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { extractNanos } from './date_conversion';
+
+describe('function extractNanos', function () {
+  test('extract nanos of 2014-01-01', function () {
+    expect(extractNanos('2014-01-01')).toBe('000000000');
+  });
+  test('extract nanos of 2014-01-01T12:12:12.234Z', function () {
+    expect(extractNanos('2014-01-01T12:12:12.234Z')).toBe('234000000');
+  });
+  test('extract nanos of 2014-01-01T12:12:12.234123321Z', function () {
+    expect(extractNanos('2014-01-01T12:12:12.234123321Z')).toBe('234123321');
+  });
+});

--- a/src/plugins/discover/public/application/components/context/api/utils/date_conversion.ts
+++ b/src/plugins/discover/public/application/components/context/api/utils/date_conversion.ts
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import moment from 'moment';
+/**
+ * extract nanoseconds if available in ISO timestamp
+ * returns the nanos as string like this:
+ * 9ns -> 000000009
+ * 10000ns -> 0000010000
+ * returns 000000000 for invalid timestamps or timestamps with just date
+ **/
+export function extractNanos(timeFieldValue: string = ''): string {
+  const fieldParts = timeFieldValue.split('.');
+  const fractionSeconds = fieldParts.length === 2 ? fieldParts[1].replace('Z', '') : '';
+  return fractionSeconds.length !== 9 ? fractionSeconds.padEnd(9, '0') : fractionSeconds;
+}
+
+/**
+ * convert an iso formatted string to number of milliseconds since
+ * 1970-01-01T00:00:00.000Z
+ * @param {string} isoValue
+ * @returns {number}
+ */
+export function convertIsoToMillis(isoValue: string): number {
+  const date = new Date(isoValue);
+  return date.getTime();
+}
+/**
+ * the given time value in milliseconds is converted to a ISO formatted string
+ * if nanosValue is provided, the given value replaces the fractional seconds part
+ * of the formated string since moment.js doesn't support formatting timestamps
+ * with a higher precision then microseconds
+ * The browser rounds date nanos values:
+ * 2019-09-18T06:50:12.999999999 -> browser rounds to 1568789413000000000
+ * 2019-09-18T06:50:59.999999999 -> browser rounds to 1568789460000000000
+ * 2017-12-31T23:59:59.999999999 -> browser rounds 1514761199999999999 to 1514761200000000000
+ */
+export function convertTimeValueToIso(timeValueMillis: number, nanosValue: string): string | null {
+  if (!timeValueMillis) {
+    return null;
+  }
+  const isoString = moment(timeValueMillis).toISOString();
+  if (!isoString) {
+    return null;
+  } else if (nanosValue !== '') {
+    return `${isoString.substring(0, isoString.length - 4)}${nanosValue}Z`;
+  }
+  return isoString;
+}

--- a/src/plugins/discover/public/application/components/context/api/utils/fetch_hits_in_interval.ts
+++ b/src/plugins/discover/public/application/components/context/api/utils/fetch_hits_in_interval.ts
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  ISearchSource,
+  OpenSearchQuerySortValue,
+  SortDirection,
+} from '../../../../../../../data/public';
+import { convertTimeValueToIso } from './date_conversion';
+import { OpenSearchHitRecordList, OpenSearchHitRecord } from '../context';
+import { IntervalValue } from './generate_intervals';
+import { OpenSearchQuerySearchAfter } from './get_opensearch_query_search_after';
+
+interface RangeQuery {
+  format: string;
+  lte?: string | null;
+  gte?: string | null;
+}
+
+/**
+ * Fetch the hits between a given `interval` up to a maximum of `maxCount` documents.
+ * The documents are sorted by `sort`
+ *
+ * The `searchSource` is assumed to have the appropriate index pattern
+ * and filters set.
+ */
+export async function fetchHitsInInterval(
+  searchSource: ISearchSource,
+  timeField: string,
+  sort: [OpenSearchQuerySortValue, OpenSearchQuerySortValue],
+  sortDir: SortDirection,
+  interval: IntervalValue[],
+  searchAfter: OpenSearchQuerySearchAfter,
+  maxCount: number,
+  nanosValue: string,
+  anchorId: string
+): Promise<OpenSearchHitRecordList> {
+  const range: RangeQuery = {
+    format: 'strict_date_optional_time',
+  };
+  const [start, stop] = interval;
+
+  if (start) {
+    range[sortDir === SortDirection.asc ? 'gte' : 'lte'] = convertTimeValueToIso(start, nanosValue);
+  }
+
+  if (stop) {
+    range[sortDir === SortDirection.asc ? 'lte' : 'gte'] = convertTimeValueToIso(stop, nanosValue);
+  }
+  const response = await searchSource
+    .setField('size', maxCount)
+    .setField('query', {
+      query: {
+        bool: {
+          must: {
+            constant_score: {
+              filter: {
+                range: {
+                  [timeField]: range,
+                },
+              },
+            },
+          },
+          must_not: {
+            ids: {
+              values: [anchorId],
+            },
+          },
+        },
+      },
+      language: 'lucene',
+    })
+    .setField('searchAfter', searchAfter)
+    .setField('sort', sort)
+    .setField('version', true)
+    .fetch();
+
+  // TODO: There's a difference in the definition of SearchResponse and OpenSearchHitRecord
+  return ((response.hits?.hits as unknown) as OpenSearchHitRecord[]) || [];
+}

--- a/src/plugins/discover/public/application/components/context/api/utils/generate_intervals.ts
+++ b/src/plugins/discover/public/application/components/context/api/utils/generate_intervals.ts
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { SortDirection } from '../../../../../../../data/public';
+
+export type IntervalValue = number | null;
+
+/**
+ * Generate a sequence of pairs from the iterable that looks like
+ * `[[x_0, x_1], [x_1, x_2], [x_2, x_3], ..., [x_(n-1), x_n]]`.
+ */
+export function* asPairs(iterable: Iterable<IntervalValue>): IterableIterator<IntervalValue[]> {
+  let currentPair: IntervalValue[] = [];
+  for (const value of iterable) {
+    currentPair = [...currentPair, value].slice(-2);
+    if (currentPair.length === 2) {
+      yield currentPair;
+    }
+  }
+}
+
+/**
+ * Returns a iterable containing intervals `[start,end]` for OpenSearch date range queries
+ * depending on type (`successors` or `predecessors`) and sort (`asc`, `desc`) these are ascending or descending intervals.
+ */
+export function generateIntervals(
+  offsets: number[],
+  startTime: number,
+  type: string,
+  sort: SortDirection
+): IterableIterator<IntervalValue[]> {
+  const offsetSign =
+    (sort === SortDirection.asc && type === 'successors') ||
+    (sort === SortDirection.desc && type === 'predecessors')
+      ? 1
+      : -1;
+  // ending with `null` opens the last interval
+  return asPairs([...offsets.map((offset) => startTime + offset * offsetSign), null]);
+}

--- a/src/plugins/discover/public/application/components/context/api/utils/get_opensearch_query_search_after.ts
+++ b/src/plugins/discover/public/application/components/context/api/utils/get_opensearch_query_search_after.ts
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { SurrDocType, OpenSearchHitRecordList, OpenSearchHitRecord } from '../context';
+
+export type OpenSearchQuerySearchAfter = [string | number, string | number];
+
+/**
+ * Get the searchAfter query value for opensearch
+ * When there are already documents available, which means successors or predecessors
+ * were already fetched, the new searchAfter for the next fetch has to be the sort value
+ * of the first (prececessor), or last (successor) of the list
+ */
+export function getOpenSearchQuerySearchAfter(
+  type: SurrDocType,
+  documents: OpenSearchHitRecordList,
+  timeFieldName: string,
+  anchor: OpenSearchHitRecord,
+  nanoSeconds: string
+): OpenSearchQuerySearchAfter {
+  if (documents.length) {
+    // already surrounding docs -> first or last record  is used
+    const afterTimeRecIdx = type === 'successors' && documents.length ? documents.length - 1 : 0;
+    const afterTimeDoc = documents[afterTimeRecIdx];
+    const afterTimeValue = nanoSeconds ? afterTimeDoc._source[timeFieldName] : afterTimeDoc.sort[0];
+    return [afterTimeValue, afterTimeDoc.sort[1]];
+  }
+  // if data_nanos adapt timestamp value for sorting, since numeric value was rounded by browser
+  // OpenSearch search_after also works when number is provided as string
+  return [nanoSeconds ? anchor._source[timeFieldName] : anchor.sort[0], anchor.sort[1]];
+}

--- a/src/plugins/discover/public/application/components/context/api/utils/get_opensearch_query_sort.ts
+++ b/src/plugins/discover/public/application/components/context/api/utils/get_opensearch_query_sort.ts
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  OpenSearchQuerySortValue,
+  SortDirection,
+} from '../../../../../opensearch_dashboards_services';
+
+/**
+ * Returns `OpenSearchQuerySort` which is used to sort records in the OpenSearch query
+ * https://opensearch.org/docs/latest/opensearch/ux/#sort-results
+ * @param timeField
+ * @param tieBreakerField
+ * @param sortDir
+ */
+export function getOpenSearchQuerySort(
+  timeField: string,
+  tieBreakerField: string,
+  sortDir: SortDirection
+): [OpenSearchQuerySortValue, OpenSearchQuerySortValue] {
+  return [{ [timeField]: sortDir }, { [tieBreakerField]: sortDir }];
+}

--- a/src/plugins/discover/public/application/components/context/api/utils/sorting.test.ts
+++ b/src/plugins/discover/public/application/components/context/api/utils/sorting.test.ts
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { reverseSortDir, SortDirection } from './sorting';
+
+describe('function reverseSortDir', function () {
+  test('reverse a given sort direction', function () {
+    expect(reverseSortDir(SortDirection.asc)).toBe(SortDirection.desc);
+    expect(reverseSortDir(SortDirection.desc)).toBe(SortDirection.asc);
+  });
+});

--- a/src/plugins/discover/public/application/components/context/api/utils/sorting.ts
+++ b/src/plugins/discover/public/application/components/context/api/utils/sorting.ts
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IndexPattern } from '../../../../../opensearch_dashboards_services';
+
+export enum SortDirection {
+  asc = 'asc',
+  desc = 'desc',
+}
+
+/**
+ * The list of field names that are allowed for sorting, but not included in
+ * index pattern fields.
+ */
+const META_FIELD_NAMES: string[] = ['_seq_no', '_doc', '_uid'];
+
+/**
+ * Returns a field from the intersection of the set of sortable fields in the
+ * given index pattern and a given set of candidate field names.
+ */
+export function getFirstSortableField(indexPattern: IndexPattern, fieldNames: string[]) {
+  const sortableFields = fieldNames.filter(
+    (fieldName) =>
+      META_FIELD_NAMES.includes(fieldName) ||
+      // @ts-ignore
+      (indexPattern.fields.getByName(fieldName) || { sortable: false }).sortable
+  );
+  return sortableFields[0];
+}
+
+/**
+ * Return the reversed sort direction.
+ */
+export function reverseSortDir(sortDirection: SortDirection) {
+  return sortDirection === SortDirection.asc ? SortDirection.desc : SortDirection.asc;
+}

--- a/src/plugins/discover/public/application/components/context/components/action_bar/action_bar.tsx
+++ b/src/plugins/discover/public/application/components/context/components/action_bar/action_bar.tsx
@@ -1,0 +1,182 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState } from 'react';
+import { i18n } from '@osd/i18n';
+import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
+import {
+  EuiButtonEmpty,
+  EuiFieldNumber,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiSpacer,
+} from '@elastic/eui';
+import { ActionBarWarning } from './action_bar_warning';
+import { SurrDocType } from '../../api/context';
+import { MAX_CONTEXT_SIZE, MIN_CONTEXT_SIZE } from '../../query_parameters/constants';
+
+export interface ActionBarProps {
+  /**
+   *  the number of documents fetched initially and added when the load button is clicked
+   */
+  defaultStepSize: number;
+  /**
+   * the number of docs to be displayed
+   */
+  docCount: number;
+  /**
+   *  the number of documents that are  available
+   *  display warning when it's lower than docCount
+   */
+  docCountAvailable: number;
+  /**
+   * is true while the anchor record is fetched
+   */
+  isDisabled: boolean;
+  /**
+   * is true when list entries are fetched
+   */
+  isLoading: boolean;
+  /**
+   * is triggered when the input containing count is changed
+   * @param count
+   */
+  onChangeCount: (type: SurrDocType, count: number) => void;
+  /**
+   * can be `predecessors` or `successors`, usage in context:
+   * predecessors action bar + records (these are newer records)
+   * anchor record
+   * successors records + action bar (these are older records)
+   */
+  type: SurrDocType;
+}
+
+export function ActionBar({
+  defaultStepSize,
+  docCount,
+  docCountAvailable,
+  isDisabled,
+  isLoading,
+  onChangeCount,
+  type,
+}: ActionBarProps) {
+  const showWarning = !isDisabled && !isLoading && docCountAvailable < docCount;
+  const isSuccessor = type === 'successors';
+  const [newDocCount, setNewDocCount] = useState(docCount);
+  const isValid = (value: number) => value >= MIN_CONTEXT_SIZE && value <= MAX_CONTEXT_SIZE;
+  const onSubmit = (ev: React.FormEvent<HTMLFormElement>) => {
+    ev.preventDefault();
+    if (newDocCount !== docCount && isValid(newDocCount)) {
+      onChangeCount(type, newDocCount);
+    }
+  };
+
+  return (
+    <I18nProvider>
+      <form onSubmit={onSubmit}>
+        {isSuccessor && <EuiSpacer size="s" />}
+        {isSuccessor && showWarning && (
+          <ActionBarWarning docCount={docCountAvailable} type={type} />
+        )}
+        {isSuccessor && showWarning && <EuiSpacer size="s" />}
+        <EuiFlexGroup direction="row" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              data-test-subj={`${type}LoadMoreButton`}
+              iconType={isSuccessor ? 'arrowDown' : 'arrowUp'}
+              isDisabled={isDisabled}
+              isLoading={isLoading}
+              onClick={() => {
+                const value = newDocCount + defaultStepSize;
+                if (isValid(value)) {
+                  setNewDocCount(value);
+                  onChangeCount(type, value);
+                }
+              }}
+              flush="right"
+            >
+              <FormattedMessage id="discover.context.loadButtonLabel" defaultMessage="Load" />
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFormRow>
+              <EuiFieldNumber
+                aria-label={
+                  isSuccessor
+                    ? i18n.translate('discover.context.olderDocumentsAriaLabel', {
+                        defaultMessage: 'Number of older documents',
+                      })
+                    : i18n.translate('discover.context.newerDocumentsAriaLabel', {
+                        defaultMessage: 'Number of newer documents',
+                      })
+                }
+                className="cxtSizePicker"
+                data-test-subj={`${type}CountPicker`}
+                disabled={isDisabled}
+                min={MIN_CONTEXT_SIZE}
+                max={MAX_CONTEXT_SIZE}
+                onChange={(ev) => {
+                  setNewDocCount(ev.target.valueAsNumber);
+                }}
+                onBlur={() => {
+                  if (newDocCount !== docCount && isValid(newDocCount)) {
+                    onChangeCount(type, newDocCount);
+                  }
+                }}
+                type="number"
+                value={newDocCount >= 0 ? newDocCount : ''}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFormRow display={'center'}>
+              {isSuccessor ? (
+                <FormattedMessage
+                  id="discover.context.olderDocumentsDescription"
+                  defaultMessage="older documents"
+                />
+              ) : (
+                <FormattedMessage
+                  id="discover.context.newerDocumentsDescription"
+                  defaultMessage="newer documents"
+                />
+              )}
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        {!isSuccessor && showWarning && (
+          <ActionBarWarning docCount={docCountAvailable} type={type} />
+        )}
+        {!isSuccessor && <EuiSpacer size="s" />}
+      </form>
+    </I18nProvider>
+  );
+}

--- a/src/plugins/discover/public/application/components/context/components/action_bar/action_bar_warning.tsx
+++ b/src/plugins/discover/public/application/components/context/components/action_bar/action_bar_warning.tsx
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { FormattedMessage } from '@osd/i18n/react';
+import { EuiCallOut } from '@elastic/eui';
+import { SurrDocType } from '../../api/context';
+
+export function ActionBarWarning({ docCount, type }: { docCount: number; type: SurrDocType }) {
+  if (type === 'predecessors') {
+    return (
+      <EuiCallOut
+        color="warning"
+        data-test-subj="predecessorsWarningMsg"
+        iconType="bolt"
+        title={
+          docCount === 0 ? (
+            <FormattedMessage
+              id="discover.context.newerDocumentsWarningZero"
+              defaultMessage="No documents newer than the anchor could be found."
+            />
+          ) : (
+            <FormattedMessage
+              id="discover.context.newerDocumentsWarning"
+              defaultMessage="Only {docCount} documents newer than the anchor could be found."
+              values={{ docCount }}
+            />
+          )
+        }
+        size="s"
+      />
+    );
+  }
+
+  return (
+    <EuiCallOut
+      color="warning"
+      data-test-subj="successorsWarningMsg"
+      iconType="bolt"
+      title={
+        docCount === 0 ? (
+          <FormattedMessage
+            id="discover.context.olderDocumentsWarningZero"
+            defaultMessage="No documents older than the anchor could be found."
+          />
+        ) : (
+          <FormattedMessage
+            id="discover.context.olderDocumentsWarning"
+            defaultMessage="Only {docCount} documents older than the anchor could be found."
+            values={{ docCount }}
+          />
+        )
+      }
+      size="s"
+    />
+  );
+}

--- a/src/plugins/discover/public/application/components/context/context_app.scss
+++ b/src/plugins/discover/public/application/components/context/context_app.scss
@@ -1,0 +1,4 @@
+.contextTable {
+  flex: 1 0 0;
+  overflow: auto;
+}

--- a/src/plugins/discover/public/application/components/context/context_app.tsx
+++ b/src/plugins/discover/public/application/components/context/context_app.tsx
@@ -66,9 +66,6 @@ export function ContextApp({ onAddFilter, rows }: Props) {
   const isSuccessorLoading =
     successorStatus.value === LOADING_STATUS.LOADING ||
     successorStatus.value === LOADING_STATUS.UNINITIALIZED;
-  // const isAnchorLoading = false;
-  // const isPredecessorLoading = false;
-  // const isSuccessorLoading = false;
   const onChangeCount = useCallback(
     (type: SurrDocType, count: number) => {
       const countType = type === SurrDocType.SUCCESSORS ? 'successorCount' : 'predecessorCount';
@@ -82,7 +79,7 @@ export function ContextApp({ onAddFilter, rows }: Props) {
   );
 
   return (
-    <EuiFlexGroup direction="column" grow={false}>
+    <EuiFlexGroup direction="column">
       <EuiFlexItem>
         <ActionBar
           defaultStepSize={defaultStepSize}
@@ -94,24 +91,22 @@ export function ContextApp({ onAddFilter, rows }: Props) {
           type={SurrDocType.PREDECESSORS}
         />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <div className="dscContextGrid">
-          <DataGridTable
-            aria-label={'ContextTable'}
-            columns={columns}
-            indexPattern={indexPattern}
-            onAddColumn={onAddColumn}
-            onFilter={onAddFilter as DocViewFilterFn}
-            onRemoveColumn={onRemoveColumn}
-            onSetColumns={onSetColumns}
-            onSort={onSetSort}
-            sort={sort}
-            rows={rows}
-            displayTimeColumn={true}
-            services={services}
-            isToolbarVisible={false}
-          />
-        </div>
+      <EuiFlexItem>
+        <DataGridTable
+          aria-label={'ContextTable'}
+          columns={columns}
+          indexPattern={indexPattern}
+          onAddColumn={onAddColumn}
+          onFilter={onAddFilter as DocViewFilterFn}
+          onRemoveColumn={onRemoveColumn}
+          onSetColumns={onSetColumns}
+          onSort={onSetSort}
+          sort={sort}
+          rows={rows}
+          displayTimeColumn={true}
+          services={services}
+          isToolbarVisible={false}
+        />
       </EuiFlexItem>
       <EuiFlexItem>
         <ActionBar

--- a/src/plugins/discover/public/application/components/context/context_app.tsx
+++ b/src/plugins/discover/public/application/components/context/context_app.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useMemo } from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { useCallback } from 'react';
+import { SurrDocType } from './api/context';
+import { ActionBar } from './components/action_bar/action_bar';
+import { CONTEXT_STEP_SETTING } from '../../../../common';
+import { DiscoverViewServices } from '../../../build_services';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import {
+  addContextColumn,
+  removeContextColumn,
+  setContextColumns,
+  setContextSort,
+  setPredecessorCount,
+  setSuccessorCount,
+  useDispatch,
+  useSelector,
+} from '../../utils/state_management';
+import { useDiscoverContext } from '../../view_components/context';
+import { LOADING_STATUS } from './query/constants';
+import { IndexPatternField } from '../../../../../data/public';
+import { DataGridTable } from '../data_grid/data_grid_table';
+import { DocViewFilterFn } from '../../doc_views/doc_views_types';
+
+export interface Props {
+  onAddFilter: (field: IndexPatternField, values: string, operation: '+' | '-') => void;
+  rows: any[];
+}
+
+export function ContextApp({ onAddFilter, rows }: Props) {
+  const { services } = useOpenSearchDashboards<DiscoverViewServices>();
+  const { uiSettings } = services;
+  const { indexPattern } = useDiscoverContext();
+  const dispatch = useDispatch();
+  const defaultStepSize = useMemo(() => parseInt(uiSettings.get(CONTEXT_STEP_SETTING), 10), [
+    uiSettings,
+  ]);
+  const {
+    sort,
+    columns,
+    predecessorCount,
+    successorCount,
+    predecessors,
+    successors,
+    contextFetchStatus,
+  } = useSelector((state) => state.discoverContext);
+
+  const onAddColumn = (col: string) => dispatch(addContextColumn({ col }));
+  const onRemoveColumn = (col: string) => dispatch(removeContextColumn(col));
+  const onSetColumns = (cols: string[]) =>
+    dispatch(setContextColumns({ timefield: indexPattern.timeFieldName, cols }));
+  const onSetSort = (s: Array<[string, string]>) => dispatch(setContextSort(s));
+
+  const { anchorStatus, predecessorStatus, successorStatus } = contextFetchStatus;
+  const isAnchorLoading =
+    anchorStatus.value === LOADING_STATUS.LOADING ||
+    anchorStatus.value === LOADING_STATUS.UNINITIALIZED;
+  const isPredecessorLoading =
+    predecessorStatus.value === LOADING_STATUS.LOADING ||
+    predecessorStatus.value === LOADING_STATUS.UNINITIALIZED;
+  const isSuccessorLoading =
+    successorStatus.value === LOADING_STATUS.LOADING ||
+    successorStatus.value === LOADING_STATUS.UNINITIALIZED;
+  // const isAnchorLoading = false;
+  // const isPredecessorLoading = false;
+  // const isSuccessorLoading = false;
+  const onChangeCount = useCallback(
+    (type: SurrDocType, count: number) => {
+      const countType = type === SurrDocType.SUCCESSORS ? 'successorCount' : 'predecessorCount';
+      if (countType === 'successorCount') {
+        dispatch(setSuccessorCount(count));
+      } else {
+        dispatch(setPredecessorCount(count));
+      }
+    },
+    [dispatch]
+  );
+
+  return (
+    <EuiFlexGroup direction="column" grow={false}>
+      <EuiFlexItem>
+        <ActionBar
+          defaultStepSize={defaultStepSize}
+          docCount={predecessorCount}
+          docCountAvailable={predecessors.length}
+          isDisabled={isAnchorLoading}
+          isLoading={isPredecessorLoading}
+          onChangeCount={onChangeCount}
+          type={SurrDocType.PREDECESSORS}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <div className="dscContextGrid">
+          <DataGridTable
+            aria-label={'ContextTable'}
+            columns={columns}
+            indexPattern={indexPattern}
+            onAddColumn={onAddColumn}
+            onFilter={onAddFilter as DocViewFilterFn}
+            onRemoveColumn={onRemoveColumn}
+            onSetColumns={onSetColumns}
+            onSort={onSetSort}
+            sort={sort}
+            rows={rows}
+            displayTimeColumn={true}
+            services={services}
+            isToolbarVisible={false}
+          />
+        </div>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <ActionBar
+          defaultStepSize={defaultStepSize}
+          docCount={successorCount}
+          docCountAvailable={successors.length}
+          isDisabled={isAnchorLoading}
+          isLoading={isSuccessorLoading}
+          onChangeCount={onChangeCount}
+          type={SurrDocType.SUCCESSORS}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/src/plugins/discover/public/application/components/context/query/constants.ts
+++ b/src/plugins/discover/public/application/components/context/query/constants.ts
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const FAILURE_REASONS = {
+  UNKNOWN: 'unknown',
+  INVALID_TIEBREAKER: 'invalid_tiebreaker',
+};
+
+export const LOADING_STATUS = {
+  FAILED: 'failed',
+  LOADED: 'loaded',
+  LOADING: 'loading',
+  UNINITIALIZED: 'uninitialized',
+};

--- a/src/plugins/discover/public/application/components/context/query/types.ts
+++ b/src/plugins/discover/public/application/components/context/query/types.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ContextFetchStatus {
+  anchorStatus: { value: string; reason?: string };
+  predecessorStatus: { value: string; reason?: string };
+  successorStatus: { value: string; reason?: string };
+}

--- a/src/plugins/discover/public/application/components/context/query/use_query_actions.ts
+++ b/src/plugins/discover/public/application/components/context/query/use_query_actions.ts
@@ -1,0 +1,189 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { i18n } from '@osd/i18n';
+import { useMemo } from 'react';
+import {
+  setAnchor,
+  setPredecessors,
+  setSuccessors,
+  setContextFetchStatus,
+  useDispatch,
+} from '../../../utils/state_management';
+
+import { Filter } from '../../../../../../../../src/plugins/data/public';
+import { fetchAnchor } from '../api/anchor';
+import { OpenSearchHitRecord, fetchSurroundingDocs } from '../api/context';
+import { FAILURE_REASONS, LOADING_STATUS } from './constants';
+// import { MarkdownSimple, toMountPoint } from '../../../../../../opensearch_dashboards_react/public';
+import { DiscoverViewServices } from '../../../../build_services';
+import { useOpenSearchDashboards } from '../../../../../../opensearch_dashboards_react/public';
+import { CONTEXT_TIE_BREAKER_FIELDS_SETTING } from '../../../../../common';
+import { getFirstSortableField, SortDirection } from '../api/utils/sorting';
+import { useDiscoverContext } from '../../../view_components/context';
+import { SurrDocType } from '../api/context';
+
+export interface Props {
+  anchorId: string;
+}
+
+export function useQueryActions() {
+  const dispatch = useDispatch();
+  const { indexPattern } = useDiscoverContext();
+  const { services } = useOpenSearchDashboards<DiscoverViewServices>();
+  const { data, uiSettings, toastNotifications } = services;
+  const searchSource = useMemo(() => {
+    return data.search.searchSource.createEmpty();
+  }, [data.search.searchSource]);
+  const tieBreakerField = useMemo(
+    () => getFirstSortableField(indexPattern, uiSettings.get(CONTEXT_TIE_BREAKER_FIELDS_SETTING)),
+    [uiSettings, indexPattern]
+  );
+
+  const fetchAnchorRow = async (anchorId: string) => {
+    if (!tieBreakerField) {
+      setContextFetchStatus({
+        anchorStatus: { value: LOADING_STATUS.FAILED, reason: FAILURE_REASONS.INVALID_TIEBREAKER },
+      });
+      return;
+    }
+
+    try {
+      dispatch(setContextFetchStatus({ anchorStatus: { value: LOADING_STATUS.LOADING } }));
+      const sort = [
+        { [indexPattern.timeFieldName!]: SortDirection.desc },
+        { [tieBreakerField]: SortDirection.desc },
+      ];
+      const fetchAnchorResult = await fetchAnchor(anchorId, indexPattern, searchSource, sort);
+      dispatch(setAnchor(fetchAnchorResult));
+      dispatch(setContextFetchStatus({ anchorStatus: { value: LOADING_STATUS.LOADED } }));
+      return fetchAnchorResult;
+    } catch (error) {
+      setContextFetchStatus({
+        anchorStatus: { value: LOADING_STATUS.FAILED, reason: FAILURE_REASONS.UNKNOWN },
+      });
+      toastNotifications.addDanger({
+        title: i18n.translate('discover.context.unableToLoadAnchorDocumentDescription', {
+          defaultMessage: 'Unable to fetch anchor document',
+        }),
+        text: 'fail',
+      });
+    }
+  };
+
+  const fetchSurroundingRows = async (
+    type: SurrDocType,
+    count: number,
+    filters: Filter[],
+    anchor: OpenSearchHitRecord
+  ) => {
+    try {
+      if (type === SurrDocType.PREDECESSORS) {
+        dispatch(setContextFetchStatus({ predecessorStatus: { value: LOADING_STATUS.LOADING } }));
+      } else {
+        dispatch(setContextFetchStatus({ successorStatus: { value: LOADING_STATUS.LOADING } }));
+      }
+
+      const rows = await fetchSurroundingDocs(
+        type,
+        indexPattern,
+        anchor as OpenSearchHitRecord,
+        tieBreakerField,
+        SortDirection.desc,
+        count,
+        filters
+      );
+      if (type === SurrDocType.PREDECESSORS) {
+        dispatch(setPredecessors(rows));
+        dispatch(setContextFetchStatus({ predecessorStatus: { value: LOADING_STATUS.LOADED } }));
+      } else {
+        dispatch(setSuccessors(rows));
+        dispatch(setContextFetchStatus({ successorStatus: { value: LOADING_STATUS.LOADED } }));
+      }
+    } catch (error) {
+      if (type === SurrDocType.PREDECESSORS) {
+        dispatch(
+          setContextFetchStatus({
+            predecessorStatus: { value: LOADING_STATUS.FAILED, reason: FAILURE_REASONS.UNKNOWN },
+          })
+        );
+      } else {
+        dispatch(
+          setContextFetchStatus({
+            successorStatus: { value: LOADING_STATUS.FAILED, reason: FAILURE_REASONS.UNKNOWN },
+          })
+        );
+        toastNotifications.addDanger({
+          title: i18n.translate('discover.context.unableToLoadDocumentDescription', {
+            defaultMessage: 'Unable to fetch surrounding documents',
+          }),
+          text: 'fail',
+        });
+      }
+    }
+  };
+
+  const fetchContextRows = async (
+    predecessorCount: number,
+    successorCount: number,
+    filters: Filter[],
+    anchor: OpenSearchHitRecord
+  ) =>
+    Promise.all([
+      fetchSurroundingRows(SurrDocType.PREDECESSORS, predecessorCount, filters, anchor),
+      fetchSurroundingRows(SurrDocType.SUCCESSORS, successorCount, filters, anchor),
+    ]);
+
+  const fetchAllRows = async (
+    anchorId: string,
+    predecessorCount: number,
+    successorCount: number,
+    filters: Filter[]
+  ) => {
+    try {
+      const anchor = await fetchAnchorRow(anchorId);
+      fetchContextRows(predecessorCount, successorCount, filters, anchor);
+    } catch (error) {
+      toastNotifications.addDanger({
+        title: i18n.translate('discover.context.unableToLoadDocumentDescription', {
+          defaultMessage: 'Unable to fetch all documents',
+        }),
+        text: 'fail',
+      });
+    }
+  };
+
+  return {
+    fetchAnchorRow,
+    fetchAllRows,
+    fetchContextRows,
+    fetchSurroundingRows,
+  };
+}

--- a/src/plugins/discover/public/application/components/context/query_parameters/constants.ts
+++ b/src/plugins/discover/public/application/components/context/query_parameters/constants.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const MAX_CONTEXT_SIZE = 10000; // OpenSearch's default maximum size limit
+export const MIN_CONTEXT_SIZE = 0;

--- a/src/plugins/discover/public/application/components/context/surrounding_documents_flyout.tsx
+++ b/src/plugins/discover/public/application/components/context/surrounding_documents_flyout.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useCallback, useMemo, useRef } from 'react';
+
+import { EuiFlyout, EuiFlyoutHeader, EuiFlyoutBody, EuiTitle, EuiText } from '@elastic/eui';
+import { FormattedMessage } from '@osd/i18n/react';
+import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
+import { DiscoverViewServices } from '../../../build_services';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import { ContextApp } from './context_app';
+import { IndexPatternField, opensearchFilters } from '../../../../../data/public';
+import { useDiscoverContext } from '../../view_components/context';
+import { useDispatch, useSelector } from '../../utils/state_management';
+import { isEqualFilters } from '../../utils/filters';
+import { useQueryActions } from './query/use_query_actions';
+import { SurrDocType } from './api/context';
+import {
+  setAnchorId,
+  setContextFilters,
+} from '../../utils/state_management/discover_context_slice';
+
+interface Props {
+  hit: OpenSearchSearchHit;
+  setDetailFlyoutOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setSurroundingFlyoutOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setExpandedHit: (hit?: OpenSearchSearchHit) => void;
+}
+
+export function SurroundingDocumentsFlyout({
+  hit,
+  setDetailFlyoutOpen,
+  setSurroundingFlyoutOpen,
+  setExpandedHit,
+}: Props) {
+  const { indexPattern } = useDiscoverContext();
+  const {
+    services: {
+      navigation: {
+        ui: { TopNavMenu },
+      },
+      data: {
+        query: { filterManager },
+      },
+    },
+  } = useOpenSearchDashboards<DiscoverViewServices>();
+  const dispatch = useDispatch();
+  const {
+    anchor,
+    anchorId,
+    filters,
+    predecessorCount,
+    successorCount,
+    predecessors,
+    successors,
+    contextFetchStatus,
+  } = useSelector((state) => state.discoverContext);
+
+  const previousContextState = useRef({
+    anchor,
+    anchorId,
+    filters,
+    predecessorCount,
+    successorCount,
+    contextFetchStatus,
+  });
+
+  const onClose = () => {
+    setSurroundingFlyoutOpen(false);
+    setExpandedHit(undefined);
+    setDetailFlyoutOpen(false);
+  };
+  const onAddFilter = useCallback(
+    (field: IndexPatternField, values: string, operation: '+' | '-') => {
+      const newFilters = opensearchFilters.generateFilters(
+        filterManager,
+        field,
+        values,
+        operation,
+        indexPattern.id
+      );
+      return filterManager.addFilters(newFilters);
+    },
+    [filterManager, indexPattern]
+  );
+
+  const { fetchContextRows, fetchAllRows, fetchSurroundingRows } = useQueryActions();
+
+  if (anchorId !== hit._id) dispatch(setAnchorId(hit._id));
+  if (!isEqualFilters(filters, filterManager.getFilters()))
+    dispatch(setContextFilters(filterManager.getFilters()));
+
+  useEffect(() => {
+    if (previousContextState.current.predecessorCount !== predecessorCount) {
+      fetchSurroundingRows(SurrDocType.PREDECESSORS, predecessorCount, filters, anchor);
+    } else if (previousContextState.current.successorCount !== successorCount) {
+      fetchSurroundingRows(SurrDocType.SUCCESSORS, successorCount, filters, anchor);
+    } else if (
+      previousContextState.current.anchorId !== anchorId ||
+      Object.keys(previousContextState.current.anchor).length === 0
+    ) {
+      fetchAllRows(anchorId, predecessorCount, successorCount, filters);
+    } else if (!isEqualFilters(previousContextState.current.filters, filters)) {
+      fetchContextRows(predecessorCount, successorCount, filters, anchor);
+    }
+    previousContextState.current = {
+      anchor,
+      anchorId,
+      filters,
+      predecessorCount,
+      successorCount,
+      contextFetchStatus,
+    };
+  }, [
+    dispatch,
+    anchor,
+    anchorId,
+    predecessorCount,
+    successorCount,
+    filters,
+    contextFetchStatus,
+    fetchAllRows,
+    fetchContextRows,
+    fetchSurroundingRows,
+  ]);
+
+  const rows = useMemo(
+    () => [...(predecessors || []), ...(anchor ? [anchor] : []), ...(successors || [])],
+    [predecessors, anchor, successors]
+  );
+  return (
+    <EuiFlyout onClose={onClose} size="m">
+      <EuiFlyoutHeader>
+        <EuiTitle>
+          <EuiText>
+            <strong>
+              <FormattedMessage
+                id="discover.context.docId"
+                defaultMessage="Context of #{anchorId}"
+                values={{ anchorId }}
+              />
+            </strong>
+          </EuiText>
+        </EuiTitle>
+        <TopNavMenu
+          appName={'discoverContext'}
+          showSearchBar={true}
+          showQueryBar={false}
+          showDatePicker={false}
+          indexPatterns={[indexPattern]}
+          useDefaultBehaviors={true}
+        />
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <ContextApp onAddFilter={onAddFilter} rows={rows} />
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+}

--- a/src/plugins/discover/public/application/components/context/surrounding_documents_flyout.tsx
+++ b/src/plugins/discover/public/application/components/context/surrounding_documents_flyout.tsx
@@ -55,7 +55,6 @@ export function SurroundingDocumentsFlyout({
     successorCount,
     predecessors,
     successors,
-    contextFetchStatus,
   } = useSelector((state) => state.discoverContext);
 
   const previousContextState = useRef({
@@ -64,7 +63,6 @@ export function SurroundingDocumentsFlyout({
     filters,
     predecessorCount,
     successorCount,
-    contextFetchStatus,
   });
 
   const onClose = () => {
@@ -111,16 +109,13 @@ export function SurroundingDocumentsFlyout({
       filters,
       predecessorCount,
       successorCount,
-      contextFetchStatus,
     };
   }, [
-    dispatch,
     anchor,
     anchorId,
     predecessorCount,
     successorCount,
     filters,
-    contextFetchStatus,
     fetchAllRows,
     fetchContextRows,
     fetchSurroundingRows,

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_context.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_context.tsx
@@ -13,6 +13,7 @@ export interface DataGridContextProps {
   setExpandedHit: (hit?: OpenSearchSearchHit) => void;
   rows: OpenSearchSearchHit[];
   indexPattern: IndexPattern;
+  setDetailFlyoutOpen: (isOpen: boolean) => void;
 }
 
 export const DataGridContext = React.createContext<DataGridContextProps>(

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_docview_expand_button.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_docview_expand_button.tsx
@@ -6,19 +6,24 @@
 import React from 'react';
 import { EuiToolTip, EuiButtonIcon, EuiDataGridCellValueElementProps } from '@elastic/eui';
 import { useDataGridContext } from './data_grid_table_context';
+import { setAnchorId, useDispatch, useSelector } from '../../utils/state_management';
 
 export const DocViewExpandButton = ({
   rowIndex,
   setCellProps,
 }: EuiDataGridCellValueElementProps) => {
-  const { expandedHit, setExpandedHit, rows } = useDataGridContext();
+  const { expandedHit, setExpandedHit, rows, setDetailFlyoutOpen } = useDataGridContext();
   const currentExpanded = rows[rowIndex];
   const isCurrentExpanded = currentExpanded === expandedHit;
+  const onClick = () => {
+    setExpandedHit(isCurrentExpanded ? undefined : currentExpanded);
+    setDetailFlyoutOpen(true);
+  };
 
   return (
     <EuiToolTip content={`Expand row ${rowIndex}`}>
       <EuiButtonIcon
-        onClick={() => setExpandedHit(isCurrentExpanded ? undefined : currentExpanded)}
+        onClick={onClick}
         iconType={isCurrentExpanded ? 'minimize' : 'expand'}
         aria-label={`Expand row ${rowIndex}`}
       />

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_flyout.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_flyout.tsx
@@ -26,6 +26,8 @@ interface Props {
   onClose: () => void;
   onFilter: DocViewFilterFn;
   onRemoveColumn: (column: string) => void;
+  setDetailFlyoutOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setSurroundingFlyoutOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export function DataGridFlyout({
@@ -36,9 +38,16 @@ export function DataGridFlyout({
   onClose,
   onFilter,
   onRemoveColumn,
+  setDetailFlyoutOpen,
+  setSurroundingFlyoutOpen,
 }: Props) {
   // TODO: replace EuiLink with doc_view_links registry
   // TODO: Also move the flyout higher in the react tree to prevent redrawing the table component and slowing down page performance
+  const openSurroundingFlyout = () => {
+    setSurroundingFlyoutOpen(true);
+    setDetailFlyoutOpen(false);
+  };
+
   return (
     <EuiFlyout onClose={onClose} size="m">
       <EuiFlyoutHeader>
@@ -49,7 +58,7 @@ export function DataGridFlyout({
       <EuiFlyoutBody>
         <EuiFlexGroup direction="column">
           <EuiFlexItem>
-            <DocViewerLinks hit={hit} indexPattern={indexPattern} columns={columns} />
+            <DocViewerLinks hit={hit} indexPattern={indexPattern} columns={columns} onClick={openSurroundingFlyout} />
           </EuiFlexItem>
           <EuiFlexItem>
             <DocViewer

--- a/src/plugins/discover/public/application/components/doc_viewer_links/doc_viewer_links.tsx
+++ b/src/plugins/discover/public/application/components/doc_viewer_links/doc_viewer_links.tsx
@@ -17,7 +17,8 @@ export function DocViewerLinks(renderProps: DocViewLinkRenderProps) {
       const listItem: EuiListGroupItemProps = {
         'data-test-subj': 'docTableRowAction',
         ...props,
-        href: generateCb ? generateCb(renderProps).url : href,
+        //href: generateCb ? generateCb(renderProps).url : href,
+        onClick: renderProps.onClick,
       };
 
       return listItem;

--- a/src/plugins/discover/public/application/doc_views_links/doc_views_links_types.ts
+++ b/src/plugins/discover/public/application/doc_views_links/doc_views_links_types.ts
@@ -22,4 +22,5 @@ export interface DocViewLinkRenderProps {
   columns?: string[];
   hit: OpenSearchSearchHit;
   indexPattern: IndexPattern;
+  onClick: () => void;
 }

--- a/src/plugins/discover/public/application/utils/filters.ts
+++ b/src/plugins/discover/public/application/utils/filters.ts
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { opensearchFilters, Filter } from '../../../../../../src/plugins/data/public';
+
+
+/**
+ * Helper function to compare 2 different filter states
+ */
+export function isEqualFilters(filtersA: Filter[], filtersB: Filter[]) {
+    if (!filtersA && !filtersB) {
+      return true;
+    } else if (!filtersA || !filtersB) {
+      return false;
+    }
+    return opensearchFilters.compareFilters(
+      filtersA,
+      filtersB,
+      opensearchFilters.COMPARE_ALL_OPTIONS
+    );
+}

--- a/src/plugins/discover/public/application/utils/state_management/commonUtils.ts
+++ b/src/plugins/discover/public/application/utils/state_management/commonUtils.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const addColumn = (columns: string[], action: { column: string; index?: number }) => {
+    const { column, index } = action;
+    const newColumns = [...(columns || [])];
+    if (index !== undefined) newColumns.splice(index, 0, column);
+    else newColumns.push(column);
+    return newColumns;
+};
+
+export const removeColumn = (columns: string[], actionColumn: string) => {
+  return (columns || []).filter((column) => column !== actionColumn);
+};
+
+export const reorderColumn = (columns: string[], source: number, destination: number) => {
+  const newColumns = [...(columns || [])];
+  const [removed] = newColumns.splice(source, 1);
+  newColumns.splice(destination, 0, removed);
+  return newColumns;
+};
+
+export const setColumns = (timeField: string | undefined, columns: string[]) => {
+    const newColumns = timeField && timeField === columns[0] ? columns.slice(1): columns;
+    return newColumns;
+};

--- a/src/plugins/discover/public/application/utils/state_management/discover_context_slice.tsx
+++ b/src/plugins/discover/public/application/utils/state_management/discover_context_slice.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { DiscoverServices } from '../../../build_services';
+import { Filter, Query } from '../../../../../data/public';
+import { OpenSearchHitRecord, OpenSearchHitRecordList } from '../../components/context/api/context';
+import { LOADING_STATUS } from '../../components/context/query/constants';
+import { ContextFetchStatus } from '../../components/context/query/types';
+import { buildColumns } from '../columns';
+import { addColumn, removeColumn, reorderColumn, setColumns } from './commonUtils';
+
+export interface DiscoverContextState {
+  columns: string[];
+  filters: Filter[];
+  predecessorCount: number;
+  sort: Array<[string, string]>;
+  successorCount: number;
+  query?: Query;
+  predecessors: any;
+  successors: any;
+  anchorId: string;
+  anchor: OpenSearchHitRecord;
+  contextFetchStatus: ContextFetchStatus;
+}
+
+const initialState: DiscoverContextState = {
+  columns: ['_source'],
+  filters: [],
+  predecessorCount: 5,
+  sort: [],
+  successorCount: 5,
+  anchorId: '',
+  anchor: {} as OpenSearchHitRecord,
+  predecessors: [],
+  successors: [],
+  contextFetchStatus: {
+    anchorStatus: { value: LOADING_STATUS.UNINITIALIZED },
+    predecessorStatus: { value: LOADING_STATUS.UNINITIALIZED },
+    successorStatus: { value: LOADING_STATUS.UNINITIALIZED },
+  },
+};
+
+export const getPreloadedDiscoverContextState = async ({
+  data,
+}: DiscoverServices): Promise<DiscoverContextState> => {
+  return {
+    ...initialState,
+  };
+};
+
+export const discoverContextSlice = createSlice({
+  name: 'discoverContext',
+  initialState,
+  reducers: {
+    setContextState(state, action: PayloadAction<DiscoverContextState>) {
+      return action.payload;
+    },
+    addContextColumn(state, action: PayloadAction<{ column: string; index?: number }>) {
+      const columns = addColumn(state.columns || [], action.payload);
+      return { ...state, columns: buildColumns(columns) };
+    },
+    removeContextColumn(state, action: PayloadAction<string>) {
+      const columns = removeColumn(state.columns, action.payload);
+      const sort = state.sort && state.sort.length? state.sort.filter((s) => s[0] !== action.payload): [];
+      return {
+        ...state,
+        columns: buildColumns(columns),
+        sort: sort,
+      };
+    },
+    reorderContextColumn(state, action: PayloadAction<{ source: number; destination: number }>) {
+      const columns = reorderColumn(state.columns, action.payload.source, action.payload.destination);
+      return {
+        ...state,
+        columns: columns,
+      };
+    },
+    setContextColumns(state, action: PayloadAction<{ timeField: string | undefined, columns: string[]}>) {
+      const columns = setColumns(action.payload.timeField, action.payload.columns);
+      return {
+        ...state,
+        columns: columns,
+      };
+    },
+    setContextSort(state, action: PayloadAction<Array<[string, string]>>) {
+      return {
+        ...state,
+        sort: action.payload,
+      };
+    },
+    setAnchorId(state, action: PayloadAction<string>) {
+      state.anchorId = action.payload;
+    },
+    setAnchor(state, action: PayloadAction<OpenSearchHitRecord>) {
+      state.anchor = action.payload;
+    },
+    setPredecessorCount(state, action: PayloadAction<number>) {
+      state.predecessorCount = action.payload;
+    },
+    setPredecessors(state, action: PayloadAction<OpenSearchHitRecordList>) {
+      state.predecessors = action.payload;
+    },
+    setSuccessorCount(state, action: PayloadAction<number>) {
+      state.successorCount = action.payload;
+    },
+    setSuccessors(state, action: PayloadAction<OpenSearchHitRecordList>) {
+      state.successors = action.payload;
+    },
+    setContextFetchStatus(state, action: PayloadAction<Partial<ContextFetchStatus>>) {
+      const prevContextFetchStatus = state.contextFetchStatus;
+      state.contextFetchStatus = { ...prevContextFetchStatus, ...action.payload };
+    },
+    setContextFilters(state, action: PayloadAction<Filter[]>) {
+      state.filters = action.payload;
+    },
+    updateContextState(state, action: PayloadAction<Partial<DiscoverContextState>>) {
+      return {
+        ...state,
+        ...action.payload,
+      };
+    },
+  },
+});
+
+// Exposing the state functions as generics
+export const {
+  addContextColumn,
+  removeContextColumn,
+  reorderContextColumn,
+  setContextColumns,
+  setContextSort,
+  setContextState,
+  setAnchorId,
+  setAnchor,
+  setPredecessorCount,
+  setPredecessors,
+  setSuccessorCount,
+  setSuccessors,
+  setContextFetchStatus,
+  setContextFilters,
+  updateContextState,
+} = discoverContextSlice.actions;
+export const { reducer } = discoverContextSlice;

--- a/src/plugins/discover/public/application/utils/state_management/index.ts
+++ b/src/plugins/discover/public/application/utils/state_management/index.ts
@@ -6,11 +6,38 @@
 import { TypedUseSelectorHook } from 'react-redux';
 import { RootState, useTypedDispatch, useTypedSelector } from '../../../../../data_explorer/public';
 import { DiscoverState } from './discover_slice';
+import { DiscoverContextState } from './discover_context_slice';
 
-export * from './discover_slice';
+export {
+  addDiscoverColumn,
+  removeDiscoverColumn,
+  reorderDiscoverColumn,
+  setDiscoverColumns,
+  setDiscoverState,
+  setDiscoverSort,
+  updateDiscoverState
+} from './discover_slice';
+export {
+  addContextColumn,
+  removeContextColumn,
+  reorderContextColumn,
+  setContextColumns,
+  setContextSort,
+  setContextState,
+  setAnchorId,
+  setAnchor,
+  setPredecessorCount,
+  setPredecessors,
+  setSuccessorCount,
+  setSuccessors,
+  setContextFetchStatus,
+  setContextFilters,
+  updateContextState,
+} from './discover_context_slice';
 
 export interface DiscoverRootState extends RootState {
   discover: DiscoverState;
+  discoverContext: DiscoverContextState;
 }
 
 export const useSelector: TypedUseSelectorHook<DiscoverRootState> = useTypedSelector;

--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -3,14 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { History } from 'history';
 import { DiscoverViewServices } from '../../../build_services';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { DataGridTable } from '../../components/data_grid/data_grid_table';
 import { useDiscoverContext } from '../context';
-import { addColumn, removeColumn, useDispatch, useSelector } from '../../utils/state_management';
+import { addDiscoverColumn, removeDiscoverColumn, setDiscoverColumns, setDiscoverSort, useDispatch, useSelector } from '../../utils/state_management';
 import { SearchData } from '../utils/use_search';
+import { IndexPatternField, opensearchFilters } from '../../../../../data/public';
+import { DocViewFilterFn } from '../../doc_views/doc_views_types';
 
 interface Props {
   history: History;
@@ -18,14 +20,30 @@ interface Props {
 
 export const DiscoverTable = ({ history }: Props) => {
   const { services } = useOpenSearchDashboards<DiscoverViewServices>();
+  const { filterManager } = services.data.query;
   const { data$, indexPattern } = useDiscoverContext();
   const [fetchState, setFetchState] = useState<SearchData>({
     status: data$.getValue().status,
     rows: [],
   });
 
-  const { columns } = useSelector((state) => state.discover);
+  const { columns, sort } = useSelector((state) => state.discover);
   const dispatch = useDispatch();
+  const onAddColumn=(column:string) => dispatch(addDiscoverColumn({column,}));
+  const onRemoveColumn=(column:string) => dispatch(removeDiscoverColumn(column));
+  const onSetColumns=(columns:string[]) => dispatch(setDiscoverColumns({ timefield: indexPattern.timeFieldName, columns: columns}));
+  const onSetSort=(sort:Array<[string, string]>) => dispatch(setDiscoverSort(sort));
+  const onAddFilter = useCallback(
+    (field: IndexPatternField, values: string, operation: '+' | '-') => {
+      const newFilters = opensearchFilters.generateFilters(
+        filterManager,
+        field,
+        values,
+        operation,
+        indexPattern.id
+      );
+    return filterManager.addFilters(newFilters);
+  }, [filterManager, opensearchFilters, indexPattern]);
 
   const { rows } = fetchState || {};
 
@@ -54,18 +72,13 @@ export const DiscoverTable = ({ history }: Props) => {
     <DataGridTable
       columns={columns}
       indexPattern={indexPattern}
-      onAddColumn={(column) =>
-        dispatch(
-          addColumn({
-            column,
-          })
-        )
-      }
-      onFilter={() => {}}
-      onRemoveColumn={(column) => dispatch(removeColumn(column))}
-      onSetColumns={() => {}}
-      onSort={() => {}}
-      sort={[]}
+      onAddColumn={onAddColumn}
+      onFilter={onAddFilter as DocViewFilterFn}
+      onRemoveColumn={onRemoveColumn}
+      onSetColumns={onSetColumns}
+      onSort={onSetSort}
+      onResize={() => {}}
+      sort={sort}
       rows={rows}
       displayTimeColumn={true}
       services={services}

--- a/src/plugins/discover/public/application/view_components/panel/index.tsx
+++ b/src/plugins/discover/public/application/view_components/panel/index.tsx
@@ -6,9 +6,9 @@
 import React, { useEffect, useState } from 'react';
 import { ViewProps } from '../../../../../data_explorer/public';
 import {
-  addColumn,
-  removeColumn,
-  reorderColumn,
+  addDiscoverColumn,
+  removeDiscoverColumn,
+  reorderDiscoverColumn,
   useDispatch,
   useSelector,
 } from '../../utils/state_management';
@@ -42,18 +42,18 @@ export default function DiscoverPanel(props: ViewProps) {
       hits={fetchState.rows || []}
       onAddField={(fieldName, index) => {
         dispatch(
-          addColumn({
+          addDiscoverColumn({
             column: fieldName,
             index,
           })
         );
       }}
       onRemoveField={(fieldName) => {
-        dispatch(removeColumn(fieldName));
+        dispatch(removeDiscoverColumn(fieldName));
       }}
       onReorderFields={(source, destination) => {
         dispatch(
-          reorderColumn({
+          reorderDiscoverColumn({
             source,
             destination,
           })


### PR DESCRIPTION
## Description
#### Separate context application and discover state. Discover application now has two applications states: 

```
export interface DiscoverRootState extends RootState {
  discover: DiscoverState;
  discoverContext: DiscoverContextState;
}
```
#### Allow view to register multiple redux slices
  
Slices is now an Slice array and views can register multiple slices
```
readonly ui?: {
    defaults: T | (() => T) | (() => Promise<T>);
    slices: Slice[];
  };

views.forEach((view) => {
    if (!view.ui) return;

    view.ui.slices.forEach((slice) => {
      registerSlice(slice);
    });
  });
```  
For defaults, modify the logic. To minimize the impact, check `if (view.id in defaultResult) {`. Previously, Discover only has one slice `discover`. If an application wants to have multiple slices, one slice should be named as view.id. For example, if Discover want to register multiple slices, one slice should be named as `discover`. This would make sure that the change won't affect current usage and provide us a simple check clause.

```
if (typeof defaults === 'function') {
      const defaultResult = await defaults();

      // Check if the result contains the view's ID key.
      // This is used to distinguish between a single registered state and multiple states.
      // Multiple registered states should return an object with multiple key-value pairs with one key always equal to view.id.
      if (view.id in defaultResult) {
        for (const key in defaultResult) {
          // The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype
          if (defaultResult.hasOwnProperty(key)) {
            rootState[key] = defaultResult[key];
          }
        }
      } else {
        rootState[view.id] = defaultResult;
      }
```
#### Add surrounding flyout `SurrondingDocumentFlyout`.  This component will be render if there is an clicked document (`expandedHit`) and `surroundingFlyoutOpen` is true. This `surroundingFlyoutOpen` is controlled by clicking `View Surrouding documents`.
#### Restore original context application to surrounding flyout
#### Restore and simplify the fetch logic from context application (use_query_actions.ts)
    
## Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4231
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4230
    
## Screenshot

<img width="1157" alt="Screenshot 2023-08-14 at 15 30 46" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/b7c6c5af-5af1-4fa8-8c89-f331040c51ca">


## ToDo
1. Toggle doesn’t update the surrounding document
2. Update surrounding document is slow and should settle at the same time
3. Format table 
4. Implement and test resize.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
