### PR TITLE
[Data Explorer][Discover 2.0] Fix issues when change index pattern

### DIFF
--- a/src/plugins/discover/public/application/components/sidebar/lib/get_index_pattern_field_list.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/get_index_pattern_field_list.ts
@@ -36,18 +36,5 @@ export function getIndexPatternFieldList(
   fieldCounts?: Record<string, number>
 ) {
   if (!indexPattern || !fieldCounts) return [];
-
-  const fieldNamesInDocs = Object.keys(fieldCounts);
-  const fieldNamesInIndexPattern = indexPattern.fields.getAll().map((fld) => fld.name);
-  const unknownTypes: IndexPatternField[] = [];
-
-  difference(fieldNamesInDocs, fieldNamesInIndexPattern).forEach((unknownFieldName) => {
-    unknownTypes.push({
-      displayName: String(unknownFieldName),
-      name: String(unknownFieldName),
-      type: 'unknown',
-    } as IndexPatternField);
-  });
-
-  return [...indexPattern.fields.getAll(), ...unknownTypes];
+  return [...indexPattern.fields.getAll()];
 }

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiCallOut, EuiLink } from '@elastic/eui';
 import { TopNav } from './top_nav';
 import { ViewProps } from '../../../../../data_explorer/public';
@@ -14,10 +14,26 @@ import { ResultStatus, SearchData } from '../utils/use_search';
 import { DiscoverNoResults } from '../../components/no_results/no_results';
 import { DiscoverUninitialized } from '../../components/uninitialized/uninitialized';
 import { LoadingSpinner } from '../../components/loading_spinner/loading_spinner';
+import { setColumns, useDispatch, useSelector } from '../../utils/state_management';
+import { DiscoverViewServices } from '../../../build_services';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import { filterColumns } from '../utils/filter_columns';
+import { DEFAULT_COLUMNS_SETTING } from '../../../../common';
 
 // eslint-disable-next-line import/no-default-export
 export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewProps) {
   const { data$, refetch$, indexPattern } = useDiscoverContext();
+  const {
+    services: { uiSettings },
+  } = useOpenSearchDashboards<DiscoverViewServices>();
+  const { columns } = useSelector((state) => state.discover);
+  const filteredColumns = filterColumns(
+    columns,
+    indexPattern,
+    uiSettings.get(DEFAULT_COLUMNS_SETTING)
+  );
+  const dispatch = useDispatch();
+  const prevIndexPattern = useRef(indexPattern);
 
   const [fetchState, setFetchState] = useState<SearchData>({
     status: data$.getValue().status,
@@ -68,6 +84,13 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
       subscription.unsubscribe();
     };
   }, [data$, fetchState]);
+
+  useEffect(() => {
+    if (indexPattern !== prevIndexPattern.current) {
+      dispatch(setColumns({ columns: filteredColumns }));
+      prevIndexPattern.current = indexPattern;
+    }
+  }, [dispatch, filteredColumns, indexPattern]);
 
   const timeField = indexPattern?.timeFieldName ? indexPattern.timeFieldName : undefined;
 

--- a/src/plugins/discover/public/application/view_components/utils/filter_columns.test.ts
+++ b/src/plugins/discover/public/application/view_components/utils/filter_columns.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { filterColumns } from './filter_columns';
+import { IndexPattern } from '../../../opensearch_dashboards_services';
+
+describe('filterColumns', () => {
+  const indexPatternMock = {
+    fields: {
+      getAll: () => [{ name: 'a' }, { name: 'c' }, { name: 'd' }],
+    },
+  } as IndexPattern;
+  const defaultColumns = ['_defaultColumn'];
+
+  it('should return columns that exist in the index pattern fields', () => {
+    const columns = ['a', 'b'];
+    const result = filterColumns(columns, indexPatternMock, defaultColumns);
+    expect(result).toEqual(['a']);
+  });
+
+  it('should return defaultColumns if no columns exist in the index pattern fields', () => {
+    const columns = ['b', 'e'];
+    const result = filterColumns(columns, indexPatternMock, defaultColumns);
+    expect(result).toEqual(defaultColumns);
+  });
+
+  it('should return defaultColumns if no columns and indexPattern is null', () => {
+    const columns = ['b', 'e'];
+    const result = filterColumns(columns, null, defaultColumns);
+    expect(result).toEqual(defaultColumns);
+  });
+});

--- a/src/plugins/discover/public/application/view_components/utils/filter_columns.ts
+++ b/src/plugins/discover/public/application/view_components/utils/filter_columns.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IndexPattern } from '../../../opensearch_dashboards_services';
+
+/**
+ * Helper function to filter columns based on the fields of the index pattern.
+ * This function is used when we switch between index patterns. We want to keep the columns that are
+ * still available in the new index pattern and remove the ones that are not.
+ * If the resulting array is empty, it provides a fallback to the default column.
+ * @param columns Array of column names
+ * @param indexPattern Index pattern object
+ * @param defaultColumns Array of default columns
+ */
+export function filterColumns(
+  columns: string[],
+  indexPattern: IndexPattern,
+  defaultColumns: string[]
+) {
+  const fieldsName = indexPattern?.fields.getAll().map((fld) => fld.name) || [];
+  const filteredColumns = columns.filter((column) => fieldsName.includes(column));
+  return filteredColumns.length > 0 ? filteredColumns : defaultColumns;
+}


### PR DESCRIPTION
### Description
* side nav only shows the selected index pattern fields after switch index pattern
<img width="1754" alt="Screenshot 2023-08-31 at 09 23 24" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/63993906-9840-495d-bcd2-27b368a1a92c">

* allow reset column state when switch index pattern

There are two conditions: 1) If there is common field, common field will be saved. 
<img width="756" alt="Screenshot 2023-08-31 at 09 23 51" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/cddf3572-66e2-473d-a724-ea64a6e77900">

<img width="1007" alt="Screenshot 2023-08-31 at 09 23 59" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/8c44201f-8071-438d-bfb5-052a52dc16a0">

2) if no common field, will show `_source` after switch
<img width="965" alt="Screenshot 2023-08-31 at 09 23 34" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/20726214-eaf6-40e6-aee5-0fed6cff460f">

<img width="1576" alt="Screenshot 2023-08-31 at 09 23 43" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/ebc88583-717b-46ed-b048-60bad50dd475">


### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4840 https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4846


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
