### PR TITLE
[Data Explorer] Altrnate result state views + fixes

### DIFF
--- a/src/plugins/discover/public/application/components/loading_spinner/loading_spinner.scss
+++ b/src/plugins/discover/public/application/components/loading_spinner/loading_spinner.scss
@@ -1,0 +1,4 @@
+.discoverNoResults {
+  display: flex;
+  align-items: center;
+}

--- a/src/plugins/discover/public/application/components/loading_spinner/loading_spinner.tsx
+++ b/src/plugins/discover/public/application/components/loading_spinner/loading_spinner.tsx
@@ -28,20 +28,24 @@
  * under the License.
  */
 
+import './loading_spinner.scss';
 import React from 'react';
-import { EuiLoadingSpinner, EuiTitle, EuiSpacer } from '@elastic/eui';
+import { EuiTitle, EuiPanel, EuiEmptyPrompt, EuiLoadingSpinner } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 
 export function LoadingSpinner() {
   return (
-    <>
-      <EuiTitle size="s" data-test-subj="loadingSpinnerText">
-        <h2>
-          <FormattedMessage id="discover.searchingTitle" defaultMessage="Searching" />
-        </h2>
-      </EuiTitle>
-      <EuiSpacer size="m" />
-      <EuiLoadingSpinner size="l" data-test-subj="loadingSpinner" />
-    </>
+    <EuiPanel hasBorder={false} hasShadow={false} color="transparent" className="discoverNoResults">
+      <EuiEmptyPrompt
+        icon={<EuiLoadingSpinner data-test-subj="loadingSpinner" size="xl" />}
+        title={
+          <EuiTitle size="s" data-test-subj="loadingSpinnerText">
+            <h2>
+              <FormattedMessage id="discover.searchingTitle" defaultMessage="Searching" />
+            </h2>
+          </EuiTitle>
+        }
+      />
+    </EuiPanel>
   );
 }

--- a/src/plugins/discover/public/application/components/no_results/no_results.tsx
+++ b/src/plugins/discover/public/application/components/no_results/no_results.tsx
@@ -28,23 +28,26 @@
  * under the License.
  */
 
-import React, { Component, Fragment } from 'react';
+import React, { Fragment } from 'react';
 import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
