### PR TITLE
Remove examples and other unwanted artifacts from installed dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump `node-sass` to a version that uses a newer `libsass` ([#4649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4649))
 - [CVE-2019-11358] Bump version of tinygradient from 0.4.3 to 1.1.5 ([#4742](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4742))
 - [CVE-2021-3520] Bump `lmdb` from `2.8.0` to `2.8.5` ([#4804](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4804))
+- Remove examples and other unwanted artifacts from installed dependencies ([#4896](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4896))
 
 ### 📈 Features/Enhancements
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "author": "opensearch-project",
   "scripts": {
     "preinstall": "scripts/use_node ./preinstall_check",
+    "postinstall": "scripts/use_node scripts/postinstall",
     "osd": "scripts/use_node scripts/osd",
     "opensearch": "scripts/use_node scripts/opensearch",
     "test": "grunt test",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint no-restricted-syntax: 0 */
+
+const fs = require('fs/promises');
+
+/**
+ * Some libraries pack their demos and examples into their release artifacts.
+ * This unwanted content makes our release artifacts larger but more importantly,
+ * some contain in-browser references to outdated and vulnerable versions of
+ * libraries that are not even mentioned in the dependency tree. This is a
+ * problem when vulnerability scanners point them out, and we have no way to fix
+ * them. This function looks for folders that are unwanted and deletes them.
+ */
+const removeUnwantedFolders = async (root, unwantedNames) => {
+  const items = await fs.readdir(root, { withFileTypes: true });
+  const promises = [];
+  for (const item of items) {
+    if (!item.isDirectory()) continue;
+
+    if (unwantedNames.includes(item.name)) {
+      promises.push(fs.rm(`${root}/${item.name}`, { recursive: true, force: true }));
+    } else {
+      promises.push(...(await removeUnwantedFolders(`${root}/${item.name}`, unwantedNames)));
+    }
+  }
+
+  return promises;
+};
+const run = async () => {
+  const promises = await removeUnwantedFolders('node_modules', ['demo', 'example', 'examples']);
+  await Promise.all(promises);
+};
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Description

Remove examples and other unwanted artifacts from installed dependencies using a postinstall script.

List of folders that will be deleted:
```
% find node_modules -type d -name "demo"
node_modules/opentracing/lib/examples/demo
node_modules/opentracing/src/examples/demo
node_modules/argparse/node_modules/sprintf-js/demo
node_modules/leaflet.heat/demo
node_modules/grunt-peg/node_modules/argparse/node_modules/sprintf-js/demo
node_modules/leaflet-vega/demo
node_modules/grunt-run/node_modules/argparse/node_modules/sprintf-js/demo
node_modules/tinycolor2/demo
node_modules/grunt-available-tasks/node_modules/argparse/node_modules/sprintf-js/demo

% find node_modules -type d -name "example" 
node_modules/@types/http-aws-es/node_modules/is-typed-array/node_modules/object-inspect/example
node_modules/@types/http-aws-es/node_modules/object-inspect/example
node_modules/@types/globby/node_modules/safe-regex/example
node_modules/fastest-stable-stringify/example
node_modules/defined/example
node_modules/is-typed-array/node_modules/object-inspect/example
node_modules/wordwrap/example
node_modules/vm-browserify/example
node_modules/brace/example
node_modules/copy-to-clipboard/example
node_modules/text-table/example
node_modules/fast-json-stable-stringify/example
node_modules/camelize/example
node_modules/resolve/example
node_modules/retry/example
node_modules/deep-equal/example
node_modules/fast-redact/example
node_modules/parse-link-header/example
node_modules/typedarray/example
node_modules/grunt/node_modules/resolve/example
node_modules/toggle-selection/example
node_modules/commondir/example
node_modules/json-stable-stringify/example
node_modules/minimist/example
node_modules/resumer/example
node_modules/grunt-cli/node_modules/resolve/example
node_modules/crypto-browserify/example
node_modules/json-stable-stringify-without-jsonify/example
node_modules/grunt-peg/node_modules/resolve/example
node_modules/grunt-peg/node_modules/concat-map/example
node_modules/lmdb/dependencies/lz4/lib/dll/example
node_modules/deep-freeze-strict/example
node_modules/@microsoft/api-documenter/node_modules/resolve/example
node_modules/@microsoft/tsdoc-config/node_modules/resolve/example
node_modules/@microsoft/api-extractor/node_modules/resolve/example
node_modules/glob-all/example
node_modules/concat-map/example
node_modules/detective/example
node_modules/tape/example
node_modules/tape/node_modules/resolve/example
node_modules/load-bmfont/node_modules/buffer-equal/example
node_modules/grunt-run/node_modules/resolve/example
node_modules/grunt-run/node_modules/concat-map/example
node_modules/eslint-plugin-react/node_modules/resolve/example
node_modules/dom-walk/example
node_modules/safe-regex/example
node_modules/@rushstack/node-core-library/node_modules/resolve/example
node_modules/@rushstack/rig-package/node_modules/resolve/example
node_modules/deep-is/example
node_modules/object-inspect/example
node_modules/grunt-available-tasks/node_modules/resolve/example
node_modules/grunt-available-tasks/node_modules/concat-map/example
node_modules/buffer-equal/example

% find node_modules -type d -name "examples"
node_modules/opentracing/lib/examples
node_modules/opentracing/src/examples
node_modules/jsonparse/examples
node_modules/needle/examples
node_modules/element-resize-detector/examples
node_modules/jimp/browser/examples
node_modules/JSONStream/examples
node_modules/archy/examples
node_modules/grunt/node_modules/colors/examples
node_modules/grunt/node_modules/nopt/examples
node_modules/ngreact/examples
node_modules/react-input-autosize/examples
node_modules/leaflet-draw/docs/examples
node_modules/license-checker/node_modules/mkdirp/examples
node_modules/pegjs/examples
node_modules/grunt-peg/node_modules/pegjs/examples
node_modules/grunt-peg/node_modules/colors/examples
node_modules/grunt-peg/node_modules/nopt/examples
node_modules/treeify/examples
node_modules/colors/examples
node_modules/react-dropzone/examples
node_modules/murmurhash3js/examples
node_modules/d3-cloud/examples
node_modules/traverse/examples
node_modules/socks/docs/examples
node_modules/wildcard/examples
node_modules/ui-select/docs/examples
node_modules/grunt-run/node_modules/colors/examples
node_modules/grunt-run/node_modules/nopt/examples
node_modules/grunt-available-tasks/node_modules/colors/examples
node_modules/grunt-available-tasks/node_modules/nopt/examples
node_modules/nopt/examples
node_modules/worker-farm/examples
```


### Issues Resolved

`/node_modules/leaflet-draw/docs/examples`
Fixes #4722
Fixes #4723
Fixes #4725
Fixes #4727
Fixes #4728
Fixes #4729

`/node_modules/leaflet-vega/demo`
Fixes #3525 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
