### PR TITLE
Correct the generated path for downloading plugins by their names on Windows

### DIFF
--- a/.lycheeexclude
+++ b/.lycheeexclude
@@ -124,3 +124,4 @@ http://helpmenow.com/problem2
 https://sass-lang.com/*
 http://api.jquery.com/*
 http://brandonaaron.net
+https://www.circl.lu/doc/misp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [TSVB, Dashboards] Fix inconsistent dark mode code editor themes ([#4609](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4609))
 - [Legacy Maps] Fix dark mode style overrides ([#4658](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4658))
 - [BUG] Fix management overview page duplicate rendering ([#4636](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4636))
-- Fixes broken app when management is turned off ([#4891](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4891))
+- Fix broken app when management is turned off ([#4891](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4891))
+- Correct the generated path for downloading plugins by their names on Windows ([#4953](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4953))
 
 ### 🚞 Infrastructure
 

--- a/src/cli_plugin/install/settings.js
+++ b/src/cli_plugin/install/settings.js
@@ -42,10 +42,11 @@ function generateUrls({ version, plugin }) {
 }
 
 function generatePluginUrl(version, plugin) {
-  const platform = process.platform === 'win32' ? 'windows' : process.platform;
+  const [platform, type] =
+    process.platform === 'win32' ? ['windows', 'zip'] : [process.platform, 'tar'];
   const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
 
-  return `${LATEST_PLUGIN_BASE_URL}/${version}/latest/${platform}/${arch}/tar/builds/opensearch-dashboards/plugins/${plugin}-${version}.zip`;
+  return `${LATEST_PLUGIN_BASE_URL}/${version}/latest/${platform}/${arch}/${type}/builds/opensearch-dashboards/plugins/${plugin}-${version}.zip`;
 }
 
 export function parseMilliseconds(val) {

--- a/src/cli_plugin/install/settings.test.js
+++ b/src/cli_plugin/install/settings.test.js
@@ -157,7 +157,7 @@ describe('parse function', function () {
         "timeout": 0,
         "urls": Array [
           "plugin name",
-          "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1234/latest/windows/x64/tar/builds/opensearch-dashboards/plugins/plugin name-1234.zip",
+          "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1234/latest/windows/x64/zip/builds/opensearch-dashboards/plugins/plugin name-1234.zip",
         ],
         "version": 1234,
         "workingPath": <absolute path>/plugins/.plugin.installing,


### PR DESCRIPTION
### Description

When OSD plugins are installed by their name, irrespective of the platform:
* the url path has `/tar` hard-coded,
* the url points to a zip file, even though the path is under `/tar`.

However, experimenting with the URLs, these two worked for me:
* https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.9.0/latest/windows/x64/zip/builds/opensearch-dashboards/plugins/anomalyDetectionDashboards-2.9.0.zip
* https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.9.0/latest/linux/x64/tar/builds/opensearch-dashboards/plugins/anomalyDetectionDashboards-2.9.0.zip

This indicates that Windows plugins are not in fact placed in `/tar/` but are placed in `/zip/`.

### Issues Resolved

Fixes #4952


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
