### PR TITLE
[Data Explorer] Fix dashboard test for legacy discover

### DIFF
--- a/test/functional/apps/dashboard/dashboard_state.js
+++ b/test/functional/apps/dashboard/dashboard_state.js
@@ -116,6 +116,9 @@ export default function ({ getService, getPageObjects }) {
       expect(inViewMode).to.be(true);
 
       await PageObjects.header.clickDiscover();
+      // Add load save search here since discover link won't take it to the save search link for
+      // the legacy discover plugin
+      await PageObjects.discover.loadSavedSearch('my search');
       await PageObjects.discover.clickFieldListItemAdd('agent');
       await PageObjects.discover.saveSearch('my search');
       await PageObjects.header.waitUntilLoadingHasFinished();
@@ -135,6 +138,9 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.dashboard.saveDashboard('Has local edits');
 
       await PageObjects.header.clickDiscover();
+      // Add load save search here since discover link won't take it to the save search link for
+      // the legacy discover plugin
+      await PageObjects.discover.loadSavedSearch('my search');
       await PageObjects.discover.clickFieldListItemAdd('clientip');
       await PageObjects.discover.saveSearch('my search');
       await PageObjects.header.waitUntilLoadingHasFinished();

--- a/test/functional/apps/dashboard/dashboard_time_picker.js
+++ b/test/functional/apps/dashboard/dashboard_time_picker.js
@@ -83,7 +83,7 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.dashboard.clickNewDashboard();
       log.debug('Clicked new dashboard');
       await dashboardVisualizations.createAndAddSavedSearch({
-        name: 'saved search',
+        name: 'saved search 1',
         fields: ['bytes', 'agent'],
       });
       log.debug('added saved search');

--- a/test/functional/apps/dashboard/index.js
+++ b/test/functional/apps/dashboard/index.js
@@ -102,15 +102,15 @@ export default function ({ getService, loadTestFile }) {
     // the data once to save on time. Eventually, all of these tests should just use current data and we can reserve
     // legacy data only for specifically testing BWC situations.
     describe('using legacy data', function () {
-      this.tags('ciGroupx');
+      this.tags('ciGroup4');
       before(loadLogstash);
       after(unloadLogstash);
 
-      //loadTestFile(require.resolve('./dashboard_time_picker'));
-      // loadTestFile(require.resolve('./bwc_shared_urls'));
-      // loadTestFile(require.resolve('./panel_replacing'));
-      // loadTestFile(require.resolve('./panel_cloning'));
-      // loadTestFile(require.resolve('./panel_context_menu'));
+      loadTestFile(require.resolve('./dashboard_time_picker'));
+      loadTestFile(require.resolve('./bwc_shared_urls'));
+      loadTestFile(require.resolve('./panel_replacing'));
+      loadTestFile(require.resolve('./panel_cloning'));
+      loadTestFile(require.resolve('./panel_context_menu'));
       loadTestFile(require.resolve('./dashboard_state'));
     });
 

--- a/test/functional/apps/dashboard/index.js
+++ b/test/functional/apps/dashboard/index.js
@@ -102,15 +102,15 @@ export default function ({ getService, loadTestFile }) {
     // the data once to save on time. Eventually, all of these tests should just use current data and we can reserve
     // legacy data only for specifically testing BWC situations.
     describe('using legacy data', function () {
-      this.tags('ciGroup4');
+      this.tags('ciGroupx');
       before(loadLogstash);
       after(unloadLogstash);
 
-      loadTestFile(require.resolve('./dashboard_time_picker'));
-      loadTestFile(require.resolve('./bwc_shared_urls'));
-      loadTestFile(require.resolve('./panel_replacing'));
-      loadTestFile(require.resolve('./panel_cloning'));
-      loadTestFile(require.resolve('./panel_context_menu'));
+      //loadTestFile(require.resolve('./dashboard_time_picker'));
+      // loadTestFile(require.resolve('./bwc_shared_urls'));
+      // loadTestFile(require.resolve('./panel_replacing'));
+      // loadTestFile(require.resolve('./panel_cloning'));
+      // loadTestFile(require.resolve('./panel_context_menu'));
       loadTestFile(require.resolve('./dashboard_state'));
     });
 


### PR DESCRIPTION
### Description

Fix the failed dashboard functional test for discover. 

Need to add a line `await PageObjects.discover.loadSavedSearch('my search');` as a workaround since the discover link won't take it to the previously accessed saved search page link, it will only take it to the discover page. The issue is documented here: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4698#issuecomment-1672592217

Since we plan to get rid of legacy discover soon, this should not be a problem.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
