### PR TITLE
[Follow-up] Fix extraction script

### DIFF
--- a/src/plugins/discover/public/application/components/doc_views/context/utils/use_query_actions.ts
+++ b/src/plugins/discover/public/application/components/doc_views/context/utils/use_query_actions.ts
@@ -131,7 +131,7 @@ export function useQueryActions(anchorId: string, indexPattern: IndexPattern) {
           }));
         }
         toastNotifications.addDanger({
-          title: i18n.translate('discover.context.unableToLoadDocumentDescription', {
+          title: i18n.translate('discover.context.unableToLoadSurroundingDocumentDescription', {
             defaultMessage: 'Unable to fetch surrounding documents',
           }),
           text: 'fail',

--- a/src/plugins/discover/public/application/components/doc_views/single_doc_app.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/single_doc_app.tsx
@@ -52,7 +52,7 @@ export function SingleDocApp() {
       ...getRootBreadcrumbs(),
       {
         text: i18n.translate('discover.single.breadcrumb', {
-          defaultMessage: `${index}#${docId}`,
+          defaultMessage: '{index}#{docId}',
           values: {
             index,
             docId,

--- a/src/plugins/discover/public/application/view_components/utils/index_pattern_helper.ts
+++ b/src/plugins/discover/public/application/view_components/utils/index_pattern_helper.ts
@@ -76,9 +76,9 @@ export function resolveIndexPattern(
 
   if (stateVal && !stateValFound) {
     const warningTitle = i18n.translate('discover.valueIsNotConfiguredIndexPatternIDWarningTitle', {
-      defaultMessage: '{stateVal} is not a configured index pattern ID',
+      defaultMessage: '{id} is not a configured index pattern ID',
       values: {
-        stateVal: `"${stateVal}"`,
+        id: `"${stateVal}"`,
       },
     });
 

--- a/src/plugins/vis_type_vega/public/expressions/line_vega_spec_fn.ts
+++ b/src/plugins/vis_type_vega/public/expressions/line_vega_spec_fn.ts
@@ -47,7 +47,7 @@ export const createLineVegaSpecFn = (
   name: 'line_vega_spec',
   type: 'string',
   inputTypes: ['opensearch_dashboards_datatable'],
-  help: i18n.translate('visTypeVega.function.help', {
+  help: i18n.translate('visTypeVega.function.helpSpec', {
     defaultMessage: 'Construct line vega spec',
   }),
   args: {

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -577,7 +577,8 @@ export class VisualizeEmbeddable
           const { toasts } = getNotifications();
           toasts.addError(err, {
             title: i18n.translate('visualizations.renderVisTitle', {
-              defaultMessage: `Error loading data on the ${this.vis.title} chart`,
+              defaultMessage: 'Error loading data on the {visTitle} chart',
+              values: { visTitle: this.vis.title },
             }),
             toastMessage: ' ',
             id: this.id,


### PR DESCRIPTION
### Description

This is a follow-up fix to https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4794, after the initial bug was solved in [this pr](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4805). There were 2 additional errors that prevented script from running after I tried to running script later.
```
ERROR  I18N ERROR  Error in src/plugins/vis_type_vega/public/expressions/vega_fn.ts
      Error: There is more than one default message for the same id "visTypeVega.function.help":
      "Construct line vega spec" and "Vega visualization"
```
```
ERROR  I18N ERROR  Error in src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
      Error: expressions are not allowed in template literals ("visualizations.renderVisTitle").
```
I tried running script again after some time and there were 3 more new errors
<img width="1155" alt="image" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/67782303/aaeb2f42-df91-46c4-bf65-b2dd28973135">
It looks like they were introduced in recent PRs related to discover.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4794

## Screenshot


<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

We can test it by running the script from https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4794
`./scripts/use_node scripts/i18n_extract.js --output-dir plugins/dashboards-i18n/translations/` It will create en.json file in output directory without any errors. If no such directory we can output result to root directory to check `./scripts/use_node scripts/i18n_extract.js --output-dir plugins/dashboards-i18n/translations/`

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
