### PR TITLE
[Console] Enhance support for JSON with long numerals

### DIFF
--- a/src/core/server/opensearch/client/cluster_client.test.ts
+++ b/src/core/server/opensearch/client/cluster_client.test.ts
@@ -55,19 +55,32 @@ describe('ClusterClient', () => {
   let getAuthHeaders: jest.MockedFunction<GetAuthHeaders>;
   let internalClient: ReturnType<typeof opensearchClientMock.createInternalClient>;
   let scopedClient: ReturnType<typeof opensearchClientMock.createInternalClient>;
+  let internalClientWithLongNumeralsSupport: ReturnType<typeof opensearchClientMock.createInternalClient>;
+  let scopedClientWithLongNumeralsSupport: ReturnType<typeof opensearchClientMock.createInternalClient>;
 
   beforeEach(() => {
     logger = loggingSystemMock.createLogger();
     internalClient = opensearchClientMock.createInternalClient();
     scopedClient = opensearchClientMock.createInternalClient();
+    internalClientWithLongNumeralsSupport = opensearchClientMock.createInternalClient(true);
+    scopedClientWithLongNumeralsSupport = opensearchClientMock.createInternalClient(true);
     getAuthHeaders = jest.fn().mockImplementation(() => ({
       authorization: 'auth',
       foo: 'bar',
     }));
 
-    configureClientMock.mockImplementation((config, { scoped = false }) => {
-      return scoped ? scopedClient : internalClient;
-    });
+    configureClientMock.mockImplementation(
+      (config, { scoped = false, withLongNumeralsSupport = false }) => {
+        // prettier-ignore
+        return withLongNumeralsSupport
+          ? scoped
+            ? scopedClientWithLongNumeralsSupport
+            : internalClientWithLongNumeralsSupport
+          : scoped
+            ? scopedClient
+            : internalClient;
+      }
+    );
   });
 
   afterEach(() => {
@@ -79,7 +92,7 @@ describe('ClusterClient', () => {
 
     new ClusterClient(config, logger, getAuthHeaders);
 
-    expect(configureClientMock).toHaveBeenCalledTimes(2);
+    expect(configureClientMock).toHaveBeenCalledTimes(4);
     expect(configureClientMock).toHaveBeenCalledWith(config, { logger });
     expect(configureClientMock).toHaveBeenCalledWith(config, { logger, scoped: true });
   });
@@ -100,18 +113,22 @@ describe('ClusterClient', () => {
       const scopedClusterClient = clusterClient.asScoped(request);
 
       const expected = { headers: expect.any(Object) };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
 
       expect(scopedClusterClient.asInternalUser).toBe(clusterClient.asInternalUser);
       expect(scopedClusterClient.asCurrentUser).toBe(scopedClient.child.mock.results[0].value);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClusterClient.asInternalUserWithLongNumeralsSupport).toBe(
+        clusterClient.asInternalUserWithLongNumeralsSupport
+      );
+      expect(scopedClusterClient.asCurrentUserWithLongNumeralsSupport).toBe(
+        scopedClientWithLongNumeralsSupport.child.mock.results[0].value
+      );
     });
 
     it('returns a distinct scoped cluster client on each call', () => {
@@ -121,10 +138,14 @@ describe('ClusterClient', () => {
       const scopedClusterClient1 = clusterClient.asScoped(request);
       const scopedClusterClient2 = clusterClient.asScoped(request);
 
-      expect(scopedClient.child).toHaveBeenCalledTimes(2 * 2);
+      expect(scopedClient.child).toHaveBeenCalledTimes(2);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(2);
 
       expect(scopedClusterClient1).not.toBe(scopedClusterClient2);
       expect(scopedClusterClient1.asInternalUser).toBe(scopedClusterClient2.asInternalUser);
+      expect(scopedClusterClient1.asInternalUserWithLongNumeralsSupport).toBe(
+        scopedClusterClient2.asInternalUserWithLongNumeralsSupport
+      );
     });
 
     it('creates a scoped client with filtered request headers', () => {
@@ -146,15 +167,12 @@ describe('ClusterClient', () => {
       const expected = {
         headers: { ...DEFAULT_HEADERS, foo: 'bar', 'x-opaque-id': expect.any(String) },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
 
     it('creates a scoped facade with filtered auth headers', () => {
@@ -174,15 +192,12 @@ describe('ClusterClient', () => {
       const expected = {
         headers: { ...DEFAULT_HEADERS, authorization: 'auth', 'x-opaque-id': expect.any(String) },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
 
     it('respects auth headers precedence', () => {
@@ -206,15 +221,12 @@ describe('ClusterClient', () => {
       const expected = {
         headers: { ...DEFAULT_HEADERS, authorization: 'auth', 'x-opaque-id': expect.any(String) },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
 
     it('includes the `customHeaders` from the config without filtering them', () => {
@@ -240,15 +252,12 @@ describe('ClusterClient', () => {
           'x-opaque-id': expect.any(String),
         },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
 
     it('adds the x-opaque-id header based on the request id', () => {
@@ -271,15 +280,12 @@ describe('ClusterClient', () => {
           'x-opaque-id': 'my-fake-id',
         },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
 
     it('respect the precedence of auth headers over config headers', () => {
@@ -307,15 +313,12 @@ describe('ClusterClient', () => {
           'x-opaque-id': expect.any(String),
         },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
 
     it('respect the precedence of request headers over config headers', () => {
@@ -343,15 +346,12 @@ describe('ClusterClient', () => {
           'x-opaque-id': expect.any(String),
         },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
 
     it('respect the precedence of config headers over default headers', () => {
@@ -374,15 +374,12 @@ describe('ClusterClient', () => {
           'x-opaque-id': expect.any(String),
         },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
 
     it('respect the precedence of request headers over default headers', () => {
@@ -405,15 +402,12 @@ describe('ClusterClient', () => {
           'x-opaque-id': expect.any(String),
         },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
 
     it('respect the precedence of x-opaque-id header over config headers', () => {
@@ -441,15 +435,12 @@ describe('ClusterClient', () => {
           'x-opaque-id': 'from request',
         },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
 
     it('filter headers when called with a `FakeRequest`', () => {
@@ -471,15 +462,12 @@ describe('ClusterClient', () => {
       const expected = {
         headers: { ...DEFAULT_HEADERS, authorization: 'auth' },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
 
     it('does not add auth headers when called with a `FakeRequest`', () => {
@@ -503,39 +491,43 @@ describe('ClusterClient', () => {
       const expected = {
         headers: { ...DEFAULT_HEADERS, foo: 'bar' },
       };
-      expect(scopedClient.child).toHaveBeenCalledTimes(2);
-      expect(scopedClient.child).toHaveBeenNthCalledWith(1, expect.objectContaining(expected));
-      expect(scopedClient.child).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          ...expected,
-          enableLongNumeralSupport: true,
-        })
-      );
+
+      expect(scopedClient.child).toHaveBeenCalledTimes(1);
+      expect(scopedClient.child).toHaveBeenCalledWith(expected);
+
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.child).toHaveBeenCalledWith(expected);
     });
   });
 
   describe('#close', () => {
-    it('closes both underlying clients', async () => {
+    it('closes all underlying clients', async () => {
       const clusterClient = new ClusterClient(createConfig(), logger, getAuthHeaders);
 
       await clusterClient.close();
 
       expect(internalClient.close).toHaveBeenCalledTimes(1);
       expect(scopedClient.close).toHaveBeenCalledTimes(1);
+
+      expect(internalClientWithLongNumeralsSupport.close).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.close).toHaveBeenCalledTimes(1);
     });
 
-    it('waits for both clients to close', (done) => {
-      expect.assertions(4);
+    it('waits for all clients to close', (done) => {
+      expect.assertions(8);
 
       const clusterClient = new ClusterClient(createConfig(), logger, getAuthHeaders);
 
       let internalClientClosed = false;
       let scopedClientClosed = false;
+      let internalClientWithLongNumeralsSupportClosed = false;
+      let scopedClientWithLongNumeralsSupportClosed = false;
       let clusterClientClosed = false;
 
       let closeInternalClient: () => void;
       let closeScopedClient: () => void;
+      let closeInternalClientWithLongNumeralsSupport: () => void;
+      let closeScopedClientWithLongNumeralsSupport: () => void;
 
       internalClient.close.mockReturnValue(
         new Promise((resolve) => {
@@ -553,16 +545,36 @@ describe('ClusterClient', () => {
           scopedClientClosed = true;
         })
       );
+      internalClientWithLongNumeralsSupport.close.mockReturnValue(
+        new Promise((resolve) => {
+          closeInternalClientWithLongNumeralsSupport = resolve;
+        }).then(() => {
+          expect(clusterClientClosed).toBe(false);
+          internalClientWithLongNumeralsSupportClosed = true;
+        })
+      );
+      scopedClientWithLongNumeralsSupport.close.mockReturnValue(
+        new Promise((resolve) => {
+          closeScopedClientWithLongNumeralsSupport = resolve;
+        }).then(() => {
+          expect(clusterClientClosed).toBe(false);
+          scopedClientWithLongNumeralsSupportClosed = true;
+        })
+      );
 
       clusterClient.close().then(() => {
         clusterClientClosed = true;
         expect(internalClientClosed).toBe(true);
         expect(scopedClientClosed).toBe(true);
+        expect(internalClientWithLongNumeralsSupportClosed).toBe(true);
+        expect(scopedClientWithLongNumeralsSupportClosed).toBe(true);
         done();
       });
 
       closeInternalClient!();
       closeScopedClient!();
+      closeInternalClientWithLongNumeralsSupport!();
+      closeScopedClientWithLongNumeralsSupport!();
     });
 
     it('return a rejected promise is any client rejects', async () => {
@@ -583,11 +595,17 @@ describe('ClusterClient', () => {
       expect(internalClient.close).toHaveBeenCalledTimes(1);
       expect(scopedClient.close).toHaveBeenCalledTimes(1);
 
+      expect(internalClientWithLongNumeralsSupport.close).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.close).toHaveBeenCalledTimes(1);
+
       await clusterClient.close();
       await clusterClient.close();
 
       expect(internalClient.close).toHaveBeenCalledTimes(1);
       expect(scopedClient.close).toHaveBeenCalledTimes(1);
+
+      expect(internalClientWithLongNumeralsSupport.close).toHaveBeenCalledTimes(1);
+      expect(scopedClientWithLongNumeralsSupport.close).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/core/server/opensearch/client/configure_client.ts
+++ b/src/core/server/opensearch/client/configure_client.ts
@@ -38,9 +38,15 @@ import { parseClientOptions, OpenSearchClientConfig } from './client_config';
 
 export const configureClient = (
   config: OpenSearchClientConfig,
-  { logger, scoped = false }: { logger: Logger; scoped?: boolean }
+  {
+    logger,
+    scoped = false,
+    withLongNumeralsSupport = false,
+  }: { logger: Logger; scoped?: boolean; withLongNumeralsSupport?: boolean }
 ): Client => {
   const clientOptions = parseClientOptions(config, scoped);
+  // @ts-expect-error - ToDo: Remove ignoring after https://github.com/opensearch-project/opensearch-js/pull/598 is included in a release
+  if (withLongNumeralsSupport) clientOptions.enableLongNumeralSupport = true;
 
   const client = new Client(clientOptions);
   addLogging(client, logger, config.logQueries);

--- a/src/core/server/opensearch/client/scoped_cluster_client.test.ts
+++ b/src/core/server/opensearch/client/scoped_cluster_client.test.ts
@@ -36,27 +36,39 @@ describe('ScopedClusterClient', () => {
     const internalClient = opensearchClientMock.createOpenSearchClient();
     const scopedClient = opensearchClientMock.createOpenSearchClient();
 
+    const internalClientWithLongNumeralsSupport = opensearchClientMock.createOpenSearchClient(true);
+    const scopedClientWithLongNumeralsSupport = opensearchClientMock.createOpenSearchClient(true);
+
     const scopedClusterClient = new ScopedClusterClient(
       internalClient,
       scopedClient,
-      internalClient,
-      scopedClient
+      internalClientWithLongNumeralsSupport,
+      scopedClientWithLongNumeralsSupport
     );
 
     expect(scopedClusterClient.asInternalUser).toBe(internalClient);
+    expect(scopedClusterClient.asInternalUserWithLongNumeralsSupport).toBe(
+      internalClientWithLongNumeralsSupport
+    );
   });
 
   it('uses the scoped client passed in the constructor', () => {
     const internalClient = opensearchClientMock.createOpenSearchClient();
     const scopedClient = opensearchClientMock.createOpenSearchClient();
 
+    const internalClientWithLongNumeralsSupport = opensearchClientMock.createOpenSearchClient(true);
+    const scopedClientWithLongNumeralsSupport = opensearchClientMock.createOpenSearchClient(true);
+
     const scopedClusterClient = new ScopedClusterClient(
       internalClient,
       scopedClient,
-      internalClient,
-      scopedClient
+      internalClientWithLongNumeralsSupport,
+      scopedClientWithLongNumeralsSupport
     );
 
     expect(scopedClusterClient.asCurrentUser).toBe(scopedClient);
+    expect(scopedClusterClient.asCurrentUserWithLongNumeralsSupport).toBe(
+      scopedClientWithLongNumeralsSupport
+    );
   });
 });


### PR DESCRIPTION
### Description

Enhance support for JSON with long numerals: Followup to #4562
* Improve testing of clients with long numerals support
* Work around serializer inheritance in the JS client


### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
