### PR TITLE
Bump `underscore.string` to version `3.3.6` to fix ReDoS vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [WS-2021-0638] Bump mocha from `7.2.0` to `10.1.0` ([#2711](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2711))
 - [CVE-2023-26115] Bump `word-wrap` from `1.2.3` to `1.2.4` ([#4589](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4589))
 - Bump `node-sass` to a version that uses a newer `libsass` ([#4649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4649))
+- Bump `underscore.string` to version `3.3.6` which has fix to ReDOS vulnerability ([#4750](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4750))
 
 ### 📈 Features/Enhancements
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "**/semver": "^7.5.3",
     "**/set-value": "^4.1.0",
     "**/xml2js": "^0.5.0",
-    "**/yaml": "^2.2.2"
+    "**/yaml": "^2.2.2",
+    "**/underscore.string": "^3.3.6"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -17439,7 +17439,7 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-underscore.string@~3.3.5:
+underscore.string@^3.3.6, underscore.string@~3.3.5:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.6.tgz#ad8cf23d7423cb3b53b898476117588f4e2f9159"
   integrity sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ==


### PR DESCRIPTION
### Description

Before applying this change - 
```
yarn why underscore.string
yarn why v1.22.19
[1/4] Why do we have the module "underscore.string"...?
[2/4] Initialising dependency graph...
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~4.5.2"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "grunt#underscore.string@3.3.6"
info Reasons this module exists
   - "_project_#grunt#grunt-legacy-util" depends on it
   - Hoisted from "_project_#grunt#grunt-legacy-util#underscore.string"
   - in the nohoist list ["/_project_/**/@types/*","/_project_/**/@types/*/**","/_project_/**/grunt-*","/_project_/**/grunt-*/**","/_project_/@elastic/eui/rehype-react","/_project_/@elastic/eui/remark-rehype","/_project_/@elastic/eui/remark-rehype/**"]
info Disk size without dependencies: "444KB"
info Disk size with unique dependencies: "548KB"
info Disk size with transitive dependencies: "548KB"
info Number of shared dependencies: 2
Done in 0.82s.
```
With the current state in main, package manager is already installing `underscore.string` 3.3.6 version as its locked in the yarn.lock file. This change is explicitly locking the versions to 3.3.6 by resolving `underscore.string` in package.json. 

### Issues Resolved


https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4734


### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
