### PR TITLE
[Data Explorer][Discover 2.0] restore single and surroundings doc view

### DIFF
--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -12,9 +12,8 @@ import { DocViewInspectButton } from './data_grid_table_docview_inspect_button';
 import { DataGridFlyout } from './data_grid_table_flyout';
 import { DiscoverGridContextProvider } from './data_grid_table_context';
 import { toolbarVisibility } from './constants';
-import { DocViewFilterFn } from '../../doc_views/doc_views_types';
+import { DocViewFilterFn, OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { DiscoverServices } from '../../../build_services';
-import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { usePagination } from '../utils/use_pagination';
 import { SortOrder } from '../../../saved_searches/types';
 

--- a/src/plugins/discover/public/application/components/doc_viewer/doc_viewer.test.tsx
+++ b/src/plugins/discover/public/application/components/doc_viewer/doc_viewer.test.tsx
@@ -33,7 +33,7 @@ import { mount, shallow } from 'enzyme';
 import { DocViewer } from './doc_viewer';
 import { findTestSubject } from 'test_utils/helpers';
 import { getDocViewsRegistry } from '../../../opensearch_dashboards_services';
-import { DocViewRenderProps } from '../../doc_views/doc_views_types';
+import { DocViewRenderProps } from '../../../doc_views/doc_views_types';
 
 jest.mock('../../../opensearch_dashboards_services', () => {
   let registry: any[] = [];

--- a/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_render_tab.test.tsx
+++ b/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_render_tab.test.tsx
@@ -31,7 +31,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { DocViewRenderTab } from './doc_viewer_render_tab';
-import { DocViewRenderProps } from '../../doc_views/doc_views_types';
+import { DocViewRenderProps } from '../../../doc_views/doc_views_types';
 
 test('Mounting and unmounting DocViewerRenderTab', () => {
   const unmountFn = jest.fn();

--- a/src/plugins/discover/public/application/components/doc_viewer_links/doc_viewer_links.test.tsx
+++ b/src/plugins/discover/public/application/components/doc_viewer_links/doc_viewer_links.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { DocViewerLinks } from './doc_viewer_links';
 import { getDocViewsLinksRegistry } from '../../../opensearch_dashboards_services';
-import { DocViewLinkRenderProps } from '../../doc_views_links/doc_views_links_types';
+import { DocViewLinkRenderProps } from '../doc_views/doc_views_links/doc_views_links_types';
 
 jest.mock('../../../opensearch_dashboards_services', () => {
   let registry: any[] = [];

--- a/src/plugins/discover/public/application/components/doc_views/context/NOTES.md
+++ b/src/plugins/discover/public/application/components/doc_views/context/NOTES.md
@@ -1,0 +1,55 @@
+# Discover Context App Implementation Notes
+
+## Principles
+**Single Source of Truth**: A good user experience depends on the UI displaying consistent information across the whole page. To achieve this, there should always be a single source of truth for the application's state. In the updated application, this is managed via the useContextState and useQueryActions hooks, which manage the application state and actions respectively.
+
+**Unidirectional Data Flow**: While a single state promotes rendering consistency, it does little to make the state changes easier to reason about. To avoid having state mutations scattered all over the code, this app implements a unidirectional data flow architecture. That means that the state is treated as immutable throughout the application except for actions, which may modify it to cause re-render and updates.
+
+**Unit-Testability**: Creating unit tests for large parts of the UI code is made easy by expressing as much of the logic as possible as side-effect-free functions. The only place where side-effects are allowed are actions.
+
+**Loose Coupling**: An attempt was made to couple the parts that make up this app as loosely as possible. This means using pure functions whenever possible and isolating the components diligently. It does not access the OpenSearch Dashboards AppState directly but communicates only via its properties.
+
+## Concepts
+To adhere to the principles mentioned above, this app borrows some concepts from the redux architecture that forms a circular unidirectional data flow.
+
+**State**: The `contextAppState` and `contextQueryState` are the single sources of truth and may only be modified by actions.
+
+**Action**: Actions are functions that are called in response to user or system actions and may modify the state they are bound to via their closure. For example, the `setContextAppState` and `fetchSurroundingRows` functions in the `useContextState` and `useQueryActions` hooks, respectively.
+
+## Implementation
+The updated application leverages React hooks to manage state and actions. The useContextState hook manages the application state and provides functions to update the state, while the useQueryActions hook manages the fetching of documents and provides functions to fetch the anchor document, surrounding documents, and all documents.
+
+The `useContextState` hook uses the useState and useEffect hooks to manage the application state and side effects. The `contextAppState` is the application state, and the `setContextAppState` function is used to update the state. The useEffect hook is used to reset the `contextQueryState` and to fetch the surrounding documents based on the `contextAppState`.
+
+The `useQueryActions` hook uses the useState, useMemo, and useCallback hooks to manage the query state and actions. The `contextQueryState` is the query state, and various functions are provided to update the state and fetch documents. The useMemo hook is used to derive the rows from the contextQueryState, and the useCallback hook is used to create memoized versions of the functions that update the state and fetch documents.
+
+The `useQueryActions` hook provides several functions for fetching documents:
+
+**fetchAnchorRow**: Fetches the anchor document.
+
+**fetchSurroundingRows**: Fetches the surrounding documents (predecessors or successors) of the anchor document.
+
+**fetchContextRows**: Fetches both the predecessors and successors of the anchor document.
+
+**fetchAllRows**: Fetches the anchor document and then fetches the surrounding documents.
+**resetContextQueryState**: Resets the contextQueryState to its initial state.
+
+These functions update the `contextQueryState` to reflect the loading status and the fetched documents.
+
+
+## Directory Structure
+
+**components/action_bar**: Defines the `ActionBar` component.
+
+**api/anchor.ts**: Exports `fetchAnchor()` function that creates and executes the query for the anchor document. It also exports `updateSearchSource()` function which updates the search source with specified parameters.
+
+**api/context.ts**: Exports `fetchSurroundingDocs()` function that fetches the surrounding documents (either successors or predecessors) of a specified anchor document. It also exports `createSearchSource()` function that creates a search source with specified index pattern and filters.
+
+**api/utils**: Exports various functions used to create and transform
+queries.
+
+**utils/context_state**: Exports functions for fetching surrounding documents, creating a search source, and managing application and global states. Additionally, several helper functions are exported for comparing filters and states, retrieving filters from a state, and creating the initial app state. The module also defines constants for the global and app state URL keys.
+
+**utils/use_query_actions**: Defines a React hook to manage and fetch data related to OpenSearch documents. The hook maintains a local state, contextQueryState, to track the status of fetching operations and the fetched documents. It provides several functions: `fetchAnchorRow()` to fetch the anchor document, `fetchSurroundingRows()` to fetch surrounding documents, `fetchContextRows()` to fetch both predecessors and successors, and `fetchAllRows()` to fetch the anchor and all surrounding documents. Additionally, it provides a `resetContextQueryState()` function to reset the local state to its initial value. Each fetch operation updates the contextQueryState and, in case of an error, displays a toast notification with a failure message.
+
+**utils/use_context_query**: Defines a React hook that manages the application state and synchronization with the URL and OpenSearch Dashboards services. The `startSync` and `stopSync` functions are used to start and stop the synchronization of the application state with the URL. The `setContextAppState` function is used to update the application state and immediately reflect the changes in the URL. The hook returns the current `contextAppState` and the `setContextAppState` function, which can be used by the components that consume this hook.

--- a/src/plugins/discover/public/application/components/doc_views/context/_index.scss
+++ b/src/plugins/discover/public/application/components/doc_views/context/_index.scss
@@ -1,0 +1,8 @@
+// Prefix all styles with "cxt" to avoid conflicts.
+// Examples
+//   cxtChart
+//   cxtChart__legend
+//   cxtChart__legend--small
+//   cxtChart__legend-isLoading
+
+@import "components/action_bar/index";

--- a/src/plugins/discover/public/application/components/doc_views/context/api/_stubs.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/api/_stubs.ts
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import sinon, { SinonSpy } from 'sinon';
+import moment from 'moment';
+import { OpenSearchHitRecordList } from './context';
+
+type Hit = {
+  [key in string]: number;
+} & {
+  sort: [number, number];
+};
+
+interface SearchSourceStub {
+  _stubHits: any[];
+  _stubTimeField?: string;
+  _createStubHit: (timestamp: any, tiebreaker?: number) => Record<string, any>;
+  setParent: SinonSpy;
+  setField: SinonSpy;
+  getField: SinonSpy;
+  fetch: SinonSpy;
+}
+
+export function createIndexPatternsStub() {
+  return {
+    get: sinon.spy((indexPatternId) =>
+      Promise.resolve({
+        id: indexPatternId,
+        isTimeNanosBased: () => false,
+        popularizeField: () => {},
+      })
+    ),
+  };
+}
+
+/**
+ * A stubbed search source with a `fetch` method that returns all of `_stubHits`.
+ */
+export function createSearchSourceStub(hits: OpenSearchHitRecordList, timeField?: string) {
+  const searchSourceStub: Partial<SearchSourceStub> = {
+    _stubHits: hits,
+    _stubTimeField: timeField,
+    _createStubHit: (timestamp: number, tiebreaker = 0) => ({
+      [searchSourceStub._stubTimeField]: timestamp,
+      sort: [timestamp, tiebreaker],
+    }),
+  };
+
+  searchSourceStub.setParent = sinon.spy(() => searchSourceStub);
+  searchSourceStub.setField = sinon.spy(() => searchSourceStub);
+
+  searchSourceStub.getField = sinon.spy((key: string) => {
+    const previousSetCall = searchSourceStub.setField?.withArgs(key).lastCall;
+    return previousSetCall ? previousSetCall.args[1] : null;
+  });
+
+  searchSourceStub.fetch = sinon.spy(() =>
+    Promise.resolve({
+      hits: {
+        hits: searchSourceStub._stubHits,
+        total: searchSourceStub._stubHits.length,
+      },
+    })
+  );
+
+  return searchSourceStub as SearchSourceStub;
+}
+
+/**
+ * A stubbed search source with a `fetch` method that returns a filtered set of `_stubHits`.
+ */
+export function createContextSearchSourceStub(
+  hits: OpenSearchHitRecordList,
+  timeField: string = '@timestamp'
+) {
+  const searchSourceStub = createSearchSourceStub(hits, timeField);
+
+  searchSourceStub.fetch = sinon.spy(() => {
+    const timeFieldStr = searchSourceStub._stubTimeField as string;
+    const lastQuery = searchSourceStub.setField.withArgs('query').lastCall.args[1];
+    const timeRange = lastQuery.query.bool.must.constant_score.filter.range[timeFieldStr];
+    const lastSort = searchSourceStub.setField.withArgs('sort').lastCall.args[1];
+    const sortDirection = lastSort[0][timeFieldStr];
+    const sortFunction =
+      sortDirection === 'asc'
+        ? (first: Hit, second: Hit) => first[timeFieldStr] - second[timeFieldStr]
+        : (first: Hit, second: Hit) => second[timeFieldStr] - first[timeFieldStr];
+    const filteredHits = searchSourceStub._stubHits
+      .filter(
+        (hit: Hit) =>
+          moment(hit[timeFieldStr]).isSameOrAfter(timeRange.gte) &&
+          moment(hit[timeFieldStr]).isSameOrBefore(timeRange.lte)
+      )
+      .sort(sortFunction);
+
+    return Promise.resolve({
+      hits: {
+        hits: filteredHits,
+        total: filteredHits.length,
+      },
+    });
+  });
+
+  return searchSourceStub;
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/api/anchor.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/api/anchor.ts
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { i18n } from '@osd/i18n';
+
+import {
+  ISearchSource,
+  OpenSearchQuerySortValue,
+  IndexPattern,
+} from '../../../../../../../data/public';
+import { OpenSearchHitRecord } from './context';
+
+export async function fetchAnchor(
+  anchorId: string,
+  indexPattern: IndexPattern,
+  searchSource: ISearchSource,
+  sort: OpenSearchQuerySortValue[]
+): Promise<OpenSearchHitRecord> {
+  updateSearchSource(searchSource, anchorId, sort, indexPattern);
+
+  const response = await searchSource.fetch();
+  const doc = response.hits?.hits?.[0];
+
+  if (!doc) {
+    throw new Error(
+      i18n.translate('discover.context.failedToLoadAnchorDocumentErrorDescription', {
+        defaultMessage: 'Failed to load anchor document.',
+      })
+    );
+  }
+
+  return {
+    ...doc,
+    isAnchor: true,
+  } as OpenSearchHitRecord;
+}
+
+export function updateSearchSource(
+  searchSource: ISearchSource,
+  anchorId: string,
+  sort: OpenSearchQuerySortValue[],
+  indexPattern: IndexPattern
+) {
+  searchSource
+    .setParent(undefined)
+    .setField('index', indexPattern)
+    .setField('version', true)
+    .setField('size', 1)
+    .setField('query', {
+      query: {
+        constant_score: {
+          filter: {
+            ids: {
+              values: [anchorId],
+            },
+          },
+        },
+      },
+      language: 'lucene',
+    })
+    .setField('sort', sort);
+
+  return searchSource;
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/api/context.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/api/context.ts
@@ -1,0 +1,133 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Filter, IndexPatternsContract, IndexPattern } from 'src/plugins/data/public';
+import { reverseSortDir, SortDirection } from './utils/sorting';
+import { extractNanos, convertIsoToMillis } from './utils/date_conversion';
+import { fetchHitsInInterval } from './utils/fetch_hits_in_interval';
+import { generateIntervals } from './utils/generate_intervals';
+import { getOpenSearchQuerySearchAfter } from './utils/get_opensearch_query_search_after';
+import { getOpenSearchQuerySort } from './utils/get_opensearch_query_sort';
+import { getServices } from '../../../../../opensearch_dashboards_services';
+
+export enum SurrDocType {
+  SUCCESSORS = 'successors',
+  PREDECESSORS = 'predecessors',
+}
+export interface OpenSearchHitRecord {
+  fields: Record<string, any>;
+  sort: number[];
+  _source: Record<string, any>;
+  _id: string;
+  isAnchor?: boolean;
+}
+export type OpenSearchHitRecordList = OpenSearchHitRecord[];
+
+const DAY_MILLIS = 24 * 60 * 60 * 1000;
+
+// look from 1 day up to 10000 days into the past and future
+const LOOKUP_OFFSETS = [0, 1, 7, 30, 365, 10000].map((days) => days * DAY_MILLIS);
+
+/**
+ * Fetch successor or predecessor documents of a given anchor document
+ *
+ * @param {SurrDocType} type - `successors` or `predecessors`
+ * @param {string} indexPatternId
+ * @param {OpenSearchHitRecord} anchor - anchor record
+ * @param {string} timeField - name of the timefield, that's sorted on
+ * @param {string} tieBreakerField - name of the tie breaker, the 2nd sort field
+ * @param {SortDirection} sortDir - direction of sorting
+ * @param {number} size - number of records to retrieve
+ * @param {Filter[]} filters - to apply in the query
+ * @returns {Promise<object[]>}
+ */
+
+export async function fetchSurroundingDocs(
+  type: SurrDocType,
+  indexPattern: IndexPattern,
+  anchor: OpenSearchHitRecord,
+  tieBreakerField: string,
+  sortDir: SortDirection,
+  size: number,
+  filters: Filter[]
+) {
+  if (typeof anchor !== 'object' || anchor === null || !size) {
+    return [];
+  }
+  const timeField = indexPattern.timeFieldName!;
+  const searchSource = await createSearchSource(indexPattern, filters);
+  const sortDirToApply = type === 'successors' ? sortDir : reverseSortDir(sortDir);
+
+  const nanos = indexPattern.isTimeNanosBased() ? extractNanos(anchor._source[timeField]) : '';
+  const timeValueMillis =
+    nanos !== '' ? convertIsoToMillis(anchor._source[timeField]) : anchor.sort[0];
+
+  const intervals = generateIntervals(LOOKUP_OFFSETS, timeValueMillis, type, sortDir);
+  let documents: OpenSearchHitRecordList = [];
+
+  for (const interval of intervals) {
+    const remainingSize = size - documents.length;
+
+    if (remainingSize <= 0) {
+      break;
+    }
+
+    const searchAfter = getOpenSearchQuerySearchAfter(type, documents, timeField, anchor, nanos);
+
+    const sort = getOpenSearchQuerySort(timeField, tieBreakerField, sortDirToApply);
+
+    const hits = await fetchHitsInInterval(
+      searchSource,
+      timeField,
+      sort,
+      sortDirToApply,
+      interval,
+      searchAfter,
+      remainingSize,
+      nanos,
+      anchor._id
+    );
+
+    documents =
+      type === 'successors' ? [...documents, ...hits] : [...hits.slice().reverse(), ...documents];
+  }
+
+  return documents;
+}
+
+export async function createSearchSource(indexPattern: IndexPattern, filters: Filter[]) {
+  const { data } = getServices();
+
+  const searchSource = await data.search.searchSource.create();
+  return searchSource
+    .setParent(undefined)
+    .setField('index', indexPattern)
+    .setField('filter', filters);
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/api/utils/date_conversion.test.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/api/utils/date_conversion.test.ts
@@ -28,24 +28,16 @@
  * under the License.
  */
 
-import React, { useRef, useEffect } from 'react';
-import { DocViewRenderFn, DocViewRenderProps } from '../../../doc_views/doc_views_types';
+import { extractNanos } from './date_conversion';
 
-interface Props {
-  render: DocViewRenderFn;
-  renderProps: DocViewRenderProps;
-}
-/**
- * Responsible for rendering a tab provided by a render function.
- * The provided `render` function is called with a reference to the
- * component's `HTMLDivElement` as 1st arg and `renderProps` as 2nd arg
- */
-export function DocViewRenderTab({ render, renderProps }: Props) {
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (ref && ref.current) {
-      return render(ref.current, renderProps);
-    }
-  }, [render, renderProps]);
-  return <div ref={ref} />;
-}
+describe('function extractNanos', function () {
+  test('extract nanos of 2014-01-01', function () {
+    expect(extractNanos('2014-01-01')).toBe('000000000');
+  });
+  test('extract nanos of 2014-01-01T12:12:12.234Z', function () {
+    expect(extractNanos('2014-01-01T12:12:12.234Z')).toBe('234000000');
+  });
+  test('extract nanos of 2014-01-01T12:12:12.234123321Z', function () {
+    expect(extractNanos('2014-01-01T12:12:12.234123321Z')).toBe('234123321');
+  });
+});

--- a/src/plugins/discover/public/application/components/doc_views/context/api/utils/date_conversion.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/api/utils/date_conversion.ts
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import moment from 'moment';
+/**
+ * extract nanoseconds if available in ISO timestamp
+ * returns the nanos as string like this:
+ * 9ns -> 000000009
+ * 10000ns -> 0000010000
+ * returns 000000000 for invalid timestamps or timestamps with just date
+ **/
+export function extractNanos(timeFieldValue: string = ''): string {
+  const fieldParts = timeFieldValue.split('.');
+  const fractionSeconds = fieldParts.length === 2 ? fieldParts[1].replace('Z', '') : '';
+  return fractionSeconds.length !== 9 ? fractionSeconds.padEnd(9, '0') : fractionSeconds;
+}
+
+/**
+ * convert an iso formatted string to number of milliseconds since
+ * 1970-01-01T00:00:00.000Z
+ * @param {string} isoValue
+ * @returns {number}
+ */
+export function convertIsoToMillis(isoValue: string): number {
+  const date = new Date(isoValue);
+  return date.getTime();
+}
+/**
+ * the given time value in milliseconds is converted to a ISO formatted string
+ * if nanosValue is provided, the given value replaces the fractional seconds part
+ * of the formated string since moment.js doesn't support formatting timestamps
+ * with a higher precision then microseconds
+ * The browser rounds date nanos values:
+ * 2019-09-18T06:50:12.999999999 -> browser rounds to 1568789413000000000
+ * 2019-09-18T06:50:59.999999999 -> browser rounds to 1568789460000000000
+ * 2017-12-31T23:59:59.999999999 -> browser rounds 1514761199999999999 to 1514761200000000000
+ */
+export function convertTimeValueToIso(timeValueMillis: number, nanosValue: string): string | null {
+  if (!timeValueMillis) {
+    return null;
+  }
+  const isoString = moment(timeValueMillis).toISOString();
+  if (!isoString) {
+    return null;
+  } else if (nanosValue !== '') {
+    return `${isoString.substring(0, isoString.length - 4)}${nanosValue}Z`;
+  }
+  return isoString;
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/api/utils/fetch_hits_in_interval.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/api/utils/fetch_hits_in_interval.ts
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  ISearchSource,
+  OpenSearchQuerySortValue,
+  SortDirection,
+} from '../../../../../../../../data/public';
+import { convertTimeValueToIso } from './date_conversion';
+import { OpenSearchHitRecordList, OpenSearchHitRecord } from '../context';
+import { IntervalValue } from './generate_intervals';
+import { OpenSearchQuerySearchAfter } from './get_opensearch_query_search_after';
+
+interface RangeQuery {
+  format: string;
+  lte?: string | null;
+  gte?: string | null;
+}
+
+/**
+ * Fetch the hits between a given `interval` up to a maximum of `maxCount` documents.
+ * The documents are sorted by `sort`
+ *
+ * The `searchSource` is assumed to have the appropriate index pattern
+ * and filters set.
+ */
+export async function fetchHitsInInterval(
+  searchSource: ISearchSource,
+  timeField: string,
+  sort: [OpenSearchQuerySortValue, OpenSearchQuerySortValue],
+  sortDir: SortDirection,
+  interval: IntervalValue[],
+  searchAfter: OpenSearchQuerySearchAfter,
+  maxCount: number,
+  nanosValue: string,
+  anchorId: string
+): Promise<OpenSearchHitRecordList> {
+  const range: RangeQuery = {
+    format: 'strict_date_optional_time',
+  };
+  const [start, stop] = interval;
+
+  if (start) {
+    range[sortDir === SortDirection.asc ? 'gte' : 'lte'] = convertTimeValueToIso(start, nanosValue);
+  }
+
+  if (stop) {
+    range[sortDir === SortDirection.asc ? 'lte' : 'gte'] = convertTimeValueToIso(stop, nanosValue);
+  }
+  const response = await searchSource
+    .setField('size', maxCount)
+    .setField('query', {
+      query: {
+        bool: {
+          must: {
+            constant_score: {
+              filter: {
+                range: {
+                  [timeField]: range,
+                },
+              },
+            },
+          },
+          must_not: {
+            ids: {
+              values: [anchorId],
+            },
+          },
+        },
+      },
+      language: 'lucene',
+    })
+    .setField('searchAfter', searchAfter)
+    .setField('sort', sort)
+    .setField('version', true)
+    .fetch();
+
+  // TODO: There's a difference in the definition of SearchResponse and OpenSearchHitRecord
+  return ((response.hits?.hits as unknown) as OpenSearchHitRecord[]) || [];
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/api/utils/generate_intervals.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/api/utils/generate_intervals.ts
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { SortDirection } from '../../../../../../../../data/public';
+
+export type IntervalValue = number | null;
+
+/**
+ * Generate a sequence of pairs from the iterable that looks like
+ * `[[x_0, x_1], [x_1, x_2], [x_2, x_3], ..., [x_(n-1), x_n]]`.
+ */
+export function* asPairs(iterable: Iterable<IntervalValue>): IterableIterator<IntervalValue[]> {
+  let currentPair: IntervalValue[] = [];
+  for (const value of iterable) {
+    currentPair = [...currentPair, value].slice(-2);
+    if (currentPair.length === 2) {
+      yield currentPair;
+    }
+  }
+}
+
+/**
+ * Returns a iterable containing intervals `[start,end]` for OpenSearch date range queries
+ * depending on type (`successors` or `predecessors`) and sort (`asc`, `desc`) these are ascending or descending intervals.
+ */
+export function generateIntervals(
+  offsets: number[],
+  startTime: number,
+  type: string,
+  sort: SortDirection
+): IterableIterator<IntervalValue[]> {
+  const offsetSign =
+    (sort === SortDirection.asc && type === 'successors') ||
+    (sort === SortDirection.desc && type === 'predecessors')
+      ? 1
+      : -1;
+  // ending with `null` opens the last interval
+  return asPairs([...offsets.map((offset) => startTime + offset * offsetSign), null]);
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/api/utils/get_opensearch_query_search_after.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/api/utils/get_opensearch_query_search_after.ts
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { SurrDocType, OpenSearchHitRecordList, OpenSearchHitRecord } from '../context';
+
+export type OpenSearchQuerySearchAfter = [string | number, string | number];
+
+/**
+ * Get the searchAfter query value for opensearch
+ * When there are already documents available, which means successors or predecessors
+ * were already fetched, the new searchAfter for the next fetch has to be the sort value
+ * of the first (prececessor), or last (successor) of the list
+ */
+export function getOpenSearchQuerySearchAfter(
+  type: SurrDocType,
+  documents: OpenSearchHitRecordList,
+  timeFieldName: string,
+  anchor: OpenSearchHitRecord,
+  nanoSeconds: string
+): OpenSearchQuerySearchAfter {
+  if (documents.length) {
+    // already surrounding docs -> first or last record  is used
+    const afterTimeRecIdx = type === 'successors' && documents.length ? documents.length - 1 : 0;
+    const afterTimeDoc = documents[afterTimeRecIdx];
+    const afterTimeValue = nanoSeconds ? afterTimeDoc._source[timeFieldName] : afterTimeDoc.sort[0];
+    return [afterTimeValue, afterTimeDoc.sort[1]];
+  }
+  // if data_nanos adapt timestamp value for sorting, since numeric value was rounded by browser
+  // OpenSearch search_after also works when number is provided as string
+  return [nanoSeconds ? anchor._source[timeFieldName] : anchor.sort[0], anchor.sort[1]];
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/api/utils/get_opensearch_query_sort.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/api/utils/get_opensearch_query_sort.ts
@@ -28,24 +28,22 @@
  * under the License.
  */
 
-import React, { useRef, useEffect } from 'react';
-import { DocViewRenderFn, DocViewRenderProps } from '../../../doc_views/doc_views_types';
+import {
+  OpenSearchQuerySortValue,
+  SortDirection,
+} from '../../../../../../opensearch_dashboards_services';
 
-interface Props {
-  render: DocViewRenderFn;
-  renderProps: DocViewRenderProps;
-}
 /**
- * Responsible for rendering a tab provided by a render function.
- * The provided `render` function is called with a reference to the
- * component's `HTMLDivElement` as 1st arg and `renderProps` as 2nd arg
+ * Returns `OpenSearchQuerySort` which is used to sort records in the OpenSearch query
+ * https://opensearch.org/docs/latest/opensearch/ux/#sort-results
+ * @param timeField
+ * @param tieBreakerField
+ * @param sortDir
  */
-export function DocViewRenderTab({ render, renderProps }: Props) {
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (ref && ref.current) {
-      return render(ref.current, renderProps);
-    }
-  }, [render, renderProps]);
-  return <div ref={ref} />;
+export function getOpenSearchQuerySort(
+  timeField: string,
+  tieBreakerField: string,
+  sortDir: SortDirection
+): [OpenSearchQuerySortValue, OpenSearchQuerySortValue] {
+  return [{ [timeField]: sortDir }, { [tieBreakerField]: sortDir }];
 }

--- a/src/plugins/discover/public/application/components/doc_views/context/api/utils/sorting.test.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/api/utils/sorting.test.ts
@@ -28,24 +28,11 @@
  * under the License.
  */
 
-import React, { useRef, useEffect } from 'react';
-import { DocViewRenderFn, DocViewRenderProps } from '../../../doc_views/doc_views_types';
+import { reverseSortDir, SortDirection } from './sorting';
 
-interface Props {
-  render: DocViewRenderFn;
-  renderProps: DocViewRenderProps;
-}
-/**
- * Responsible for rendering a tab provided by a render function.
- * The provided `render` function is called with a reference to the
- * component's `HTMLDivElement` as 1st arg and `renderProps` as 2nd arg
- */
-export function DocViewRenderTab({ render, renderProps }: Props) {
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (ref && ref.current) {
-      return render(ref.current, renderProps);
-    }
-  }, [render, renderProps]);
-  return <div ref={ref} />;
-}
+describe('function reverseSortDir', function () {
+  test('reverse a given sort direction', function () {
+    expect(reverseSortDir(SortDirection.asc)).toBe(SortDirection.desc);
+    expect(reverseSortDir(SortDirection.desc)).toBe(SortDirection.asc);
+  });
+});

--- a/src/plugins/discover/public/application/components/doc_views/context/components/action_bar/_action_bar.scss
+++ b/src/plugins/discover/public/application/components/doc_views/context/components/action_bar/_action_bar.scss
@@ -1,0 +1,10 @@
+.cxtSizePicker {
+  text-align: center;
+  width: $euiSize * 5;
+
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    appearance: none; // Hide increment and decrement buttons for type="number" input.
+    margin: 0;
+  }
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/components/action_bar/_index.scss
+++ b/src/plugins/discover/public/application/components/doc_views/context/components/action_bar/_index.scss
@@ -1,0 +1,1 @@
+@import "action_bar";

--- a/src/plugins/discover/public/application/components/doc_views/context/components/action_bar/action_bar.test.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/context/components/action_bar/action_bar.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
+import { ActionBar, ActionBarProps } from './action_bar';
+import { findTestSubject } from 'test_utils/helpers';
+import { MAX_CONTEXT_SIZE, MIN_CONTEXT_SIZE } from './action_bar';
+
+describe('Test Discover Context ActionBar for successor | predecessor records', () => {
+  ['successors', 'predecessors'].forEach((type) => {
+    const onChangeCount = jest.fn();
+    const props = {
+      defaultStepSize: 5,
+      docCount: 20,
+      docCountAvailable: 0,
+      isDisabled: false,
+      isLoading: false,
+      onChangeCount,
+      type,
+    } as ActionBarProps;
+    const wrapper = mountWithIntl(<ActionBar {...props} />);
+
+    const input = findTestSubject(wrapper, `${type}CountPicker`);
+    const btn = findTestSubject(wrapper, `${type}LoadMoreButton`);
+
+    test(`${type}: Load button click`, () => {
+      btn.simulate('click');
+      expect(onChangeCount).toHaveBeenCalledWith(type, 25);
+    });
+
+    test(`${type}: Load button click doesnt submit when MAX_CONTEXT_SIZE was reached`, () => {
+      onChangeCount.mockClear();
+      input.simulate('change', { target: { valueAsNumber: MAX_CONTEXT_SIZE } });
+      btn.simulate('click');
+      expect(onChangeCount).toHaveBeenCalledTimes(0);
+    });
+
+    test(`${type}: Count input change submits on blur`, () => {
+      input.simulate('change', { target: { valueAsNumber: 123 } });
+      input.simulate('blur');
+      expect(onChangeCount).toHaveBeenCalledWith(type, 123);
+    });
+
+    test(`${type}: Count input change submits on return`, () => {
+      input.simulate('change', { target: { valueAsNumber: 124 } });
+      input.simulate('submit');
+      expect(onChangeCount).toHaveBeenCalledWith(type, 124);
+    });
+
+    test(`${type}: Count input doesnt submits values higher than MAX_CONTEXT_SIZE `, () => {
+      onChangeCount.mockClear();
+      input.simulate('change', { target: { valueAsNumber: MAX_CONTEXT_SIZE + 1 } });
+      input.simulate('submit');
+      expect(onChangeCount).toHaveBeenCalledTimes(0);
+    });
+
+    test(`${type}: Count input doesnt submits values lower than MIN_CONTEXT_SIZE `, () => {
+      onChangeCount.mockClear();
+      input.simulate('change', { target: { valueAsNumber: MIN_CONTEXT_SIZE - 1 } });
+      input.simulate('submit');
+      expect(onChangeCount).toHaveBeenCalledTimes(0);
+    });
+
+    test(`${type}: Warning about limitation of additional records`, () => {
+      if (type === 'predecessors') {
+        expect(findTestSubject(wrapper, 'predecessorsWarningMsg').text()).toBe(
+          'No documents newer than the anchor could be found.'
+        );
+      } else {
+        expect(findTestSubject(wrapper, 'successorsWarningMsg').text()).toBe(
+          'No documents older than the anchor could be found.'
+        );
+      }
+    });
+  });
+});

--- a/src/plugins/discover/public/application/components/doc_views/context/components/action_bar/action_bar.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/context/components/action_bar/action_bar.tsx
@@ -1,0 +1,190 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { i18n } from '@osd/i18n';
+import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
+import {
+  EuiButtonEmpty,
+  EuiFieldNumber,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiSpacer,
+} from '@elastic/eui';
+import { ActionBarWarning } from './action_bar_warning';
+import { SurrDocType } from '../../api/context';
+
+export const MAX_CONTEXT_SIZE = 10000; // OpenSearch's default maximum size limit
+export const MIN_CONTEXT_SIZE = 0;
+
+export interface ActionBarProps {
+  /**
+   *  the number of documents fetched initially and added when the load button is clicked
+   */
+  defaultStepSize: number;
+  /**
+   * the number of docs to be displayed
+   */
+  docCount: number;
+  /**
+   *  the number of documents that are  available
+   *  display warning when it's lower than docCount
+   */
+  docCountAvailable: number;
+  /**
+   * is true while the anchor record is fetched
+   */
+  isDisabled: boolean;
+  /**
+   * is true when list entries are fetched
+   */
+  isLoading: boolean;
+  /**
+   * is triggered when the input containing count is changed
+   * @param count
+   */
+  onChangeCount: (type: SurrDocType, count: number) => void;
+  /**
+   * can be `predecessors` or `successors`, usage in context:
+   * predecessors action bar + records (these are newer records)
+   * anchor record
+   * successors records + action bar (these are older records)
+   */
+  type: SurrDocType;
+}
+
+export function ActionBar({
+  defaultStepSize,
+  docCount,
+  docCountAvailable,
+  isDisabled,
+  isLoading,
+  onChangeCount,
+  type,
+}: ActionBarProps) {
+  const showWarning = !isDisabled && !isLoading && docCountAvailable < docCount;
+  const isSuccessor = type === 'successors';
+  const [newDocCount, setNewDocCount] = useState(docCount);
+  const isValid = (value: number) => value >= MIN_CONTEXT_SIZE && value <= MAX_CONTEXT_SIZE;
+  const onSubmit = (ev: React.FormEvent<HTMLFormElement>) => {
+    ev.preventDefault();
+    if (newDocCount !== docCount && isValid(newDocCount)) {
+      onChangeCount(type, newDocCount);
+    }
+  };
+
+  useEffect(() => {
+    if (newDocCount !== docCount && newDocCount === 0) {
+      setNewDocCount(docCount);
+    }
+  }, [docCount, newDocCount]);
+
+  return (
+    <I18nProvider>
+      <form onSubmit={onSubmit}>
+        {isSuccessor && <EuiSpacer size="s" />}
+        {isSuccessor && showWarning && (
+          <ActionBarWarning docCount={docCountAvailable} type={type} />
+        )}
+        {isSuccessor && showWarning && <EuiSpacer size="s" />}
+        <EuiFlexGroup direction="row" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              data-test-subj={`${type}LoadMoreButton`}
+              iconType={isSuccessor ? 'arrowDown' : 'arrowUp'}
+              isDisabled={isDisabled}
+              isLoading={isLoading}
+              onClick={() => {
+                const value = newDocCount + defaultStepSize;
+                if (isValid(value)) {
+                  setNewDocCount(value);
+                  onChangeCount(type, value);
+                }
+              }}
+              flush="right"
+            >
+              <FormattedMessage id="discover.context.loadButtonLabel" defaultMessage="Load" />
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFormRow>
+              <EuiFieldNumber
+                aria-label={
+                  isSuccessor
+                    ? i18n.translate('discover.context.olderDocumentsAriaLabel', {
+                        defaultMessage: 'Number of older documents',
+                      })
+                    : i18n.translate('discover.context.newerDocumentsAriaLabel', {
+                        defaultMessage: 'Number of newer documents',
+                      })
+                }
+                className="cxtSizePicker"
+                data-test-subj={`${type}CountPicker`}
+                disabled={isDisabled}
+                min={MIN_CONTEXT_SIZE}
+                max={MAX_CONTEXT_SIZE}
+                onChange={(ev) => {
+                  setNewDocCount(ev.target.valueAsNumber);
+                }}
+                onBlur={() => {
+                  if (newDocCount !== docCount && isValid(newDocCount)) {
+                    onChangeCount(type, newDocCount);
+                  }
+                }}
+                type="number"
+                value={newDocCount >= 0 ? newDocCount : ''}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFormRow display={'center'}>
+              {isSuccessor ? (
+                <FormattedMessage
+                  id="discover.context.olderDocumentsDescription"
+                  defaultMessage="older documents"
+                />
+              ) : (
+                <FormattedMessage
+                  id="discover.context.newerDocumentsDescription"
+                  defaultMessage="newer documents"
+                />
+              )}
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        {!isSuccessor && showWarning && (
+          <ActionBarWarning docCount={docCountAvailable} type={type} />
+        )}
+        {!isSuccessor && <EuiSpacer size="s" />}
+      </form>
+    </I18nProvider>
+  );
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/components/action_bar/action_bar_warning.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/context/components/action_bar/action_bar_warning.tsx
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { FormattedMessage } from '@osd/i18n/react';
+import { EuiCallOut } from '@elastic/eui';
+import { SurrDocType } from '../../api/context';
+
+export function ActionBarWarning({ docCount, type }: { docCount: number; type: SurrDocType }) {
+  if (type === 'predecessors') {
+    return (
+      <EuiCallOut
+        color="warning"
+        data-test-subj="predecessorsWarningMsg"
+        iconType="bolt"
+        title={
+          docCount === 0 ? (
+            <FormattedMessage
+              id="discover.context.newerDocumentsWarningZero"
+              defaultMessage="No documents newer than the anchor could be found."
+            />
+          ) : (
+            <FormattedMessage
+              id="discover.context.newerDocumentsWarning"
+              defaultMessage="Only {docCount} documents newer than the anchor could be found."
+              values={{ docCount }}
+            />
+          )
+        }
+        size="s"
+      />
+    );
+  }
+
+  return (
+    <EuiCallOut
+      color="warning"
+      data-test-subj="successorsWarningMsg"
+      iconType="bolt"
+      title={
+        docCount === 0 ? (
+          <FormattedMessage
+            id="discover.context.olderDocumentsWarningZero"
+            defaultMessage="No documents older than the anchor could be found."
+          />
+        ) : (
+          <FormattedMessage
+            id="discover.context.olderDocumentsWarning"
+            defaultMessage="Only {docCount} documents older than the anchor could be found."
+            values={{ docCount }}
+          />
+        )
+      }
+      size="s"
+    />
+  );
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/utils/context_query_state.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/utils/context_query_state.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OpenSearchHitRecord, OpenSearchHitRecordList } from '../api/context';
+
+export interface ContextQueryState {
+  anchor: OpenSearchHitRecord;
+  anchorStatus: ContextQueryStatus;
+  predecessors: OpenSearchHitRecordList;
+  predecessorsStatus: ContextQueryStatus;
+  successors: OpenSearchHitRecordList;
+  successorsStatus: ContextQueryStatus;
+}
+
+export interface ContextQueryStatus {
+  value: LOADING_STATUS;
+  reason?: FAILURE_REASONS;
+}
+
+export enum LOADING_STATUS {
+  LOADING = 'loading',
+  LOADED = 'loaded',
+  FAILED = 'failed',
+  UNINITIALIZED = 'uninitialized',
+}
+
+export enum FAILURE_REASONS {
+  UNKNOWN = 'unknown',
+  INVALID_TIEBREAKER = 'invalid_tiebreaker',
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/utils/context_state.test.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/utils/context_state.test.ts
@@ -1,0 +1,204 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getState } from './context_state';
+import { createBrowserHistory, History } from 'history';
+import { FilterManager, Filter } from '../../../../../../../data/public';
+import { coreMock } from '../../../../../../../../core/public/mocks';
+const setupMock = coreMock.createSetup();
+
+describe('Test Discover Context State', () => {
+  let history: History;
+  let state: any;
+  const getCurrentUrl = () => history.createHref(history.location);
+  beforeEach(async () => {
+    history = createBrowserHistory();
+    history.push('/');
+    state = await getState({
+      defaultStepSize: '4',
+      timeFieldName: 'time',
+      history,
+    });
+    state.startSync();
+  });
+  afterEach(() => {
+    state.stopSync();
+  });
+  test('getState function default return', () => {
+    expect(state.appState.getState()).toMatchInlineSnapshot(`
+      Object {
+        "columns": Array [
+          "_source",
+        ],
+        "filters": Array [],
+        "predecessorCount": 4,
+        "sort": Array [
+          "time",
+          "desc",
+        ],
+        "successorCount": 4,
+      }
+    `);
+    expect(state.globalState.getState()).toMatchInlineSnapshot(`null`);
+    expect(state.startSync).toBeDefined();
+    expect(state.stopSync).toBeDefined();
+    expect(state.getFilters()).toStrictEqual([]);
+  });
+  test('getState -> setAppState syncing to url', async () => {
+    state.setAppState({ predecessorCount: 10 });
+    state.flushToUrl();
+    expect(getCurrentUrl()).toMatchInlineSnapshot(
+      `"/#?_a=(columns:!(_source),filters:!(),predecessorCount:10,sort:!(time,desc),successorCount:4)"`
+    );
+  });
+  test('getState -> url to appState syncing', async () => {
+    history.push(
+      '/#?_a=(columns:!(_source),predecessorCount:1,sort:!(time,desc),successorCount:1)'
+    );
+    expect(state.appState.getState()).toMatchInlineSnapshot(`
+      Object {
+        "columns": Array [
+          "_source",
+        ],
+        "predecessorCount": 1,
+        "sort": Array [
+          "time",
+          "desc",
+        ],
+        "successorCount": 1,
+      }
+    `);
+  });
+  test('getState -> url to appState syncing with return to a url without state', async () => {
+    history.push(
+      '/#?_a=(columns:!(_source),predecessorCount:1,sort:!(time,desc),successorCount:1)'
+    );
+    expect(state.appState.getState()).toMatchInlineSnapshot(`
+      Object {
+        "columns": Array [
+          "_source",
+        ],
+        "predecessorCount": 1,
+        "sort": Array [
+          "time",
+          "desc",
+        ],
+        "successorCount": 1,
+      }
+    `);
+    history.push('/');
+    expect(state.appState.getState()).toMatchInlineSnapshot(`
+      Object {
+        "columns": Array [
+          "_source",
+        ],
+        "predecessorCount": 1,
+        "sort": Array [
+          "time",
+          "desc",
+        ],
+        "successorCount": 1,
+      }
+    `);
+  });
+
+  test('getState -> filters', async () => {
+    const filterManager = new FilterManager(setupMock.uiSettings);
+    const filterGlobal = {
+      query: { match: { extension: { query: 'jpg', type: 'phrase' } } },
+      meta: { index: 'logstash-*', negate: false, disabled: false, alias: null },
+    } as Filter;
+    filterManager.setGlobalFilters([filterGlobal]);
+    const filterApp = {
+      query: { match: { extension: { query: 'png', type: 'phrase' } } },
+      meta: { index: 'logstash-*', negate: true, disabled: false, alias: null },
+    } as Filter;
+    filterManager.setAppFilters([filterApp]);
+    state.setFilters(filterManager);
+    expect(state.getFilters()).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "$state": Object {
+            "store": "globalState",
+          },
+          "meta": Object {
+            "alias": null,
+            "disabled": false,
+            "index": "logstash-*",
+            "key": "extension",
+            "negate": false,
+            "params": Object {
+              "query": "jpg",
+            },
+            "type": "phrase",
+            "value": [Function],
+          },
+          "query": Object {
+            "match": Object {
+              "extension": Object {
+                "query": "jpg",
+                "type": "phrase",
+              },
+            },
+          },
+        },
+        Object {
+          "$state": Object {
+            "store": "appState",
+          },
+          "meta": Object {
+            "alias": null,
+            "disabled": false,
+            "index": "logstash-*",
+            "key": "extension",
+            "negate": true,
+            "params": Object {
+              "query": "png",
+            },
+            "type": "phrase",
+            "value": [Function],
+          },
+          "query": Object {
+            "match": Object {
+              "extension": Object {
+                "query": "png",
+                "type": "phrase",
+              },
+            },
+          },
+        },
+      ]
+    `);
+    state.flushToUrl();
+    expect(getCurrentUrl()).toMatchInlineSnapshot(
+      `"/#?_g=(filters:!(('$state':(store:globalState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:extension,negate:!f,params:(query:jpg),type:phrase),query:(match:(extension:(query:jpg,type:phrase))))))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:extension,negate:!t,params:(query:png),type:phrase),query:(match:(extension:(query:png,type:phrase))))),predecessorCount:4,sort:!(time,desc),successorCount:4)"`
+    );
+  });
+});

--- a/src/plugins/discover/public/application/components/doc_views/context/utils/context_state.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/utils/context_state.ts
@@ -1,0 +1,307 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import _ from 'lodash';
+import { History } from 'history';
+import { NotificationsStart } from 'opensearch-dashboards/public';
+import {
+  createStateContainer,
+  createOsdUrlStateStorage,
+  syncStates,
+  BaseStateContainer,
+  withNotifyOnErrors,
+} from '../../../../../../../opensearch_dashboards_utils/public';
+import { opensearchFilters, FilterManager, Filter, Query } from '../../../../../../../data/public';
+
+export interface AppState {
+  /**
+   * Columns displayed in the table, cannot be changed by UI, just in discover's main app
+   */
+  columns: string[];
+  /**
+   * Array of filters
+   */
+  filters: Filter[];
+  /**
+   * Number of records to be fetched before anchor records (newer records)
+   */
+  predecessorCount: number;
+  /**
+   * Sorting of the records to be fetched, assumed to be a legacy parameter
+   */
+  sort: string[];
+  /**
+   * Number of records to be fetched after the anchor records (older records)
+   */
+  successorCount: number;
+  query?: Query;
+}
+
+interface GlobalState {
+  /**
+   * Array of filters
+   */
+  filters: Filter[];
+}
+
+interface GetStateParams {
+  /**
+   * Number of records to be fetched when 'Load' link/button is clicked
+   */
+  defaultStepSize: string;
+  /**
+   * The timefield used for sorting
+   */
+  timeFieldName: string;
+  /**
+   * Determins the use of long vs. short/hashed urls
+   */
+  storeInSessionStorage?: boolean;
+  /**
+   * History instance to use
+   */
+  history: History;
+
+  /**
+   * Core's notifications.toasts service
+   * In case it is passed in,
+   * osdUrlStateStorage will use it notifying about inner errors
+   */
+  toasts?: NotificationsStart['toasts'];
+}
+
+interface GetStateReturn {
+  /**
+   * Global state, the _g part of the URL
+   */
+  globalState: BaseStateContainer<GlobalState>;
+  /**
+   * App state, the _a part of the URL
+   */
+  appState: BaseStateContainer<AppState>;
+  /**
+   * Start sync between state and URL
+   */
+  startSync: () => void;
+  /**
+   * Stop sync between state and URL
+   */
+  stopSync: () => void;
+  /**
+   * Set app state to with a partial new app state
+   */
+  setAppState: (newState: Partial<AppState>) => void;
+  /**
+   * Get all filters, global and app state
+   */
+  getFilters: () => Filter[];
+  /**
+   * Set global state and app state filters by the given FilterManager instance
+   * @param filterManager
+   */
+  setFilters: (filterManager: FilterManager) => void;
+  /**
+   * sync state to URL, used for testing
+   */
+  flushToUrl: (replace?: boolean) => void;
+}
+const GLOBAL_STATE_URL_KEY = '_g';
+const APP_STATE_URL_KEY = '_a';
+
+/**
+ * Builds and returns appState and globalState containers
+ * provides helper functions to start/stop syncing with URL
+ */
+export function getState({
+  defaultStepSize,
+  timeFieldName,
+  storeInSessionStorage = false,
+  history,
+  toasts,
+}: GetStateParams): GetStateReturn {
+  const stateStorage = createOsdUrlStateStorage({
+    useHash: storeInSessionStorage,
+    history,
+    ...(toasts && withNotifyOnErrors(toasts)),
+  });
+
+  const globalStateInitial = stateStorage.get(GLOBAL_STATE_URL_KEY) as GlobalState;
+  const globalStateContainer = createStateContainer<GlobalState>(globalStateInitial);
+
+  const appStateFromUrl = stateStorage.get(APP_STATE_URL_KEY) as AppState;
+  const appStateInitial = createInitialAppState(defaultStepSize, timeFieldName, appStateFromUrl);
+  const appStateContainer = createStateContainer<AppState>(appStateInitial);
+
+  const { start, stop } = syncStates([
+    {
+      storageKey: GLOBAL_STATE_URL_KEY,
+      stateContainer: {
+        ...globalStateContainer,
+        ...{
+          set: (value: GlobalState | null) => {
+            if (value) {
+              globalStateContainer.set(value);
+            }
+          },
+        },
+      },
+      stateStorage,
+    },
+    {
+      storageKey: APP_STATE_URL_KEY,
+      stateContainer: {
+        ...appStateContainer,
+        ...{
+          set: (value: AppState | null) => {
+            if (value) {
+              appStateContainer.set(value);
+            }
+          },
+        },
+      },
+      stateStorage,
+    },
+  ]);
+
+  return {
+    globalState: globalStateContainer,
+    appState: appStateContainer,
+    startSync: start,
+    stopSync: stop,
+    setAppState: (newState: Partial<AppState>) => {
+      const oldState = appStateContainer.getState();
+      const mergedState = { ...oldState, ...newState };
+
+      if (!isEqualState(oldState, mergedState)) {
+        appStateContainer.set(mergedState);
+      }
+    },
+    getFilters: () => [
+      ...getFilters(globalStateContainer.getState()),
+      ...getFilters(appStateContainer.getState()),
+    ],
+    setFilters: (filterManager: FilterManager) => {
+      // global state filters
+      const globalFilters = filterManager.getGlobalFilters();
+      const globalFilterChanged = !isEqualFilters(
+        globalFilters,
+        getFilters(globalStateContainer.getState())
+      );
+      if (globalFilterChanged) {
+        globalStateContainer.set({ filters: globalFilters });
+      }
+      // app state filters
+      const appFilters = filterManager.getAppFilters();
+      const appFilterChanged = !isEqualFilters(
+        appFilters,
+        getFilters(appStateContainer.getState())
+      );
+      if (appFilterChanged) {
+        appStateContainer.set({ ...appStateContainer.getState(), ...{ filters: appFilters } });
+      }
+    },
+    // helper function just needed for testing
+    flushToUrl: (replace?: boolean) => stateStorage.flush({ replace }),
+  };
+}
+
+/**
+ * Helper function to compare 2 different filter states
+ */
+export function isEqualFilters(filtersA: Filter[], filtersB: Filter[]) {
+  if (!filtersA && !filtersB) {
+    return true;
+  } else if (!filtersA || !filtersB) {
+    return false;
+  }
+  return opensearchFilters.compareFilters(
+    filtersA,
+    filtersB,
+    opensearchFilters.COMPARE_ALL_OPTIONS
+  );
+}
+
+/**
+ * Helper function to compare 2 different states, is needed since comparing filters
+ * works differently, doesn't work with _.isEqual
+ */
+function isEqualState(stateA: AppState | GlobalState, stateB: AppState | GlobalState) {
+  if (!stateA && !stateB) {
+    return true;
+  } else if (!stateA || !stateB) {
+    return false;
+  }
+  const { filters: stateAFilters = [], ...stateAPartial } = stateA;
+  const { filters: stateBFilters = [], ...stateBPartial } = stateB;
+  return (
+    _.isEqual(stateAPartial, stateBPartial) &&
+    opensearchFilters.compareFilters(
+      stateAFilters,
+      stateBFilters,
+      opensearchFilters.COMPARE_ALL_OPTIONS
+    )
+  );
+}
+
+/**
+ * Helper function to return array of filter object of a given state
+ */
+function getFilters(state: AppState | GlobalState): Filter[] {
+  if (!state || !Array.isArray(state.filters)) {
+    return [];
+  }
+  return state.filters;
+}
+
+/**
+ * Helper function to return the initial app state, which is a merged object of url state and
+ * default state. The default size is the default number of successor/predecessor records to fetch
+ */
+function createInitialAppState(
+  defaultSize: string,
+  timeFieldName: string,
+  urlState: AppState
+): AppState {
+  const defaultState = {
+    columns: ['_source'],
+    filters: [],
+    predecessorCount: parseInt(defaultSize, 10),
+    sort: [timeFieldName, 'desc'],
+    successorCount: parseInt(defaultSize, 10),
+  };
+  if (typeof urlState !== 'object') {
+    return defaultState;
+  }
+
+  return {
+    ...defaultState,
+    ...urlState,
+  };
+}

--- a/src/plugins/discover/public/application/components/doc_views/context/utils/use_context_state.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/utils/use_context_state.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useEffect, useMemo } from 'react';
+import { cloneDeep } from 'lodash';
+import { CONTEXT_DEFAULT_SIZE_SETTING } from '../../../../../../common';
+import { DiscoverServices } from '../../../../../build_services';
+import { AppState, getState } from './context_state';
+import { IndexPattern } from '../../../../../opensearch_dashboards_services';
+
+export interface Props {
+  services: DiscoverServices;
+  indexPattern: IndexPattern;
+}
+
+export const useContextState = ({ services, indexPattern }: Props) => {
+  const { uiSettings, history, core, filterManager } = services;
+
+  const {
+    appState: appStateContainer,
+    setAppState: setAppStateContainer,
+    startSync,
+    stopSync,
+    getFilters,
+    setFilters,
+    flushToUrl,
+  } = useMemo(() => {
+    return getState({
+      defaultStepSize: uiSettings.get(CONTEXT_DEFAULT_SIZE_SETTING),
+      timeFieldName: indexPattern.timeFieldName,
+      storeInSessionStorage: uiSettings.get('state:storeInSessionStorage'),
+      history: history(),
+      toasts: core.notifications.toasts,
+    });
+  }, [uiSettings, history, core.notifications.toasts, indexPattern.timeFieldName]);
+
+  const [contextAppState, setContextState] = useState<AppState>(appStateContainer.getState());
+
+  useEffect(() => {
+    filterManager.setFilters(cloneDeep(getFilters()));
+
+    startSync();
+
+    const unsubscribeFromAppStateChanges = appStateContainer.subscribe((newState) => {
+      setContextState((currentState) => ({ ...currentState, ...newState }));
+    });
+
+    const filterObservable = filterManager.getUpdates$().subscribe(() => {
+      setFilters(filterManager);
+    });
+
+    return () => {
+      stopSync();
+      unsubscribeFromAppStateChanges();
+      filterObservable.unsubscribe();
+    };
+  }, [filterManager, getFilters, setFilters, startSync, stopSync, appStateContainer]);
+
+  const setContextAppState = (newValues: Partial<AppState>) => {
+    for (const [key, value] of Object.entries(newValues)) {
+      setAppStateContainer({ [key]: value });
+      flushToUrl(true);
+    }
+  };
+
+  return { contextAppState, setContextAppState };
+};

--- a/src/plugins/discover/public/application/components/doc_views/context/utils/use_query_actions.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/utils/use_query_actions.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import { useMemo, useCallback, useState } from 'react';
+
+import { Filter } from '../../../../../../../data/public';
+import { fetchAnchor } from '../api/anchor';
+import { OpenSearchHitRecord, fetchSurroundingDocs } from '../api/context';
+import { DiscoverServices } from '../../../../../build_services';
+import { useOpenSearchDashboards } from '../../../../../../../opensearch_dashboards_react/public';
+import { CONTEXT_TIE_BREAKER_FIELDS_SETTING } from '../../../../../../common';
+import { getFirstSortableField, SortDirection } from '../api/utils/sorting';
+import { SurrDocType } from '../api/context';
+import { IndexPattern } from '../../../../../opensearch_dashboards_services';
+import { ContextQueryState, FAILURE_REASONS, LOADING_STATUS } from './context_query_state';
+
+const initialState: ContextQueryState = {
+  anchor: {} as OpenSearchHitRecord,
+  predecessors: [],
+  successors: [],
+  anchorStatus: { value: LOADING_STATUS.UNINITIALIZED },
+  predecessorsStatus: { value: LOADING_STATUS.UNINITIALIZED },
+  successorsStatus: { value: LOADING_STATUS.UNINITIALIZED },
+};
+
+export function useQueryActions(anchorId: string, indexPattern: IndexPattern) {
+  const { services } = useOpenSearchDashboards<DiscoverServices>();
+  const { data, uiSettings, toastNotifications } = services;
+  const searchSource = useMemo(() => {
+    return data.search.searchSource.createEmpty();
+  }, [data.search.searchSource]);
+  const tieBreakerField = useMemo(
+    () => getFirstSortableField(indexPattern, uiSettings.get(CONTEXT_TIE_BREAKER_FIELDS_SETTING)),
+    [uiSettings, indexPattern]
+  );
+  const [contextQueryState, setContextQueryState] = useState<ContextQueryState>(initialState);
+
+  const fetchAnchorRow = useCallback(async () => {
+    if (!tieBreakerField) {
+      setContextQueryState((prevState) => ({
+        ...prevState,
+        anchorStatus: {
+          value: LOADING_STATUS.FAILED,
+          reason: FAILURE_REASONS.INVALID_TIEBREAKER,
+        },
+      }));
+      return;
+    }
+
+    try {
+      setContextQueryState((prevState) => ({
+        ...prevState,
+        anchorStatus: { value: LOADING_STATUS.LOADING },
+      }));
+      const sort = [
+        { [indexPattern.timeFieldName!]: SortDirection.desc },
+        { [tieBreakerField]: SortDirection.desc },
+      ];
+      const fetchAnchorResult = await fetchAnchor(anchorId, indexPattern, searchSource, sort);
+      setContextQueryState((prevState) => ({
+        ...prevState,
+        anchor: fetchAnchorResult,
+        anchorStatus: { value: LOADING_STATUS.LOADED },
+      }));
+      return fetchAnchorResult;
+    } catch (error) {
+      setContextQueryState((prevState) => ({
+        ...prevState,
+        anchorStatus: { value: LOADING_STATUS.FAILED, reason: FAILURE_REASONS.UNKNOWN },
+      }));
+      toastNotifications.addDanger({
+        title: i18n.translate('discover.context.unableToLoadAnchorDocumentDescription', {
+          defaultMessage: 'Unable to fetch anchor document',
+        }),
+        text: 'fail',
+      });
+    }
+  }, [anchorId, indexPattern, searchSource, tieBreakerField, toastNotifications]);
+
+  const fetchSurroundingRows = useCallback(
+    async (type: SurrDocType, count: number, filters: Filter[], anchor?: OpenSearchHitRecord) => {
+      try {
+        if (type === SurrDocType.PREDECESSORS) {
+          setContextQueryState((prevState) => ({
+            ...prevState,
+            predecessorsStatus: { value: LOADING_STATUS.LOADING },
+          }));
+        } else {
+          setContextQueryState((prevState) => ({
+            ...prevState,
+            successorsStatus: { value: LOADING_STATUS.LOADING },
+          }));
+        }
+        const fetchedAchor = anchor || contextQueryState.anchor;
+
+        const rows = await fetchSurroundingDocs(
+          type,
+          indexPattern,
+          fetchedAchor as OpenSearchHitRecord,
+          tieBreakerField,
+          SortDirection.desc,
+          count,
+          filters
+        );
+        if (type === SurrDocType.PREDECESSORS) {
+          setContextQueryState((prevState) => ({
+            ...prevState,
+            predecessors: rows,
+            predecessorsStatus: { value: LOADING_STATUS.LOADED },
+          }));
+        } else {
+          setContextQueryState((prevState) => ({
+            ...prevState,
+            successors: rows,
+            successorsStatus: { value: LOADING_STATUS.LOADED },
+          }));
+        }
+      } catch (error) {
+        if (type === SurrDocType.PREDECESSORS) {
+          setContextQueryState((prevState) => ({
+            ...prevState,
+            predecessorsStatus: { value: LOADING_STATUS.FAILED, reason: FAILURE_REASONS.UNKNOWN },
+          }));
+        } else {
+          setContextQueryState((prevState) => ({
+            ...prevState,
+            successorsStatus: { value: LOADING_STATUS.FAILED, reason: FAILURE_REASONS.UNKNOWN },
+          }));
+        }
+        toastNotifications.addDanger({
+          title: i18n.translate('discover.context.unableToLoadDocumentDescription', {
+            defaultMessage: 'Unable to fetch surrounding documents',
+          }),
+          text: 'fail',
+        });
+      }
+    },
+    [contextQueryState.anchor, indexPattern, tieBreakerField, toastNotifications]
+  );
+
+  const fetchContextRows = useCallback(
+    async (
+      predecessorCount: number,
+      successorCount: number,
+      filters: Filter[],
+      anchor?: OpenSearchHitRecord
+    ) =>
+      Promise.all([
+        fetchSurroundingRows(SurrDocType.PREDECESSORS, predecessorCount, filters, anchor),
+        fetchSurroundingRows(SurrDocType.SUCCESSORS, successorCount, filters, anchor),
+      ]),
+    [fetchSurroundingRows]
+  );
+
+  const fetchAllRows = useCallback(
+    async (predecessorCount: number, successorCount: number, filters: Filter[]) => {
+      try {
+        await fetchAnchorRow().then(
+          (anchor) => anchor && fetchContextRows(predecessorCount, successorCount, filters, anchor)
+        );
+      } catch (error) {
+        toastNotifications.addDanger({
+          title: i18n.translate('discover.context.unableToLoadDocumentDescription', {
+            defaultMessage: 'Unable to fetch all documents',
+          }),
+          text: 'fail',
+        });
+      }
+    },
+    [fetchAnchorRow, fetchContextRows, toastNotifications]
+  );
+
+  const resetContextQueryState = useCallback(() => {
+    setContextQueryState(initialState);
+  }, []);
+
+  return {
+    contextQueryState,
+    fetchAnchorRow,
+    fetchAllRows,
+    fetchContextRows,
+    fetchSurroundingRows,
+    resetContextQueryState,
+  };
+}

--- a/src/plugins/discover/public/application/components/doc_views/context_app.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/context_app.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useMemo, Fragment } from 'react';
+import { useCallback } from 'react';
+import { SurrDocType } from './context/api/context';
+import { ActionBar } from './context/components/action_bar/action_bar';
+import { CONTEXT_STEP_SETTING } from '../../../../common';
+import { DiscoverViewServices } from '../../../build_services';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import { LOADING_STATUS } from './context/utils/context_query_state';
+import { SortDirection } from '../../../../../data/public';
+import { DataGridTable } from '../data_grid/data_grid_table';
+import { DocViewFilterFn } from '../../doc_views/doc_views_types';
+import { IndexPattern } from '../../../opensearch_dashboards_services';
+import { AppState } from './context/utils/context_state';
+
+export interface Props {
+  onAddFilter: DocViewFilterFn;
+  rows: any[];
+  indexPattern: IndexPattern;
+  setAppState: (state: Partial<AppState>) => void;
+  onAddColumn?: (col: string) => void;
+  onRemoveColumn?: (col: string) => void;
+  onSetColumns?: (cols: string[]) => void;
+  onSetSort?: (s: Array<[string, string]>) => void;
+  contextQueryState: any;
+  appState: AppState;
+}
+
+export function ContextApp({
+  onAddFilter,
+  rows,
+  indexPattern,
+  setAppState,
+  contextQueryState,
+  appState,
+}: Props) {
+  const { services } = useOpenSearchDashboards<DiscoverViewServices>();
+  const { uiSettings } = services;
+  const defaultStepSize = useMemo(() => parseInt(uiSettings.get(CONTEXT_STEP_SETTING), 10), [
+    uiSettings,
+  ]);
+  const { columns, predecessorCount, successorCount } = appState;
+  const {
+    anchorStatus,
+    predecessorsStatus,
+    successorsStatus,
+    predecessors,
+    successors,
+  } = contextQueryState;
+  const isAnchorLoading =
+    anchorStatus.value === LOADING_STATUS.LOADING ||
+    anchorStatus.value === LOADING_STATUS.UNINITIALIZED;
+  const isPredecessorLoading =
+    predecessorsStatus.value === LOADING_STATUS.LOADING ||
+    predecessorsStatus.value === LOADING_STATUS.UNINITIALIZED;
+  const isSuccessorLoading =
+    successorsStatus.value === LOADING_STATUS.LOADING ||
+    successorsStatus.value === LOADING_STATUS.UNINITIALIZED;
+
+  const onChangeCount = useCallback(
+    (type: SurrDocType, count: number) => {
+      const countType = type === SurrDocType.SUCCESSORS ? 'successorCount' : 'predecessorCount';
+      if (countType === 'successorCount') {
+        setAppState({ successorCount: count });
+      } else {
+        setAppState({ predecessorCount: count });
+      }
+    },
+    [setAppState]
+  );
+
+  const sort = useMemo(() => {
+    return [[indexPattern.timeFieldName!, SortDirection.desc]];
+  }, [indexPattern]);
+
+  return (
+    <Fragment>
+      <ActionBar
+        defaultStepSize={defaultStepSize}
+        docCount={predecessorCount}
+        docCountAvailable={predecessors.length}
+        isDisabled={isAnchorLoading}
+        isLoading={isPredecessorLoading}
+        onChangeCount={onChangeCount}
+        type={SurrDocType.PREDECESSORS}
+      />
+      <div className="dscDocsGrid">
+        <DataGridTable
+          aria-label={'ContextTable'}
+          columns={columns}
+          indexPattern={indexPattern}
+          onAddColumn={() => {}}
+          onFilter={onAddFilter}
+          onRemoveColumn={() => {}}
+          onSetColumns={() => {}}
+          onSort={() => {}}
+          sort={sort}
+          rows={rows}
+          displayTimeColumn={true}
+          services={services}
+          isToolbarVisible={false}
+        />
+      </div>
+      <ActionBar
+        defaultStepSize={defaultStepSize}
+        docCount={successorCount}
+        docCountAvailable={successors.length}
+        isDisabled={isAnchorLoading}
+        isLoading={isSuccessorLoading}
+        onChangeCount={onChangeCount}
+        type={SurrDocType.SUCCESSORS}
+      />
+    </Fragment>
+  );
+}

--- a/src/plugins/discover/public/application/components/doc_views/doc_views_router.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/doc_views_router.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Switch, Router, Route, Redirect } from 'react-router-dom';
+import { History } from 'history';
+import { getServices } from '../../../opensearch_dashboards_services';
+import { OpenSearchDashboardsContextProvider } from '../../../../../opensearch_dashboards_react/public';
+import { SingleDocApp } from './single_doc_app';
+import { SurroundingDocsApp } from './surrounding_docs_app';
+
+export const docViewsRouter = (history: History) => {
+  const services = getServices();
+  if (services === undefined) return <div>{'loading...'}</div>;
+
+  return (
+    <OpenSearchDashboardsContextProvider services={services}>
+      <Router history={history}>
+        <Switch>
+          <Route path="/context/:indexPatternId/:id" component={SurroundingDocsApp} />
+          <Route
+            path="/doc/:indexPattern/:index/:type"
+            render={(props) => (
+              <Redirect
+                to={`/doc/${props.match.params.indexPattern}/${props.match.params.index}`}
+              />
+            )}
+          />
+          <Route path="/doc/:indexPatternId/:index" component={SingleDocApp} />
+        </Switch>
+      </Router>
+    </OpenSearchDashboardsContextProvider>
+  );
+};

--- a/src/plugins/discover/public/application/components/doc_views/generate_doc_views_url.ts
+++ b/src/plugins/discover/public/application/components/doc_views/generate_doc_views_url.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Generate an updated URL by removing the "data-explorer" segment
+ * from the current location and appending the provided URL.
+ *
+ * @param {string} url - The URL to append to the current location.
+ * @returns {string} The updated URL.
+ */
+export function generateDocViewsUrl(url: string) {
+  // split the current location into segments
+  const urlSegments = window.location.href.split('/');
+  // find the index of the "data-explorer" segment
+  const indexOfDataExplorerInUrl = urlSegments.indexOf('data-explorer');
+  // if "data-explorer" is found, remove it from the array
+  if (indexOfDataExplorerInUrl !== -1) {
+    urlSegments.splice(indexOfDataExplorerInUrl, 1);
+  }
+  // create a new URL object from the current location
+  const newUrl = urlSegments.join('/');
+  const updatedUrlSegments = newUrl.split('#');
+  // append the provided URL to the current location
+  updatedUrlSegments[1] = url;
+  // join the segments to form the doc views URL
+  const docViewsUrl = updatedUrlSegments.join('');
+  return docViewsUrl;
+}

--- a/src/plugins/discover/public/application/components/doc_views/index.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/index.tsx
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { toMountPoint } from '../../../../../opensearch_dashboards_react/public';
+import { docViewsRouter } from './doc_views_router';
+import { getServices } from '../../../opensearch_dashboards_services';
+
+export const renderDocView = (element: HTMLElement) => {
+  const { history } = getServices();
+  const unmount = toMountPoint(docViewsRouter(history()))(element);
+  return unmount;
+};

--- a/src/plugins/discover/public/application/components/doc_views/single_doc_app.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/single_doc_app.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useParams, useLocation } from 'react-router-dom';
+import { i18n } from '@osd/i18n';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import { DiscoverServices } from '../../../build_services';
+import { getRootBreadcrumbs } from '../../helpers/breadcrumbs';
+import { IndexPattern } from '../../../opensearch_dashboards_services';
+import { Doc } from '../doc/doc';
+
+export interface SingleDocUrlParams {
+  index: string;
+  indexPatternId: string;
+}
+
+function useQueryString() {
+  return new URLSearchParams(useLocation().search);
+}
+
+export function SingleDocApp() {
+  const {
+    services: { chrome, timefilter, indexPatterns },
+  } = useOpenSearchDashboards<DiscoverServices>();
+
+  const { index, indexPatternId } = useParams<SingleDocUrlParams>();
+  const [indexPattern, setIndexPattern] = useState<IndexPattern | undefined>(undefined);
+  const [error, setError] = useState<Error | null>(null);
+
+  // get query string
+  const query = useQueryString();
+  // get doc id from query string
+  const docId = query.get('id') || '';
+
+  useEffect(() => {
+    async function getIndexPatternById() {
+      try {
+        const ip = await indexPatterns.get(indexPatternId);
+        setIndexPattern(ip);
+      } catch (e) {
+        setError(e);
+      }
+    }
+    getIndexPatternById();
+  }, [indexPatternId, indexPatterns]);
+
+  useEffect(() => {
+    chrome.setBreadcrumbs([
+      ...getRootBreadcrumbs(),
+      {
+        text: i18n.translate('discover.single.breadcrumb', {
+          defaultMessage: `${index}#${docId}`,
+          values: {
+            index,
+            docId,
+          },
+        }),
+      },
+    ]);
+  }, [chrome, index, docId]);
+
+  useEffect(() => {
+    timefilter.disableAutoRefreshSelector();
+    timefilter.disableTimeRangeSelector();
+  });
+
+  if (error) {
+    return <div>Error fetching index pattern: {error.message}</div>;
+  }
+
+  if (!indexPattern) {
+    return <div>Index pattern loading</div>;
+  }
+
+  return (
+    <div className="single doc view">
+      <Doc
+        id={docId}
+        index={index}
+        indexPatternId={indexPatternId}
+        indexPatternService={indexPatterns}
+      />
+    </div>
+  );
+}

--- a/src/plugins/discover/public/application/components/doc_views/surrounding_docs_app.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/surrounding_docs_app.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { i18n } from '@osd/i18n';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import { DiscoverServices } from '../../../build_services';
+import { getRootBreadcrumbs } from '../../helpers/breadcrumbs';
+import { SurroundingDocsView } from './surrounding_docs_view';
+import { IndexPattern } from '../../../opensearch_dashboards_services';
+import { PLUGIN_ID } from '../../../../common';
+
+export interface SurroundingDocsUrlParams {
+  id: string;
+  indexPatternId: string;
+}
+
+export function SurroundingDocsApp() {
+  const {
+    services: {
+      chrome,
+      indexPatterns,
+      core: {
+        application: { getUrlForApp },
+      },
+    },
+  } = useOpenSearchDashboards<DiscoverServices>();
+  const baseUrl = getUrlForApp(PLUGIN_ID);
+  const { id, indexPatternId } = useParams<SurroundingDocsUrlParams>();
+  const [indexPattern, setIndexPattern] = useState<IndexPattern | undefined>(undefined);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    async function getIndexPatternById() {
+      try {
+        const ip = await indexPatterns.get(indexPatternId);
+        setIndexPattern(ip);
+      } catch (e) {
+        setError(e);
+      }
+    }
+    getIndexPatternById();
+  }, [indexPatternId, indexPatterns]);
+
+  useEffect(() => {
+    chrome.setBreadcrumbs([
+      ...getRootBreadcrumbs(baseUrl),
+      {
+        text: i18n.translate('discover.context.breadcrumb', {
+          defaultMessage: `Context of #{docId}`,
+          values: {
+            docId: id,
+          },
+        }),
+      },
+    ]);
+  }, [id, chrome, baseUrl]);
+
+  if (error) {
+    return <div>Error fetching index pattern: {error.message}</div>;
+  }
+
+  if (!indexPattern) {
+    return <div>Index pattern loading</div>;
+  }
+  return <SurroundingDocsView id={id} indexPattern={indexPattern} />;
+}

