### PR TITLE
[Vis Colors] Update color mapper to prioritize unique colors per vis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Home] Add modal to introduce the `next` theme ([#4715](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4715))
 - Remove visualization editor sidebar background ([#4719](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4719))
 - [Vis Colors] Remove customized colors from sample visualizations and dashboards ([#4741](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4741))
+- [Vis Colors] Update color mapper to prioritize unique colors per visualization rather than across entire dashboard ([#4890](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4890))
 - [Decouple] Allow plugin manifest config to define semver compatible OpenSearch plugin and verify if it is installed on the cluster([#4612](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4612))
 - Adds Data explorer framework and implements Discover using it ([#4806](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4806))
 

--- a/src/plugins/charts/public/services/colors/colors.ts
+++ b/src/plugins/charts/public/services/colors/colors.ts
@@ -64,7 +64,7 @@ export class ColorsService {
   ) {
     if (!Array.isArray(arrayOfStringsOrNumbers)) {
       throw new Error(
-        `createColorLookupFunction expects an array but recived: ${typeof arrayOfStringsOrNumbers}`
+        `createColorLookupFunction expects an array but received: ${typeof arrayOfStringsOrNumbers}`
       );
     }
 

--- a/src/plugins/charts/public/services/colors/mapped_colors.ts
+++ b/src/plugins/charts/public/services/colors/mapped_colors.ts
@@ -83,34 +83,36 @@ export class MappedColors {
     const configColors = _.values(configMapping);
     const oldColors = _.values(this._oldMap);
 
+    const alreadyUsedColors: string[] = [];
     const keysToMap: Array<string | number> = [];
     _.each(keys, (key) => {
       // If this key is mapped in the config, it's unnecessary to have it mapped here
-      if (configMapping[key as any]) delete this._mapping[key];
+      if (configMapping[key as any]) {
+        delete this._mapping[key];
+        alreadyUsedColors.push(configMapping[key]);
+      }
 
       // If this key is mapped to a color used by the config color mapping, we need to remap it
       if (_.includes(configColors, this._mapping[key])) keysToMap.push(key);
 
       // if key exist in oldMap, move it to mapping
-      if (this._oldMap[key]) this._mapping[key] = this._oldMap[key];
+      if (this._oldMap[key]) {
+        this._mapping[key] = this._oldMap[key];
+        alreadyUsedColors.push(this._mapping[key]);
+      }
 
       // If this key isn't mapped, we need to map it
       if (this.get(key) == null) keysToMap.push(key);
     });
 
-    // Generate a color palette big enough that all new keys can have unique color values
-    const allColors = _(this._mapping).values().union(configColors).union(oldColors).value();
-    const numColors = allColors.length + keysToMap.length;
+    // Choose colors from euiPaletteColorBlind and filter out any already assigned to keys
     const colorPalette = euiPaletteColorBlind({
-      rotations: Math.ceil(numColors / 10),
+      rotations: Math.ceil(keys.length / 10),
       direction: 'both',
-    }).slice(0, numColors);
-    let newColors = _.difference(colorPalette, allColors);
+    })
+      .filter((color) => !alreadyUsedColors.includes(color.toLowerCase()))
+      .slice(0, keysToMap.length);
 
-    while (keysToMap.length > newColors.length) {
-      newColors = newColors.concat(_.sampleSize(allColors, keysToMap.length - newColors.length));
-    }
-
-    _.merge(this._mapping, _.zipObject(keysToMap, newColors));
+    _.merge(this._mapping, _.zipObject(keysToMap, colorPalette));
   }
 }


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Instead of trying to generate unique colors for an entire dashboard.

Visualizations that use the color mapper (VisLib, VisBuilder, TSVB) will now have the following behavior:

1. Every visualization will preferentially use the colors from [the OUI qualitative palette](https://oui.opensearch.org/1.2/#/utilities/color-palettes). Only if there are more than 10 colors needed for a single visualization, additional colors will be generated via rotations of that palette. (new feature)
2. Mapped colors on dashboards are no longer subject to race conditions, where multiple loads of the same dashboard would result in different mapped colors. That means dashboard colors are stable and there's no need to manually specify colors just to achieve consistency. (new feature)
3. Series labels that appear in multiple visualization in the same dashboard (e.g. status code "404") will have the same color, even if they're ordered differently. (existing feature maintained)
4. Within an individual visualization, every data series will get a unique color with no repeats (existing feature maintained)
5. Custom color configurations specified via the `visualization:colorMapping` advanced setting will be respected. _Additionally_, if one or more series in a visualization have custom color configurations that use OUI qualitative palette colors, those will be skipped when mapping non-customized colors to avoid duplicates. (new feature)
6. If users manually set colors via the legend (either in visualization or dashboard), it will not affect the color mapping (those are treated as overrides to mapped colors). (existing feature maintained)

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4697

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

### Sample dashboards (next light) after

 Notice the consistency across dashboards and data sets:
![Screenshot 2023-08-31 at 18-35-14 Flights Global Flight Dashboard - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/b40085e5-2840-490d-96ae-70f9723d6a42)
![Screenshot 2023-08-31 at 18-34-24 Logs Web Traffic - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/c517e676-34a4-4735-a5a9-2565574d3ebd)
![Screenshot 2023-08-31 at 18-33-43 eCommerce Revenue Dashboard - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/c5f599f1-a441-4f9d-98cf-6d4dfcdd2abb)

###  Sample dashboards (next light) before

![Screenshot 2023-08-14 at 15-06-50 eCommerce Revenue Dashboard - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/7238a15e-a8d6-4d04-aa96-b79797238b02)
![Screenshot 2023-08-14 at 15-07-28 Logs Web Traffic - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/1508248b-89b5-4001-a614-7026e6f56efd)
![Screenshot 2023-08-14 at 15-08-17 Flights Global Flight Dashboard - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/96b00b82-1415-4550-908c-b166bac71a23)

### Visual Consistency Dashboard (all themes) after

![Screenshot 2023-08-31 at 18-26-15 Visual Consistency Dashboard Copy - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/8284fa03-59d5-4a01-82b1-b9d9f45d2646)

![Screenshot 2023-08-31 at 18-30-22 Visual Consistency Dashboard Copy - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/dd78ab35-0965-470c-8968-959931c278b4)

![Screenshot 2023-08-31 at 18-32-00 Visual Consistency Dashboard Copy - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/785431b8-6273-4dcd-a328-d653617946d3)

![Screenshot 2023-08-31 at 18-32-00 Visual Consistency Dashboard Copy - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/6e0f13fc-4031-4ee1-9400-5dec11ea007a)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
