### PR TITLE
[Data Explorer][Discover 2.0] Replace hide column and add move left/right

### DIFF
--- a/src/plugins/discover/public/application/components/data_grid/constants.ts
+++ b/src/plugins/discover/public/application/components/data_grid/constants.ts
@@ -9,4 +9,5 @@ export const toolbarVisibility = {
     allowReorder: true,
   },
   showStyleSelector: false,
+  showFullScreenSelector: false,
 };

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_columns.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_columns.tsx
@@ -11,33 +11,52 @@ import { getCellActions } from './data_grid_table_cell_actions';
 export function buildDataGridColumns(
   columnNames: string[],
   idxPattern: IndexPattern,
-  displayTimeColumn: boolean
+  displayTimeColumn: boolean,
+  includeSourceInColumns: boolean,
+  isContextView: boolean
 ) {
   const timeFieldName = idxPattern.timeFieldName;
   let columnsToUse = columnNames;
 
-  if (displayTimeColumn && idxPattern.timeFieldName && !columnNames.includes(timeFieldName)) {
-    columnsToUse = [idxPattern.timeFieldName, ...columnNames];
+  if (displayTimeColumn && timeFieldName && !columnNames.includes(timeFieldName)) {
+    columnsToUse = [timeFieldName, ...columnNames];
   }
 
-  return columnsToUse.map((colName) => generateDataGridTableColumn(colName, idxPattern));
+  return columnsToUse.map((colName) =>
+    generateDataGridTableColumn(colName, idxPattern, includeSourceInColumns, isContextView)
+  );
 }
 
-export function generateDataGridTableColumn(colName: string, idxPattern: IndexPattern) {
+export function generateDataGridTableColumn(
+  colName: string,
+  idxPattern: IndexPattern,
+  includeSourceInColumns: boolean,
+  isContextView: boolean
+) {
   const timeLabel = i18n.translate('discover.timeLabel', {
     defaultMessage: 'Time',
   });
   const idxPatternField = idxPattern.getFieldByName(colName);
+  const shouldHide = colName === '_source' || colName === idxPattern.timeFieldName;
   const dataGridCol: EuiDataGridColumn = {
     id: colName,
     schema: idxPatternField?.type,
     isSortable: idxPatternField?.sortable,
     display: idxPatternField?.displayName,
-    actions: {
-      showHide: true,
-      showMoveLeft: false,
-      showMoveRight: false,
-    },
+    actions: isContextView
+      ? false
+      : {
+          showHide: shouldHide
+            ? false
+            : {
+                label: i18n.translate('discover.removeColumn.label', {
+                  defaultMessage: 'Remove column',
+                }),
+                iconType: 'cross',
+              },
+          showMoveLeft: !includeSourceInColumns,
+          showMoveRight: !includeSourceInColumns,
+        },
     cellActions: idxPatternField ? getCellActions(idxPatternField) : [],
   };
 

--- a/src/plugins/discover/public/application/components/doc_views/context_app.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/context_app.tsx
@@ -103,6 +103,7 @@ export function ContextApp({
           displayTimeColumn={true}
           services={services}
           isToolbarVisible={false}
+          isContextView={true}
         />
       </div>
       <ActionBar

--- a/src/plugins/discover/public/application/utils/state_management/common.ts
+++ b/src/plugins/discover/public/application/utils/state_management/common.ts
@@ -21,8 +21,3 @@ export const reorderColumn = (columns: string[], source: number, destination: nu
   newColumns.splice(destination, 0, removed);
   return newColumns;
 };
-
-export const setColumns = (timeField: string | undefined, columns: string[]) => {
-  const newColumns = timeField && timeField === columns[0] ? columns.slice(1) : columns;
-  return newColumns;
-};

--- a/src/plugins/discover/public/application/utils/state_management/discover_slice.tsx
+++ b/src/plugins/discover/public/application/utils/state_management/discover_slice.tsx
@@ -123,11 +123,10 @@ export const discoverSlice = createSlice({
         isDirty: true,
       };
     },
-    setColumns(state, action: PayloadAction<{ timeField: string | undefined; columns: string[] }>) {
-      const columns = utils.setColumns(action.payload.timeField, action.payload.columns);
+    setColumns(state, action: PayloadAction<{ columns: string[] }>) {
       return {
         ...state,
-        columns,
+        columns: action.payload.columns,
       };
     },
     setSort(state, action: PayloadAction<SortOrder[]>) {

--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -39,8 +39,7 @@ export const DiscoverTable = ({ history }: Props) => {
   const dispatch = useDispatch();
   const onAddColumn = (col: string) => dispatch(addColumn({ column: col }));
   const onRemoveColumn = (col: string) => dispatch(removeColumn(col));
-  const onSetColumns = (cols: string[]) =>
-    dispatch(setColumns({ timefield: indexPattern.timeFieldName, columns: cols }));
+  const onSetColumns = (cols: string[]) => dispatch(setColumns({ columns: cols }));
   const onSetSort = (s: SortOrder[]) => {
     dispatch(setSort(s));
     refetch$.next();


### PR DESCRIPTION
### Description
* disable full screen mode (see investigation from https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4824). 
<img width="955" alt="Screenshot 2023-08-28 at 09 25 53" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/ffeb63d0-6360-4f1a-9792-19080f158ca6">

* customize hide column to delete column
* add move left and move right

<img width="940" alt="Screenshot 2023-08-28 at 09 26 18" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/6f848008-dce1-4cc0-8b72-a932989e3608">


### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4822 
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4823 
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4824


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
