### PR TITLE
[BUG][Data Explorer][Discover] Automatically load solo added default index pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Data Explorer][Discover] Add onQuerySubmit to top nav and allow force update to embeddable ([#5160](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5160))
 - [BUG][Discover] Fix misc navigation issues ([#5168](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5168))
 - [BUG][Discover] Fix mobile view ([#5168](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5168))
+- [BUG][Data Explorer][Discover] Automatically load solo added default index pattern ([#5171](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5171))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/data_explorer/public/index.ts
+++ b/src/plugins/data_explorer/public/index.ts
@@ -14,4 +14,10 @@ export function plugin() {
 }
 export { DataExplorerPluginSetup, DataExplorerPluginStart, DataExplorerServices } from './types';
 export { ViewProps, ViewDefinition, DefaultViewState } from './services/view_service';
-export { RootState, useTypedSelector, useTypedDispatch } from './utils/state_management';
+export {
+  RootState,
+  Store,
+  useTypedSelector,
+  useTypedDispatch,
+  setIndexPattern,
+} from './utils/state_management';

--- a/src/plugins/discover/public/application/utils/state_management/index.ts
+++ b/src/plugins/discover/public/application/utils/state_management/index.ts
@@ -4,7 +4,13 @@
  */
 
 import { TypedUseSelectorHook } from 'react-redux';
-import { RootState, useTypedDispatch, useTypedSelector } from '../../../../../data_explorer/public';
+import {
+  RootState,
+  Store as StoreType,
+  setIndexPattern as updateIndexPattern,
+  useTypedDispatch,
+  useTypedSelector,
+} from '../../../../../data_explorer/public';
 import { DiscoverState } from './discover_slice';
 
 export * from './discover_slice';
@@ -15,3 +21,4 @@ export interface DiscoverRootState extends RootState {
 
 export const useSelector: TypedUseSelectorHook<DiscoverRootState> = useTypedSelector;
 export const useDispatch = useTypedDispatch;
+export { StoreType, updateIndexPattern };

--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -34,6 +34,7 @@ export const DiscoverTable = ({ history }: Props) => {
     data: {
       query: { filterManager },
     },
+    store,
   } = services;
   const { data$, refetch$, indexPattern } = useDiscoverContext();
   const [fetchState, setFetchState] = useState<SearchData>({
@@ -71,7 +72,7 @@ export const DiscoverTable = ({ history }: Props) => {
   );
 
   const { rows } = fetchState || {};
-  const { savedSearch } = useSearch(services);
+  const { savedSearch } = useSearch(services, store);
 
   useEffect(() => {
     const subscription = data$.subscribe((next) => {

--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -34,9 +34,8 @@ export const DiscoverTable = ({ history }: Props) => {
     data: {
       query: { filterManager },
     },
-    store,
   } = services;
-  const { data$, refetch$, indexPattern } = useDiscoverContext();
+  const { data$, refetch$, indexPattern, savedSearch } = useDiscoverContext();
   const [fetchState, setFetchState] = useState<SearchData>({
     status: data$.getValue().status,
     rows: [],
@@ -72,7 +71,6 @@ export const DiscoverTable = ({ history }: Props) => {
   );
 
   const { rows } = fetchState || {};
-  const { savedSearch } = useSearch(services, store);
 
   useEffect(() => {
     const subscription = data$.subscribe((next) => {

--- a/src/plugins/discover/public/application/view_components/context/index.tsx
+++ b/src/plugins/discover/public/application/view_components/context/index.tsx
@@ -5,6 +5,7 @@
 
 import React, { useEffect } from 'react';
 import { DataExplorerServices, ViewProps } from '../../../../../data_explorer/public';
+import { DiscoverViewServices } from '../../../build_services';
 import {
   OpenSearchDashboardsContextProvider,
   useOpenSearchDashboards,
@@ -19,10 +20,13 @@ const SearchContext = React.createContext<SearchContextValue>({} as SearchContex
 export default function DiscoverContext({ children }: React.PropsWithChildren<ViewProps>) {
   const { services: deServices } = useOpenSearchDashboards<DataExplorerServices>();
   const services = getServices();
-  const searchParams = useSearch({
-    ...deServices,
-    ...services,
-  });
+  const searchParams = useSearch(
+    {
+      ...deServices,
+      ...services,
+    },
+    store
+  );
 
   const { osdUrlStateStorage } = deServices;
 

--- a/src/plugins/discover/public/application/view_components/context/index.tsx
+++ b/src/plugins/discover/public/application/view_components/context/index.tsx
@@ -5,7 +5,6 @@
 
 import React, { useEffect } from 'react';
 import { DataExplorerServices, ViewProps } from '../../../../../data_explorer/public';
-import { DiscoverViewServices } from '../../../build_services';
 import {
   OpenSearchDashboardsContextProvider,
   useOpenSearchDashboards,
@@ -20,13 +19,10 @@ const SearchContext = React.createContext<SearchContextValue>({} as SearchContex
 export default function DiscoverContext({ children }: React.PropsWithChildren<ViewProps>) {
   const { services: deServices } = useOpenSearchDashboards<DataExplorerServices>();
   const services = getServices();
-  const searchParams = useSearch(
-    {
-      ...deServices,
-      ...services,
-    },
-    store
-  );
+  const searchParams = useSearch({
+    ...deServices,
+    ...services,
+  });
 
   const { osdUrlStateStorage } = deServices;
 

--- a/src/plugins/discover/public/application/view_components/utils/use_index_pattern.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_index_pattern.ts
@@ -33,16 +33,6 @@ export const useIndexPattern = (services: DiscoverServices, store: StoreType) =>
     let isMounted = true;
 
     const fetchIndexPatternDetails = (id: string) => {
-      const indexPatternMissingWarning = i18n.translate(
-        'discover.valueIsNotConfiguredIndexPatternIDWarningTitle',
-        {
-          defaultMessage: '{id} is not a configured index pattern ID',
-          values: {
-            id: `"${id}"`,
-          },
-        }
-      );
-
       data.indexPatterns
         .get(id)
         .then((result) => {
@@ -52,6 +42,15 @@ export const useIndexPattern = (services: DiscoverServices, store: StoreType) =>
         })
         .catch(() => {
           if (isMounted) {
+            const indexPatternMissingWarning = i18n.translate(
+              'discover.valueIsNotConfiguredIndexPatternIDWarningTitle',
+              {
+                defaultMessage: '{id} is not a configured index pattern ID',
+                values: {
+                  id: `"${id}"`,
+                },
+              }
+            );
             toastNotifications.addDanger({
               title: indexPatternMissingWarning,
             });

--- a/src/plugins/discover/public/application/view_components/utils/use_index_pattern.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_index_pattern.ts
@@ -6,46 +6,73 @@
 import { useEffect, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import { IndexPattern } from '../../../../../data/public';
-import { useSelector } from '../../utils/state_management';
+import { useSelector, updateIndexPattern, StoreType } from '../../utils/state_management';
 import { DiscoverServices } from '../../../build_services';
+import { getIndexPatternId } from '../../helpers/get_index_pattern_id';
 
-export const useIndexPattern = (services: DiscoverServices) => {
-  const indexPatternId = useSelector((state) => state.metadata.indexPattern);
+/**
+ * Custom hook to fetch and manage the index pattern based on the provided services.
+ *
+ * This hook does the following:
+ * 1. Check if there's an `indexPatternId` from the state.
+ * 2. If not, fetch a list of index patterns, determine the default, and update the store with it.
+ * 3. Once an `indexPatternId` is determined (either from the state or by fetching the default),
+ *    it fetches the details of the index pattern.
+ * 4. If there's any error fetching the index pattern details, a warning notification is shown.
+ *
+ * @param services - The services needed to fetch the index patterns and show notifications.
+ * @param store - The redux store in data_explorer to dispatch actions.
+ * @returns - The fetched index pattern.
+ */
+export const useIndexPattern = (services: DiscoverServices, store: StoreType) => {
+  const indexPatternIdFromState = useSelector((state) => state.metadata.indexPattern);
   const [indexPattern, setIndexPattern] = useState<IndexPattern | undefined>(undefined);
-  const { data, toastNotifications } = services;
+  const { data, toastNotifications, uiSettings: config } = services;
 
   useEffect(() => {
     let isMounted = true;
-    if (!indexPatternId) return;
-    const indexPatternMissingWarning = i18n.translate(
-      'discover.valueIsNotConfiguredIndexPatternIDWarningTitle',
-      {
-        defaultMessage: '{id} is not a configured index pattern ID',
-        values: {
-          id: `"${indexPatternId}"`,
-        },
-      }
-    );
 
-    data.indexPatterns
-      .get(indexPatternId)
-      .then((result) => {
-        if (isMounted) {
-          setIndexPattern(result);
+    const fetchIndexPatternDetails = (id: string) => {
+      const indexPatternMissingWarning = i18n.translate(
+        'discover.valueIsNotConfiguredIndexPatternIDWarningTitle',
+        {
+          defaultMessage: '{id} is not a configured index pattern ID',
+          values: {
+            id: `"${id}"`,
+          },
         }
-      })
-      .catch(() => {
-        if (isMounted) {
-          toastNotifications.addDanger({
-            title: indexPatternMissingWarning,
-          });
-        }
+      );
+
+      data.indexPatterns
+        .get(id)
+        .then((result) => {
+          if (isMounted) {
+            setIndexPattern(result);
+          }
+        })
+        .catch(() => {
+          if (isMounted) {
+            toastNotifications.addDanger({
+              title: indexPatternMissingWarning,
+            });
+          }
+        });
+    };
+
+    if (!indexPatternIdFromState) {
+      data.indexPatterns.getCache().then((indexPatternList) => {
+        const newId = getIndexPatternId('', indexPatternList, config.get('defaultIndex'));
+        store!.dispatch(updateIndexPattern(newId));
+        fetchIndexPatternDetails(newId);
       });
+    } else {
+      fetchIndexPatternDetails(indexPatternIdFromState);
+    }
 
     return () => {
       isMounted = false;
     };
-  }, [indexPatternId, data.indexPatterns, toastNotifications]);
+  }, [indexPatternIdFromState, data.indexPatterns, toastNotifications, config, store]);
 
   return indexPattern;
 };

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -25,7 +25,7 @@ import {
   Chart,
 } from '../../components/chart/utils';
 import { SavedSearch } from '../../../saved_searches';
-import { useSelector } from '../../utils/state_management';
+import { useSelector, StoreType } from '../../utils/state_management';
 import {
   getRequestInspectorStats,
   getResponseInspectorStats,
@@ -66,11 +66,11 @@ export type RefetchSubject = Subject<SearchRefetch>;
  * return () => subscription.unsubscribe();
  * }, [data$]);
  */
-export const useSearch = (services: DiscoverViewServices) => {
+export const useSearch = (services: DiscoverViewServices, store: StoreType) => {
   const initalSearchComplete = useRef(false);
   const [savedSearch, setSavedSearch] = useState<SavedSearch | undefined>(undefined);
   const { savedSearch: savedSearchId, sort, interval } = useSelector((state) => state.discover);
-  const indexPattern = useIndexPattern(services);
+  const indexPattern = useIndexPattern(services, store);
   const { data, filterManager, getSavedSearchById, core, toastNotifications } = services;
   const timefilter = data.query.timefilter.timefilter;
   const fetchStateRef = useRef<{

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -25,7 +25,7 @@ import {
   Chart,
 } from '../../components/chart/utils';
 import { SavedSearch } from '../../../saved_searches';
-import { useSelector, StoreType } from '../../utils/state_management';
+import { useSelector } from '../../utils/state_management';
 import {
   getRequestInspectorStats,
   getResponseInspectorStats,
@@ -66,12 +66,12 @@ export type RefetchSubject = Subject<SearchRefetch>;
  * return () => subscription.unsubscribe();
  * }, [data$]);
  */
-export const useSearch = (services: DiscoverViewServices, store: StoreType) => {
+export const useSearch = (services: DiscoverViewServices) => {
   const initalSearchComplete = useRef(false);
   const [savedSearch, setSavedSearch] = useState<SavedSearch | undefined>(undefined);
   const { savedSearch: savedSearchId, sort, interval } = useSelector((state) => state.discover);
+  const { data, filterManager, getSavedSearchById, core, toastNotifications, store } = services;
   const indexPattern = useIndexPattern(services, store);
-  const { data, filterManager, getSavedSearchById, core, toastNotifications } = services;
   const timefilter = data.query.timefilter.timefilter;
   const fetchStateRef = useRef<{
     abortController: AbortController | undefined;


### PR DESCRIPTION
### Description
This fix ensures that when add a default index pattern, Discover will automatically select and load its details.

* before 

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/1ae2e18d-27fd-494d-ab47-e92903f7c1be


* after

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/91daa15a-8375-46e8-b83f-2bcb529a60c5




### Issues Resolved
closes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5128


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
