### PR TITLE
[Workspace][Feature]Setup workspace skeleton and implement basic CRUD API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Theme] Make `next` theme the default ([#4854](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4854))
 - [Discover] Update embeddable for saved searches ([#5081](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5081))
 - [Workspace] Add core workspace service module to enable the implementation of workspace features within OSD plugins ([#5092](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5092))
+- [Workspace] Setup workspace skeleton and implement basic CRUD API ([#5075](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5075))
 
 ### 🐛 Bug Fixes
 

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -345,8 +345,8 @@ export {
   MetricsServiceStart,
 } from './metrics';
 
-export { AppCategory } from '../types';
-export { DEFAULT_APP_CATEGORIES } from '../utils';
+export { AppCategory, WorkspaceAttribute } from '../types';
+export { DEFAULT_APP_CATEGORIES, WORKSPACE_TYPE } from '../utils';
 
 export {
   SavedObject,

--- a/src/core/utils/constants.ts
+++ b/src/core/utils/constants.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const WORKSPACE_TYPE = 'workspace';

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -37,3 +37,4 @@ export {
   IContextProvider,
 } from './context';
 export { DEFAULT_APP_CATEGORIES } from './default_app_categories';
+export { WORKSPACE_TYPE } from './constants';

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID = 'workspace';

--- a/src/plugins/workspace/config.ts
+++ b/src/plugins/workspace/config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema, TypeOf } from '@osd/config-schema';
+
+export const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: false }),
+});
+
+export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/src/plugins/workspace/opensearch_dashboards.json
+++ b/src/plugins/workspace/opensearch_dashboards.json
@@ -3,7 +3,7 @@
   "version": "opensearchDashboards",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["savedObjects"],
+  "requiredPlugins": [],
   "optionalPlugins": [],
   "requiredBundles": []
 }

--- a/src/plugins/workspace/opensearch_dashboards.json
+++ b/src/plugins/workspace/opensearch_dashboards.json
@@ -1,0 +1,9 @@
+{
+  "id": "workspace",
+  "version": "opensearchDashboards",
+  "server": true,
+  "ui": true,
+  "requiredPlugins": ["savedObjects"],
+  "optionalPlugins": [],
+  "requiredBundles": []
+}

--- a/src/plugins/workspace/opensearch_dashboards.json
+++ b/src/plugins/workspace/opensearch_dashboards.json
@@ -2,8 +2,10 @@
   "id": "workspace",
   "version": "opensearchDashboards",
   "server": true,
-  "ui": true,
-  "requiredPlugins": [],
+  "ui": false,
+  "requiredPlugins": [
+    "savedObjects"
+  ],
   "optionalPlugins": [],
   "requiredBundles": []
 }

--- a/src/plugins/workspace/public/index.ts
+++ b/src/plugins/workspace/public/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WorkspacePlugin } from './plugin';
+
+export function plugin() {
+  return new WorkspacePlugin();
+}

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Plugin } from '../../../core/public';
+
+export class WorkspacePlugin implements Plugin<{}, {}, {}> {
+  public async setup() {
+    return {};
+  }
+
+  public start() {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import { Plugin } from '../../../core/public';
 
 export class WorkspacePlugin implements Plugin<{}, {}, {}> {

--- a/src/plugins/workspace/server/index.ts
+++ b/src/plugins/workspace/server/index.ts
@@ -2,8 +2,9 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { PluginInitializerContext } from '../../../core/server';
+import { PluginConfigDescriptor, PluginInitializerContext } from '../../../core/server';
 import { WorkspacePlugin } from './plugin';
+import { configSchema } from '../config';
 
 // This exports static code and TypeScript types,
 // as well as, OpenSearch Dashboards Platform `plugin()` initializer.
@@ -11,3 +12,9 @@ import { WorkspacePlugin } from './plugin';
 export function plugin(initializerContext: PluginInitializerContext) {
   return new WorkspacePlugin(initializerContext);
 }
+
+export const config: PluginConfigDescriptor = {
+  schema: configSchema,
+};
+
+export { WorkspaceFindOptions } from './types';

--- a/src/plugins/workspace/server/index.ts
+++ b/src/plugins/workspace/server/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { PluginInitializerContext } from '../../../core/server';
+import { WorkspacePlugin } from './plugin';
+
+// This exports static code and TypeScript types,
+// as well as, OpenSearch Dashboards Platform `plugin()` initializer.
+
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new WorkspacePlugin(initializerContext);
+}

--- a/src/plugins/workspace/server/index.ts
+++ b/src/plugins/workspace/server/index.ts
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import { PluginConfigDescriptor, PluginInitializerContext } from '../../../core/server';
 import { WorkspacePlugin } from './plugin';
 import { configSchema } from '../config';

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -17,14 +17,19 @@ describe('workspace service', () => {
   let root: ReturnType<typeof osdTestServer.createRoot>;
   let opensearchServer: osdTestServer.TestOpenSearchUtils;
   beforeAll(async () => {
-    const { startOpenSearch } = osdTestServer.createTestServers({
+    const { startOpenSearch, startOpenSearchDashboards } = osdTestServer.createTestServers({
       adjustTimeout: (t: number) => jest.setTimeout(t),
+      settings: {
+        osd: {
+          workspace: {
+            enabled: true,
+          },
+        },
+      },
     });
     opensearchServer = await startOpenSearch();
-    root = osdTestServer.createRootWithCorePlugins();
-
-    await root.setup();
-    await root.start();
+    const startOSDResp = await startOpenSearchDashboards();
+    root = startOSDResp.root;
   }, 30000);
   afterAll(async () => {
     await root.shutdown();

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WorkspaceAttribute } from 'src/core/types';
+import { omit } from 'lodash';
+import * as osdTestServer from '../../../../core/test_helpers/osd_server';
+
+const testWorkspace: WorkspaceAttribute = {
+  id: 'fake_id',
+  name: 'test_workspace',
+  description: 'test_workspace_description',
+};
+
+describe('workspace service', () => {
+  let root: ReturnType<typeof osdTestServer.createRoot>;
+  let opensearchServer: osdTestServer.TestOpenSearchUtils;
+  beforeAll(async () => {
+    const { startOpenSearch } = osdTestServer.createTestServers({
+      adjustTimeout: (t: number) => jest.setTimeout(t),
+    });
+    opensearchServer = await startOpenSearch();
+    root = osdTestServer.createRootWithCorePlugins();
+
+    await root.setup();
+    await root.start();
+  }, 30000);
+  afterAll(async () => {
+    await root.shutdown();
+    await opensearchServer.stop();
+  });
+  describe('Workspace CRUD apis', () => {
+    afterEach(async () => {
+      const listResult = await osdTestServer.request
+        .post(root, `/api/workspaces/_list`)
+        .send({
+          page: 1,
+        })
+        .expect(200);
+      await Promise.all(
+        listResult.body.result.workspaces.map((item: WorkspaceAttribute) =>
+          osdTestServer.request.delete(root, `/api/workspaces/${item.id}`).expect(200)
+        )
+      );
+    });
+    it('create', async () => {
+      await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: testWorkspace,
+        })
+        .expect(400);
+
+      const result: any = await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: omit(testWorkspace, 'id'),
+        })
+        .expect(200);
+
+      expect(result.body.success).toEqual(true);
+      expect(typeof result.body.result.id).toBe('string');
+    });
+    it('get', async () => {
+      const result = await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: omit(testWorkspace, 'id'),
+        })
+        .expect(200);
+
+      const getResult = await osdTestServer.request.get(
+        root,
+        `/api/workspaces/${result.body.result.id}`
+      );
+      expect(getResult.body.result.name).toEqual(testWorkspace.name);
+    });
+    it('update', async () => {
+      const result: any = await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: omit(testWorkspace, 'id'),
+        })
+        .expect(200);
+
+      await osdTestServer.request
+        .put(root, `/api/workspaces/${result.body.result.id}`)
+        .send({
+          attributes: {
+            ...omit(testWorkspace, 'id'),
+            name: 'updated',
+          },
+        })
+        .expect(200);
+
+      const getResult = await osdTestServer.request.get(
+        root,
+        `/api/workspaces/${result.body.result.id}`
+      );
+
+      expect(getResult.body.success).toEqual(true);
+      expect(getResult.body.result.name).toEqual('updated');
+    });
+    it('delete', async () => {
+      const result: any = await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: omit(testWorkspace, 'id'),
+        })
+        .expect(200);
+
+      await osdTestServer.request
+        .delete(root, `/api/workspaces/${result.body.result.id}`)
+        .expect(200);
+
+      const getResult = await osdTestServer.request.get(
+        root,
+        `/api/workspaces/${result.body.result.id}`
+      );
+
+      expect(getResult.body.success).toEqual(false);
+    });
+    it('list', async () => {
+      await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: omit(testWorkspace, 'id'),
+        })
+        .expect(200);
+
+      const listResult = await osdTestServer.request
+        .post(root, `/api/workspaces/_list`)
+        .send({
+          page: 1,
+        })
+        .expect(200);
+      expect(listResult.body.result.total).toEqual(1);
+    });
+  });
+});

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -30,7 +30,7 @@ describe('workspace service', () => {
     opensearchServer = await startOpenSearch();
     const startOSDResp = await startOpenSearchDashboards();
     root = startOSDResp.root;
-  }, 30000);
+  });
   afterAll(async () => {
     await root.shutdown();
     await opensearchServer.stop();

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -154,7 +154,7 @@ describe('workspace service', () => {
           page: 1,
         })
         .expect(200);
-      expect(listResult.body.result.total).toEqual(1);
+      expect(listResult.body.result.total).toEqual(2);
     });
   });
 });

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -35,7 +35,7 @@ describe('workspace service', () => {
     await root.shutdown();
     await opensearchServer.stop();
   });
