### PR TITLE
Add callout for both data explorer and legacy discover

### DIFF
--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiCallOut } from '@elastic/eui';
 import { TopNav } from './top_nav';
 import { ViewProps } from '../../../../../data_explorer/public';
 import { DiscoverTable } from './discover_table';
@@ -65,6 +65,12 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
       {status === ResultStatus.LOADING && <LoadingSpinner />}
       {status === ResultStatus.READY && (
         <>
+          <EuiFlexItem grow={false}>
+            <EuiCallOut
+              title="New Discover is available to switch by default and the old discover will be deprecated in 2.11."
+              iconType="alert"
+            />
+          </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="s">
               <EuiPanel>

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -67,7 +67,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
         <>
           <EuiFlexItem grow={false}>
             <EuiCallOut
-              title="New Discover is available to switch by default and the old discover will be deprecated in 2.11."
+              title="This Discover app version will be retired in OpenSearch version 2.11. To switch to the new Discover 2.0 version, toggle the New Discover."
               iconType="alert"
             />
           </EuiFlexItem>

--- a/src/plugins/discover_legacy/public/application/components/discover_legacy.tsx
+++ b/src/plugins/discover_legacy/public/application/components/discover_legacy.tsx
@@ -30,7 +30,7 @@
 
 import React, { useState, useCallback, useEffect } from 'react';
 import classNames from 'classnames';
-import { EuiButtonEmpty, EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonEmpty, EuiButtonIcon, EuiCallOut } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
 import { IUiSettingsClient, MountPoint } from 'opensearch-dashboards/public';
@@ -218,6 +218,12 @@ export function DiscoverLegacy({
               />
             </div>
             <div className={`dscWrapper ${mainSectionClassName}`}>
+              <div>
+                <EuiCallOut
+                  title="New Discover is available to switch by default and the old discover will be deprecated in 2.11."
+                  iconType="alert"
+                />
+              </div>
               {resultState === 'none' && (
                 <DiscoverNoResults
                   timeFieldName={opts.timefield}

--- a/src/plugins/discover_legacy/public/application/components/discover_legacy.tsx
+++ b/src/plugins/discover_legacy/public/application/components/discover_legacy.tsx
@@ -220,7 +220,7 @@ export function DiscoverLegacy({
             <div className={`dscWrapper ${mainSectionClassName}`}>
               <div>
                 <EuiCallOut
-                  title="New Discover is available to switch by default and the old discover will be deprecated in 2.11."
+                  title="This Discover app version will be retired in OpenSearch version 2.11. To switch to the new Discover 2.0 version, toggle the New Discover."
                   iconType="alert"
                 />
               </div>


### PR DESCRIPTION
### Description

Add callout to inform users that legacy discover will be deprecated, and they can switch between data explorer and legacy discover.

- wait for this PR from OUI to merged so it can use the dismissible callout: https://github.com/opensearch-project/oui/pull/985
- wait for official ux wording on the callout: @KrooshalUX @vagimeli 

### Issues Resolved



## Screenshot

<img width="1721" alt="Screenshot 2023-08-25 at 7 34 11 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/4e2e6daa-01c1-4e92-aaf7-5a4cb2cb8384">

<img width="1721" alt="Screenshot 2023-08-25 at 7 34 28 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/df6a51c7-1857-49d5-944c-de937afcad10">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
