### PR TITLE
[Workspace]Optional workspaces params in repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Adds Data explorer framework and implements Discover using it ([#4806](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4806))
 - [Theme] Use themes' definitions to render the initial view ([#4936](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4936/))
 - [Theme] Make `next` theme the default ([#4854](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4854/))
+- [Workspace] Optional workspaces params in repository ([#5162](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5162/))
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Decouple] Allow plugin manifest config to define semver compatible OpenSearch plugin and verify if it is installed on the cluster([#4612](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4612))
 - [Advanced Settings] Consolidate settings into new "Appearance" category and add category IDs ([#4845](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4845))
 - Adds Data explorer framework and implements Discover using it ([#4806](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4806))
-- [Theme] Use themes' definitions to render the initial view ([#4936](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4936/))
-- [Theme] Make `next` theme the default ([#4854](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4854/))
+- [Theme] Use themes' definitions to render the initial view ([#4936](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4936))
+- [Theme] Make `next` theme the default ([#4854](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4854))
 - [Discover] Update embeddable for saved searches ([#5081](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5081))
-- [Workspace] Optional workspaces params in repository ([#5162](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5162/))
+- [Workspace] Optional workspaces params in repository ([#5162](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5162))
 
 ### 🐛 Bug Fixes
 

--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -345,6 +345,7 @@ export class SavedObjectsClient {
       filter: 'filter',
       namespaces: 'namespaces',
       preference: 'preference',
+      workspaces: 'workspaces',
     };
 
     const renamedQuery = renameKeys<SavedObjectsFindOptions, any>(renameMap, options);

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
@@ -128,6 +128,7 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
+              workspaces: undefined,
             },
           ],
         ],
@@ -218,6 +219,7 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
+              workspaces: undefined,
             },
           ],
         ],
@@ -368,6 +370,7 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
+              workspaces: undefined,
             },
           ],
         ],
@@ -459,6 +462,7 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
+              workspaces: undefined,
             },
           ],
         ],
@@ -666,6 +670,7 @@ describe('getSortedObjectsForExport()', () => {
             ],
             Object {
               namespace: undefined,
+              workspaces: undefined,
             },
           ],
         ],
@@ -784,6 +789,7 @@ describe('getSortedObjectsForExport()', () => {
             ],
             Object {
               namespace: undefined,
+              workspaces: undefined,
             },
           ],
           Array [

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
@@ -857,4 +857,29 @@ describe('getSortedObjectsForExport()', () => {
       `Can't specify both "search" and "objects" properties when exporting`
     );
   });
+
+  test('rejects when both types and objecys are passed in', () => {
+    const exportOpts = {
+      exportSizeLimit: 1,
+      savedObjectsClient,
+      objects: [{ type: 'index-pattern', id: '1' }],
+      types: ['foo'],
+    };
+
+    expect(exportSavedObjectsToStream(exportOpts)).rejects.toThrowErrorMatchingInlineSnapshot(
+      `Can't specify both "types" and "objects" properties when exporting`
+    );
+  });
+
+  test('rejects when bulkGet returns an error', () => {
+    const exportOpts = {
+      exportSizeLimit: 1,
+      savedObjectsClient,
+      objects: [{ type: 'index-pattern', id: '1' }],
+    };
+
+    expect(exportSavedObjectsToStream(exportOpts)).rejects.toThrowErrorMatchingInlineSnapshot(
+      `Can't specify both "types" and "objects" properties when exporting`
+    );
+  });
 });

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
@@ -870,16 +870,4 @@ describe('getSortedObjectsForExport()', () => {
       `Can't specify both "types" and "objects" properties when exporting`
     );
   });
-
-  test('rejects when bulkGet returns an error', () => {
-    const exportOpts = {
-      exportSizeLimit: 1,
-      savedObjectsClient,
-      objects: [{ type: 'index-pattern', id: '1' }],
-    };
-
-    expect(exportSavedObjectsToStream(exportOpts)).rejects.toThrowErrorMatchingInlineSnapshot(
-      `Can't specify both "types" and "objects" properties when exporting`
-    );
-  });
 });

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
@@ -128,7 +128,6 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
-              workspaces: undefined,
             },
           ],
         ],
@@ -219,7 +218,6 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
-              workspaces: undefined,
             },
           ],
         ],
@@ -370,7 +368,6 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
-              workspaces: undefined,
             },
           ],
         ],
@@ -462,7 +459,6 @@ describe('getSortedObjectsForExport()', () => {
                 index-pattern,
                 search,
               ],
-              workspaces: undefined,
             },
           ],
         ],
@@ -670,7 +666,6 @@ describe('getSortedObjectsForExport()', () => {
             ],
             Object {
               namespace: undefined,
-              workspaces: undefined,
             },
           ],
         ],
