### PR TITLE
Change color fn used to calculate icon colors for search typeahead 

### DIFF
--- a/src/plugins/data/public/ui/typeahead/_suggestion.scss
+++ b/src/plugins/data/public/ui/typeahead/_suggestion.scss
@@ -102,7 +102,7 @@ $osdTypeaheadTypes: (
     &.osdSuggestionItem--#{$name} {
       .osdSuggestionItem__type {
         background-color: tintOrShade($color, 90%, 50%);
-        color: makeHighContrastColor($color, tintOrShade($color, 90%, 50%));
+        color: makeGraphicContrastColor($color, tintOrShade($color, 90%, 50%));
       }
     }
   }


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Icons don't need to be as high contrast as text, so the 3:1 threshold of `makeGraphicContrastColor` is more appropriate

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
fixes #4628 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
These styles aren't actually currently used, because we don't have full typeahead support available in the query bar, except for historical queries. But I've manually updated some of the suggestions with the 4 color style classes affected by this change. The colors themselves haven't changed, but it fixes the error. **Note that this change is only for the color variants - the contrast for the grayscale ones are probably worse, but defined elsewhere**:

<img width="1677" alt="Screen Shot 2023-08-31 at 2 27 34 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/61d17b6e-e276-4bf0-ad8a-d3798609aae4">
<img width="1681" alt="Screen Shot 2023-08-31 at 2 26 50 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/171fbe28-41bf-4e39-a2a6-5baead8ea287">
<img width="1676" alt="Screen Shot 2023-08-31 at 2 25 42 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/63b26a95-b77a-473b-a968-e6d7356779eb">
<img width="1682" alt="Screen Shot 2023-08-31 at 2 24 05 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/24808aac-1a21-470d-a401-8ca901dfac37">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
Before:
```
np bld    log   [21:29:23.956] [info][@osd/optimizer] starting worker [1 bundle]
np bld    log   [21:29:27.418] [warning][@osd/optimizer] worker stderr WARNING: High enough contrast could not be determined. Most likely your background color does not adjust for dark mode.
np bld    log   [21:29:27.419] [warning][@osd/optimizer] worker stderr          on line 128:7 of node_modules/@elastic/eui/src/themes/eui-next/global_styling/functions/_colors.scss, in function `makeHighContrastColor`
np bld    log   [21:29:27.419] [warning][@osd/optimizer] worker stderr          from line 105:16 of src/plugins/data/public/ui/typeahead/_suggestion.scss
np bld    log   [21:29:27.419] [warning][@osd/optimizer] worker stderr          from line 1:9 of src/plugins/data/public/ui/typeahead/_index.scss
np bld    log   [21:29:27.419] [warning][@osd/optimizer] worker stderr          from line 2:9 of src/plugins/data/public/ui/_index.scss
np bld    log   [21:29:27.419] [warning][@osd/optimizer] worker stderr          from line 2:9 of src/plugins/data/public/index.scss
np bld    log   [21:29:27.419] [warning][@osd/optimizer] worker stderr 
np bld    log   [21:29:28.509] [warning][@osd/optimizer] worker stderr WARNING: High enough contrast could not be determined. Most likely your background color does not adjust for dark mode.
np bld    log   [21:29:28.509] [warning][@osd/optimizer] worker stderr          on line 128:7 of node_modules/@elastic/eui/src/themes/eui-next/global_styling/functions/_colors.scss, in function `makeHighContrastColor`
np bld    log   [21:29:28.509] [warning][@osd/optimizer] worker stderr          from line 105:16 of src/plugins/data/public/ui/typeahead/_suggestion.scss
np bld    log   [21:29:28.509] [warning][@osd/optimizer] worker stderr          from line 1:9 of src/plugins/data/public/ui/typeahead/_index.scss
np bld    log   [21:29:28.509] [warning][@osd/optimizer] worker stderr          from line 2:9 of src/plugins/data/public/ui/_index.scss
np bld    log   [21:29:28.510] [warning][@osd/optimizer] worker stderr          from line 2:9 of src/plugins/data/public/index.scss
np bld    log   [21:29:28.510] [warning][@osd/optimizer] worker stderr 
np bld    log   [21:29:32.591] [success][@osd/optimizer] 1 bundles compiled successfully after 10.2 sec, watching for changes
```

After:
```
np bld    log   [21:29:43.878] [success][@osd/optimizer] 1 bundles compiled successfully after 5.2 sec, watching for changes
```


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
