### PR TITLE
Fixes broken app when management is turned off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [TSVB, Dashboards] Fix inconsistent dark mode code editor themes ([#4609](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4609))
 - [Legacy Maps] Fix dark mode style overrides ([#4658](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4658))
 - [BUG] Fix management overview page duplicate rendering ([#4636](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4636))
+- Fixes broken app when management is turned off ([#4891](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4891))
 
 ### 🚞 Infrastructure
 

--- a/src/core/types/capabilities.ts
+++ b/src/core/types/capabilities.ts
@@ -47,6 +47,6 @@ export interface Capabilities {
   /** Catalogue capabilities. Catalogue entries drive the visibility of the OpenSearch Dashboards homepage options. */
   catalogue: Record<string, boolean>;
 
-  /** Custom capabilities, registered by plugins. */
-  [key: string]: Record<string, boolean | Record<string, boolean>>;
+  /** Custom capabilities, registered by plugins. undefined if the key does not exist */
+  [key: string]: Record<string, boolean | Record<string, boolean>> | undefined;
 }

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_footer/overview_page_footer.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_footer/overview_page_footer.tsx
@@ -52,7 +52,8 @@ export const OverviewPageFooter: FC<Props> = ({ addBasePath, path }) => {
     },
   } = useOpenSearchDashboards<CoreStart>();
 
-  const { show, save } = application.capabilities.advancedSettings;
+  const { show, save } = application.capabilities.advancedSettings ?? {};
+
   const isAdvancedSettingsEnabled = show && save;
 
   const defaultRoutebutton =

--- a/src/plugins/vis_augmenter/public/ui_actions_bootstrap.ts
+++ b/src/plugins/vis_augmenter/public/ui_actions_bootstrap.ts
@@ -71,8 +71,15 @@ export const bootstrapUiActions = (uiActions: UiActionsSetup) => {
   uiActions.registerTrigger(externalActionTrigger);
   uiActions.registerTrigger(pluginResourceDeleteTrigger);
 
-  uiActions.addTriggerAction(EXTERNAL_ACTION_TRIGGER, openEventsFlyoutAction);
-  uiActions.addTriggerAction(CONTEXT_MENU_TRIGGER, viewEventsOptionAction);
-  uiActions.addTriggerAction(SAVED_OBJECT_DELETE_TRIGGER, savedObjectDeleteAction);
   uiActions.addTriggerAction(PLUGIN_RESOURCE_DELETE_TRIGGER, pluginResourceDeleteAction);
+  uiActions.addTriggerAction(EXTERNAL_ACTION_TRIGGER, openEventsFlyoutAction);
+
+  // These triggers are registered by other plugins. If they are disabled can throw an error.
+  try {
+    uiActions.addTriggerAction(CONTEXT_MENU_TRIGGER, viewEventsOptionAction);
+    uiActions.addTriggerAction(SAVED_OBJECT_DELETE_TRIGGER, savedObjectDeleteAction);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+  }
 };


### PR DESCRIPTION
### Description

Then `management.enabled: false` is set in the config, the app now correctly loads without breaking.

### Issues Resolved

fixes #4671

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

set `management.enabled: false` in the config file and startup OSD. All the pages should be working while the management pages are disabled.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
