### PR TITLE
[CI] allow for manual triggered cypress test jobs to accept inputs

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -6,16 +6,43 @@ on:
     branches: [ '**' ]
     paths-ignore:
       - '**/*.md'
+  workflow_dispatch:
+    inputs:
+      test_repo:
+        description: 'Test repo'
+        default: 'opensearch-project/opensearch-dashboards-functional-test'
+        required: true
+        type: string
+      test_branch:
+        description: 'Test branch (default: source branch)'
+        required: false
+        type: string
+      pr_number:
+        description: 'PR Number'
+        required: false
+        type: number
+      specs:
+        description: 'Additional tests to run'
+        required: false
+        type: string
 
 env:
+  SOURCE_REPO: ${{ github.repository }}
+  SOURCE_BRANCH: ${{ github.base_ref }}
+  TEST_REPO: ${{ inputs.test_repo != '' && inputs.test_repo || 'opensearch-project/opensearch-dashboards-functional-test' }}
+  TEST_BRANCH: "${{ inputs.test_branch != '' && inputs.test_branch || github.base_ref }}"
   FTR_PATH: 'ftr'
   START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch'
   OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot'
   SPEC: 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js,'
+  ADDITIONAL_SPEC: ${{ inputs.specs != '' && inputs.specs || '' }}
   CYPRESS_BROWSER: 'chromium'
   CYPRESS_VISBUILDER_ENABLED: true
   CYPRESS_DATASOURCE_MANAGEMENT_ENABLED: false
   OSD_SNAPSHOT_SKIP_VERIFY_CHECKSUM: true
+  COMMENT_TAG: '[MANUAL CYPRESS TEST RUN RESULTS]'
+  COMMENT_SUCCESS_MSG: ':white_check_mark: Cypress test run succeeded!'
+  COMMENT_FAILURE_MSG: ':x: Cypress test run failed!'
 
 jobs:
   cypress-tests:
@@ -30,8 +57,31 @@ jobs:
       TERM: xterm
     name: Run cypress tests
     steps:
+      - name: Get source information from PR number
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number != '' }}
+        id: get_pr_info
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: result } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ inputs.pr_number }}
+            });
+            core.setOutput('head_name', result.head.repo.full_name);
+            core.setOutput('head_ref', result.head.ref);
+
+      - name: Set source repo from PR number
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number != '' }}
+        run: |
+          echo "SOURCE_REPO=${{ steps.get_pr_info.outputs.head_name }}" >> $GITHUB_ENV
+          echo "SOURCE_BRANCH=${{ steps.get_pr_info.outputs.head_ref }}" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          repository: ${{ env.SOURCE_REPO }}
+          ref: '${{ env.SOURCE_BRANCH }}'
 
       - name: Setup Node
         uses: actions/setup-node@v2
@@ -54,8 +104,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ env.FTR_PATH }}
-          repository: opensearch-project/opensearch-dashboards-functional-test
-          ref: '${{ github.base_ref }}'
+          repository: ${{ env.TEST_REPO }}
+          ref: '${{ env.TEST_BRANCH }}'
 
       - name: Get Cypress version
         id: cypress_version
@@ -79,7 +129,7 @@ jobs:
           working-directory: ${{ env.FTR_PATH }}
           start: ${{ env.OPENSEARCH_SNAPSHOT_CMD }}, ${{ env.START_CMD }}
           wait-on: 'http://localhost:9200, http://localhost:5601'
-          command: yarn cypress:run-without-security --browser ${{ env.CYPRESS_BROWSER }} --spec ${{ env.SPEC }}
+          command: yarn cypress:run-without-security --browser ${{ env.CYPRESS_BROWSER }} --spec ${{ env.SPEC }}${{ env.ADDITIONAL_SPEC }}
 
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v3
@@ -102,3 +152,38 @@ jobs:
           name: ftr-cypress-results
           path: ${{ env.FTR_PATH }}/cypress/results
           retention-days: 1
+
+  add-comment:
+    needs: [cypress-tests]
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.pr_number != '' }}
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ inputs.pr_number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "${{ env.COMMENT_TAG }}"
+
+      - name: Add comment on the PR
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ inputs.pr_number }}
+          body: |
+            ### ${{ env.COMMENT_TAG }}
+
+            #### ${{ needs.cypress-tests.result == 'success' && env.COMMENT_SUCCESS_MSG || env.COMMENT_FAILURE_MSG }}
+
+            #### Inputs:
+            Source repo: `${{ env.SOURCE_REPO }}`
+            Source branch: `${{ env.SOURCE_BRANCH }}`
+            Test repo: `${{ env.TEST_REPO }}`
+            Test branch: ``${{ env.TEST_BRANCH }}``
+
+            #### Link to results: 
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          edit-mode: replace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Re-enable CI workflows for feature branches ([#2908](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2908))
 - Upgrade yarn version to be compatible with @opensearch-project/opensearch ([#3443](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3443))
 - Add an achievement badger to the PR ([#3721](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3721))
+- [CI] Enable inputs for manually triggered Cypress test jobs ([#5134](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5134))
 
 ### 📝 Documentation
 


### PR DESCRIPTION
### Description

Utilizing the GitHub `workflow_dispatch`, we can trigger a job with a specific inputs.

By default, we run from this repo:
https://github.com/opensearch-project/opensearch-dashboards-functional-test

This workflow uses the target branch of the PR to pull down from the FTRepo and run the tests from that specific branch.

For example, PRs against `main` will pull down `main` from the FTRepo.

The problem occurs when new functionality is opened or a bug is fixed and, per industry standard, we want to see tests added to ensure functionality, stability, and raise the bar.

However, the cypress tests PR into the FTRepo depends on the new code to be merged for the CI within the FTRepo to work. So we have a stalemate that usually slows down PR review time.

Here, a manual run can be triggered by a maintainer. It will utilize the source branch from the PR if provided.

### Issues Related

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4019

## Screenshot

Unfortunately, GitHub only enables the getting of ref from the manual run. To do this, a maintainer will have to place inputs from:

[Actions > Run cypress tests](https://github.com/opensearch-project/OpenSearch-Dashboards/actions/workflows/cypress_workflow.yml)

Which you can enter inputs and trigger the job:
![Screenshot 2023-09-27 at 5 02 23 AM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/12060704/4a918172-8f17-404d-b092-471417442fe1)


Results will show up like this if there is associated PR to the triggered run:
![Screenshot 2023-09-27 at 4 53 44 AM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/12060704/9c8f13d9-c8b3-41af-9431-a13747269668)

As you can see it ran from my own fork but i was able to run a different branch from my own fork of the functional test repo. This is like a manually verification still, I have not looked into updating the status of a PR but I believe we can set to pass still.

## Testing the changes

I was playing around with this PR by changing my default.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