@@ -789,7 +784,6 @@ describe('getSortedObjectsForExport()', () => {
             ],
             Object {
               namespace: undefined,
-              workspaces: undefined,
             },
           ],
           Array [

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
@@ -111,7 +111,6 @@ async function fetchObjectsToExport({
     }
     const bulkGetResult = await savedObjectsClient.bulkGet(objects, {
       namespace,
-      ...(workspaces ? { workspaces } : {}),
     });
     const erroredObjects = bulkGetResult.saved_objects.filter((obj) => !!obj.error);
     if (erroredObjects.length) {

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
@@ -109,7 +109,10 @@ async function fetchObjectsToExport({
     if (typeof search === 'string') {
       throw Boom.badRequest(`Can't specify both "search" and "objects" properties when exporting`);
     }
-    const bulkGetResult = await savedObjectsClient.bulkGet(objects, { namespace, workspaces });
+    const bulkGetResult = await savedObjectsClient.bulkGet(objects, {
+      namespace,
+      ...(workspaces ? { workspaces } : {}),
+    });
     const erroredObjects = bulkGetResult.saved_objects.filter((obj) => !!obj.error);
     if (erroredObjects.length) {
       const err = Boom.badRequest();
@@ -125,7 +128,7 @@ async function fetchObjectsToExport({
       search,
       perPage: exportSizeLimit,
       namespaces: namespace ? [namespace] : undefined,
-      workspaces,
+      ...(workspaces ? { workspaces } : {}),
     });
     if (findResponse.total > exportSizeLimit) {
       throw Boom.badRequest(`Can't export more than ${exportSizeLimit} objects`);

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.ts
@@ -60,6 +60,8 @@ export interface SavedObjectsExportOptions {
   excludeExportDetails?: boolean;
   /** optional namespace to override the namespace used by the savedObjectsClient. */
   namespace?: string;
+  /** optional workspaces to override the workspaces used by the savedObjectsClient. */
+  workspaces?: string[];
 }
 
 /**
@@ -87,6 +89,7 @@ async function fetchObjectsToExport({
   exportSizeLimit,
   savedObjectsClient,
   namespace,
+  workspaces,
 }: {
   objects?: SavedObjectsExportOptions['objects'];
   types?: string[];
@@ -94,6 +97,7 @@ async function fetchObjectsToExport({
   exportSizeLimit: number;
   savedObjectsClient: SavedObjectsClientContract;
   namespace?: string;
+  workspaces?: string[];
 }) {
   if ((types?.length ?? 0) > 0 && (objects?.length ?? 0) > 0) {
     throw Boom.badRequest(`Can't specify both "types" and "objects" properties when exporting`);
@@ -105,7 +109,7 @@ async function fetchObjectsToExport({
     if (typeof search === 'string') {
       throw Boom.badRequest(`Can't specify both "search" and "objects" properties when exporting`);
     }
-    const bulkGetResult = await savedObjectsClient.bulkGet(objects, { namespace });
+    const bulkGetResult = await savedObjectsClient.bulkGet(objects, { namespace, workspaces });
     const erroredObjects = bulkGetResult.saved_objects.filter((obj) => !!obj.error);
     if (erroredObjects.length) {
       const err = Boom.badRequest();
@@ -121,6 +125,7 @@ async function fetchObjectsToExport({
       search,
       perPage: exportSizeLimit,
       namespaces: namespace ? [namespace] : undefined,
+      workspaces,
     });
     if (findResponse.total > exportSizeLimit) {
       throw Boom.badRequest(`Can't export more than ${exportSizeLimit} objects`);
@@ -153,6 +158,7 @@ export async function exportSavedObjectsToStream({
   includeReferencesDeep = false,
   excludeExportDetails = false,
   namespace,
+  workspaces,
 }: SavedObjectsExportOptions) {
   const rootObjects = await fetchObjectsToExport({
     types,
@@ -161,6 +167,7 @@ export async function exportSavedObjectsToStream({
     savedObjectsClient,
     exportSizeLimit,
     namespace,
+    workspaces,
   });
   let exportedObjects: Array<SavedObject<unknown>> = [];
   let missingReferences: SavedObjectsExportResultDetails['missingReferences'] = [];

--- a/src/core/server/saved_objects/import/check_conflicts.ts
+++ b/src/core/server/saved_objects/import/check_conflicts.ts
@@ -44,6 +44,7 @@ interface CheckConflictsParams {
   ignoreRegularConflicts?: boolean;
   retries?: SavedObjectsImportRetry[];
   createNewCopies?: boolean;
+  workspaces?: string[];
 }
 
 const isUnresolvableConflict = (error: SavedObjectError) =>
@@ -56,6 +57,7 @@ export async function checkConflicts({
   ignoreRegularConflicts,
   retries = [],
   createNewCopies,
+  workspaces,
 }: CheckConflictsParams) {
   const filteredObjects: Array<SavedObject<{ title?: string }>> = [];
   const errors: SavedObjectsImportError[] = [];
@@ -77,6 +79,7 @@ export async function checkConflicts({
   });
   const checkConflictsResult = await savedObjectsClient.checkConflicts(objectsToCheck, {
     namespace,
+    workspaces,
   });
   const errorMap = checkConflictsResult.errors.reduce(
     (acc, { type, id, error }) => acc.set(`${type}:${id}`, error),

--- a/src/core/server/saved_objects/import/create_saved_objects.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.ts
@@ -39,6 +39,7 @@ interface CreateSavedObjectsParams<T> {
   importIdMap: Map<string, { id?: string; omitOriginId?: boolean }>;
   namespace?: string;
   overwrite?: boolean;
+  workspaces?: string[];
 }
 interface CreateSavedObjectsResult<T> {
   createdObjects: Array<CreatedObject<T>>;
@@ -56,6 +57,7 @@ export const createSavedObjects = async <T>({
   importIdMap,
   namespace,
   overwrite,
+  workspaces,
 }: CreateSavedObjectsParams<T>): Promise<CreateSavedObjectsResult<T>> => {
   // filter out any objects that resulted in errors
   const errorSet = accumulatedErrors.reduce(
@@ -103,6 +105,7 @@ export const createSavedObjects = async <T>({
     const bulkCreateResponse = await savedObjectsClient.bulkCreate(objectsToCreate, {
       namespace,
       overwrite,
+      workspaces,
     });
     expectedResults = bulkCreateResponse.saved_objects;
   }
@@ -110,7 +113,7 @@ export const createSavedObjects = async <T>({
   // remap results to reflect the object IDs that were submitted for import
   // this ensures that consumers understand the results
   const remappedResults = expectedResults.map<CreatedObject<T>>((result) => {
-    const { id } = objectIdMap.get(`${result.type}:${result.id}`)!;
+    const { id } = objectIdMap.get(`${result.type}:${result.id}`) || ({} as SavedObject<T>);
     // also, include a `destinationId` field if the object create attempt was made with a different ID
     return { ...result, id, ...(id !== result.id && { destinationId: result.id }) };
   });

--- a/src/core/server/saved_objects/import/create_saved_objects.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.ts
@@ -113,7 +113,7 @@ export const createSavedObjects = async <T>({
   // remap results to reflect the object IDs that were submitted for import
   // this ensures that consumers understand the results
   const remappedResults = expectedResults.map<CreatedObject<T>>((result) => {
-    const { id } = objectIdMap.get(`${result.type}:${result.id}`) || ({} as SavedObject<T>);
+    const { id } = objectIdMap.get(`${result.type}:${result.id}`)!;
     // also, include a `destinationId` field if the object create attempt was made with a different ID
     return { ...result, id, ...(id !== result.id && { destinationId: result.id }) };
   });

--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -42,7 +42,7 @@ import { typeRegistryMock } from '../saved_objects_type_registry.mock';
 import { importSavedObjectsFromStream } from './import_saved_objects';
 
 import { collectSavedObjects } from './collect_saved_objects';
-import { regenerateIds, regenerateIdsWithReference } from './regenerate_ids';
+import { regenerateIds } from './regenerate_ids';
 import { validateReferences } from './validate_references';
 import { checkConflicts } from './check_conflicts';
 import { checkOriginConflicts } from './check_origin_conflicts';
@@ -68,7 +68,6 @@ describe('#importSavedObjectsFromStream', () => {
       importIdMap: new Map(),
     });
     getMockFn(regenerateIds).mockReturnValue(new Map());
-    getMockFn(regenerateIdsWithReference).mockReturnValue(Promise.resolve(new Map()));
     getMockFn(validateReferences).mockResolvedValue([]);
     getMockFn(checkConflicts).mockResolvedValue({
       errors: [],
@@ -241,15 +240,6 @@ describe('#importSavedObjectsFromStream', () => {
           ]),
         });
         getMockFn(validateReferences).mockResolvedValue([errors[1]]);
-        getMockFn(regenerateIdsWithReference).mockResolvedValue(
-          Promise.resolve(
-            new Map([
-              ['foo', {}],
-              ['bar', {}],
-              ['baz', {}],
-            ])
-          )
-        );
         getMockFn(checkConflicts).mockResolvedValue({
           errors: [errors[2]],
           filteredObjects,
@@ -295,15 +285,6 @@ describe('#importSavedObjectsFromStream', () => {
           ]),
         });
         getMockFn(validateReferences).mockResolvedValue([errors[1]]);
-        getMockFn(regenerateIdsWithReference).mockResolvedValue(
-          Promise.resolve(
-            new Map([
-              ['foo', {}],
-              ['bar', {}],
-              ['baz', {}],
-            ])
-          )
-        );
         getMockFn(checkConflicts).mockResolvedValue({
           errors: [errors[2]],
           filteredObjects,
@@ -332,7 +313,6 @@ describe('#importSavedObjectsFromStream', () => {
           workspaces: options.workspaces,
         };
         expect(createSavedObjects).toHaveBeenCalledWith(createSavedObjectsParams);
-        expect(regenerateIdsWithReference).toBeCalledTimes(1);
       });
     });
 

--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -278,6 +278,62 @@ describe('#importSavedObjectsFromStream', () => {
         };
         expect(createSavedObjects).toHaveBeenCalledWith(createSavedObjectsParams);
       });
+
+      test('creates saved objects when workspaces param is provided', async () => {
+        const options = setupOptions();
+        options.workspaces = ['foo'];
+        const collectedObjects = [createObject()];
+        const filteredObjects = [createObject()];
+        const errors = [createError(), createError(), createError(), createError()];
+        getMockFn(collectSavedObjects).mockResolvedValue({
+          errors: [errors[0]],
+          collectedObjects,
+          importIdMap: new Map([
+            ['foo', {}],
+            ['bar', {}],
+            ['baz', {}],
+          ]),
+        });
+        getMockFn(validateReferences).mockResolvedValue([errors[1]]);
+        getMockFn(regenerateIdsWithReference).mockResolvedValue(
+          Promise.resolve(
+            new Map([
+              ['foo', {}],
+              ['bar', {}],
+              ['baz', {}],
+            ])
+          )
+        );
+        getMockFn(checkConflicts).mockResolvedValue({
+          errors: [errors[2]],
+          filteredObjects,
+          importIdMap: new Map([['bar', { id: 'newId1' }]]),
+          pendingOverwrites: new Set(),
+        });
+        getMockFn(checkOriginConflicts).mockResolvedValue({
+          errors: [errors[3]],
+          importIdMap: new Map([['baz', { id: 'newId2' }]]),
+          pendingOverwrites: new Set(),
+        });
+
+        await importSavedObjectsFromStream(options);
+        const importIdMap = new Map([
+          ['foo', {}],
+          ['bar', { id: 'newId1' }],
+          ['baz', { id: 'newId2' }],
+        ]);
+        const createSavedObjectsParams = {
+          objects: collectedObjects,
+          accumulatedErrors: errors,
+          savedObjectsClient,
+          importIdMap,
+          overwrite,
+          namespace,
+          workspaces: options.workspaces,
+        };
+        expect(createSavedObjects).toHaveBeenCalledWith(createSavedObjectsParams);
+        expect(regenerateIdsWithReference).toBeCalledTimes(1);
+      });
     });
 
     describe('with createNewCopies enabled', () => {

--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -42,7 +42,7 @@ import { typeRegistryMock } from '../saved_objects_type_registry.mock';
 import { importSavedObjectsFromStream } from './import_saved_objects';
 
 import { collectSavedObjects } from './collect_saved_objects';
-import { regenerateIds } from './regenerate_ids';
+import { regenerateIds, regenerateIdsWithReference } from './regenerate_ids';
 import { validateReferences } from './validate_references';
 import { checkConflicts } from './check_conflicts';
 import { checkOriginConflicts } from './check_origin_conflicts';
@@ -68,6 +68,7 @@ describe('#importSavedObjectsFromStream', () => {
       importIdMap: new Map(),
     });
     getMockFn(regenerateIds).mockReturnValue(new Map());
+    getMockFn(regenerateIdsWithReference).mockReturnValue(Promise.resolve(new Map()));
     getMockFn(validateReferences).mockResolvedValue([]);
     getMockFn(checkConflicts).mockResolvedValue({
       errors: [],
@@ -240,6 +241,15 @@ describe('#importSavedObjectsFromStream', () => {
           ]),
         });
         getMockFn(validateReferences).mockResolvedValue([errors[1]]);
+        getMockFn(regenerateIdsWithReference).mockResolvedValue(
+          Promise.resolve(
+            new Map([
+              ['foo', {}],
+              ['bar', {}],
+              ['baz', {}],
+            ])
+          )
+        );
         getMockFn(checkConflicts).mockResolvedValue({
           errors: [errors[2]],
           filteredObjects,

--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -165,7 +165,9 @@ describe('#importSavedObjectsFromStream', () => {
       expect(validateReferences).toHaveBeenCalledWith(
         collectedObjects,
         savedObjectsClient,
-        namespace
+        namespace,
+        undefined,
+        undefined
       );
     });
 

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -38,7 +38,7 @@ import { validateReferences } from './validate_references';
 import { checkOriginConflicts } from './check_origin_conflicts';
 import { createSavedObjects } from './create_saved_objects';
 import { checkConflicts } from './check_conflicts';
-import { regenerateIds, regenerateIdsWithReference } from './regenerate_ids';
+import { regenerateIds } from './regenerate_ids';
 
 /**
  * Import saved objects from given stream. See the {@link SavedObjectsImportOptions | options} for more
@@ -74,23 +74,17 @@ export async function importSavedObjectsFromStream({
   const validateReferencesResult = await validateReferences(
     collectSavedObjectsResult.collectedObjects,
     savedObjectsClient,
-    namespace
+    namespace,
+    undefined,
+    workspaces
   );
   errorAccumulator = [...errorAccumulator, ...validateReferencesResult];
 
   if (createNewCopies) {
     importIdMap = regenerateIds(collectSavedObjectsResult.collectedObjects);
   } else {
-    if (workspaces) {
-      importIdMap = await regenerateIdsWithReference({
-        savedObjects: collectSavedObjectsResult.collectedObjects,
-        savedObjectsClient,
-        workspaces,
-        objectLimit,
-        importIdMap,
-      });
-    }
     // Check single-namespace objects for conflicts in this namespace, and check multi-namespace objects for conflicts across all namespaces
+    // Check for conflicts across all workspaces
     const checkConflictsParams = {
       objects: collectSavedObjectsResult.collectedObjects,
       savedObjectsClient,

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -87,6 +87,7 @@ export async function importSavedObjectsFromStream({
       savedObjectsClient,
       namespace,
       ignoreRegularConflicts: overwrite,
+      workspaces,
     };
     const checkConflictsResult = await checkConflicts(checkConflictsParams);
     errorAccumulator = [...errorAccumulator, ...checkConflictsResult.errors];

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -54,6 +54,7 @@ export async function importSavedObjectsFromStream({
   savedObjectsClient,
   typeRegistry,
   namespace,
+  workspaces,
 }: SavedObjectsImportOptions): Promise<SavedObjectsImportResponse> {
   let errorAccumulator: SavedObjectsImportError[] = [];
   const supportedTypes = typeRegistry.getImportableAndExportableTypes().map((type) => type.name);
@@ -118,6 +119,7 @@ export async function importSavedObjectsFromStream({
     importIdMap,
     overwrite,
     namespace,
+    workspaces,
   };
   const createSavedObjectsResult = await createSavedObjects(createSavedObjectsParams);
   errorAccumulator = [...errorAccumulator, ...createSavedObjectsResult.errors];

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -38,7 +38,7 @@ import { validateReferences } from './validate_references';
 import { checkOriginConflicts } from './check_origin_conflicts';
 import { createSavedObjects } from './create_saved_objects';
 import { checkConflicts } from './check_conflicts';
-import { regenerateIds } from './regenerate_ids';
+import { regenerateIds, regenerateIdsWithReference } from './regenerate_ids';
 
 /**
  * Import saved objects from given stream. See the {@link SavedObjectsImportOptions | options} for more
@@ -81,6 +81,13 @@ export async function importSavedObjectsFromStream({
   if (createNewCopies) {
     importIdMap = regenerateIds(collectSavedObjectsResult.collectedObjects);
   } else {
+    importIdMap = await regenerateIdsWithReference({
+      savedObjects: collectSavedObjectsResult.collectedObjects,
+      savedObjectsClient,
+      workspaces,
+      objectLimit,
+      importIdMap,
+    });
     // Check single-namespace objects for conflicts in this namespace, and check multi-namespace objects for conflicts across all namespaces
     const checkConflictsParams = {
       objects: collectSavedObjectsResult.collectedObjects,
@@ -120,7 +127,7 @@ export async function importSavedObjectsFromStream({
     importIdMap,
     overwrite,
     namespace,
-    workspaces,
+    ...(workspaces ? { workspaces } : {}),
   };
   const createSavedObjectsResult = await createSavedObjects(createSavedObjectsParams);
   errorAccumulator = [...errorAccumulator, ...createSavedObjectsResult.errors];

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -81,13 +81,15 @@ export async function importSavedObjectsFromStream({
   if (createNewCopies) {
     importIdMap = regenerateIds(collectSavedObjectsResult.collectedObjects);
   } else {
-    importIdMap = await regenerateIdsWithReference({
-      savedObjects: collectSavedObjectsResult.collectedObjects,
-      savedObjectsClient,
-      workspaces,
-      objectLimit,
-      importIdMap,
-    });
+    if (workspaces) {
+      importIdMap = await regenerateIdsWithReference({
+        savedObjects: collectSavedObjectsResult.collectedObjects,
+        savedObjectsClient,
+        workspaces,
+        objectLimit,
+        importIdMap,
+      });
+    }
     // Check single-namespace objects for conflicts in this namespace, and check multi-namespace objects for conflicts across all namespaces
     const checkConflictsParams = {
       objects: collectSavedObjectsResult.collectedObjects,

--- a/src/core/server/saved_objects/import/regenerate_ids.test.ts
+++ b/src/core/server/saved_objects/import/regenerate_ids.test.ts
@@ -29,10 +29,8 @@
  */
 
 import { mockUuidv4 } from './__mocks__';
-import { regenerateIds, regenerateIdsWithReference } from './regenerate_ids';
+import { regenerateIds } from './regenerate_ids';
 import { SavedObject } from '../types';
-import { savedObjectsClientMock } from '../service/saved_objects_client.mock';
-import { SavedObjectsBulkResponse } from '../service';
 
 describe('#regenerateIds', () => {
   const objects = ([
@@ -58,73 +56,6 @@ describe('#regenerateIds', () => {
         },
         "baz:3" => Object {
           "id": "uuidv4 #3",
-          "omitOriginId": true,
-        },
-      }
-    `);
-  });
-});
-
-describe('#regenerateIdsWithReference', () => {
-  const objects = ([
-    { type: 'foo', id: '1' },
-    { type: 'bar', id: '2' },
-    { type: 'baz', id: '3' },
-  ] as any) as SavedObject[];
-
-  test('returns expected values', async () => {
-    const mockedSavedObjectsClient = savedObjectsClientMock.create();
-    mockUuidv4.mockReturnValueOnce('uuidv4 #1');
-    const result: SavedObjectsBulkResponse<unknown> = {
-      saved_objects: [
-        {
-          error: {
-            statusCode: 404,
-            error: '',
-            message: '',
-          },
-          id: '1',
-          type: 'foo',
-          attributes: {},
-          references: [],
-        },
-        {
-          id: '2',
-          type: 'bar',
-          attributes: {},
-          references: [],
-          workspaces: ['bar'],
-        },
-        {
-          id: '3',
-          type: 'baz',
-          attributes: {},
-          references: [],
-          workspaces: ['foo'],
-        },
-      ],
-    };
-    mockedSavedObjectsClient.bulkGet.mockResolvedValue(result);
-    expect(
-      await regenerateIdsWithReference({
-        savedObjects: objects,
-        savedObjectsClient: mockedSavedObjectsClient,
-        workspaces: ['bar'],
-        objectLimit: 1000,
-        importIdMap: new Map(),
-      })
-    ).toMatchInlineSnapshot(`
-      Map {
-        "foo:1" => Object {
-          "id": "1",
-          "omitOriginId": true,
-        },
-        "bar:2" => Object {
-          "id": "2",
-          "omitOriginId": false,
-        },
-        "baz:3" => Object {
-          "id": "uuidv4 #1",
           "omitOriginId": true,
         },
       }

--- a/src/core/server/saved_objects/import/regenerate_ids.ts
+++ b/src/core/server/saved_objects/import/regenerate_ids.ts
@@ -47,16 +47,11 @@ export const regenerateIds = (objects: SavedObject[]) => {
 export const regenerateIdsWithReference = async (props: {
   savedObjects: SavedObject[];
   savedObjectsClient: SavedObjectsClientContract;
-  workspaces?: string[];
+  workspaces: string[];
   objectLimit: number;
   importIdMap: Map<string, { id?: string; omitOriginId?: boolean }>;
 }): Promise<Map<string, { id?: string; omitOriginId?: boolean }>> => {
   const { savedObjects, savedObjectsClient, workspaces, importIdMap } = props;
-  if (!workspaces || !workspaces.length) {
-    return savedObjects.reduce((acc, object) => {
-      return acc.set(`${object.type}:${object.id}`, { id: object.id, omitOriginId: false });
-    }, importIdMap);
-  }
 
   const bulkGetResult = await savedObjectsClient.bulkGet(
     savedObjects.map((item) => ({ type: item.type, id: item.id }))

--- a/src/core/server/saved_objects/import/regenerate_ids.ts
+++ b/src/core/server/saved_objects/import/regenerate_ids.ts
@@ -29,8 +29,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { SavedObject, SavedObjectsClientContract } from '../types';
-import { SavedObjectsUtils } from '../service';
+import { SavedObject } from '../types';
 
 /**
  * Takes an array of saved objects and returns an importIdMap of randomly-generated new IDs.
@@ -42,36 +41,4 @@ export const regenerateIds = (objects: SavedObject[]) => {
     return acc.set(`${object.type}:${object.id}`, { id: uuidv4(), omitOriginId: true });
   }, new Map<string, { id: string; omitOriginId?: boolean }>());
   return importIdMap;
-};
-
-export const regenerateIdsWithReference = async (props: {
-  savedObjects: SavedObject[];
-  savedObjectsClient: SavedObjectsClientContract;
-  workspaces: string[];
-  objectLimit: number;
-  importIdMap: Map<string, { id?: string; omitOriginId?: boolean }>;
-}): Promise<Map<string, { id?: string; omitOriginId?: boolean }>> => {
-  const { savedObjects, savedObjectsClient, workspaces, importIdMap } = props;
-
-  const bulkGetResult = await savedObjectsClient.bulkGet(
-    savedObjects.map((item) => ({ type: item.type, id: item.id }))
-  );
-
-  return bulkGetResult.saved_objects.reduce((acc, object) => {
-    if (object.error?.statusCode === 404) {
-      acc.set(`${object.type}:${object.id}`, { id: object.id, omitOriginId: true });
-      return acc;
-    }
-
-    const filteredWorkspaces = SavedObjectsUtils.filterWorkspacesAccordingToBaseWorkspaces(
-      workspaces,
-      object.workspaces
-    );
-    if (filteredWorkspaces.length) {
-      acc.set(`${object.type}:${object.id}`, { id: uuidv4(), omitOriginId: true });
-    } else {
-      acc.set(`${object.type}:${object.id}`, { id: object.id, omitOriginId: false });
-    }
-    return acc;
-  }, importIdMap);
 };

--- a/src/core/server/saved_objects/import/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.ts
@@ -59,6 +59,7 @@ export async function resolveSavedObjectsImportErrors({
   typeRegistry,
   namespace,
   createNewCopies,
+  workspaces,
 }: SavedObjectsResolveImportErrorsOptions): Promise<SavedObjectsImportResponse> {
   // throw a BadRequest error if we see invalid retries
   validateRetries(retries);
@@ -157,6 +158,7 @@ export async function resolveSavedObjectsImportErrors({
       importIdMap,
       namespace,
       overwrite,
+      workspaces,
     };
     const { createdObjects, errors: bulkCreateErrors } = await createSavedObjects(
       createSavedObjectsParams

--- a/src/core/server/saved_objects/import/types.ts
+++ b/src/core/server/saved_objects/import/types.ts
@@ -187,6 +187,8 @@ export interface SavedObjectsImportOptions {
   namespace?: string;
   /** If true, will create new copies of import objects, each with a random `id` and undefined `originId`. */
   createNewCopies: boolean;
+  /** if specified, will import in given workspaces, else will import as global object */
+  workspaces?: string[];
 }
 
 /**
@@ -208,6 +210,8 @@ export interface SavedObjectsResolveImportErrorsOptions {
   namespace?: string;
   /** If true, will create new copies of import objects, each with a random `id` and undefined `originId`. */
   createNewCopies: boolean;
+  /** if specified, will import in given workspaces, else will import as global object */
+  workspaces?: string[];
 }
 
 export type CreatedObject<T> = SavedObject<T> & { destinationId?: string };

--- a/src/core/server/saved_objects/import/validate_references.test.ts
+++ b/src/core/server/saved_objects/import/validate_references.test.ts
@@ -608,8 +608,6 @@ describe('validateReferences()', () => {
         {
           type: 'index-pattern',
           id: '3',
-          error: SavedObjectsErrorHelpers.createGenericNotFoundError('index-pattern', '3').output
-            .payload,
           attributes: {},
           references: [],
           workspaces: ['foo'],
@@ -617,8 +615,6 @@ describe('validateReferences()', () => {
         {
           type: 'index-pattern',
           id: '5',
-          error: SavedObjectsErrorHelpers.createGenericNotFoundError('index-pattern', '5').output
-            .payload,
           attributes: {},
           references: [],
           workspaces: ['bar'],

--- a/src/core/server/saved_objects/import/validate_references.test.ts
+++ b/src/core/server/saved_objects/import/validate_references.test.ts
@@ -136,7 +136,6 @@ describe('getNonExistingReferenceAsKeys()', () => {
               Object {
                 fields: Array [
                   id,
-                  workspaces,
                 ],
                 id: 1,
                 type: index-pattern,
@@ -231,7 +230,6 @@ describe('getNonExistingReferenceAsKeys()', () => {
               Object {
                 fields: Array [
                   id,
-                  workspaces,
                 ],
                 id: 1,
                 type: index-pattern,
@@ -239,7 +237,6 @@ describe('getNonExistingReferenceAsKeys()', () => {
               Object {
                 fields: Array [
                   id,
-                  workspaces,
                 ],
                 id: 3,
                 type: search,
@@ -422,7 +419,6 @@ describe('validateReferences()', () => {
               Object {
                 fields: Array [
                   id,
-                  workspaces,
                 ],
                 id: 3,
                 type: index-pattern,
@@ -430,7 +426,6 @@ describe('validateReferences()', () => {
               Object {
                 fields: Array [
                   id,
-                  workspaces,
                 ],
                 id: 5,
                 type: index-pattern,
@@ -438,7 +433,6 @@ describe('validateReferences()', () => {
               Object {
                 fields: Array [
                   id,
-                  workspaces,
                 ],
                 id: 6,
                 type: index-pattern,
@@ -446,7 +440,6 @@ describe('validateReferences()', () => {
               Object {
                 fields: Array [
                   id,
-                  workspaces,
                 ],
                 id: 7,
                 type: search,
@@ -454,7 +447,6 @@ describe('validateReferences()', () => {
               Object {
                 fields: Array [
                   id,
-                  workspaces,
                 ],
                 id: 8,
                 type: search,

--- a/src/core/server/saved_objects/import/validate_references.ts
+++ b/src/core/server/saved_objects/import/validate_references.ts
@@ -74,10 +74,15 @@ export async function getNonExistingReferenceAsKeys(
     return [];
   }
 
+  const fields = ['id'];
+  if (workspaces?.length) {
+    fields.push('workspaces');
+  }
+
   // Fetch references to see if they exist
   const bulkGetOpts = Array.from(collector.values()).map((obj) => ({
     ...obj,
-    fields: ['id', 'workspaces'],
+    fields,
   }));
   const bulkGetResponse = await savedObjectsClient.bulkGet(bulkGetOpts, { namespace });
 

--- a/src/core/server/saved_objects/import/validate_references.ts
+++ b/src/core/server/saved_objects/import/validate_references.ts
@@ -31,6 +31,7 @@
 import Boom from '@hapi/boom';
 import { SavedObject, SavedObjectsClientContract } from '../types';
 import { SavedObjectsImportError, SavedObjectsImportRetry } from './types';
+import { SavedObjectsUtils } from '../service';
 
 const REF_TYPES_TO_VLIDATE = ['index-pattern', 'search'];
 
@@ -48,7 +49,8 @@ export async function getNonExistingReferenceAsKeys(
   savedObjects: SavedObject[],
   savedObjectsClient: SavedObjectsClientContract,
   namespace?: string,
-  retries?: SavedObjectsImportRetry[]
+  retries?: SavedObjectsImportRetry[],
+  workspaces?: string[]
 ) {
   const objectsToSkip = getObjectsToSkip(retries);
   const collector = new Map();
@@ -73,7 +75,10 @@ export async function getNonExistingReferenceAsKeys(
   }
 
   // Fetch references to see if they exist
-  const bulkGetOpts = Array.from(collector.values()).map((obj) => ({ ...obj, fields: ['id'] }));
+  const bulkGetOpts = Array.from(collector.values()).map((obj) => ({
+    ...obj,
+    fields: ['id', 'workspaces'],
+  }));
   const bulkGetResponse = await savedObjectsClient.bulkGet(bulkGetOpts, { namespace });
 
   // Error handling
@@ -93,6 +98,20 @@ export async function getNonExistingReferenceAsKeys(
     if (savedObject.error) {
       continue;
     }
+    /**
+     * If original workspaces have conflict with target workspace
+     * make it as NonExistingReference
+     */
+    if (workspaces) {
+      if (
+        SavedObjectsUtils.filterWorkspacesAccordingToSourceWorkspaces(
+          workspaces,
+          savedObject.workspaces
+        ).length
+      ) {
+        continue;
+      }
+    }
     collector.delete(`${savedObject.type}:${savedObject.id}`);
   }
 
@@ -103,7 +122,8 @@ export async function validateReferences(
   savedObjects: Array<SavedObject<{ title?: string }>>,
   savedObjectsClient: SavedObjectsClientContract,
   namespace?: string,
-  retries?: SavedObjectsImportRetry[]
+  retries?: SavedObjectsImportRetry[],
+  workspaces?: string[]
 ) {
   const objectsToSkip = getObjectsToSkip(retries);
   const errorMap: { [key: string]: SavedObjectsImportError } = {};
@@ -111,7 +131,8 @@ export async function validateReferences(
     savedObjects,
     savedObjectsClient,
     namespace,
-    retries
+    retries,
+    workspaces
   );
 
   // Filter out objects with missing references, add to error object

--- a/src/core/server/saved_objects/migrations/core/__snapshots__/build_active_mappings.test.ts.snap
+++ b/src/core/server/saved_objects/migrations/core/__snapshots__/build_active_mappings.test.ts.snap
@@ -13,6 +13,7 @@ Object {
       "references": "7997cf5a56cc02bdc9c93361bde732b0",
       "type": "2f4316de49999235636386fe51dc06c1",
       "updated_at": "00da57df13e94e9d98437d13ace4bfe0",
+      "workspaces": "2f4316de49999235636386fe51dc06c1",
     },
   },
   "dynamic": "strict",
@@ -56,6 +57,9 @@ Object {
     "updated_at": Object {
       "type": "date",
     },
+    "workspaces": Object {
+      "type": "keyword",
+    },
   },
 }
 `;
@@ -74,6 +78,7 @@ Object {
       "thirdType": "510f1f0adb69830cf8a1c5ce2923ed82",
       "type": "2f4316de49999235636386fe51dc06c1",
       "updated_at": "00da57df13e94e9d98437d13ace4bfe0",
+      "workspaces": "2f4316de49999235636386fe51dc06c1",
     },
   },
   "dynamic": "strict",
@@ -133,6 +138,9 @@ Object {
     },
     "updated_at": Object {
       "type": "date",
+    },
+    "workspaces": Object {
+      "type": "keyword",
     },
   },
 }

--- a/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
+++ b/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
@@ -175,6 +175,9 @@ function defaultMapping(): IndexMapping {
           },
         },
       },
+      workspaces: {
+        type: 'keyword',
+      },
     },
   };
 }

--- a/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
+++ b/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
@@ -82,6 +82,7 @@ describe('IndexMigrator', () => {
               references: '7997cf5a56cc02bdc9c93361bde732b0',
               type: '2f4316de49999235636386fe51dc06c1',
               updated_at: '00da57df13e94e9d98437d13ace4bfe0',
+              workspaces: '2f4316de49999235636386fe51dc06c1',
             },
           },
           properties: {
@@ -92,6 +93,9 @@ describe('IndexMigrator', () => {
             originId: { type: 'keyword' },
             type: { type: 'keyword' },
             updated_at: { type: 'date' },
+            workspaces: {
+              type: 'keyword',
+            },
             references: {
               type: 'nested',
               properties: {
@@ -199,6 +203,7 @@ describe('IndexMigrator', () => {
               references: '7997cf5a56cc02bdc9c93361bde732b0',
               type: '2f4316de49999235636386fe51dc06c1',
               updated_at: '00da57df13e94e9d98437d13ace4bfe0',
+              workspaces: '2f4316de49999235636386fe51dc06c1',
             },
           },
           properties: {
@@ -210,6 +215,9 @@ describe('IndexMigrator', () => {
             originId: { type: 'keyword' },
             type: { type: 'keyword' },
             updated_at: { type: 'date' },
+            workspaces: {
+              type: 'keyword',
+            },
             references: {
               type: 'nested',
               properties: {
@@ -260,6 +268,7 @@ describe('IndexMigrator', () => {
               references: '7997cf5a56cc02bdc9c93361bde732b0',
               type: '2f4316de49999235636386fe51dc06c1',
               updated_at: '00da57df13e94e9d98437d13ace4bfe0',
+              workspaces: '2f4316de49999235636386fe51dc06c1',
             },
           },
           properties: {
@@ -271,6 +280,9 @@ describe('IndexMigrator', () => {
             originId: { type: 'keyword' },
             type: { type: 'keyword' },
             updated_at: { type: 'date' },
+            workspaces: {
+              type: 'keyword',
+            },
             references: {
               type: 'nested',
               properties: {

--- a/src/core/server/saved_objects/migrations/opensearch_dashboards/__snapshots__/opensearch_dashboards_migrator.test.ts.snap
+++ b/src/core/server/saved_objects/migrations/opensearch_dashboards/__snapshots__/opensearch_dashboards_migrator.test.ts.snap
@@ -13,6 +13,7 @@ Object {
       "references": "7997cf5a56cc02bdc9c93361bde732b0",
       "type": "2f4316de49999235636386fe51dc06c1",
       "updated_at": "00da57df13e94e9d98437d13ace4bfe0",
+      "workspaces": "2f4316de49999235636386fe51dc06c1",
     },
   },
   "dynamic": "strict",
@@ -63,6 +64,9 @@ Object {
     },
     "updated_at": Object {
       "type": "date",
+    },
+    "workspaces": Object {
+      "type": "keyword",
     },
   },
 }

--- a/src/core/server/saved_objects/routes/bulk_create.ts
+++ b/src/core/server/saved_objects/routes/bulk_create.ts
@@ -38,6 +38,9 @@ export const registerBulkCreateRoute = (router: IRouter) => {
       validate: {
         query: schema.object({
           overwrite: schema.boolean({ defaultValue: false }),
+          workspaces: schema.maybe(
+            schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
+          ),
         }),
         body: schema.arrayOf(
           schema.object({
@@ -62,7 +65,14 @@ export const registerBulkCreateRoute = (router: IRouter) => {
     },
     router.handleLegacyErrors(async (context, req, res) => {
       const { overwrite } = req.query;
-      const result = await context.core.savedObjects.client.bulkCreate(req.body, { overwrite });
+      let workspaces = req.query.workspaces;
+      if (typeof workspaces === 'string') {
+        workspaces = [workspaces];
+      }
+      const result = await context.core.savedObjects.client.bulkCreate(req.body, {
+        overwrite,
+        workspaces,
+      });
       return res.ok({ body: result });
     })
   );

--- a/src/core/server/saved_objects/routes/create.ts
+++ b/src/core/server/saved_objects/routes/create.ts
@@ -56,15 +56,23 @@ export const registerCreateRoute = (router: IRouter) => {
             )
           ),
           initialNamespaces: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
+          workspaces: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
         }),
       },
     },
     router.handleLegacyErrors(async (context, req, res) => {
       const { type, id } = req.params;
       const { overwrite } = req.query;
-      const { attributes, migrationVersion, references, initialNamespaces } = req.body;
+      const { attributes, migrationVersion, references, initialNamespaces, workspaces } = req.body;
 
-      const options = { id, overwrite, migrationVersion, references, initialNamespaces };
+      const options = {
+        id,
+        overwrite,
+        migrationVersion,
+        references,
+        initialNamespaces,
+        workspaces,
+      };
       const result = await context.core.savedObjects.client.create(type, attributes, options);
       return res.ok({ body: result });
     })

--- a/src/core/server/saved_objects/routes/export.ts
+++ b/src/core/server/saved_objects/routes/export.ts
@@ -57,12 +57,20 @@ export const registerExportRoute = (router: IRouter, config: SavedObjectConfig) 
           search: schema.maybe(schema.string()),
           includeReferencesDeep: schema.boolean({ defaultValue: false }),
           excludeExportDetails: schema.boolean({ defaultValue: false }),
+          workspaces: schema.maybe(schema.arrayOf(schema.string())),
         }),
       },
     },
     router.handleLegacyErrors(async (context, req, res) => {
       const savedObjectsClient = context.core.savedObjects.client;
-      const { type, objects, search, excludeExportDetails, includeReferencesDeep } = req.body;
+      const {
+        type,
+        objects,
+        search,
+        excludeExportDetails,
+        includeReferencesDeep,
+        workspaces,
+      } = req.body;
       const types = typeof type === 'string' ? [type] : type;
 
       // need to access the registry for type validation, can't use the schema for this
@@ -98,6 +106,7 @@ export const registerExportRoute = (router: IRouter, config: SavedObjectConfig) 
         exportSizeLimit: maxImportExportSize,
         includeReferencesDeep,
         excludeExportDetails,
+        workspaces,
       });
 
       const docsToExport: string[] = await createPromiseFromStreams([

--- a/src/core/server/saved_objects/routes/find.ts
+++ b/src/core/server/saved_objects/routes/find.ts
@@ -59,6 +59,9 @@ export const registerFindRoute = (router: IRouter) => {
           namespaces: schema.maybe(
             schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
           ),
+          workspaces: schema.maybe(
+            schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
+          ),
         }),
       },
     },
@@ -67,6 +70,10 @@ export const registerFindRoute = (router: IRouter) => {
 
       const namespaces =
         typeof req.query.namespaces === 'string' ? [req.query.namespaces] : req.query.namespaces;
+      let workspaces = req.query.workspaces;
+      if (typeof workspaces === 'string') {
+        workspaces = [workspaces];
+      }
 
       const result = await context.core.savedObjects.client.find({
         perPage: query.per_page,
@@ -81,6 +88,7 @@ export const registerFindRoute = (router: IRouter) => {
         fields: typeof query.fields === 'string' ? [query.fields] : query.fields,
         filter: query.filter,
         namespaces,
+        workspaces,
       });
 
       return res.ok({ body: result });

--- a/src/core/server/saved_objects/routes/import.ts
+++ b/src/core/server/saved_objects/routes/import.ts
@@ -60,6 +60,9 @@ export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) 
           {
             overwrite: schema.boolean({ defaultValue: false }),
             createNewCopies: schema.boolean({ defaultValue: false }),
+            workspaces: schema.maybe(
+              schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
+            ),
           },
           {
             validate: (object) => {
@@ -91,6 +94,11 @@ export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) 
         });
       }
 
+      let workspaces = req.query.workspaces;
+      if (typeof workspaces === 'string') {
+        workspaces = [workspaces];
+      }
+
       const result = await importSavedObjectsFromStream({
         savedObjectsClient: context.core.savedObjects.client,
         typeRegistry: context.core.savedObjects.typeRegistry,
@@ -98,6 +106,7 @@ export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) 
         objectLimit: maxImportExportSize,
         overwrite,
         createNewCopies,
+        workspaces,
       });
 
       return res.ok({ body: result });

--- a/src/core/server/saved_objects/routes/integration_tests/find.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/find.test.ts
@@ -288,4 +288,38 @@ describe('GET /api/saved_objects/_find', () => {
       defaultSearchOperator: 'OR',
     });
   });
+
+  it('accepts the query parameter workspaces as a string', async () => {
+    await supertest(httpSetup.server.listener)
+      .get('/api/saved_objects/_find?type=index-pattern&workspaces=foo')
+      .expect(200);
+
+    expect(savedObjectsClient.find).toHaveBeenCalledTimes(1);
+
+    const options = savedObjectsClient.find.mock.calls[0][0];
+    expect(options).toEqual({
+      defaultSearchOperator: 'OR',
+      perPage: 20,
+      page: 1,
+      type: ['index-pattern'],
+      workspaces: ['foo'],
+    });
+  });
+
+  it('accepts the query parameter workspaces as an array', async () => {
+    await supertest(httpSetup.server.listener)
+      .get('/api/saved_objects/_find?type=index-pattern&workspaces=default&workspaces=foo')
+      .expect(200);
+
+    expect(savedObjectsClient.find).toHaveBeenCalledTimes(1);
+
+    const options = savedObjectsClient.find.mock.calls[0][0];
+    expect(options).toEqual({
+      perPage: 20,
+      page: 1,
+      type: ['index-pattern'],
+      workspaces: ['default', 'foo'],
+      defaultSearchOperator: 'OR',
+    });
+  });
 });

--- a/src/core/server/saved_objects/routes/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/routes/resolve_import_errors.ts
@@ -58,6 +58,9 @@ export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedO
       validate: {
         query: schema.object({
           createNewCopies: schema.boolean({ defaultValue: false }),
+          workspaces: schema.maybe(
+            schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
+          ),
         }),
         body: schema.object({
           file: schema.stream(),
@@ -98,6 +101,11 @@ export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedO
         });
       }
 
+      let workspaces = req.query.workspaces;
+      if (typeof workspaces === 'string') {
+        workspaces = [workspaces];
+      }
+
       const result = await resolveSavedObjectsImportErrors({
         typeRegistry: context.core.savedObjects.typeRegistry,
         savedObjectsClient: context.core.savedObjects.client,
@@ -105,6 +113,7 @@ export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedO
         retries: req.body.retries,
         objectLimit: maxImportExportSize,
         createNewCopies: req.query.createNewCopies,
+        workspaces,
       });
 
       return res.ok({ body: result });

--- a/src/core/server/saved_objects/serialization/serializer.ts
+++ b/src/core/server/saved_objects/serialization/serializer.ts
@@ -73,7 +73,7 @@ export class SavedObjectsSerializer {
    */
   public rawToSavedObject(doc: SavedObjectsRawDoc): SavedObjectSanitizedDoc {
     const { _id, _source, _seq_no, _primary_term } = doc;
-    const { type, namespace, namespaces, originId } = _source;
+    const { type, namespace, namespaces, originId, workspaces } = _source;
 
     const version =
       _seq_no != null || _primary_term != null
@@ -91,6 +91,7 @@ export class SavedObjectsSerializer {
       ...(_source.migrationVersion && { migrationVersion: _source.migrationVersion }),
       ...(_source.updated_at && { updated_at: _source.updated_at }),
       ...(version && { version }),
+      ...(workspaces && { workspaces }),
     };
   }
 
@@ -112,6 +113,7 @@ export class SavedObjectsSerializer {
       updated_at,
       version,
       references,
+      workspaces,
     } = savedObj;
     const source = {
       [type]: attributes,
@@ -122,6 +124,7 @@ export class SavedObjectsSerializer {
       ...(originId && { originId }),
       ...(migrationVersion && { migrationVersion }),
       ...(updated_at && { updated_at }),
+      ...(workspaces && { workspaces }),
     };
 
     return {

--- a/src/core/server/saved_objects/serialization/types.ts
+++ b/src/core/server/saved_objects/serialization/types.ts
@@ -52,6 +52,7 @@ export interface SavedObjectsRawDocSource {
   updated_at?: string;
   references?: SavedObjectReference[];
   originId?: string;
+  workspaces?: string[];
 
   [typeMapping: string]: any;
 }
@@ -69,6 +70,7 @@ interface SavedObjectDoc<T = unknown> {
   version?: string;
   updated_at?: string;
   originId?: string;
+  workspaces?: string[];
 }
 
 interface Referencable {

--- a/src/core/server/saved_objects/service/lib/integration_tests/repository.test.ts
+++ b/src/core/server/saved_objects/service/lib/integration_tests/repository.test.ts
@@ -1,0 +1,303 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { SavedObject } from 'src/core/types';
+import { isEqual } from 'lodash';
+import * as osdTestServer from '../../../../../test_helpers/osd_server';
+import { Readable } from 'stream';
+
+const dashboard: Omit<SavedObject, 'id'> = {
+  type: 'dashboard',
+  attributes: {},
+  references: [],
+};
+
+describe('repository integration test', () => {
+  let root: ReturnType<typeof osdTestServer.createRoot>;
+  let opensearchServer: osdTestServer.TestOpenSearchUtils;
+  beforeAll(async () => {
+    const { startOpenSearch, startOpenSearchDashboards } = osdTestServer.createTestServers({
+      adjustTimeout: (t: number) => jest.setTimeout(t),
+    });
+    opensearchServer = await startOpenSearch();
+    const startOSDResp = await startOpenSearchDashboards();
+    root = startOSDResp.root;
+  }, 30000);
+  afterAll(async () => {
+    await root.shutdown();
+    await opensearchServer.stop();
+  });
+
+  const deleteItem = async (object: Pick<SavedObject, 'id' | 'type'>) => {
+    await osdTestServer.request
+      .delete(root, `/api/saved_objects/${object.type}/${object.id}`)
+      .expect(200);
+  };
+
+  const getItem = async (object: Pick<SavedObject, 'id' | 'type'>) => {
+    return await osdTestServer.request
+      .get(root, `/api/saved_objects/${object.type}/${object.id}`)
+      .expect(200);
+  };
+
+  describe('workspace related CRUD', () => {
+    it('create', async () => {
+      const createResult = await osdTestServer.request
+        .post(root, `/api/saved_objects/${dashboard.type}`)
+        .send({
+          attributes: dashboard.attributes,
+          workspaces: ['foo'],
+        })
+        .expect(200);
+
+      expect(createResult.body.workspaces).toEqual(['foo']);
+      await deleteItem({
+        type: dashboard.type,
+        id: createResult.body.id,
+      });
+    });
+
+    it('create-with-override', async () => {
+      const createResult = await osdTestServer.request
+        .post(root, `/api/saved_objects/${dashboard.type}`)
+        .send({
+          attributes: dashboard.attributes,
+          workspaces: ['foo'],
+        })
+        .expect(200);
+
+      /**
+       * Override without workspace, in this case workspaces field should be retained.
+       */
+      const correctOverride = await osdTestServer.request
+        .post(root, `/api/saved_objects/${dashboard.type}/${createResult.body.id}?overwrite=true`)
+        .send({
+          attributes: {
+            title: 'foo',
+          },
+        })
+        .expect(200);
+
+      expect(correctOverride.body.workspaces).toEqual(['foo']);
+      expect(correctOverride.body.attributes.title).toEqual('foo');
+
+      await osdTestServer.request
+        .post(root, `/api/saved_objects/${dashboard.type}/${createResult.body.id}?overwrite=true`)
+        .send({
+          attributes: dashboard.attributes,
+          workspaces: ['bar'],
+        })
+        .expect(409);
+
+      await deleteItem({
+        type: dashboard.type,
+        id: createResult.body.id,
+      });
+    });
+
+    it('bulk create', async () => {
+      const createResultFoo = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=foo`)
+        .send([
+          {
+            ...dashboard,
+            id: 'foo',
+          },
+        ])
+        .expect(200);
+
+      const createResultBar = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=bar`)
+        .send([
+          {
+            ...dashboard,
+            id: 'bar',
+          },
+        ])
+        .expect(200);
+
+      expect((createResultFoo.body.saved_objects as any[]).some((item) => item.error)).toEqual(
+        false
+      );
+      expect(
+        (createResultFoo.body.saved_objects as any[]).every((item) =>
+          isEqual(item.workspaces, ['foo'])
+        )
+      ).toEqual(true);
+      expect((createResultBar.body.saved_objects as any[]).some((item) => item.error)).toEqual(
+        false
+      );
+      expect(
+        (createResultBar.body.saved_objects as any[]).every((item) =>
+          isEqual(item.workspaces, ['bar'])
+        )
+      ).toEqual(true);
+      await Promise.all(
+        [...createResultFoo.body.saved_objects, ...createResultBar.body.saved_objects].map((item) =>
+          deleteItem({
+            type: item.type,
+            id: item.id,
+          })
+        )
+      );
+    });
+
+    it('bulk create with conflict', async () => {
+      const createResultFoo = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=foo`)
+        .send([
+          {
+            ...dashboard,
+            id: 'foo',
+          },
+        ])
+        .expect(200);
+
+      const createResultBar = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=bar`)
+        .send([
+          {
+            ...dashboard,
+            id: 'bar',
+          },
+        ])
+        .expect(200);
+
+      /**
+       * overwrite without workspaces
+       */
+      const overwriteWithoutWorkspacesResult = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?overwrite=true`)
+        .send([
+          {
+            ...dashboard,
+            id: 'bar',
+          },
+          {
+            ...dashboard,
+            id: 'foo',
+          },
+        ])
+        .expect(200);
+
+      const getFooResult = await getItem({
+        type: dashboard.type,
+        id: 'foo',
+      });
+
+      const getBarResult = await getItem({
+        type: dashboard.type,
+        id: 'bar',
+      });
+
+      expect(getFooResult.body.workspaces).toEqual(['foo']);
+      expect(getBarResult.body.workspaces).toEqual(['bar']);
+      expect(
+        (overwriteWithoutWorkspacesResult.body.saved_objects as any[]).some((item) => item.error)
+      ).toEqual(false);
+
+      /**
+       * overwrite with workspaces
+       */
+      const overwriteWithWorkspacesResult = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?overwrite=true&workspaces=foo`)
+        .send([
+          {
+            ...dashboard,
+            id: 'bar',
+          },
+          {
+            ...dashboard,
+            id: 'foo',
+            attributes: {
+              title: 'foo',
+            },
+          },
+        ])
+        .expect(200);
+
+      expect(overwriteWithWorkspacesResult.body.saved_objects[0].error.statusCode).toEqual(409);
+      expect(overwriteWithWorkspacesResult.body.saved_objects[1].attributes.title).toEqual('foo');
+      expect(overwriteWithWorkspacesResult.body.saved_objects[1].workspaces).toEqual(['foo']);
+
+      await Promise.all(
+        [...createResultFoo.body.saved_objects, ...createResultBar.body.saved_objects].map((item) =>
+          deleteItem({
+            type: item.type,
+            id: item.id,
+          })
+        )
+      );
+    });
+
+    it('checkConflicts when importing ndjson', async () => {
+      const createResultFoo = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=foo`)
+        .send([
+          {
+            ...dashboard,
+            id: 'foo',
+          },
+        ])
+        .expect(200);
+
+      const createResultBar = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create?workspaces=bar`)
+        .send([
+          {
+            ...dashboard,
+            id: 'bar',
+          },
+        ])
+        .expect(200);
+
+      const getResultFoo = await getItem({
+        type: dashboard.type,
+        id: 'foo',
+      });
+      const getResultBar = await getItem({
+        type: dashboard.type,
+        id: 'bar',
+      });
+
+      const readableStream = new Readable();
+      readableStream.push(
+        `Content-Disposition: form-data; name="file"; filename="tmp.ndjson"\r\n\r\n`
+      );
+      readableStream.push(
+        [JSON.stringify(getResultFoo.body), JSON.stringify(getResultBar.body)].join('\n')
+      );
+      readableStream.push(null);
+
+      /**
+       * import with workspaces when conflicts
+       */
+      const importWithWorkspacesResult = await osdTestServer.request
+        .post(root, `/api/saved_objects/_import?workspaces=foo&overwrite=false`)
+        .attach(
+          'file',
+          Buffer.from(
+            [JSON.stringify(getResultFoo.body), JSON.stringify(getResultBar.body)].join('\n'),
+            'utf-8'
+          ),
+          'tmp.ndjson'
+        )
+        .expect(200);
+
+      expect(importWithWorkspacesResult.body.success).toEqual(false);
+      expect(importWithWorkspacesResult.body.errors.length).toEqual(1);
+      expect(importWithWorkspacesResult.body.errors[0].id).toEqual('foo');
+      expect(importWithWorkspacesResult.body.errors[0].error.type).toEqual('conflict');
+
+      await Promise.all(
+        [...createResultFoo.body.saved_objects, ...createResultBar.body.saved_objects].map((item) =>
+          deleteItem({
+            type: item.type,
+            id: item.id,
+          })
+        )
+      );
+    });
+  });
+});

--- a/src/core/server/saved_objects/service/lib/repository.test.js
+++ b/src/core/server/saved_objects/service/lib/repository.test.js
@@ -1846,9 +1846,17 @@ describe('SavedObjectsRepository', () => {
 
     const createSuccess = async (type, attributes, options) => {
       const result = await savedObjectsRepository.create(type, attributes, options);
-      expect(client.get).toHaveBeenCalledTimes(
-        registry.isMultiNamespace(type) && options.overwrite ? 1 : 0
-      );
+      let count = 0;
+      if (options?.overwrite && options?.id) {
+        /**
+         * workspace will call extra one to get latest status of current object
+         */
+        count++;
+      }
+      if (registry.isMultiNamespace(type) && options.overwrite) {
+        count++;
+      }
+      expect(client.get).toHaveBeenCalledTimes(count);
       return result;
     };
 

--- a/src/core/server/saved_objects/service/lib/repository.test.js
+++ b/src/core/server/saved_objects/service/lib/repository.test.js
@@ -1259,6 +1259,12 @@ describe('SavedObjectsRepository', () => {
         migrationVersion: doc._source.migrationVersion,
       });
 
+      it(`returns early for undefined objects argument`, async () => {
+        const result = await savedObjectsRepository.bulkGet();
+        expect(result).toEqual({ saved_objects: [] });
+        expect(client.mget).not.toHaveBeenCalled();
+      });
+
       it(`returns early for empty objects argument`, async () => {
         const result = await bulkGet([]);
         expect(result).toEqual({ saved_objects: [] });

--- a/src/core/server/saved_objects/service/lib/repository.test.js
+++ b/src/core/server/saved_objects/service/lib/repository.test.js
@@ -27,7 +27,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { omit } from 'lodash';
 import { SavedObjectsRepository } from './repository';
 import * as getSearchDslNS from './search_dsl/search_dsl';
 import { SavedObjectsErrorHelpers } from './errors';
@@ -53,6 +52,12 @@ const createGenericNotFoundError = (...args) =>
   SavedObjectsErrorHelpers.createGenericNotFoundError(...args).output.payload;
 const createUnsupportedTypeError = (...args) =>
   SavedObjectsErrorHelpers.createUnsupportedTypeError(...args).output.payload;
+
+const omitWorkspace = (object) => {
+  const newObject = JSON.parse(JSON.stringify(object));
+  delete newObject.workspaces;
+  return newObject;
+};
 
 describe('SavedObjectsRepository', () => {
   let client;
@@ -1922,9 +1927,9 @@ describe('SavedObjectsRepository', () => {
         expect(client.mget).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
           errors: [
-            { ...omit(obj8, 'workspaces'), error: createConflictError(obj8.type, obj8.id) },
+            { ...omitWorkspace(obj8), error: createConflictError(obj8.type, obj8.id) },
             {
-              ...omit(obj9, 'workspaces'),
+              ...omitWorkspace(obj9),
               error: {
                 ...createConflictError(obj9.type, obj9.id),
                 metadata: {

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -383,7 +383,7 @@ export class SavedObjectsRepository {
       /**
        * It requires a check when overwriting objects to target workspaces
        */
-      const requiresWorkspaceCheck = !!(object.id && overwrite && options.workspaces);
+      const requiresWorkspaceCheck = !!(object.id && options.workspaces);
 
       if (object.id == null) object.id = uuid.v1();
 

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -285,8 +285,14 @@ export class SavedObjectsRepository {
     if (id && overwrite && workspaces) {
       try {
         const currentItem = await this.get(type, id);
-        if (currentItem && currentItem.workspaces) {
-          // do not overwrite workspaces
+        if (
+          SavedObjectsUtils.filterWorkspacesAccordingToBaseWorkspaces(
+            workspaces,
+            currentItem.workspaces
+          ).length
+        ) {
+          throw SavedObjectsErrorHelpers.createConflictError(type, id);
+        } else {
           savedObjectWorkspaces = currentItem.workspaces;
         }
       } catch (e) {
@@ -419,8 +425,6 @@ export class SavedObjectsRepository {
         method,
       } = expectedBulkGetResult.value;
       let savedObjectWorkspaces: string[] | undefined;
-      let finalMethod = method;
-      let finalObjectId = object.id;
       if (opensearchRequestIndex !== undefined) {
         const indexFound = bulkGetResponse?.statusCode !== 404;
         const actualResult = indexFound
@@ -467,19 +471,9 @@ export class SavedObjectsRepository {
         versionProperties = getExpectedVersionProperties(version);
       }
 
-      if (expectedBulkGetResult.value.method === 'create') {
-        savedObjectWorkspaces = options.workspaces;
-      } else {
-        const changeToCreate = () => {
-          finalMethod = 'create';
-          finalObjectId = object.id;
-          savedObjectWorkspaces = options.workspaces;
-          versionProperties = {};
-        };
-        /**
-         * When overwrite, need to check if the object is workspace-specific
-         * if so, copy object to target workspace instead of refering it.
-         */
+      savedObjectWorkspaces = options.workspaces;
+
+      if (expectedBulkGetResult.value.method !== 'create') {
         const rawId = this._serializer.generateRawId(namespace, object.type, object.id);
         const findObject =
           bulkGetResponse?.statusCode !== 404
@@ -493,31 +487,31 @@ export class SavedObjectsRepository {
             options.workspaces,
             transformedObject.workspaces
           );
-          /**
-           * We need to create a new object when the object
-           * is about to import into workspaces it is not belong to
-           */
           if (filteredWorkspaces.length) {
-            /**
-             * Create a new object but only belong to the set of (target workspaces - original workspace)
-             */
-            changeToCreate();
-            finalObjectId = uuid.v1();
-            savedObjectWorkspaces = filteredWorkspaces;
+            const { id, type } = object;
+            return {
+              tag: 'Left' as 'Left',
+              error: {
+                id,
+                type,
+                error: {
+                  ...errorContent(SavedObjectsErrorHelpers.createConflictError(type, id)),
+                  metadata: { isNotOverwritable: true },
+                },
+              },
+            };
           } else {
             savedObjectWorkspaces = transformedObject.workspaces;
           }
-        } else {
-          savedObjectWorkspaces = options.workspaces;
         }
       }
 
       const expectedResult = {
         opensearchRequestIndex: bulkRequestIndexCounter++,
-        requestedId: finalObjectId,
+        requestedId: object.id,
         rawMigratedDoc: this._serializer.savedObjectToRaw(
           this._migrator.migrateDocument({
-            id: finalObjectId,
+            id: object.id,
             type: object.type,
             attributes: object.attributes,
             migrationVersion: object.migrationVersion,
@@ -533,7 +527,7 @@ export class SavedObjectsRepository {
 
       bulkCreateParams.push(
         {
-          [finalMethod]: {
+          [method]: {
             _id: expectedResult.rawMigratedDoc._id,
             _index: this.getIndexForType(object.type),
             ...(overwrite && versionProperties),
@@ -647,13 +641,24 @@ export class SavedObjectsRepository {
       const { type, id, opensearchRequestIndex } = expectedResult.value;
       const doc = bulkGetResponse?.body.docs[opensearchRequestIndex];
       if (doc?.found) {
+        let workspaceConflict = false;
+        if (options.workspaces) {
+          const transformedObject = this._serializer.rawToSavedObject(doc as SavedObjectsRawDoc);
+          const filteredWorkspaces = SavedObjectsUtils.filterWorkspacesAccordingToBaseWorkspaces(
+            options.workspaces,
+            transformedObject.workspaces
+          );
+          if (filteredWorkspaces.length) {
+            workspaceConflict = true;
+          }
+        }
         errors.push({
           id,
           type,
           error: {
             ...errorContent(SavedObjectsErrorHelpers.createConflictError(type, id)),
             // @ts-expect-error MultiGetHit._source is optional
-            ...(!this.rawDocExistsInNamespace(doc!, namespace) && {
+            ...((!this.rawDocExistsInNamespace(doc!, namespace) || workspaceConflict) && {
               metadata: { isNotOverwritable: true },
             }),
           },

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -282,7 +282,7 @@ export class SavedObjectsRepository {
 
     let savedObjectWorkspaces = workspaces;
 
-    if (id && overwrite) {
+    if (id && overwrite && workspaces) {
       let currentItem;
       try {
         currentItem = await this.get(type, id);
@@ -383,7 +383,7 @@ export class SavedObjectsRepository {
       /**
        * Only when importing an object to a target workspace should we check if the object is workspace-specific.
        */
-      const requiresWorkspaceCheck = object.id;
+      const requiresWorkspaceCheck = object.id && options.workspaces;
 
       if (object.id == null) object.id = uuid.v1();
 

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -282,7 +282,7 @@ export class SavedObjectsRepository {
 
     let savedObjectWorkspaces = workspaces;
 
-    if (id && overwrite && workspaces) {
+    if (id && overwrite) {
       try {
         const currentItem = await this.get(type, id);
         if (

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -291,7 +291,7 @@ export class SavedObjectsRepository {
       }
       if (currentItem) {
         if (
-          SavedObjectsUtils.filterWorkspacesAccordingToBaseWorkspaces(
+          SavedObjectsUtils.filterWorkspacesAccordingToSourceWorkspaces(
             workspaces,
             currentItem.workspaces
           ).length
@@ -493,7 +493,7 @@ export class SavedObjectsRepository {
           const transformedObject = this._serializer.rawToSavedObject(
             findObject as SavedObjectsRawDoc
           ) as SavedObject;
-          const filteredWorkspaces = SavedObjectsUtils.filterWorkspacesAccordingToBaseWorkspaces(
+          const filteredWorkspaces = SavedObjectsUtils.filterWorkspacesAccordingToSourceWorkspaces(
             options.workspaces,
             transformedObject.workspaces
           );
@@ -658,7 +658,7 @@ export class SavedObjectsRepository {
         let workspaceConflict = false;
         if (options.workspaces) {
           const transformedObject = this._serializer.rawToSavedObject(doc as SavedObjectsRawDoc);
-          const filteredWorkspaces = SavedObjectsUtils.filterWorkspacesAccordingToBaseWorkspaces(
+          const filteredWorkspaces = SavedObjectsUtils.filterWorkspacesAccordingToSourceWorkspaces(
             options.workspaces,
             transformedObject.workspaces
           );

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -811,6 +811,7 @@ export class SavedObjectsRepository {
    * @property {string} [options.namespace]
    * @property {object} [options.hasReference] - { type, id }
    * @property {string} [options.preference]
+   * @property {Array<string>} [options.workspaces]
    * @returns {promise} - { saved_objects: [{ id, type, version, attributes }], total, per_page, page }
    */
   async find<T = unknown>(options: SavedObjectsFindOptions): Promise<SavedObjectsFindResponse<T>> {

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -444,7 +444,7 @@ export class SavedObjectsRepository {
       if (opensearchRequestIndex !== undefined) {
         const indexFound = bulkGetResponse?.statusCode !== 404;
         const actualResult = indexFound
-          ? bulkGetResponse?.body.docs[opensearchRequestIndex]
+          ? bulkGetResponse?.body.docs?.[opensearchRequestIndex]
           : undefined;
         const docFound = indexFound && actualResult?.found === true;
         let hasSetNamespace = false;
@@ -960,7 +960,7 @@ export class SavedObjectsRepository {
    */
   async bulkGet<T = unknown>(
     objects: SavedObjectsBulkGetObject[] = [],
-    options: SavedObjectsBaseOptions = {}
+    options: Omit<SavedObjectsBaseOptions, 'workspaces'> = {}
   ): Promise<SavedObjectsBulkResponse<T>> {
     const namespace = normalizeNamespace(options.namespace);
 
@@ -1048,7 +1048,7 @@ export class SavedObjectsRepository {
   async get<T = unknown>(
     type: string,
     id: string,
-    options: SavedObjectsBaseOptions = {}
+    options: Omit<SavedObjectsBaseOptions, 'workspaces'> = {}
   ): Promise<SavedObject<T>> {
     if (!this._allowedTypes.includes(type)) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundError(type, id);

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.test.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.test.ts
@@ -625,6 +625,27 @@ describe('#getQueryParams', () => {
         ]);
       });
     });
+
+    describe('when using workspace search', () => {
+      it('using normal workspaces', () => {
+        const result: Result = getQueryParams({
+          registry,
+          workspaces: ['foo'],
+        });
+        expect(result.query.bool.filter[1]).toEqual({
+          bool: {
+            should: [
+              {
+                bool: {
+                  must: [{ term: { workspaces: 'foo' } }],
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        });
+      });
+    });
   });
 
   describe('namespaces property', () => {

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
@@ -131,14 +131,8 @@ function getClauseForType(
  *  Gets the clause that will filter for the workspace.
  */
 function getClauseForWorkspace(workspace: string) {
-  if (workspace === '*') {
-    return {
-      bool: {
-        must: {
-          match_all: {},
-        },
-      },
-    };
+  if (!workspace) {
+    return {};
   }
 
   return {
@@ -246,12 +240,14 @@ export function getQueryParams({
     ],
   };
 
-  if (workspaces) {
+  if (workspaces?.filter((workspace) => workspace).length) {
     bool.filter.push({
       bool: {
-        should: workspaces.map((workspace) => {
-          return getClauseForWorkspace(workspace);
-        }),
+        should: workspaces
+          .filter((workspace) => workspace)
+          .map((workspace) => {
+            return getClauseForWorkspace(workspace);
+          }),
         minimum_should_match: 1,
       },
     });

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
@@ -127,6 +127,26 @@ function getClauseForType(
     },
   };
 }
+/**
+ *  Gets the clause that will filter for the workspace.
+ */
+function getClauseForWorkspace(workspace: string) {
+  if (workspace === '*') {
+    return {
+      bool: {
+        must: {
+          match_all: {},
+        },
+      },
+    };
+  }
+
+  return {
+    bool: {
+      must: [{ term: { workspaces: workspace } }],
+    },
+  };
+}
 
 interface HasReferenceQueryParams {
   type: string;
@@ -144,6 +164,7 @@ interface QueryParams {
   defaultSearchOperator?: string;
   hasReference?: HasReferenceQueryParams;
   kueryNode?: KueryNode;
+  workspaces?: string[];
 }
 
 export function getClauseForReference(reference: HasReferenceQueryParams) {
@@ -200,6 +221,7 @@ export function getQueryParams({
   defaultSearchOperator,
   hasReference,
   kueryNode,
+  workspaces,
 }: QueryParams) {
   const types = getTypes(
     registry,
@@ -223,6 +245,17 @@ export function getQueryParams({
       },
     ],
   };
+
+  if (workspaces) {
+    bool.filter.push({
+      bool: {
+        should: workspaces.map((workspace) => {
+          return getClauseForWorkspace(workspace);
+        }),
+        minimum_should_match: 1,
+      },
+    });
+  }
 
   if (search) {
     const useMatchPhrasePrefix = shouldUseMatchPhrasePrefix(search);

--- a/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/query_params.ts
@@ -131,10 +131,6 @@ function getClauseForType(
  *  Gets the clause that will filter for the workspace.
  */
 function getClauseForWorkspace(workspace: string) {
-  if (!workspace) {
-    return {};
-  }
-
   return {
     bool: {
       must: [{ term: { workspaces: workspace } }],
@@ -245,9 +241,7 @@ export function getQueryParams({
       bool: {
         should: workspaces
           .filter((workspace) => workspace)
-          .map((workspace) => {
-            return getClauseForWorkspace(workspace);
-          }),
+          .map((workspace) => getClauseForWorkspace(workspace)),
         minimum_should_match: 1,
       },
     });

--- a/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
+++ b/src/core/server/saved_objects/service/lib/search_dsl/search_dsl.ts
@@ -52,6 +52,7 @@ interface GetSearchDslOptions {
     id: string;
   };
   kueryNode?: KueryNode;
+  workspaces?: string[];
 }
 
 export function getSearchDsl(
@@ -71,6 +72,7 @@ export function getSearchDsl(
     typeToNamespacesMap,
     hasReference,
     kueryNode,
+    workspaces,
   } = options;
 
   if (!type) {
@@ -93,6 +95,7 @@ export function getSearchDsl(
       defaultSearchOperator,
       hasReference,
       kueryNode,
+      workspaces,
     }),
     ...getSortingParams(mappings, type, sortField, sortOrder),
   };

--- a/src/core/server/saved_objects/service/lib/utils.ts
+++ b/src/core/server/saved_objects/service/lib/utils.ts
@@ -81,7 +81,7 @@ export class SavedObjectsUtils {
     saved_objects: [],
   });
 
-  public static filterWorkspacesAccordingToBaseWorkspaces(
+  public static filterWorkspacesAccordingToSourceWorkspaces(
     targetWorkspaces?: string[],
     sourceWorkspaces?: string[]
   ): string[] {

--- a/src/core/server/saved_objects/service/lib/utils.ts
+++ b/src/core/server/saved_objects/service/lib/utils.ts
@@ -83,8 +83,8 @@ export class SavedObjectsUtils {
 
   public static filterWorkspacesAccordingToBaseWorkspaces(
     targetWorkspaces?: string[],
-    baseWorkspaces?: string[]
+    sourceWorkspaces?: string[]
   ): string[] {
-    return targetWorkspaces?.filter((item) => !baseWorkspaces?.includes(item)) || [];
+    return targetWorkspaces?.filter((item) => !sourceWorkspaces?.includes(item)) || [];
   }
 }

--- a/src/core/server/saved_objects/service/lib/utils.ts
+++ b/src/core/server/saved_objects/service/lib/utils.ts
@@ -80,4 +80,11 @@ export class SavedObjectsUtils {
     total: 0,
     saved_objects: [],
   });
+
+  public static filterWorkspacesAccordingToBaseWorkspaces(
+    targetWorkspaces?: string[],
+    baseWorkspaces?: string[]
+  ): string[] {
+    return targetWorkspaces?.filter((item) => !baseWorkspaces?.includes(item)) || [];
+  }
 }

--- a/src/core/server/saved_objects/service/saved_objects_client.ts
+++ b/src/core/server/saved_objects/service/saved_objects_client.ts
@@ -363,7 +363,7 @@ export class SavedObjectsClient {
    */
   async bulkGet<T = unknown>(
     objects: SavedObjectsBulkGetObject[] = [],
-    options: SavedObjectsBaseOptions = {}
+    options: Omit<SavedObjectsBaseOptions, 'workspaces'> = {}
   ): Promise<SavedObjectsBulkResponse<T>> {
     return await this._repository.bulkGet(objects, options);
   }

--- a/src/core/server/saved_objects/types.ts
+++ b/src/core/server/saved_objects/types.ts
@@ -110,6 +110,7 @@ export interface SavedObjectsFindOptions {
   typeToNamespacesMap?: Map<string, string[] | undefined>;
   /** An optional OpenSearch preference value to be used for the query **/
   preference?: string;
+  /** If specified, will find all objects belong to specified workspaces **/
   workspaces?: string[];
 }
 
@@ -120,6 +121,7 @@ export interface SavedObjectsFindOptions {
 export interface SavedObjectsBaseOptions {
   /** Specify the namespace for this operation */
   namespace?: string;
+  /** Specify the workspaces for this operation */
   workspaces?: string[];
 }
 

--- a/src/core/server/saved_objects/types.ts
+++ b/src/core/server/saved_objects/types.ts
@@ -110,6 +110,7 @@ export interface SavedObjectsFindOptions {
   typeToNamespacesMap?: Map<string, string[] | undefined>;
   /** An optional OpenSearch preference value to be used for the query **/
   preference?: string;
+  workspaces?: string[];
 }
 
 /**
@@ -119,6 +120,7 @@ export interface SavedObjectsFindOptions {
 export interface SavedObjectsBaseOptions {
   /** Specify the namespace for this operation */
   namespace?: string;
+  workspaces?: string[];
 }
 
 /**

--- a/src/core/types/saved_objects.ts
+++ b/src/core/types/saved_objects.ts
@@ -113,6 +113,7 @@ export interface SavedObject<T = unknown> {
    * space.
    */
   originId?: string;
+  /** Workspaces that this saved object exists in. */
   workspaces?: string[];
 }
 

--- a/src/core/types/saved_objects.ts
+++ b/src/core/types/saved_objects.ts
@@ -113,6 +113,7 @@ export interface SavedObject<T = unknown> {
    * space.
    */
   originId?: string;
+  workspaces?: string[];
 }
 
 export interface SavedObjectError {


### PR DESCRIPTION
### Description

As workspace will be a new concept to organize saved objects, this PR add a new field `workspaces` to indicate which workspaces the objects belong to and consume the field in related methods.

- [x] Add workspaces field in saved objects mappings
- [x] Consume worksapces when create object
- [x] Consume workspaces when bulkCreate objects
- [x] Consume workspaces when checkConflicts
- [x] Consume workspaces when validating reference

### Issues Resolved

Partial #4944 

## Screenshot

N/A

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
  - [x] `yarn test:ftr`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
