### PR TITLE
Add missing 1.3.x patch release notes to 2.x branch

### DIFF
--- a/release-notes/opensearch-dashboards.release-notes-1.3.10.md
+++ b/release-notes/opensearch-dashboards.release-notes-1.3.10.md
@@ -1,0 +1,33 @@
+# Version 1.3.10 Release Notes
+
+### 🛡 Security
+
+- [CVE-2020-15366][1.x] Bump ajv from 4.11.8 to 6.12.6 ([#4035](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4035))
+- [CVE-2022-48285][1.x] Bump jszip from 3.7.1 to 3.10.1 ([#4011](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4011))
+- [CVE-2021-35065][1.x] Bump glob-parent from 6.0.0 to 6.0.2 ([#4005](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4005))
+- [CVE-2022-25851][1.x] Bump jpeg-js from 0.4.1 to 0.4.4 ([#3860](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3860))
+- [CVE-2022-25858][1.x] Bump terser from 4.8.0 to 4.8.1 ([#3786](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3786))
+- [CVE-2021-23490][1.x] Bump parse-link-header from 1.0.1 to 2.0.0 ([#3820](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3820))
+- [CVE-2021-3765][1.x] Bump validator from 8.2.0 to 13.9.0 ([#3753](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3753))
+- [CVE-2022-25758][1.x] Bump scss-tokenizer from 0.3.0 to 0.4.3 ([#3789](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3789))
+- [CVE-2021-3803][1.x] Bump nth-check from 1.0.2 to 2.0.1 ([#3745](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3745))
+- Bump highlight.js from 9.18.5 to 10.7.3 to solve security concerns （[#4062](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4062))
+
+### 📈 Features/Enhancements
+
+- Add tooltip to help icon ([#3872](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3872))
+
+### 🐛 Bug Fixes
+
+- [TSVB] Fix the link to "serial differencing aggregation" documentation ([#3503](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3503))
+
+### 📝 Documentation
+
+- Update jest documentation links ([#3939](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3939))
+
+### 🛠 Maintenance
+
+- Add threshold to code coverage changes for project ([#4050](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4050))
+- Temporarily hardcode chromedriver to 112.0.0 to enable all ftr tests ([#4039]())
+- Update MAINTAINERS.md and CODEOWNERS ([#3938](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3938))
+- Add opensearch-dashboards-docker-dev to .gitignore ([#3781](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3781))

--- a/release-notes/opensearch-dashboards.release-notes-1.3.11.md
+++ b/release-notes/opensearch-dashboards.release-notes-1.3.11.md
@@ -1,0 +1,18 @@
+# Version 1.3.11 Release Notes
+
+### 🛡 Security
+
+- [CVE-2022-1537] Bump grunt from `1.5.2` to `1.5.3` ([#4276](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4276))
+- [CVE-2020-15366] Bump ajv from `4.11.8` to `6.12.6` ([#3769](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3769))
+
+### 📈 Features/Enhancements
+
+### 🐛 Bug Fixes
+
+### 🚞 Infrastructure
+
+- Upgrade the backport workflow ([#4343](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4343))
+
+### 📝 Documentation
+
+### 🛠 Maintenance

--- a/release-notes/opensearch-dashboards.release-notes-1.3.12.md
+++ b/release-notes/opensearch-dashboards.release-notes-1.3.12.md
@@ -1,0 +1,26 @@
+# Version 1.3.12 Release Notes
+
+### 🛡 Security
+
+- [CVE-2021-23382] Bump postcss from `8.2.10` to `8.4.24` ([#4403](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4403))
+- Bump `joi` to v14 to avoid the possibility of prototype poisoning in a nested dependency ([#3952](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3952))
+- [WS-2018-0347] Bump `sass-lint` from `1.12.1` to `1.13.0` to fix `eslint` security issue ([#4338](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4338))
+- [CVE-2022-25883] Resolve `semver` to `7.5.3` and remove unused package ([#4411](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4411), [#4686](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4686))
+- [CVE-2022-1537] Bump grunt from `1.4.1` to `1.5.3` ([#3723](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3723))
+- [CVE-2022-0436] Bump grunt from `1.4.1` to `1.5.3` ([#3723](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3723))
+- [CVE-2023-26136] Resolve `tough-cookie` to `4.1.3` ([#4682](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4682))
+
+### 📈 Features/Enhancements
+
+### 🐛 Bug Fixes
+
+### 🚞 Infrastructure
+
+### 📝 Documentation
+
+### 🛠 Maintenance
+
+- Adding @ZilongX and @Flyingliuhub as maintainers. ([#4137](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4137))
+- Add new MAINTAINERS to CODEOWNERS file. ([#4199](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4199))
+- Adding @BSFishy as maintainer. ([#4469](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4469))
+- [Version] Increment version to 1.3.12 ([#4656](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4656))

--- a/release-notes/opensearch-dashboards.release-notes-1.3.2.md
+++ b/release-notes/opensearch-dashboards.release-notes-1.3.2.md
@@ -1,0 +1,18 @@
+## Version 1.3.2 Release Notes
+
+### 🛡 Security
+* [CVE-2022-24785] Bumps moment from 2.29.1 to 2.29.2 ([#1456](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1456))
+* [CVE-2020-8203] [CVE-2021-23337] [CVE-2020-28500] Bumps lodash-es from 4.17.15 to 4.17.21 ([#1343](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1343))
+* [CVE-2022-0436] Bumps grunt from v1.4.1 to v1.5.2 ([#1451](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1451))
+* [CVE-2021-3918] Bumps json-schema from 0.2.3 to 0.4.0 ([#1385](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1385))
+* [CVE-2022-29078] Bumps ejs from 3.1.6 to 3.1.7 ([#1512](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1512))
+* [CVE-2021-44906] Bumps minimist from 1.2.5 to 1.2.6 ([#1377](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1377))
+* [CVE-2021-23566] Bumps nanoid from 3.1.30 to 3.2.0 ([#1173](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1173))
+
+### 🐛 Bug Fixes
+* Updates re2 build for arm under node 10 ([#1482](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1482))
+* fix(actions): Better type checks for icons ([#1496](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1496))
+
+### 🔩 Tests
+* [Tests] Fixes inconsistent plugin installation tests ([#1346](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1346))
+* [Tests] Bumps chromedriver to v100 ([#1410](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1410))

--- a/release-notes/opensearch-dashboards.release-notes-1.3.3.md
+++ b/release-notes/opensearch-dashboards.release-notes-1.3.3.md
@@ -1,0 +1,10 @@
+## Version 1.3.3 Release Notes
+
+### 🐛 Bug Fixes
+* [Bug] Fixes missing discover context icon ([#1545](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1545))
+* [Bug] Fixes the header loading spinner position in Firefox ([#1570](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1570))
+* [Bug] Fixes metric vizualization cut off text ([#1650](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1650))
+
+### 🛠 Maintenance
+* Removes irrelevant upsell in the timeout message ([#1599](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1599))
+* Removes duplicate var in opensearch-dashboards-docker ([#1649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1649))

--- a/release-notes/opensearch-dashboards.release-notes-1.3.5.md
+++ b/release-notes/opensearch-dashboards.release-notes-1.3.5.md
@@ -1,0 +1,14 @@
+## Version 1.3.5 Release Notes
+
+### 🛡 Security
+* Bump moment from 2.29.2 to 2.29.4 ([#1931](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1931))
+* [CVE] Add resolution for url-parse ([#2181](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2181))
+
+### 🐛 Bug Fixes
+Fix WMS can't load when unable access maps services([#1550](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1550))
+
+### 🔩 Tests
+* Bump chrome driver version in PR check workflow ([#2186](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2186))
+
+### 🛠 Maintenance
+* Version increment to 1.3.5 ([#1901](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1901))

--- a/release-notes/opensearch-dashboards.release-notes-1.3.6.md
+++ b/release-notes/opensearch-dashboards.release-notes-1.3.6.md
@@ -1,0 +1,25 @@
+## Version 1.3.6 Release Notes
+
+### 📈 Features/Enhancements
+
+* Custom healthcheck with filters ([#2232](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2232), [#2277](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2277)). To configure see example in [config/opensearch_dashboards.yml](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/6e2ec97459ae179c86201c611ce744c2c24ce150/config/opensearch_dashboards.yml#L44-L46)
+### 🛡 Security
+
+* [CVE-2021-3807] Resolves ansi-regex to v5.0.1 ([#2425](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2425))
+* [CVE-2022-23713] Handle invalid query, index and date in vega charts filter handlers ([#1932](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1932))
+* Use a forced CSP-compliant interpreter with Vega visualizations ([#2352](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2352))
+* Bump moment-timezone from 0.5.34 to 0.5.37 ([#2361](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2361))
+* [CVE-2022-0144] Bump shelljs from 0.8.4 to 0.8.5 ([#2511](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2511))
+
+### 🚞 Infrastructure
+
+* Add CHANGELOG.md and related workflows ([#2414](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2414))
+* Extends plugin-helpers to be used for automating version changes ([#2398](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2398),[#2486](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2486))
+
+### 🛠 Maintenance
+
+* Version Increment to 1.3.6 ([#2420](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2420))
+
+### 🔩 Tests
+
+* Update caniuse to fix failed integration tests ([#2322](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2322))

--- a/release-notes/opensearch-dashboards.release-notes-1.3.9.md
+++ b/release-notes/opensearch-dashboards.release-notes-1.3.9.md
@@ -1,0 +1,31 @@
+# Version 1.3.9 Release Notes
+
+### 🛡 Security
+
+- [CVE-2022-2499] Resolve qs from 6.5.2 and 6.7.0 to 6.11.0 in 1.x ([#3451](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3451))
+- [CVE-2020-36632] [REQUIRES PLUGIN VALIDATION] Bump flat from 4.1.1 to 5.0.2 ([#3539](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3539)). To the best of our knowledge, this is a non-breaking change, but if your plugin relies on `mocha` tests, validate that they still work correctly (and plan to migrate them to `jest` [in preparation for `mocha` deprecation](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1572).
+- [CVE-2023-25653] Bump node-jose to 2.2.0 ([#3445](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3445))
+- [CVE-2021-23807] Bump jsonpointer from 4.1.0 to 5.0.1 ([#3535](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3535))
+- [CVE-2021-23424] Bump ansi-html from 0.0.7 to 0.0.8 ([#3536](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3536))
+- [CVE-2022-24999] Bump express from 4.17.1 to 4.18.2 ([#3542](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3542))
+
+### 📈 Features/Enhancements
+
+- [I18n] Register ru, ru-RU locale ([#2817](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2817))
+
+### 🐛 Bug Fixes
+
+- [TSVB] Fix the link to "serial differencing aggregation" documentation ([#3503](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3503))
+
+### 📝 Documentation
+
+- [TSVB] Fix a spelling error in the README file ([#3518](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3518))
+- Simplify the in-code instructions for upgrading `re2` ([#3328](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3328))
+- [Doc] Improve DEVELOPER_GUIDE to make first time setup quicker and easier ([#3421](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3421))
+
+### 🛠 Maintenance
+
+- Update MAINTAINERS.md formatting and maintainer list ([#3338](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3338))
+- Remove `github-checks-reporter`, an unused dependency ([#3126](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3126))
+- [Version] Increment to 1.3.9 ([#3375](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3375))
+- Remove the unused `renovate.json5` file ([3489](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3489))


### PR DESCRIPTION
### Description
Add missing 1.3.x patch release notes to 2.x branch

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4646


### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
