### PR TITLE
Updating yarn installation step from the Dev guide

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -64,12 +64,10 @@ If it's the only version of node installed, it will automatically be set to the 
 
 #### Install `yarn`
 
-Take a look at the [latest Yarn release](https://github.com/yarnpkg/berry/releases/latest), note the version number, and run:
+To install yarn run:
 
 ```bash
-$ npm i -g corepack
-
-$ corepack prepare yarn@<version> --activate
+$ npm i -g yarn
 ```
 
 (See the [Yarn installation documentation](https://yarnpkg.com/getting-started/install) for more information.)


### PR DESCRIPTION
### Description
Fixes issue with yarn install step in developer guides

### Issues Resolved
N/A

## Screenshot
N/A

## Testing the changes
@cwperks  and I had run through the developer guide end to end and ran into issues with the current step but re-running with `npm i -g yarn` worked to install the right version of yarn so the dependencies could be installed. 

### Check List

- [X] Commits are signed per the DCO using --signoff
