### PR TITLE
[Data Explorer] Fix darkmode for histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `node-sass` to a version that uses a newer `libsass` ([#4649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4649))
 - [CVE-2019-11358] Bump version of tinygradient from 0.4.3 to 1.1.5 ([#4742](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4742))
 - [CVE-2021-3520] Bump `lmdb` from `2.8.0` to `2.8.5` ([#4804](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4804))
+- [Data Explorer] Fix darkmode for histogram ([#4858](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4858)) 
 
 ### 📈 Features/Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `node-sass` to a version that uses a newer `libsass` ([#4649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4649))
 - [CVE-2019-11358] Bump version of tinygradient from 0.4.3 to 1.1.5 ([#4742](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4742))
 - [CVE-2021-3520] Bump `lmdb` from `2.8.0` to `2.8.5` ([#4804](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4804))
-- [Data Explorer] Fix darkmode for histogram ([#4858](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4858)) 
 
 ### 📈 Features/Enhancements
 

--- a/src/plugins/discover/public/application/components/chart/_histogram.scss
+++ b/src/plugins/discover/public/application/components/chart/_histogram.scss
@@ -1,0 +1,11 @@
+.dscHistogram__header--partial {
+  font-weight: $euiFontWeightRegular;
+  min-width: $euiSize * 12;
+}
+
+// Temporary override to inlined styles provided by ElasticCharts theming
+// Will be unnecessary when we migrate the histogram to a different rendering library:
+// https: //github.com/opensearch-project/OpenSearch-Dashboards/issues/4643
+.dscHistogram .echChartBackground {
+  background-color: inherit !important;
+}

--- a/src/plugins/discover/public/application/components/chart/chart.tsx
+++ b/src/plugins/discover/public/application/components/chart/chart.tsx
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import './_histogram.scss';
+
 import React, { useCallback } from 'react';
 import moment from 'moment';
 import dateMath from '@elastic/datemath';


### PR DESCRIPTION
### Description
Fix darkmode for histogram. Previously after switching to darkmode, histogram still have light mode color scheme.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/ff12ff69-9513-474e-a585-31036f444806



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
