### PR TITLE
[Data Explorer][Discover][Functional Test] fix ciGroup 8

### DIFF
--- a/src/plugins/data_explorer/public/components/sidebar/index.tsx
+++ b/src/plugins/data_explorer/public/components/sidebar/index.tsx
@@ -76,6 +76,7 @@ export const Sidebar: FC = ({ children }) => {
         <EuiSplitPanel.Inner paddingSize="s" color="subdued" grow={false}>
           <EuiComboBox
             placeholder="Select a datasource"
+            data-test-subj="dataExplorerDSSelect"
             singleSelection={{ asPlainText: true }}
             options={options}
             selectedOptions={selectedOption ? [selectedOption] : []}

--- a/test/functional/apps/management/_handle_alias.js
+++ b/test/functional/apps/management/_handle_alias.js
@@ -67,6 +67,7 @@ export default function ({ getService, getPageObjects }) {
     it('should be able to discover and verify no of hits for alias1', async function () {
       const expectedHitCount = '4';
       await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.selectIndexPattern('alias1*');
       await retry.try(async function () {
         expect(await PageObjects.discover.getHitCount()).to.be(expectedHitCount);
       });

--- a/test/functional/page_objects/discover_page.ts
+++ b/test/functional/page_objects/discover_page.ts
@@ -43,6 +43,7 @@ export function DiscoverPageProvider({ getService, getPageObjects }: FtrProvider
   const opensearchChart = getService('opensearchChart');
   const docTable = getService('docTable');
   const dataGridTable = getService('dataGrid');
+  const comboBox = getService('comboBox');
 
   /*
    * This page is left unchanged since some of the other selenium tests, ex. dashboard tests, visualization tests
@@ -345,12 +346,9 @@ export function DiscoverPageProvider({ getService, getPageObjects }: FtrProvider
       await header.waitUntilLoadingHasFinished();
     }
 
-    public async selectIndexPattern(indexPattern: string) {
-      await testSubjects.click('indexPattern-switch-link');
-      await find.setValue('[data-test-subj="indexPattern-switcher"] input', indexPattern);
-      await find.clickByCssSelector(
-        `[data-test-subj="indexPattern-switcher"] [title="${indexPattern}"]`
-      );
+    public async selectIndexPattern(indexPatternTitle: string) {
+      const dataExplorerComboBoxElement = await testSubjects.find('dataExplorerDSSelect');
+      await comboBox.setElement(dataExplorerComboBoxElement, indexPatternTitle);
       await header.waitUntilLoadingHasFinished();
     }
 


### PR DESCRIPTION
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5103

### Description
Update index pattern fetch method in discover page due to changing to `EuiComboBox`.



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
