### PR TITLE
Update yarn install step from dev guide

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -74,7 +74,7 @@ $ # Install the correct version of yarn
 $ corepack install
 ```
 
-(See the [corepack documentation](https://github.com/nodejs/corepack?tab=readme-ov-file#-corepack) for more information.)
+(See the [corepack documentation](https://github.com/nodejs/corepack#-corepack) for more information.)
 
 ### Fork and clone OpenSearch Dashboards
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -67,7 +67,7 @@ If it's the only version of node installed, it will automatically be set to the 
 OpenSearch Dashboards is set up using yarn v1. To install it, run:
 
 ```bash
-$ corepack prepare yarn@1 --activate
+$ corepack enable
 ```
 
 (See the [Yarn installation documentation](https://classic.yarnpkg.com/en/docs/install) for more information.)

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -64,13 +64,13 @@ If it's the only version of node installed, it will automatically be set to the 
 
 #### Install `yarn`
 
-To install yarn run:
+OpenSearch Dashboards is set up using yarn v1. To install it, run:
 
 ```bash
-$ npm i -g yarn
+$ corepack prepare yarn@1 --activate
 ```
 
-(See the [Yarn installation documentation](https://yarnpkg.com/getting-started/install) for more information.)
+(See the [Yarn installation documentation](https://classic.yarnpkg.com/en/docs/install) for more information.)
 
 ### Fork and clone OpenSearch Dashboards
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -64,13 +64,17 @@ If it's the only version of node installed, it will automatically be set to the 
 
 #### Install `yarn`
 
-OpenSearch Dashboards is set up using yarn v1. To install it, run:
+OpenSearch Dashboards is set up using yarn, which can be installed through corepack. To install yarn, run:
 
 ```bash
-$ corepack enable
+$ # Update corepack to the latest version
+$ npm i -g corepack
+
+$ # Install the correct version of yarn
+$ corepack install
 ```
 
-(See the [Yarn installation documentation](https://classic.yarnpkg.com/en/docs/install) for more information.)
+(See the [corepack documentation](https://github.com/nodejs/corepack?tab=readme-ov-file#-corepack) for more information.)
 
 ### Fork and clone OpenSearch Dashboards
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "bugs": {
     "url": "http://github.com/opensearch-project/OpenSearch-Dashboards/issues"
   },
+  "packageManager": "yarn@1.22.19",
   "opensearchDashboards": {
     "clean": {
       "extraPatterns": [


### PR DESCRIPTION
### Description

Update developer guide after #5065 was merged. I was concerned because everything I've seen says to install yarn through `corepack`, so I did some digging. The old dev guide said to install yarn using the latest version from yarn trunk (v3 something), which would break bootstrap and everything with that. However, OSD is built using yarn v1, which is incompatible with yarn v3. Essentially, there are significant differences between yarn v1 and v3, which make all of the guides in Dashboards break, since they were built for v1 instead of v3. This PR updates the guides to use `corepack`, which is the recommended way to install yarn, but to still install v1.

### Issues Resolved

N/a

## Screenshot

N/a

## Testing the changes

Ran this on Node version 14, 16, and 18 to get yarn v1.22.18 installed and tested clean and bootstrap with that version.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
  - [x] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
