### PR TITLE
[Discover 2.0] fixes add filter and dismissible callout

### DIFF
--- a/src/plugins/discover/public/application/view_components/canvas/discover_chart_container.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_chart_container.tsx
@@ -20,22 +20,22 @@ export const DiscoverChartContainer = ({ hits, bucketInterval, chartData }: Sear
     indexPattern,
   ]);
 
+  if (!hits || !chartData || !bucketInterval) return null;
+
   return (
-    hits && (
-      <DiscoverChart
-        bucketInterval={bucketInterval}
-        chartData={chartData}
-        config={uiSettings}
-        data={data}
-        hits={hits}
-        resetQuery={() => {
-          window.location.href = `#/view/${savedSearch?.id}`;
-          window.location.reload();
-        }}
-        services={services}
-        showResetButton={!!savedSearch && !!savedSearch.id}
-        isTimeBased={isTimeBased}
-      />
-    )
+    <DiscoverChart
+      bucketInterval={bucketInterval}
+      chartData={chartData}
+      config={uiSettings}
+      data={data}
+      hits={hits}
+      resetQuery={() => {
+        window.location.href = `#/view/${savedSearch?.id}`;
+        window.location.reload();
+      }}
+      services={services}
+      showResetButton={!!savedSearch && !!savedSearch.id}
+      isTimeBased={isTimeBased}
+    />
   );
 };

--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -51,13 +51,15 @@ export const DiscoverTable = ({ history }: Props) => {
     refetch$.next();
   };
   const onAddFilter = useCallback(
-    (field: IndexPatternField, values: string, operation: '+' | '-') => {
+    (field: string | IndexPatternField, values: string, operation: '+' | '-') => {
+      if (!indexPattern) return;
+
       const newFilters = opensearchFilters.generateFilters(
         filterManager,
         field,
         values,
         operation,
-        indexPattern.id
+        indexPattern.id ?? ''
       );
       return filterManager.addFilters(newFilters);
     },

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -20,6 +20,8 @@ import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_re
 import { filterColumns } from '../utils/filter_columns';
 import { DEFAULT_COLUMNS_SETTING } from '../../../../common';
 
+const KEY_SHOW_NOTICE = 'discover:deprecation-notice:show';
+
 // eslint-disable-next-line import/no-default-export
 export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewProps) {
   const { data$, refetch$, indexPattern } = useDiscoverContext();
@@ -41,8 +43,13 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
     bucketInterval: {},
   });
 
-  const [isCallOutVisible, setIsCallOutVisible] = useState(true);
-  const closeCallOut = () => setIsCallOutVisible(false);
+  const [isCallOutVisible, setIsCallOutVisible] = useState(
+    localStorage.getItem(KEY_SHOW_NOTICE) !== 'false'
+  );
+  const closeCallOut = () => {
+    localStorage.setItem(KEY_SHOW_NOTICE, 'false');
+    setIsCallOutVisible(false);
+  };
 
   let callOut;
 

--- a/src/plugins/discover/public/application/view_components/utils/filter_columns.ts
+++ b/src/plugins/discover/public/application/view_components/utils/filter_columns.ts
@@ -16,7 +16,7 @@ import { IndexPattern } from '../../../opensearch_dashboards_services';
  */
 export function filterColumns(
   columns: string[],
-  indexPattern: IndexPattern,
+  indexPattern: IndexPattern | undefined,
   defaultColumns: string[]
 ) {
   const fieldsName = indexPattern?.fields.getAll().map((fld) => fld.name) || [];

--- a/src/plugins/discover_legacy/public/application/components/discover_legacy.tsx
+++ b/src/plugins/discover_legacy/public/application/components/discover_legacy.tsx
@@ -101,6 +101,8 @@ export interface DiscoverLegacyProps {
   vis?: Vis;
 }
 
+const KEY_SHOW_NOTICE = 'discover:deprecation-notice:show';
+
 export function DiscoverLegacy({
   addColumn,
   fetch,
@@ -132,7 +134,9 @@ export function DiscoverLegacy({
   vis,
 }: DiscoverLegacyProps) {
   const [isSidebarClosed, setIsSidebarClosed] = useState(false);
-  const [isCallOutVisible, setIsCallOutVisible] = useState(true);
+  const [isCallOutVisible, setIsCallOutVisible] = useState(
+    localStorage.getItem(KEY_SHOW_NOTICE) !== 'false'
+  );
   const { TopNavMenu } = getServices().navigation.ui;
   const { savedSearch, indexPatternList } = opts;
   const bucketAggConfig = vis?.data?.aggs?.aggs[1];
@@ -142,7 +146,10 @@ export function DiscoverLegacy({
       : undefined;
   const [fixedScrollEl, setFixedScrollEl] = useState<HTMLElement | undefined>();
 
-  const closeCallOut = () => setIsCallOutVisible(false);
+  const closeCallOut = () => {
+    localStorage.setItem(KEY_SHOW_NOTICE, 'false');
+    setIsCallOutVisible(false);
+  };
 
   let callOut;
 


### PR DESCRIPTION
### Description

This fixes 4 small issues:

1. Fixes the add filter in the sidebar for discover 2.0
2. Fixes the deprecation notice not persisting on page refresh
3. Loads the filters and query from a saved search
4. minor type errors.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

fixes #5027

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/20453492/36fc7c2c-ddf0-493f-b382-05126c193862


<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

Pull down the changes and open the discover app. Adding filters in the side panel should work. The dismissable callout should stay dismissed after the page refresh.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
