### PR TITLE
Add  `bootstrap` package resolution to version `3.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [CVE-2023-26115] Bump `word-wrap` from `1.2.3` to `1.2.4` ([#4589](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4589))
 - Bump `node-sass` to a version that uses a newer `libsass` ([#4649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4649))
 - [CVE-2019-11358] Bump version of tinygradient from 0.4.3 to 1.1.5 ([#4742](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4742))
+- [CVE-2016-10735] Bump version of `bootstrap` from `3.3.7` to `3.4.0` ([#4757](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4757))
+- [CVE-2018-20676] Bump version of `bootstrap` from `3.3.7` to `3.4.0` ([#4757](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4757))
+- [CVE-2018-14042] Bump version of `bootstrap` from `3.3.7` to `3.4.0` ([#4757](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4757))
+- [CVE-2018-20677] Bump version of `bootstrap` from `3.3.7` to `3.4.0` ([#4757](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4757))
+- [CVE-2018-14040] Bump version of `bootstrap` from `3.3.7` to `3.4.0` ([#4757](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4757))
+- [CVE-2019-8331] Bump version of `bootstrap` from `3.3.7` to `3.4.0` ([#4757](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4757))
 
 ### 📈 Features/Enhancements
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "**/semver": "^7.5.3",
     "**/set-value": "^4.1.0",
     "**/xml2js": "^0.5.0",
-    "**/yaml": "^2.2.2"
+    "**/yaml": "^2.2.2",
+    "**/bootstrap": "^3.4.0"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5211,6 +5211,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
### Description

Path to dependency file: /node_modules/leaflet-draw/docs/examples/basic.html

Path to vulnerable library: /node_modules/leaflet-draw/docs/examples/basic.html 

Currently in main, one of the node modules `leaflet-draw` pulls version of `bootstrap-3.3.7` through CDN link which has vulnerability. Adding package resolution to 3.4.0 to install safer version.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4729
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4728
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4727
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4725
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4723
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4722

### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
