### PR TITLE
[Manual Backport 2.x] Bump `agentkeepalive` to v4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Data Explorer] Fix display for index pattern without a default time field ([#4821](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4821))
 - Fixes broken app when management is turned off ([#4891](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4891))
 - [CCI] Fix EUI/OUI type errors ([#3798](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3798))
+- Bump `agentkeepalive` to v4.5.0 to solve a problem preventing the use `https://ip` in `opensearch.hosts` ([#4949](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4949))
 
 ### 🚞 Infrastructure
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "**/async": "^3.2.3",
     "**/d3-color": "^3.1.0",
     "**/flat": "^5.0.2",
+    "**/elasticsearch/agentkeepalive": "^4.5.0",
     "**/glob-parent": "^6.0.0",
     "**/hoist-non-react-statics": "^3.3.2",
     "**/json-schema": "^0.4.0",

--- a/src/core/server/legacy/integration_tests/logging.test.ts
+++ b/src/core/server/legacy/integration_tests/logging.test.ts
@@ -149,10 +149,15 @@ describe('logging service', () => {
         platformLogger.warn('warn');
         platformLogger.error('error');
 
-        expect(mockConsoleLog).toHaveBeenCalledTimes(3);
+        /* ToDo: change to `toHaveBeenCalledTimes(3) and clean the snapshot when the dependency
+         *       on `elasticsearch` is removed. There should only be 3 calls but we get an extra
+         *       one from `agentkeepalive:deprecated`.
+         */
+        expect(mockConsoleLog).toHaveBeenCalledTimes(4);
 
         expect(getPlatformLogsFromMock(mockConsoleLog)).toMatchInlineSnapshot(`
           Array [
+            "[agentkeepalive:deprecated] %s",
             "[xxxx-xx-xxTxx:xx:xx.xxxZ][INFO ][test-file] info",
             "[xxxx-xx-xxTxx:xx:xx.xxxZ][WARN ][test-file] warn",
             "[xxxx-xx-xxTxx:xx:xx.xxxZ][ERROR][test-file] error",
@@ -180,10 +185,15 @@ describe('logging service', () => {
         platformLogger.warn('warn');
         platformLogger.error('error');
 
-        expect(mockConsoleLog).toHaveBeenCalledTimes(3);
+        /* ToDo: change to `toHaveBeenCalledTimes(3) and clean the snapshot when the dependency
+         *       on `elasticsearch` is removed. There should only be 3 calls but we get an extra
+         *       one from `agentkeepalive:deprecated`.
+         */
+        expect(mockConsoleLog).toHaveBeenCalledTimes(4);
 
         expect(getPlatformLogsFromMock(mockConsoleLog)).toMatchInlineSnapshot(`
           Array [
+            "[agentkeepalive:deprecated] %s",
             "[xxxx-xx-xxTxx:xx:xx.xxxZ][INFO ][test-file] info",
             "[xxxx-xx-xxTxx:xx:xx.xxxZ][WARN ][test-file] warn",
             "[xxxx-xx-xxTxx:xx:xx.xxxZ][ERROR][test-file] error",
@@ -217,10 +227,15 @@ describe('logging service', () => {
         platformLogger.warn('warn');
         platformLogger.error('error');
 
-        expect(mockConsoleLog).toHaveBeenCalledTimes(3);
+        /* ToDo: change to `toHaveBeenCalledTimes(3) and clean the snapshot when the dependency
+         *       on `elasticsearch` is removed. There should only be 3 calls but we get an extra
+         *       one from `agentkeepalive:deprecated`.
+         */
+        expect(mockConsoleLog).toHaveBeenCalledTimes(4);
 
         expect(getPlatformLogsFromMock(mockConsoleLog)).toMatchInlineSnapshot(`
           Array [
+            "[agentkeepalive:deprecated] %s",
             "[xxxx-xx-xxTxx:xx:xx.xxxZ][INFO ][test-file] info",
             "[xxxx-xx-xxTxx:xx:xx.xxxZ][WARN ][test-file] warn",
             "[xxxx-xx-xxTxx:xx:xx.xxxZ][ERROR][test-file] error",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4324,20 +4324,11 @@ agent-base@6, agent-base@^6.0.2:
   dependencies:
     debug "4"
 
-agentkeepalive@^3.4.1:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-3.5.2.tgz#a113924dd3fa24a0bc3b78108c450c2abee00f67"
-  integrity sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==
+agentkeepalive@^3.4.1, agentkeepalive@^4.1.3, agentkeepalive@^4.2.1, agentkeepalive@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.5.0.tgz#2673ad1389b3c418c5a20c5d7364f93ca04be923"
+  integrity sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==
   dependencies:
-    humanize-ms "^1.2.1"
-
-agentkeepalive@^4.1.3, agentkeepalive@^4.2.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.3.0.tgz#bb999ff07412653c1803b3ced35e50729830a255"
-  integrity sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==
-  dependencies:
-    debug "^4.1.0"
-    depd "^2.0.0"
     humanize-ms "^1.2.1"
 
 aggregate-error@^3.0.0:
@@ -7109,11 +7100,6 @@ delete-empty@^2.0.0:
     log-ok "^0.1.1"
     relative "^3.0.2"
     rimraf "^2.6.2"
-
-depd@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 dependency-check@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Backport d017c5caddd732fafc1c2a2fc8ca4be99fac7c0b from https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4949