### PR TITLE
[CI][Cypress] set NODE_OPTIONS and cluster disk allocation

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -34,12 +34,13 @@ env:
   TEST_BRANCH: "${{ inputs.test_branch != '' && inputs.test_branch || github.base_ref }}"
   FTR_PATH: 'ftr'
   START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch'
-  OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot'
+  OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot -E cluster.routing.allocation.disk.threshold_enabled=false'
   SPEC: ${{ inputs.specs != '' && inputs.specs || 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js,' }} 
   CYPRESS_BROWSER: 'chromium'
   CYPRESS_VISBUILDER_ENABLED: true
   CYPRESS_DATASOURCE_MANAGEMENT_ENABLED: false
   OSD_SNAPSHOT_SKIP_VERIFY_CHECKSUM: true
+  NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
   COMMENT_TAG: '[MANUAL CYPRESS TEST RUN RESULTS]'
   COMMENT_SUCCESS_MSG: ':white_check_mark: Cypress test run succeeded!'
   COMMENT_FAILURE_MSG: ':x: Cypress test run failed!'
@@ -179,13 +180,15 @@ jobs:
             #### ${{ needs.cypress-tests.result == 'success' && env.COMMENT_SUCCESS_MSG || env.COMMENT_FAILURE_MSG }}
 
             #### Inputs:
-            Source repo: `${{ env.SOURCE_REPO }}`
-            Source branch: ``${{ env.SOURCE_BRANCH }}``
-            Test repo: `${{ env.TEST_REPO }}`
-            Test branch: ``${{ env.TEST_BRANCH }}``
+            ```
+            Source repo: '${{ env.SOURCE_REPO }}'
+            Source branch: '${{ env.SOURCE_BRANCH }}'
+            Test repo: '${{ env.TEST_REPO }}'
+            Test branch: '${{ env.TEST_BRANCH }}'
 
             Test spec:
-            `${{ env.SPEC }}`
+            '${{ env.SPEC }}'
+            ```
 
             #### Link to results: 
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Upgrade yarn version to be compatible with @opensearch-project/opensearch ([#3443](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3443))
 - Add an achievement badger to the PR ([#3721](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3721))
 - [CI] Enable inputs for manually triggered Cypress test jobs ([#5134](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5134))
+- [CI] Add `NODE_OPTIONS` and disable disk allocation threshold ([#5172](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5172))
 
 ### 📝 Documentation
 


### PR DESCRIPTION
### Description

Set env variable of NODE_OPTIONS for OSD to reference on startup to ensure stable env.

Disable threshold enabled for disk allocation

### Issue Related

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4019

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