--- a/src/plugins/discover/public/application/components/doc_views/surrounding_docs_view.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/surrounding_docs_view.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { Fragment, useEffect, useRef, useCallback, useMemo } from 'react';
+import { EuiPageContent, EuiPage } from '@elastic/eui';
+import { cloneDeep } from 'lodash';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import { DiscoverServices } from '../../../build_services';
+import { IndexPatternField, opensearchFilters } from '../../../../../data/public';
+import { AppState, isEqualFilters } from './context/utils/context_state';
+import { useContextState } from './context/utils/use_context_state';
+import { useQueryActions } from './context/utils/use_query_actions';
+import { ContextApp } from './context_app';
+import { LOADING_STATUS } from './context/utils/context_query_state';
+import { IndexPattern } from '../../../opensearch_dashboards_services';
+import { SurrDocType } from './context/api/context';
+import { DocViewFilterFn } from '../../doc_views/doc_views_types';
+
+export interface SurroundingDocsViewParams {
+  id: string;
+  indexPattern: IndexPattern;
+}
+
+export const SurroundingDocsView = ({ id, indexPattern }: SurroundingDocsViewParams) => {
+  const { services } = useOpenSearchDashboards<DiscoverServices>();
+  const {
+    navigation: {
+      ui: { TopNavMenu },
+    },
+    data: {
+      query: { filterManager },
+    },
+  } = services;
+
+  const { contextAppState, setContextAppState } = useContextState({ services, indexPattern });
+  const currentAppState = useRef<AppState>();
+
+  const {
+    contextQueryState,
+    fetchContextRows,
+    fetchAllRows,
+    fetchSurroundingRows,
+    resetContextQueryState,
+  } = useQueryActions(id, indexPattern);
+
+  // derive loading state
+  const isLoading = [
+    contextQueryState.anchorStatus.value,
+    contextQueryState.predecessorsStatus.value,
+    contextQueryState.successorsStatus.value,
+  ].some((status) => status === LOADING_STATUS.LOADING || status === LOADING_STATUS.UNINITIALIZED);
+
+  // derive rows
+  const rows = useMemo(
+    () => [
+      ...(contextQueryState.predecessors || []),
+      ...(contextQueryState.anchor ? [contextQueryState.anchor] : []),
+      ...(contextQueryState.successors || []),
+    ],
+    [contextQueryState.predecessors, contextQueryState.anchor, contextQueryState.successors]
+  );
+
+  // data fetch logic
+  useEffect(() => {
+    if (currentAppState.current) {
+      currentAppState.current = undefined;
+      resetContextQueryState();
+    }
+  }, [id, resetContextQueryState]);
+
+  useEffect(() => {
+    const { predecessorCount, successorCount, filters } = contextAppState;
+    if (!currentAppState.current) {
+      fetchAllRows(predecessorCount, successorCount, filters);
+    } else if (currentAppState.current.predecessorCount !== predecessorCount) {
+      fetchSurroundingRows(SurrDocType.PREDECESSORS, predecessorCount, filters);
+    } else if (currentAppState.current.successorCount !== successorCount) {
+      fetchSurroundingRows(SurrDocType.SUCCESSORS, successorCount, filters);
+    } else if (!isEqualFilters(currentAppState.current.filters, filters)) {
+      fetchContextRows(contextAppState.predecessorCount, successorCount, filters);
+    }
+
+    currentAppState.current = cloneDeep(contextAppState);
+  }, [contextAppState, id, fetchContextRows, fetchAllRows, fetchSurroundingRows]);
+
+  // add filter logic
+  const onAddFilter = useCallback(
+    (field: IndexPatternField, values: string, operation: '+' | '-') => {
+      const newFilters = opensearchFilters.generateFilters(
+        filterManager,
+        field,
+        values,
+        operation,
+        indexPattern.id
+      );
+      return filterManager.addFilters(newFilters);
+    },
+    [filterManager, indexPattern]
+  );
+
+  // memoize context app
+  const contextAppMemoized = useMemo(
+    () => (
+      <ContextApp
+        onAddFilter={onAddFilter as DocViewFilterFn}
+        rows={rows}
+        indexPattern={indexPattern}
+        setAppState={setContextAppState}
+        contextQueryState={contextQueryState}
+        appState={contextAppState}
+      />
+    ),
+    [onAddFilter, rows, indexPattern, setContextAppState, contextQueryState, contextAppState]
+  );
+
+  return (
+    !isLoading && (
+      <Fragment>
+        <TopNavMenu
+          appName={'discover.context.surroundingDocs.topNavMenu'}
+          showSearchBar={true}
+          showQueryBar={false}
+          showDatePicker={false}
+          indexPatterns={[indexPattern]}
+          useDefaultBehaviors={true}
+        />
+        <EuiPage className="discover.context.appPage">
+          <EuiPageContent paddingSize="s" className="dscDocsContent">
+            {contextAppMemoized}
+          </EuiPageContent>
+        </EuiPage>
+      </Fragment>
+    )
+  );
+};

