### PR TITLE
[CI] Cypress test run spec input

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -22,20 +22,20 @@ on:
         required: false
         type: number
       specs:
-        description: 'Additional tests to run'
+        description: 'Tests to run (default: core)'
+        default: 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js,'
         required: false
         type: string
 
 env:
   SOURCE_REPO: ${{ github.repository }}
-  SOURCE_BRANCH: ${{ github.base_ref }}
+  SOURCE_BRANCH: "${{ github.base_ref }}"
   TEST_REPO: ${{ inputs.test_repo != '' && inputs.test_repo || 'opensearch-project/opensearch-dashboards-functional-test' }}
   TEST_BRANCH: "${{ inputs.test_branch != '' && inputs.test_branch || github.base_ref }}"
   FTR_PATH: 'ftr'
   START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch'
   OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot'
-  SPEC: 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js,'
-  ADDITIONAL_SPEC: ${{ inputs.specs != '' && inputs.specs || '' }}
+  SPEC: ${{ inputs.specs != '' && inputs.specs || 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js,' }} 
   CYPRESS_BROWSER: 'chromium'
   CYPRESS_VISBUILDER_ENABLED: true
   CYPRESS_DATASOURCE_MANAGEMENT_ENABLED: false
@@ -129,7 +129,7 @@ jobs:
           working-directory: ${{ env.FTR_PATH }}
           start: ${{ env.OPENSEARCH_SNAPSHOT_CMD }}, ${{ env.START_CMD }}
           wait-on: 'http://localhost:9200, http://localhost:5601'
-          command: yarn cypress:run-without-security --browser ${{ env.CYPRESS_BROWSER }} --spec ${{ env.SPEC }}${{ env.ADDITIONAL_SPEC }}
+          command: yarn cypress:run-without-security --browser ${{ env.CYPRESS_BROWSER }} --spec ${{ env.SPEC }}
 
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v3
@@ -180,9 +180,12 @@ jobs:
 
             #### Inputs:
             Source repo: `${{ env.SOURCE_REPO }}`
-            Source branch: `${{ env.SOURCE_BRANCH }}`
+            Source branch: ``${{ env.SOURCE_BRANCH }}``
             Test repo: `${{ env.TEST_REPO }}`
             Test branch: ``${{ env.TEST_BRANCH }}``
+
+            Test spec:
+            `${{ env.SPEC }}`
 
             #### Link to results: 
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
### Description

Originally:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5134

I believed it to be a good idea to ensure that triggering the CI should always run a batch of tests. But I realized that some tests can be added and just be bad tests until updated. Or if we want to verify a flaky test in the CI.

So instead of only making it additional tests, the spec input will complete replace the default tests (unless you append to the default).

Empty will run the default spec still. This will append on to the PR comment with the spec that was run. So at least maintainers can see it passed for a set of tests but it did not run the ones we usually run.

Also adding some formatting for empty values for the PR comment.

### Issues Related

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4019

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