-  describe('Workspace CRUD apis', () => {
+  describe('Workspace CRUD APIs', () => {
     afterEach(async () => {
       const listResult = await osdTestServer.request
         .post(root, `/api/workspaces/_list`)

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -4,8 +4,12 @@
  */
 
 import { WorkspaceAttribute } from 'src/core/types';
-import { omit } from 'lodash';
 import * as osdTestServer from '../../../../core/test_helpers/osd_server';
+
+const omitId = <T extends { id?: string }>(object: T): Omit<T, 'id'> => {
+  const { id, ...others } = object;
+  return others;
+};
 
 const testWorkspace: WorkspaceAttribute = {
   id: 'fake_id',
@@ -60,7 +64,7 @@ describe('workspace service', () => {
       const result: any = await osdTestServer.request
         .post(root, `/api/workspaces`)
         .send({
-          attributes: omit(testWorkspace, 'id'),
+          attributes: omitId(testWorkspace),
         })
         .expect(200);
 
@@ -71,7 +75,7 @@ describe('workspace service', () => {
       const result = await osdTestServer.request
         .post(root, `/api/workspaces`)
         .send({
-          attributes: omit(testWorkspace, 'id'),
+          attributes: omitId(testWorkspace),
         })
         .expect(200);
 
@@ -85,7 +89,7 @@ describe('workspace service', () => {
       const result: any = await osdTestServer.request
         .post(root, `/api/workspaces`)
         .send({
-          attributes: omit(testWorkspace, 'id'),
+          attributes: omitId(testWorkspace),
         })
         .expect(200);
 
@@ -93,7 +97,7 @@ describe('workspace service', () => {
         .put(root, `/api/workspaces/${result.body.result.id}`)
         .send({
           attributes: {
-            ...omit(testWorkspace, 'id'),
+            ...omitId(testWorkspace),
             name: 'updated',
           },
         })
@@ -111,7 +115,7 @@ describe('workspace service', () => {
       const result: any = await osdTestServer.request
         .post(root, `/api/workspaces`)
         .send({
-          attributes: omit(testWorkspace, 'id'),
+          attributes: omitId(testWorkspace),
         })
         .expect(200);
 
@@ -130,7 +134,17 @@ describe('workspace service', () => {
       await osdTestServer.request
         .post(root, `/api/workspaces`)
         .send({
-          attributes: omit(testWorkspace, 'id'),
+          attributes: omitId(testWorkspace),
+        })
+        .expect(200);
+
+      await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: {
+            ...omitId(testWorkspace),
+            name: 'another test workspace',
+          },
         })
         .expect(200);
 

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -156,5 +156,67 @@ describe('workspace service', () => {
         .expect(200);
       expect(listResult.body.result.total).toEqual(2);
     });
+    it('unable to perform operations on workspace by calling saved objects APIs', async () => {
+      const result = await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: omitId(testWorkspace),
+        })
+        .expect(200);
+
+      /**
+       * Can not create workspace by saved objects API
+       */
+      await osdTestServer.request
+        .post(root, `/api/saved_objects/workspace`)
+        .send({
+          attributes: {
+            ...omitId(testWorkspace),
+            name: 'another test workspace',
+          },
+        })
+        .expect(400);
+
+      /**
+       * Can not get workspace by saved objects API
+       */
+      await osdTestServer.request
+        .get(root, `/api/saved_objects/workspace/${result.body.result.id}`)
+        .expect(404);
+
+      /**
+       * Can not update workspace by saved objects API
+       */
+      await osdTestServer.request
+        .put(root, `/api/saved_objects/workspace/${result.body.result.id}`)
+        .send({
+          attributes: {
+            name: 'another test workspace',
+          },
+        })
+        .expect(404);
+
+      /**
+       * Can not delete workspace by saved objects API
+       */
+      await osdTestServer.request
+        .delete(root, `/api/saved_objects/workspace/${result.body.result.id}`)
+        .expect(404);
+
+      /**
+       * Can not find workspace by saved objects API
+       */
+      const findResult = await osdTestServer.request
+        .get(root, `/api/saved_objects/_find?type=workspace`)
+        .expect(200);
+      const listResult = await osdTestServer.request
+        .post(root, `/api/workspaces/_list`)
+        .send({
+          page: 1,
+        })
+        .expect(200);
+      expect(findResult.body.total).toEqual(0);
+      expect(listResult.body.result.total).toEqual(1);
+    });
   });
 });

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { PluginInitializerContext, CoreSetup, Plugin, Logger } from '../../../core/server';
+import { IWorkspaceDBImpl } from './types';
+import { WorkspaceClientWithSavedObject } from './workspace_client';
+import { registerRoutes } from './routes';
+
+export class WorkspacePlugin implements Plugin<{}, {}> {
+  private readonly logger: Logger;
+  private client?: IWorkspaceDBImpl;
+
+  constructor(initializerContext: PluginInitializerContext) {
+    this.logger = initializerContext.logger.get('plugins', 'workspace');
+  }
+
+  public async setup(core: CoreSetup) {
+    this.logger.debug('Setting up Workspaces service');
+
+    this.client = new WorkspaceClientWithSavedObject(core);
+
+    await this.client.setup(core);
+
+    registerRoutes({
+      http: core.http,
+      logger: this.logger,
+      client: this.client as IWorkspaceDBImpl,
+    });
+
+    return {
+      client: this.client,
+    };
+  }
+
+  public start() {
+    this.logger.debug('Starting SavedObjects service');
+
+    return {
+      client: this.client as IWorkspaceDBImpl,
+    };
+  }
+
+  public stop() {}
+}

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -34,7 +34,7 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
   }
 
   public start() {
-    this.logger.debug('Starting SavedObjects service');
+    this.logger.debug('Starting Workspace service');
 
     return {
       client: this.client as IWorkspaceDBImpl,

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -2,7 +2,13 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { PluginInitializerContext, CoreSetup, Plugin, Logger } from '../../../core/server';
+import {
+  PluginInitializerContext,
+  CoreSetup,
+  Plugin,
+  Logger,
+  CoreStart,
+} from '../../../core/server';
 import { IWorkspaceDBImpl } from './types';
 import { WorkspaceClientWithSavedObject } from './workspace_client';
 import { registerRoutes } from './routes';
@@ -33,8 +39,9 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
     };
   }
 
-  public start() {
+  public start(core: CoreStart) {
     this.logger.debug('Starting Workspace service');
+    this.client?.setSavedObjects(core.savedObjects);
 
     return {
       client: this.client as IWorkspaceDBImpl,

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import {
   PluginInitializerContext,
   CoreSetup,
@@ -9,13 +10,13 @@ import {
   Logger,
   CoreStart,
 } from '../../../core/server';
-import { IWorkspaceDBImpl } from './types';
-import { WorkspaceClientWithSavedObject } from './workspace_client';
+import { IWorkspaceClientImpl } from './types';
+import { WorkspaceClient } from './workspace_client';
 import { registerRoutes } from './routes';
 
 export class WorkspacePlugin implements Plugin<{}, {}> {
   private readonly logger: Logger;
-  private client?: IWorkspaceDBImpl;
+  private client?: IWorkspaceClientImpl;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.logger = initializerContext.logger.get('plugins', 'workspace');
@@ -24,14 +25,14 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
   public async setup(core: CoreSetup) {
     this.logger.debug('Setting up Workspaces service');
 
-    this.client = new WorkspaceClientWithSavedObject(core);
+    this.client = new WorkspaceClient(core);
 
     await this.client.setup(core);
 
     registerRoutes({
       http: core.http,
       logger: this.logger,
-      client: this.client as IWorkspaceDBImpl,
+      client: this.client as IWorkspaceClientImpl,
     });
 
     return {
@@ -44,7 +45,7 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
     this.client?.setSavedObjects(core.savedObjects);
 
     return {
-      client: this.client as IWorkspaceDBImpl,
+      client: this.client as IWorkspaceClientImpl,
     };
   }
 

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -55,15 +55,7 @@ export function registerRoutes({
         return res.ok({ body: result });
       }
       return res.ok({
-        body: {
-          ...result,
-          result: {
-            ...result.result,
-            workspaces: result.result.workspaces.map((workspace) => ({
-              ...workspace,
-            })),
-          },
-        },
+        body: result,
       });
     })
   );

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { schema } from '@osd/config-schema';
+
+import { CoreSetup, Logger } from '../../../../core/server';
+import { IWorkspaceDBImpl } from '../types';
+
+const WORKSPACES_API_BASE_URL = '/api/workspaces';
+
+const workspaceAttributesSchema = schema.object({
+  description: schema.maybe(schema.string()),
+  name: schema.string(),
+  features: schema.maybe(schema.arrayOf(schema.string())),
+  color: schema.maybe(schema.string()),
+  icon: schema.maybe(schema.string()),
+  defaultVISTheme: schema.maybe(schema.string()),
+});
+
+export function registerRoutes({
+  client,
+  logger,
+  http,
+}: {
+  client: IWorkspaceDBImpl;
+  logger: Logger;
+  http: CoreSetup['http'];
+}) {
+  const router = http.createRouter();
+  router.post(
+    {
+      path: `${WORKSPACES_API_BASE_URL}/_list`,
+      validate: {
+        body: schema.object({
+          search: schema.maybe(schema.string()),
+          sortOrder: schema.maybe(schema.string()),
+          perPage: schema.number({ min: 0, defaultValue: 20 }),
+          page: schema.number({ min: 0, defaultValue: 1 }),
+          sortField: schema.maybe(schema.string()),
+          searchFields: schema.maybe(schema.arrayOf(schema.string())),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, req, res) => {
+      const result = await client.list(
+        {
+          context,
+          request: req,
+          logger,
+        },
+        req.body
+      );
+      if (!result.success) {
+        return res.ok({ body: result });
+      }
+      return res.ok({
+        body: {
+          ...result,
+          result: {
+            ...result.result,
+            workspaces: result.result.workspaces.map((workspace) => ({
+              ...workspace,
+            })),
+          },
+        },
+      });
+    })
+  );
+  router.get(
+    {
+      path: `${WORKSPACES_API_BASE_URL}/{id}`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, req, res) => {
+      const { id } = req.params;
+      const result = await client.get(
+        {
+          context,
+          request: req,
+          logger,
+        },
+        id
+      );
+      if (!result.success) {
+        return res.ok({ body: result });
+      }
+
+      return res.ok({
+        body: {
+          ...result,
+          result: {
+            ...result.result,
+          },
+        },
+      });
+    })
+  );
+  router.post(
+    {
+      path: `${WORKSPACES_API_BASE_URL}`,
+      validate: {
+        body: schema.object({
+          attributes: workspaceAttributesSchema,
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, req, res) => {
+      const { attributes } = req.body;
+
+      const result = await client.create(
+        {
+          context,
+          request: req,
+          logger,
+        },
+        {
+          ...attributes,
+        }
+      );
+      return res.ok({ body: result });
+    })
+  );
+  router.put(
+    {
+      path: `${WORKSPACES_API_BASE_URL}/{id?}`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+        body: schema.object({
+          attributes: workspaceAttributesSchema,
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, req, res) => {
+      const { id } = req.params;
+      const { attributes } = req.body;
+
+      const result = await client.update(
+        {
+          context,
+          request: req,
+          logger,
+        },
+        id,
+        {
+          ...attributes,
+        }
+      );
+      return res.ok({ body: result });
+    })
+  );
+  router.delete(
+    {
+      path: `${WORKSPACES_API_BASE_URL}/{id?}`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, req, res) => {
+      const { id } = req.params;
+
+      const result = await client.delete(
+        {
+          context,
+          request: req,
+          logger,
+        },
+        id
+      );
+      return res.ok({ body: result });
+    })
+  );
+}

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -2,10 +2,10 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { schema } from '@osd/config-schema';
 
+import { schema } from '@osd/config-schema';
 import { CoreSetup, Logger } from '../../../../core/server';
-import { IWorkspaceDBImpl } from '../types';
+import { IWorkspaceClientImpl } from '../types';
 
 const WORKSPACES_API_BASE_URL = '/api/workspaces';
 
@@ -23,7 +23,7 @@ export function registerRoutes({
   logger,
   http,
 }: {
-  client: IWorkspaceDBImpl;
+  client: IWorkspaceClientImpl;
   logger: Logger;
   http: CoreSetup['http'];
 }) {
@@ -78,17 +78,9 @@ export function registerRoutes({
         },
         id
       );
-      if (!result.success) {
-        return res.ok({ body: result });
-      }
 
       return res.ok({
-        body: {
-          ...result,
-          result: {
-            ...result.result,
-          },
-        },
+        body: result,
       });
     })
   );
@@ -110,9 +102,7 @@ export function registerRoutes({
           request: req,
           logger,
         },
-        {
-          ...attributes,
-        }
+        attributes
       );
       return res.ok({ body: result });
     })
@@ -140,9 +130,7 @@ export function registerRoutes({
           logger,
         },
         id,
-        {
-          ...attributes,
-        }
+        attributes
       );
       return res.ok({ body: result });
     })

--- a/src/plugins/workspace/server/saved_objects/index.ts
+++ b/src/plugins/workspace/server/saved_objects/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { workspace } from './workspace';

--- a/src/plugins/workspace/server/saved_objects/workspace.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsType, WORKSPACE_TYPE } from '../../../../core/server';
+
+export const workspace: SavedObjectsType = {
+  name: WORKSPACE_TYPE,
+  namespaceType: 'agnostic',
+  hidden: false,
+  /**
+   * workspace won't appear in management page.
+   */
+  mappings: {
+    dynamic: false,
+    properties: {
+      name: {
+        type: 'keyword',
+      },
+      description: {
+        type: 'text',
+      },
+      /**
+       * In opensearch, string[] is also mapped to text
+       */
+      features: {
+        type: 'text',
+      },
+      color: {
+        type: 'text',
+      },
+      icon: {
+        type: 'text',
+      },
+      defaultVISTheme: {
+        type: 'text',
+      },
+    },
+  },
+};

--- a/src/plugins/workspace/server/saved_objects/workspace.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace.ts
@@ -25,16 +25,19 @@ export const workspace: SavedObjectsType = {
        * In opensearch, string[] is also mapped to text
        */
       features: {
-        type: 'text',
+        type: 'keyword',
       },
       color: {
-        type: 'text',
+        type: 'keyword',
       },
       icon: {
-        type: 'text',
+        type: 'keyword',
       },
       defaultVISTheme: {
-        type: 'text',
+        type: 'keyword',
+      },
+      reserved: {
+        type: 'boolean',
       },
     },
   },

--- a/src/plugins/workspace/server/saved_objects/workspace.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace.ts
@@ -8,7 +8,10 @@ import { SavedObjectsType, WORKSPACE_TYPE } from '../../../../core/server';
 export const workspace: SavedObjectsType = {
   name: WORKSPACE_TYPE,
   namespaceType: 'agnostic',
-  hidden: false,
+  /**
+   * Disable operation by using saved objects APIs on workspace metadata
+   */
+  hidden: true,
   /**
    * workspace won't appear in management page.
    */

--- a/src/plugins/workspace/server/saved_objects/workspace.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace.ts
@@ -21,9 +21,6 @@ export const workspace: SavedObjectsType = {
       description: {
         type: 'text',
       },
-      /**
-       * In opensearch, string[] is also mapped to text
-       */
       features: {
         type: 'keyword',
       },

--- a/src/plugins/workspace/server/types.ts
+++ b/src/plugins/workspace/server/types.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  Logger,
+  OpenSearchDashboardsRequest,
+  RequestHandlerContext,
+  SavedObjectsFindResponse,
+  CoreSetup,
+  WorkspaceAttribute,
+  ISavedObjectsRepository,
+} from '../../../core/server';
+
+export interface WorkspaceFindOptions {
+  page?: number;
+  perPage?: number;
+  search?: string;
+  searchFields?: string[];
+  sortField?: string;
+  sortOrder?: string;
+}
+
+export interface IRequestDetail {
+  request: OpenSearchDashboardsRequest;
+  context: RequestHandlerContext;
+  logger: Logger;
+}
+
+export interface IWorkspaceDBImpl {
+  setup(dep: CoreSetup): Promise<IResponse<boolean>>;
+  setInternalRepository(repository: ISavedObjectsRepository): void;
+  create(
+    requestDetail: IRequestDetail,
+    payload: Omit<WorkspaceAttribute, 'id'>
+  ): Promise<IResponse<{ id: WorkspaceAttribute['id'] }>>;
+  list(
+    requestDetail: IRequestDetail,
+    options: WorkspaceFindOptions
+  ): Promise<
+    IResponse<
+      {
+        workspaces: WorkspaceAttribute[];
+      } & Pick<SavedObjectsFindResponse, 'page' | 'per_page' | 'total'>
+    >
+  >;
+  get(requestDetail: IRequestDetail, id: string): Promise<IResponse<WorkspaceAttribute>>;
+  update(
+    requestDetail: IRequestDetail,
+    id: string,
+    payload: Omit<WorkspaceAttribute, 'id'>
+  ): Promise<IResponse<boolean>>;
+  delete(requestDetail: IRequestDetail, id: string): Promise<IResponse<boolean>>;
+  destroy(): Promise<IResponse<boolean>>;
+}
+
+export type IResponse<T> =
+  | {
+      result: T;
+      success: true;
+    }
+  | {
+      success: false;
+      error?: string;
+    };

--- a/src/plugins/workspace/server/types.ts
+++ b/src/plugins/workspace/server/types.ts
@@ -9,7 +9,7 @@ import {
   SavedObjectsFindResponse,
   CoreSetup,
   WorkspaceAttribute,
-  ISavedObjectsRepository,
+  SavedObjectsServiceStart,
 } from '../../../core/server';
 
 export interface WorkspaceFindOptions {
@@ -29,7 +29,7 @@ export interface IRequestDetail {
 
 export interface IWorkspaceDBImpl {
   setup(dep: CoreSetup): Promise<IResponse<boolean>>;
-  setInternalRepository(repository: ISavedObjectsRepository): void;
+  setSavedObjects(savedObjects: SavedObjectsServiceStart): void;
   create(
     requestDetail: IRequestDetail,
     payload: Omit<WorkspaceAttribute, 'id'>

--- a/src/plugins/workspace/server/types.ts
+++ b/src/plugins/workspace/server/types.ts
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import {
   Logger,
   OpenSearchDashboardsRequest,
@@ -27,7 +28,7 @@ export interface IRequestDetail {
   logger: Logger;
 }
 
-export interface IWorkspaceDBImpl {
+export interface IWorkspaceClientImpl {
   setup(dep: CoreSetup): Promise<IResponse<boolean>>;
   setSavedObjects(savedObjects: SavedObjectsServiceStart): void;
   create(

--- a/src/plugins/workspace/server/types.ts
+++ b/src/plugins/workspace/server/types.ts
@@ -29,12 +29,38 @@ export interface IRequestDetail {
 }
 
 export interface IWorkspaceClientImpl {
+  /**
+   * Setup function for workspace client, need to be called before any other methods.
+   * @param dep {@link CoreSetup}
+   * @returns a promise indicate if the setup has successed.
+   * @public
+   */
   setup(dep: CoreSetup): Promise<IResponse<boolean>>;
+  /**
+   * Set saved objects client that will be used inside the workspace client.
+   * @param savedObjects {@link SavedObjectsServiceStart}
+   * @returns void
+   * @public
+   */
   setSavedObjects(savedObjects: SavedObjectsServiceStart): void;
+  /**
+   * Create a workspace
+   * @param requestDetail {@link IRequestDetail}
+   * @param payload {@link WorkspaceAttribute}
+   * @returns a Promise with a new-created id for the workspace
+   * @public
+   */
   create(
     requestDetail: IRequestDetail,
     payload: Omit<WorkspaceAttribute, 'id'>
   ): Promise<IResponse<{ id: WorkspaceAttribute['id'] }>>;
+  /**
+   * List workspaces
+   * @param requestDetail {@link IRequestDetail}
+   * @param options {@link WorkspaceFindOptions}
+   * @returns a Promise with workspaces list
+   * @public
+   */
   list(
     requestDetail: IRequestDetail,
     options: WorkspaceFindOptions
@@ -45,13 +71,40 @@ export interface IWorkspaceClientImpl {
       } & Pick<SavedObjectsFindResponse, 'page' | 'per_page' | 'total'>
     >
   >;
+  /**
+   * Get the detail of a given workspace id
+   * @param requestDetail {@link IRequestDetail}
+   * @param id workspace id
+   * @returns a Promise with the detail of {@link WorkspaceAttribute}
+   * @public
+   */
   get(requestDetail: IRequestDetail, id: string): Promise<IResponse<WorkspaceAttribute>>;
+  /**
+   * Update the detail of a given workspace
+   * @param requestDetail {@link IRequestDetail}
+   * @param id workspace id
+   * @param payload {@link WorkspaceAttribute}
+   * @returns a Promise with a boolean result indicating if the update operation successed.
+   * @public
+   */
   update(
     requestDetail: IRequestDetail,
     id: string,
     payload: Omit<WorkspaceAttribute, 'id'>
   ): Promise<IResponse<boolean>>;
+  /**
+   * Delete a given workspace
+   * @param requestDetail {@link IRequestDetail}
+   * @param id workspace id
+   * @returns a Promise with a boolean result indicating if the delete operation successed.
+   * @public
+   */
   delete(requestDetail: IRequestDetail, id: string): Promise<IResponse<boolean>>;
+  /**
+   * Destroy the workspace client, should be called after the server disposes.
+   * @returns a Promise with a boolean result indicating if the destroy operation successed.
+   * @public
+   */
   destroy(): Promise<IResponse<boolean>>;
 }
 

--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { generateRandomId } from './utils';
+
+describe('workspace utils', () => {
+  it('should generate id with the specified size', () => {
+    expect(generateRandomId(6)).toHaveLength(6);
+  });
+
+  it('should generate random IDs', () => {
+    const NUM_OF_ID = 10000;
+    const ids = new Set<string>();
+    for (let i = 0; i < NUM_OF_ID; i++) {
+      ids.add(generateRandomId(6));
+    }
+    expect(ids.size).toBe(NUM_OF_ID);
+  });
+});

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import crypto from 'crypto';
+
+/**
+ * Generate URL friendly random ID
+ */
+export const generateRandomId = (size: number) => {
+  return crypto.randomBytes(size).toString('base64url').slice(0, size);
+};

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { i18n } from '@osd/i18n';
+import type {
+  SavedObject,
+  SavedObjectsClientContract,
+  CoreSetup,
+  WorkspaceAttribute,
+  ISavedObjectsRepository,
+} from '../../../core/server';
+import { WORKSPACE_TYPE } from '../../../core/server';
+import { IWorkspaceDBImpl, WorkspaceFindOptions, IResponse, IRequestDetail } from './types';
+import { workspace } from './saved_objects';
+import { generateRandomId } from './utils';
+
+const WORKSPACE_ID_SIZE = 6;
+
+const DUPLICATE_WORKSPACE_NAME_ERROR = i18n.translate('workspace.duplicate.name.error', {
+  defaultMessage: 'workspace name has already been used, try with a different name',
+});
+
+export class WorkspaceClientWithSavedObject implements IWorkspaceDBImpl {
+  private setupDep: CoreSetup;
+
+  private internalSavedObjectsRepository?: ISavedObjectsRepository;
+  setInternalRepository(repository: ISavedObjectsRepository) {
+    this.internalSavedObjectsRepository = repository;
+  }
+
+  constructor(core: CoreSetup) {
+    this.setupDep = core;
+  }
+  private getSavedObjectClientsFromRequestDetail(
+    requestDetail: IRequestDetail
+  ): SavedObjectsClientContract {
+    return requestDetail.context.core.savedObjects.client;
+  }
+  private getFlattenedResultWithSavedObject(
+    savedObject: SavedObject<WorkspaceAttribute>
+  ): WorkspaceAttribute {
+    return {
+      ...savedObject.attributes,
+      id: savedObject.id,
+    };
+  }
+  private formatError(error: Error | any): string {
+    return error.message || error.error || 'Error';
+  }
+  public async setup(core: CoreSetup): Promise<IResponse<boolean>> {
+    this.setupDep.savedObjects.registerType(workspace);
+    return {
+      success: true,
+      result: true,
+    };
+  }
+  public async create(
+    requestDetail: IRequestDetail,
+    payload: Omit<WorkspaceAttribute, 'id'>
+  ): ReturnType<IWorkspaceDBImpl['create']> {
+    try {
+      const attributes = payload;
+      const id = generateRandomId(WORKSPACE_ID_SIZE);
+      const client = this.getSavedObjectClientsFromRequestDetail(requestDetail);
+      const existingWorkspaceRes = await this.internalSavedObjectsRepository?.find({
+        type: WORKSPACE_TYPE,
+        search: attributes.name,
+        searchFields: ['name'],
+      });
+      if (existingWorkspaceRes && existingWorkspaceRes.total > 0) {
+        throw new Error(DUPLICATE_WORKSPACE_NAME_ERROR);
+      }
+      const result = await client.create<Omit<WorkspaceAttribute, 'id'>>(
+        WORKSPACE_TYPE,
+        attributes,
+        {
+          id,
+        }
+      );
+      return {
+        success: true,
+        result: {
+          id: result.id,
+        },
+      };
+    } catch (e: unknown) {
+      return {
+        success: false,
+        error: this.formatError(e),
+      };
+    }
+  }
+  public async list(
+    requestDetail: IRequestDetail,
+    options: WorkspaceFindOptions
+  ): ReturnType<IWorkspaceDBImpl['list']> {
+    try {
+      const {
+        saved_objects: savedObjects,
+        ...others
+      } = await this.getSavedObjectClientsFromRequestDetail(requestDetail).find<WorkspaceAttribute>(
+        {
+          ...options,
+          type: WORKSPACE_TYPE,
+        }
+      );
+      return {
+        success: true,
+        result: {
+          ...others,
+          workspaces: savedObjects.map((item) => this.getFlattenedResultWithSavedObject(item)),
+        },
+      };
+    } catch (e: unknown) {
+      return {
+        success: false,
+        error: this.formatError(e),
+      };
+    }
+  }
+  public async get(
+    requestDetail: IRequestDetail,
+    id: string
+  ): Promise<IResponse<WorkspaceAttribute>> {
+    try {
+      const result = await this.getSavedObjectClientsFromRequestDetail(requestDetail).get<
+        WorkspaceAttribute
+      >(WORKSPACE_TYPE, id);
+      return {
+        success: true,
+        result: this.getFlattenedResultWithSavedObject(result),
+      };
+    } catch (e: unknown) {
+      return {
+        success: false,
+        error: this.formatError(e),
+      };
+    }
+  }
+  public async update(
+    requestDetail: IRequestDetail,
+    id: string,
+    payload: Omit<WorkspaceAttribute, 'id'>
+  ): Promise<IResponse<boolean>> {
+    const attributes = payload;
+    try {
+      const client = this.getSavedObjectClientsFromRequestDetail(requestDetail);
+      const workspaceInDB: SavedObject<WorkspaceAttribute> = await client.get(WORKSPACE_TYPE, id);
+      if (workspaceInDB.attributes.name !== attributes.name) {
+        const existingWorkspaceRes = await this.internalSavedObjectsRepository?.find({
+          type: WORKSPACE_TYPE,
+          search: attributes.name,
+          searchFields: ['name'],
+          fields: ['_id'],
+        });
+        if (existingWorkspaceRes && existingWorkspaceRes.total > 0) {
+          throw new Error(DUPLICATE_WORKSPACE_NAME_ERROR);
+        }
+      }
+      await client.update<Omit<WorkspaceAttribute, 'id'>>(WORKSPACE_TYPE, id, attributes, {});
+      return {
+        success: true,
+        result: true,
+      };
+    } catch (e: unknown) {
+      return {
+        success: false,
+        error: this.formatError(e),
+      };
+    }
+  }
+  public async delete(requestDetail: IRequestDetail, id: string): Promise<IResponse<boolean>> {
+    try {
+      await this.getSavedObjectClientsFromRequestDetail(requestDetail).delete(WORKSPACE_TYPE, id);
+      return {
+        success: true,
+        result: true,
+      };
+    } catch (e: unknown) {
+      return {
+        success: false,
+        error: this.formatError(e),
+      };
+    }
+  }
+  public async destroy(): Promise<IResponse<boolean>> {
+    return {
+      success: true,
+      result: true,
+    };
+  }
+}

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -36,13 +36,16 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
   ): SavedObjectsClientContract | undefined {
     return this.savedObjects?.getScopedClient(requestDetail.request, {
       excludedWrappers: [WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID],
+      includedHiddenTypes: [WORKSPACE_TYPE],
     });
   }
 
   private getSavedObjectClientsFromRequestDetail(
     requestDetail: IRequestDetail
   ): SavedObjectsClientContract {
-    return requestDetail.context.core.savedObjects.client;
+    return this.savedObjects?.getScopedClient(requestDetail.request, {
+      includedHiddenTypes: [WORKSPACE_TYPE],
+    }) as SavedObjectsClientContract;
   }
   private getFlattenedResultWithSavedObject(
     savedObject: SavedObject<WorkspaceAttribute>

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import { i18n } from '@osd/i18n';
 import type {
   SavedObject,
@@ -11,7 +12,7 @@ import type {
   SavedObjectsServiceStart,
 } from '../../../core/server';
 import { WORKSPACE_TYPE } from '../../../core/server';
-import { IWorkspaceDBImpl, WorkspaceFindOptions, IResponse, IRequestDetail } from './types';
+import { IWorkspaceClientImpl, WorkspaceFindOptions, IResponse, IRequestDetail } from './types';
 import { workspace } from './saved_objects';
 import { generateRandomId } from './utils';
 import { WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID } from '../common/constants';
@@ -22,7 +23,7 @@ const DUPLICATE_WORKSPACE_NAME_ERROR = i18n.translate('workspace.duplicate.name.
   defaultMessage: 'workspace name has already been used, try with a different name',
 });
 
-export class WorkspaceClientWithSavedObject implements IWorkspaceDBImpl {
+export class WorkspaceClient implements IWorkspaceClientImpl {
   private setupDep: CoreSetup;
   private savedObjects?: SavedObjectsServiceStart;
 
@@ -64,7 +65,7 @@ export class WorkspaceClientWithSavedObject implements IWorkspaceDBImpl {
   public async create(
     requestDetail: IRequestDetail,
     payload: Omit<WorkspaceAttribute, 'id'>
-  ): ReturnType<IWorkspaceDBImpl['create']> {
+  ): ReturnType<IWorkspaceClientImpl['create']> {
     try {
       const attributes = payload;
       const id = generateRandomId(WORKSPACE_ID_SIZE);
@@ -102,7 +103,7 @@ export class WorkspaceClientWithSavedObject implements IWorkspaceDBImpl {
   public async list(
     requestDetail: IRequestDetail,
     options: WorkspaceFindOptions
-  ): ReturnType<IWorkspaceDBImpl['list']> {
+  ): ReturnType<IWorkspaceClientImpl['list']> {
     try {
       const {
         saved_objects: savedObjects,

--- a/test/api_integration/apis/index.js
+++ b/test/api_integration/apis/index.js
@@ -45,5 +45,6 @@ export default function ({ loadTestFile }) {
     loadTestFile(require.resolve('./stats'));
     loadTestFile(require.resolve('./ui_metric'));
     loadTestFile(require.resolve('./telemetry'));
+    loadTestFile(require.resolve('./workspace'));
   });
 }

--- a/test/api_integration/apis/workspace/index.ts
+++ b/test/api_integration/apis/workspace/index.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import expect from '@osd/expect';
+import { WorkspaceAttribute } from 'opensearch-dashboards/server';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+const testWorkspace: WorkspaceAttribute = {
+  id: 'fake_id',
+  name: 'test_workspace',
+  description: 'test_workspace_description',
+};
+
+export default function ({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const opensearch = getService('legacyOpenSearch');
+
+  const MILLISECOND_IN_WEEK = 1000 * 60 * 60 * 24 * 7;
+
+  describe('Workspace CRUD apis', () => {
+    it('basic CRUD', async () => {
+      const resp = await supertest
+        .post(`/api/workspaces`)
+        .set('osd-xsrf', 'opensearch-dashboards')
+        .send(
+          JSON.stringify({
+            attributes: testWorkspace,
+          })
+        )
+        .expect(200);
+
+      expect(resp.body).to.be.an('array');
+      expect(resp.body.length).to.be.above(0);
+      expect(resp.body[0].status).to.be('not_installed');
+    });
+  });
+}

--- a/test/api_integration/apis/workspace/index.ts
+++ b/test/api_integration/apis/workspace/index.ts
@@ -123,6 +123,17 @@ export default function ({ getService }: FtrProviderContext) {
         .set('osd-xsrf', 'opensearch-dashboards')
         .expect(200);
 
+      await supertest
+        .post(`/api/workspaces`)
+        .send({
+          attributes: {
+            ...omitId(testWorkspace),
+            name: 'another test workspace',
+          },
+        })
+        .set('osd-xsrf', 'opensearch-dashboards')
+        .expect(200);
+
       const listResult = await supertest
         .post(`/api/workspaces/_list`)
         .send({
@@ -130,7 +141,7 @@ export default function ({ getService }: FtrProviderContext) {
         })
         .set('osd-xsrf', 'opensearch-dashboards')
         .expect(200);
-      expect(listResult.body.result.total).equal(1);
+      expect(listResult.body.result.total).equal(2);
     });
-  }).tags('is:workspace');
+  });
 }

--- a/test/api_integration/apis/workspace/index.ts
+++ b/test/api_integration/apis/workspace/index.ts
@@ -5,8 +5,12 @@
 
 import expect from '@osd/expect';
 import { WorkspaceAttribute } from 'opensearch-dashboards/server';
-import { omit } from 'lodash';
 import { FtrProviderContext } from '../../ftr_provider_context';
+
+const omitId = <T extends { id?: string }>(object: T): Omit<T, 'id'> => {
+  const { id, ...others } = object;
+  return others;
+};
 
 const testWorkspace: WorkspaceAttribute = {
   id: 'fake_id',
@@ -47,7 +51,7 @@ export default function ({ getService }: FtrProviderContext) {
       const result: any = await supertest
         .post(`/api/workspaces`)
         .send({
-          attributes: omit(testWorkspace, 'id'),
+          attributes: omitId(testWorkspace),
         })
         .set('osd-xsrf', 'opensearch-dashboards')
         .expect(200);
@@ -59,7 +63,7 @@ export default function ({ getService }: FtrProviderContext) {
       const result = await supertest
         .post(`/api/workspaces`)
         .send({
-          attributes: omit(testWorkspace, 'id'),
+          attributes: omitId(testWorkspace),
         })
         .set('osd-xsrf', 'opensearch-dashboards')
         .expect(200);
@@ -71,7 +75,7 @@ export default function ({ getService }: FtrProviderContext) {
       const result: any = await supertest
         .post(`/api/workspaces`)
         .send({
-          attributes: omit(testWorkspace, 'id'),
+          attributes: omitId(testWorkspace),
         })
         .set('osd-xsrf', 'opensearch-dashboards')
         .expect(200);
@@ -80,7 +84,7 @@ export default function ({ getService }: FtrProviderContext) {
         .put(`/api/workspaces/${result.body.result.id}`)
         .send({
           attributes: {
-            ...omit(testWorkspace, 'id'),
+            ...omitId(testWorkspace),
             name: 'updated',
           },
         })
@@ -96,7 +100,7 @@ export default function ({ getService }: FtrProviderContext) {
       const result: any = await supertest
         .post(`/api/workspaces`)
         .send({
-          attributes: omit(testWorkspace, 'id'),
+          attributes: omitId(testWorkspace),
         })
         .set('osd-xsrf', 'opensearch-dashboards')
         .expect(200);
@@ -114,7 +118,7 @@ export default function ({ getService }: FtrProviderContext) {
       await supertest
         .post(`/api/workspaces`)
         .send({
-          attributes: omit(testWorkspace, 'id'),
+          attributes: omitId(testWorkspace),
         })
         .set('osd-xsrf', 'opensearch-dashboards')
         .expect(200);


### PR DESCRIPTION
### Description

This PR is the initial PR for workspace, as we know workspace will be a new function that provides:
1. Organization on saved objects.
2. Manage visibility of opensearch features
3. Authorization on operations on saved objects.

And before all of the features mentioned above, we need to setup the workspace as a core plugin.

This PR includes:

- Add feature flag on workspace plugin.
- Setup workspace plugin skeleton.
- Define data structure on `workspace`.
- Implementation on CRUD operations on `workspace`.

### Issues Resolved

#4945 

## Screenshot

The changes introduced by this PR is not related to UI change.

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
  - [x] `yarn test:ftr`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