--- a/src/plugins/discover/public/application/helpers/breadcrumbs.ts
+++ b/src/plugins/discover/public/application/helpers/breadcrumbs.ts
@@ -30,22 +30,13 @@
 
 import { i18n } from '@osd/i18n';
 
-export function getRootBreadcrumbs() {
+export function getRootBreadcrumbs(baseUrl: string) {
   return [
     {
       text: i18n.translate('discover.rootBreadcrumb', {
         defaultMessage: 'Discover',
       }),
-      href: '#/',
-    },
-  ];
-}
-
-export function getSavedSearchBreadcrumbs($route: any) {
-  return [
-    ...getRootBreadcrumbs(),
-    {
-      text: $route.current.locals.savedObjects.savedSearch.id,
+      href: baseUrl,
     },
   ];
 }

--- a/src/plugins/discover/public/migrate_state.ts
+++ b/src/plugins/discover/public/migrate_state.ts
@@ -94,6 +94,11 @@ export function migrateUrlState(oldPath: string, newPath = '/'): string {
 
   // Migrate the path.
   switch (matchingPathPattern.path) {
+    // doc and context views will use the same legacy path and state
+    // so we can use the saved legacy path in new discover
+    case `doc`:
+    case `context`:
+      path = oldPath;
     case `discover`:
     case `savedSearch`:
       const params = matchPath<DiscoverParams>(oldPath, {


### PR DESCRIPTION
### Description
* add initial route logic to single/surroundings doc view and re-organize files
* restore surrounding doc view comp
<img width="1200" alt="Screenshot 2023-08-24 at 14 41 51" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/ec6691a6-ec69-4c68-9da8-272ecdefa22c">

* restore single doc view comp
<img width="1197" alt="Screenshot 2023-08-24 at 10 28 13" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/97b68d02-1d27-46cc-9868-4f4a25893110">



### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4231
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4230


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
