### PR TITLE
Fix (discover): Fix dismiss callout and next styling

### DIFF
--- a/packages/osd-stylelint-config/config/global_selectors.json
+++ b/packages/osd-stylelint-config/config/global_selectors.json
@@ -24,7 +24,8 @@
       "src/plugins/vis_builder/public/application/components/side_nav.scss",
       "packages/osd-ui-framework/src/components/button/button_group/_button_group.scss",
       "src/plugins/discover_legacy/public/application/components/sidebar/discover_sidebar.scss",
-      "src/plugins/discover_legacy/public/application/angular/doc_table/components/table_row/_open.scss"
+      "src/plugins/discover_legacy/public/application/angular/doc_table/components/table_row/_open.scss",
+      "src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.scss"
     ]
   }
 }

--- a/src/plugins/data_explorer/public/components/sidebar/index.tsx
+++ b/src/plugins/data_explorer/public/components/sidebar/index.tsx
@@ -73,7 +73,7 @@ export const Sidebar: FC = ({ children }) => {
   return (
     <EuiPageSideBar className="deSidebar" sticky>
       <EuiSplitPanel.Outer className="eui-yScroll" hasBorder={true} borderRadius="none">
-        <EuiSplitPanel.Inner paddingSize="s" grow={false}>
+        <EuiSplitPanel.Inner paddingSize="s" color="subdued" grow={false}>
           <EuiComboBox
             placeholder="Select a datasource"
             singleSelection={{ asPlainText: true }}

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.scss
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.scss
@@ -1,0 +1,3 @@
+.euiDescriptionList.euiDescriptionList--inline .euiDescriptionList__title.osdDescriptionListFieldTitle {
+  background-color: tintOrShade($euiColorPrimary, 90%, 70%);
+}

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.test.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.test.tsx
@@ -147,7 +147,9 @@ describe('Testing fetchTableDataCell function', () => {
         compressed={true}
         type="inline"
       >
-        <EuiDescriptionListTitle>
+        <EuiDescriptionListTitle
+          className="osdDescriptionListFieldTitle"
+        >
           order_date
         </EuiDescriptionListTitle>
         <EuiDescriptionListDescription

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.tsx
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+import './data_grid_table_cell_value.scss';
 
 import React, { Fragment } from 'react';
 import dompurify from 'dompurify';
@@ -30,7 +31,9 @@ function fetchSourceTypeDataCell(
     <EuiDescriptionList type="inline" compressed>
       {Object.keys(formattedRow).map((key) => (
         <Fragment key={key}>
-          <EuiDescriptionListTitle>{key}</EuiDescriptionListTitle>
+          <EuiDescriptionListTitle className="osdDescriptionListFieldTitle">
+            {key}
+          </EuiDescriptionListTitle>
           <EuiDescriptionListDescription
             dangerouslySetInnerHTML={{ __html: dompurify.sanitize(formattedRow[key]) }}
           />

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -64,7 +64,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
               .
             </p>
           </EuiCallOut>
-         </EuiPanel>
+        </EuiPanel>
       </EuiFlexItem>
     );
   }

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -49,20 +49,22 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
   if (isCallOutVisible) {
     callOut = (
       <EuiFlexItem grow={false}>
-        <EuiCallOut
-          title="You're viewing Discover 2.0. The old Discover app will be retired in OpenSearch version 2.11. To switch back to the old version, toggle the New Discover."
-          iconType="alert"
-          dismissible
-          onDismissible={closeCallOut}
-        >
-          <p>
-            To provide feedback,{' '}
-            <EuiLink href="https://github.com/opensearch-project/OpenSearch-Dashboards/issues">
-              open an issue
-            </EuiLink>
-            .
-          </p>
-        </EuiCallOut>
+        <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="s">
+          <EuiCallOut
+            title="You're viewing Discover 2.0. The old Discover app will be retired in OpenSearch version 2.11. To switch back to the old version, toggle the New Discover."
+            iconType="alert"
+            dismissible
+            onDismiss={closeCallOut}
+          >
+            <p>
+              To provide feedback,{' '}
+              <EuiLink href="https://github.com/opensearch-project/OpenSearch-Dashboards/issues">
+                open an issue
+              </EuiLink>
+              .
+            </p>
+          </EuiCallOut>
+        </EuiPanel>
       </EuiFlexItem>
     );
   }

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -51,7 +51,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
       <EuiFlexItem grow={false}>
         <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="s">
           <EuiCallOut
-            title="You're viewing Discover 2.0. The old Discover app will be retired in OpenSearch version 2.11. To switch back to the old version, toggle the New Discover."
+            title="You're viewing Discover 2.0. The old Discover app will be retired in OpenSearch version 2.11. To switch back to the old version, turn off the New Discover toggle."
             iconType="alert"
             dismissible
             onDismiss={closeCallOut}
@@ -64,21 +64,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
               .
             </p>
           </EuiCallOut>
-        </EuiPanel>
-        <EuiCallOut
-          title="You're viewing Discover 2.0. The old Discover app will be retired in OpenSearch version 2.11. To switch back to the old version, turn off the New Discover toggle."
-          iconType="alert"
-          dismissible
-          onDismiss={closeCallOut}
-        >
-          <p>
-            To provide feedback,{' '}
-            <EuiLink href="https://github.com/opensearch-project/OpenSearch-Dashboards/issues">
-              open an issue
-            </EuiLink>
-            .
-          </p>
-        </EuiCallOut>
+         </EuiPanel>
       </EuiFlexItem>
     );
   }

--- a/src/plugins/discover_legacy/public/application/components/discover_legacy.tsx
+++ b/src/plugins/discover_legacy/public/application/components/discover_legacy.tsx
@@ -153,7 +153,7 @@ export function DiscoverLegacy({
           title="This Discover app version will be retired in OpenSearch version 2.11. To switch to the new Discover 2.0 version, toggle the New Discover."
           iconType="alert"
           dismissible
-          onDismissible={closeCallOut}
+          onDismiss={closeCallOut}
         >
           <p>
             To provide feedback,{' '}


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Fixes some small styling issues identified by @KrooshalUX and @kgcreative when reviewing `next` theming

1. Fix `onDismiss` prop of callout
2. Put callout in panel for better alignment in discover
3. Add `subdued` to combobox panel
4. Use `primary`-derived color for field titles in discover (and lint-ignore)

Note - I tried to fix the histogram rect highlight color in `next` dark mode, but can't figure out the problem. I got as far as confirming that both `discover` and `legacy_discover` pass the same styling props, but somehow it's not applied the same in each case.

I also notices some other minor fit and finish issues in the video:
1. Layout jank when hovering on the source, as the inline text adjusts its width to make room for the expand button
2. Loading spinner sometimes overlaps callout and other elements
3. Time range not maintained when switching
4. The way field names break across lines seems less than ideal

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/1679762/67e4a134-ccef-4db4-b958-270abf7becfb


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
