### PR TITLE
[CI] Fix BWC related CI failures by swapping dist url to use dist min url instead.

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -15,7 +15,7 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-
+      
 env:
   TEST_BROWSER_HEADLESS: 1
   CI: 1
@@ -24,6 +24,7 @@ env:
   TEST_OPENSEARCH_DASHBOARDS_PORT: 6610
   TEST_OPENSEARCH_TRANSPORT_PORT: 9403
   TEST_OPENSEARCH_PORT: 9400
+  OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot'
   OSD_SNAPSHOT_SKIP_VERIFY_CHECKSUM: true
   NODE_OPTIONS: "--max-old-space-size=6144 --dns-result-order=ipv4first"
 
@@ -346,12 +347,12 @@ jobs:
 
       - name: Set OpenSearch URL
         run: |
-          echo "OPENSEARCH_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/tar/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz" >> $GITHUB_ENV
+          echo "OPENSEARCH_URL=OPENSEARCH_SNAPSHOT_CMD" >> $GITHUB_ENV
 
       - name: Verify if OpenSearch is available for version
         id: verify-opensearch-exists
         run: |
-          if curl -I -L ${{ env.OPENSEARCH_URL }}; then
+          if ${{ env.OPENSEARCH_URL }}; then
             echo "::set-output name=version-exists::true"
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Re-enable CI workflows for feature branches ([#2908](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2908))
 - Upgrade yarn version to be compatible with @opensearch-project/opensearch ([#3443](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3443))
 - Add an achievement badger to the PR ([#3721](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3721))
+- [CI] Fix BWC related CI failures by swapping dist url to use dist min url instead. ([#4815](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4815))
 
 ### 📝 Documentation
 


### PR DESCRIPTION

### Description
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4814

Here I'm using min url instead of snapshot.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4814



## Testing the changes


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
