### PR TITLE
[BUG] Fix buildPointSeriesData unit test fails due to local timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG] Fix management overview page duplicate rendering ([#4636](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4636))
 - Fix broken app when management is turned off ([#4891](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4891))
 - Correct the generated path for downloading plugins by their names on Windows ([#4953](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4953))
+- [BUG] Fix buildPointSeriesData unit test fails due to local timezone ([#4992](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4992))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/discover/public/application/components/chart/utils/point_series.test.ts
+++ b/src/plugins/discover/public/application/components/chart/utils/point_series.test.ts
@@ -31,8 +31,8 @@ describe('buildPointSeriesData', () => {
           intervalOpenSearchUnit: 'h',
           format: 'number',
           bounds: {
-            min: moment('2023-01-01'),
-            max: moment('2023-01-02'),
+            min: moment('2023-01-01T00:00:00Z'),
+            max: moment('2023-01-02T00:00:00Z'),
           },
         },
       },


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4865#issuecomment-1716282502

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4865

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
