### PR TITLE
[FIX] Panel header fixed

### DIFF
--- a/src/plugins/discover/public/application/components/top_nav/open_search_panel.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/open_search_panel.tsx
@@ -67,7 +67,7 @@ export function OpenSearchPanel({ onClose, makeUrl }: Props) {
           <h2>
             <FormattedMessage
               id="discover.topNav.openSearchPanel.openSearchTitle"
-              defaultMessage="Open search"
+              defaultMessage="OpenSearch"
             />
           </h2>
         </EuiTitle>


### PR DESCRIPTION
### Description

When navigated to discover page and clicked on Open, the header shows "Open search", while it should be showing "OpenSearch"

### Issues Resolved
fixes #5145 