### PR TITLE
[CI] Fix BWC related CI failures by swapping dist url with snapshot url

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Set OpenSearch URL
         run: |
-          echo "OPENSEARCH_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/tar/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz" >> $GITHUB_ENV
+          echo "OPENSEARCH_URL=https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.VERSION }}-SNAPSHOT/opensearch-min-${{ env.VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz" >> $GITHUB_ENV
 
       - name: Verify if OpenSearch is available for version
         id: verify-opensearch-exists

--- a/scripts/bwc/opensearch_service.sh
+++ b/scripts/bwc/opensearch_service.sh
@@ -24,7 +24,12 @@ function setup_opensearch() {
 function run_opensearch() {
   echo "[ Attempting to start OpenSearch... ]"
   cd "$OPENSEARCH_DIR"
-  spawn_process_and_save_PID "./opensearch-tar-install.sh > ${LOGS_DIR}/opensearch.log 2>&1 &"
+  # Check if opensearch-tar-install.sh exists
+  if [ -f "./opensearch-tar-install.sh" ]; then
+    spawn_process_and_save_PID "./opensearch-tar-install.sh > ${LOGS_DIR}/opensearch.log 2>&1 &"
+  else
+    spawn_process_and_save_PID "./bin/opensearch > ${LOGS_DIR}/opensearch.log 2>&1 &"
+  fi
 }
 
 # Checks the running status of OpenSearch


### PR DESCRIPTION
### Description

The BWC tests on 2.x are failing: https://github.com/opensearch-project/OpenSearch-Dashboards/actions/runs/5895740470/job/16189125311.

BWC test files: https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/.github/workflows/build_and_test_workflow.yml#L349 utilize the release artifact which is built by a configuration sent externally. If there are issues in the build release for OpenSearch then we will be impacted, where snapshot is built more frequently.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4814


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