-import PropTypes from 'prop-types';
 
 import {
   EuiCallOut,
   EuiCode,
   EuiDescriptionList,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiLink,
+  EuiPanel,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
 import { getServices } from '../../../opensearch_dashboards_services';
 
-export const DiscoverNoResults = (timeFieldName: string, queryLanguage: any) => {
+interface Props {
+  timeFieldName?: string;
+  queryLanguage?: string;
+}
+
+export const DiscoverNoResults = ({ timeFieldName, queryLanguage }: Props) => {
   let timeFieldMessage;
 
   if (timeFieldName) {
@@ -189,27 +192,21 @@ export const DiscoverNoResults = (timeFieldName: string, queryLanguage: any) => 
 
   return (
     <I18nProvider>
-      <Fragment>
-        <EuiSpacer size="xl" />
-
-        <EuiFlexGroup justifyContent="center">
-          <EuiFlexItem grow={false} className="dscNoResults">
-            <EuiCallOut
-              title={
-                <FormattedMessage
-                  id="discover.noResults.searchExamples.noResultsMatchSearchCriteriaTitle"
-                  defaultMessage="No results match your search criteria"
-                />
-              }
-              color="warning"
-              iconType="help"
-              data-test-subj="discoverNoResults"
+      <EuiPanel hasBorder={false} hasShadow={false} color="transparent">
+        <EuiCallOut
+          title={
+            <FormattedMessage
+              id="discover.noResults.searchExamples.noResultsMatchSearchCriteriaTitle"
+              defaultMessage="No results match your search criteria"
             />
-            {timeFieldMessage}
-            {luceneQueryMessage}
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </Fragment>
+          }
+          color="warning"
+          iconType="help"
+          data-test-subj="discoverNoResults"
+        />
+        {timeFieldMessage}
+        {luceneQueryMessage}
+      </EuiPanel>
     </I18nProvider>
   );
 };

--- a/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
@@ -153,7 +153,6 @@ export const DiscoverField = ({
       >
         <EuiButtonIcon
           iconType="plusInCircleFilled"
-          className="dscSidebarItem__action"
           onClick={(ev: React.MouseEvent<HTMLButtonElement>) => {
             if (ev.type === 'click') {
               ev.currentTarget.focus();
@@ -178,7 +177,6 @@ export const DiscoverField = ({
         <EuiButtonIcon
           color="danger"
           iconType="cross"
-          className="dscSidebarItem__action"
           onClick={(ev: React.MouseEvent<HTMLButtonElement>) => {
             if (ev.type === 'click') {
               ev.currentTarget.focus();

--- a/src/plugins/discover/public/application/components/sidebar/discover_sidebar.scss
+++ b/src/plugins/discover/public/application/components/sidebar/discover_sidebar.scss
@@ -1,3 +1,3 @@
-.dscFieldListHeader {
+.dscSideBarFieldListHeader {
   padding-left: $euiSizeS;
 }

--- a/src/plugins/discover/public/application/components/sidebar/discover_sidebar.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_sidebar.tsx
@@ -204,7 +204,7 @@ export function DiscoverSidebar({
           <EuiSplitPanel.Inner className="eui-yScroll" paddingSize="none">
             {fields.length > 0 && (
               <>
-                <EuiTitle size="xxxs" id="selected_fields" className="dscFieldListHeader">
+                <EuiTitle size="xxxs" id="selected_fields" className="dscSideBarFieldListHeader">
                   <h3>
                     <FormattedMessage
                       id="discover.fieldChooser.filter.selectedFieldsTitle"
@@ -248,7 +248,7 @@ export function DiscoverSidebar({
                     );
                   })}
                 </EuiDroppable>
-                <EuiTitle size="xxxs" id="available_fields" className="dscFieldListHeader">
+                <EuiTitle size="xxxs" id="available_fields" className="dscSideBarFieldListHeader">
                   <h3>
                     <FormattedMessage
                       id="discover.fieldChooser.filter.availableFieldsTitle"
@@ -267,7 +267,7 @@ export function DiscoverSidebar({
                     data-test-subj={`fieldList-popular`}
                     color="primary"
                   >
-                    <EuiTitle size="xxxs" className="dscFieldListHeader">
+                    <EuiTitle size="xxxs" className="dscSideBarFieldListHeader">
                       <h4 style={{ fontWeight: 'normal' }} id="available_fields_popular">
                         <FormattedMessage
                           id="discover.fieldChooser.filter.popularTitle"

--- a/src/plugins/discover/public/application/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/get_top_nav_links.tsx
@@ -65,10 +65,6 @@ export const getTopNavLinks = (
       defaultMessage: 'Save Search',
     }),
     testId: 'discoverSaveButton',
-    disableButton: () => {
-      const state: DiscoverState = store!.getState().discover; // store is defined before the view is loaded
-      return !state.isDirty;
-    },
     run: async () => {
       const onSave = async ({
         newTitle,
@@ -229,10 +225,10 @@ export const getTopNavLinks = (
     },
   };
 
-  const legacyDiscover = {
+  const legacyDiscover: TopNavMenuData = {
     id: 'discover-new',
-    label: i18n.translate('discover.localMenu.legacyDiscoverTitle', {
-      defaultMessage: 'Legacy Discover',
+    label: i18n.translate('discover.localMenu.newDiscoverTitle', {
+      defaultMessage: 'New Discover',
     }),
     description: i18n.translate('discover.localMenu.newDiscoverDescription', {
       defaultMessage: 'New Discover Experience',
@@ -242,6 +238,8 @@ export const getTopNavLinks = (
       await uiSettings.set(NEW_DISCOVER_APP, false);
       window.location.reload();
     },
+    type: 'toggle' as const,
+    emphasize: true,
   };
 
   return [

--- a/src/plugins/discover/public/application/components/top_nav/open_search_panel.test.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/open_search_panel.test.tsx
@@ -39,7 +39,7 @@ jest.mock('../../../../../opensearch_dashboards_react/public', () => ({
   useOpenSearchDashboards: jest.fn().mockReturnValue({
     services: {
       core: { uiSettings: {}, savedObjects: {} },
-      addBasePath: (path) => path,
+      addBasePath: (path: string) => path,
     },
   }),
   withOpenSearchDashboards: jest.fn(),

--- a/src/plugins/discover/public/application/view_components/canvas/discover_chart_container.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_chart_container.tsx
@@ -4,52 +4,19 @@
  */
 
 import './discover_chart_container.scss';
-import React, { useState, useEffect } from 'react';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import React from 'react';
 import { DiscoverViewServices } from '../../../build_services';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { useDiscoverContext } from '../context';
-import { useDispatch } from '../../utils/state_management';
 import { SearchData } from '../utils/use_search';
 import { DiscoverChart } from '../../components/chart/chart';
 
-export const DiscoverChartContainer = () => {
+export const DiscoverChartContainer = ({ hits, bucketInterval, chartData }: SearchData) => {
   const { services } = useOpenSearchDashboards<DiscoverViewServices>();
   const { uiSettings, data } = services;
-  const { data$, indexPattern } = useDiscoverContext();
-  const [fetchState, setFetchState] = useState<SearchData>({
-    status: data$.getValue().status,
-    hits: 0,
-    bucketInterval: {},
-    chartData: {},
-  });
+  const { indexPattern } = useDiscoverContext();
 
-  const dispatch = useDispatch();
-
-  const { hits, bucketInterval, chartData } = fetchState || {};
-
-  useEffect(() => {
-    const subscription = data$.subscribe((next) => {
-      if (
-        next.status !== fetchState.status ||
-        (next.hits && next.hits !== fetchState.hits) ||
-        (next.bucketInterval && next.bucketInterval !== fetchState.bucketInterval) ||
-        (next.chartData && next.chartData !== fetchState.chartData)
-      ) {
-        setFetchState({ ...fetchState, ...next });
-      }
-    });
-    return () => {
-      subscription.unsubscribe();
-    };
-  }, [data$, fetchState]);
-
-  if (indexPattern === undefined) {
-    // TODO: handle better
-    return null;
-  }
-
-  const timeField = indexPattern.timeFieldName ? indexPattern.timeFieldName : undefined;
+  const timeField = indexPattern?.timeFieldName ? indexPattern.timeFieldName : undefined;
 
   if (!hits || !bucketInterval || !chartData) {
     // TODO: handle better

--- a/src/plugins/discover/public/application/view_components/canvas/discover_chart_container.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_chart_container.tsx
@@ -16,7 +16,7 @@ export const DiscoverChartContainer = ({ hits, bucketInterval, chartData }: Sear
   const { uiSettings, data } = services;
   const { indexPattern } = useDiscoverContext();
 
-  const timeField = indexPattern?.timeFieldName ? indexPattern.timeFieldName : undefined;
+  const timeField = indexPattern?.timeFieldName;
 
   if (!hits || !bucketInterval || !chartData) {
     // TODO: handle better

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -3,15 +3,48 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
 import { TopNav } from './top_nav';
 import { ViewProps } from '../../../../../data_explorer/public';
 import { DiscoverTable } from './discover_table';
 import { DiscoverChartContainer } from './discover_chart_container';
+import { useDiscoverContext } from '../context';
+import { ResultStatus, SearchData } from '../utils/use_search';
+import { DiscoverNoResults } from '../../components/no_results/no_results';
+import { DiscoverUninitialized } from '../../components/uninitialized/uninitialized';
+import { LoadingSpinner } from '../../components/loading_spinner/loading_spinner';
 
 // eslint-disable-next-line import/no-default-export
 export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewProps) {
+  const { data$, refetch$, indexPattern } = useDiscoverContext();
+
+  const [fetchState, setFetchState] = useState<SearchData>({
+    status: data$.getValue().status,
+    hits: 0,
+    bucketInterval: {},
+  });
+
+  const { status } = fetchState;
+
+  useEffect(() => {
+    const subscription = data$.subscribe((next) => {
+      if (
+        next.status !== fetchState.status ||
+        (next.hits && next.hits !== fetchState.hits) ||
+        (next.bucketInterval && next.bucketInterval !== fetchState.bucketInterval) ||
+        (next.chartData && next.chartData !== fetchState.chartData)
+      ) {
+        setFetchState({ ...fetchState, ...next });
+      }
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [data$, fetchState]);
+
+  const timeField = indexPattern?.timeFieldName ? indexPattern.timeFieldName : undefined;
+
   return (
     <EuiFlexGroup direction="column" gutterSize="none">
       <EuiFlexItem grow={false}>
@@ -21,16 +54,29 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
           }}
         />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="s">
-          <EuiPanel>
-            <DiscoverChartContainer />
-          </EuiPanel>
-        </EuiPanel>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <DiscoverTable history={history} />
-      </EuiFlexItem>
+      {status === ResultStatus.NO_RESULTS && (
+        <EuiFlexItem>
+          <DiscoverNoResults timeFieldName={timeField} queryLanguage={''} />
+        </EuiFlexItem>
+      )}
+      {status === ResultStatus.UNINITIALIZED && (
+        <DiscoverUninitialized onRefresh={() => refetch$.next()} />
+      )}
+      {status === ResultStatus.LOADING && <LoadingSpinner />}
+      {status === ResultStatus.READY && (
+        <>
+          <EuiFlexItem grow={false}>
+            <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="s">
+              <EuiPanel>
+                <DiscoverChartContainer {...fetchState} />
+              </EuiPanel>
+            </EuiPanel>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <DiscoverTable history={history} />
+          </EuiFlexItem>
+        </>
+      )}
     </EuiFlexGroup>
   );
 }

--- a/src/plugins/discover_legacy/public/application/angular/discover.js
+++ b/src/plugins/discover_legacy/public/application/angular/discover.js
@@ -494,6 +494,7 @@ function discoverController($element, $route, $scope, $timeout, $window, Promise
         await getServices().uiSettings.set(NEW_DISCOVER_APP, true);
         window.location.reload();
       },
+      type: 'toggle',
     };
 
     return [

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
@@ -45,6 +45,7 @@ export interface TopNavMenuData {
   emphasize?: boolean;
   iconType?: EuiIconType;
   iconSide?: EuiButtonProps['iconSide'];
+  type?: 'toggle' | 'button'; // experimental, do not use yet. Will be removed in a future minor version
 }
 
 export interface RegisteredTopNavMenuData extends TopNavMenuData {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
@@ -45,7 +45,8 @@ export interface TopNavMenuData {
   emphasize?: boolean;
   iconType?: EuiIconType;
   iconSide?: EuiButtonProps['iconSide'];
-  type?: 'toggle' | 'button'; // experimental, do not use yet. Will be removed in a future minor version
+  // @deprecated - experimental, do not use yet. Will be removed in a future minor version
+  type?: 'toggle' | 'button';
 }
 
 export interface RegisteredTopNavMenuData extends TopNavMenuData {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
@@ -30,7 +30,7 @@
 
 import { upperFirst, isFunction } from 'lodash';
 import React, { MouseEvent } from 'react';
-import { EuiToolTip, EuiButton, EuiHeaderLink } from '@elastic/eui';
+import { EuiToolTip, EuiButton, EuiHeaderLink, EuiSwitch } from '@elastic/eui';
 import { TopNavMenuData } from './top_nav_menu_data';
 
 export function TopNavMenuItem(props: TopNavMenuData) {
@@ -58,21 +58,36 @@ export function TopNavMenuItem(props: TopNavMenuData) {
     className: props.className,
   };
 
-  const btn = props.emphasize ? (
-    <EuiButton size="s" {...commonButtonProps}>
-      {upperFirst(props.label || props.id!)}
-    </EuiButton>
-  ) : (
-    <EuiHeaderLink size="xs" color="primary" {...commonButtonProps}>
-      {upperFirst(props.label || props.id!)}
-    </EuiHeaderLink>
-  );
+  let component;
+  if (props.type === 'toggle') {
+    component = (
+      <EuiSwitch
+        label={upperFirst(props.label || props.id!)}
+        checked={props.emphasize || false}
+        onChange={(e) => {
+          handleClick((e as unknown) as MouseEvent<HTMLButtonElement>);
+        }}
+        data-test-subj={props.testId}
+        className={props.className}
+      />
+    );
+  } else {
+    component = props.emphasize ? (
+      <EuiButton size="s" {...commonButtonProps}>
+        {upperFirst(props.label || props.id!)}
+      </EuiButton>
+    ) : (
+      <EuiHeaderLink size="xs" color="primary" {...commonButtonProps}>
+        {upperFirst(props.label || props.id!)}
+      </EuiHeaderLink>
+    );
+  }
 
   const tooltip = getTooltip();
   if (tooltip) {
-    return <EuiToolTip content={tooltip}>{btn}</EuiToolTip>;
+    return <EuiToolTip content={tooltip}>{component}</EuiToolTip>;
   }
-  return btn;
+  return component;
 }
 
 TopNavMenuItem.defaultProps = {


### PR DESCRIPTION
Signed-off-by: Ashwin P Chandran <ashwinpc@amazon.com>

### Description

This PR adds views for Loading and No results along with many other fixes such as:
1. variable row height based on selected columns i.e. when source is the only column, multiple rows are displayed
2. Fixes legacy discover styles from affecting discover 2.0
3. Adds switch button for legacy new discover toggle

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
<img width="1806" alt="Screenshot 2023-08-17 at 6 27 00 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/20453492/719d0a98-1390-4aa8-b248-ffd55ffb7e15">

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
