### PR TITLE
[BUG][Data Explorer][Discover] Allow data grid to auto adjust size based on fetched data count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Discover] Fix misc navigation issues ([#5168](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5168))
 - [BUG][Discover] Fix mobile view ([#5168](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5168))
 - [BUG][Data Explorer][Discover] Automatically load solo added default index pattern ([#5171](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5171))
+- [BUG][Data Explorer][Discover] Allow data grid to auto adjust size based on fetched data count ([#5191](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5191))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -29,7 +29,6 @@ export interface DataGridTableProps {
   onSetColumns: (columns: string[]) => void;
   sort: SortOrder[];
   displayTimeColumn: boolean;
-  services: DiscoverServices;
   title?: string;
   description?: string;
   isToolbarVisible?: boolean;

--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { History } from 'history';
+import React, { useCallback, useMemo } from 'react';
 import { DiscoverViewServices } from '../../../build_services';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { DataGridTable } from '../../components/data_grid/data_grid_table';
@@ -17,17 +16,18 @@ import {
   useDispatch,
   useSelector,
 } from '../../utils/state_management';
-import { ResultStatus, SearchData, useSearch } from '../utils/use_search';
+import { useSearch } from '../utils/use_search';
 import { IndexPatternField, opensearchFilters } from '../../../../../data/public';
 import { DocViewFilterFn } from '../../doc_views/doc_views_types';
 import { SortOrder } from '../../../saved_searches/types';
 import { DOC_HIDE_TIME_COLUMN_SETTING } from '../../../../common';
+import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 
 interface Props {
-  history: History;
+  rows: OpenSearchSearchHit[];
 }
 
-export const DiscoverTable = ({ history }: Props) => {
+export const DiscoverTable = ({ rows }: Props) => {
   const { services } = useOpenSearchDashboards<DiscoverViewServices>();
   const {
     uiSettings,
@@ -35,12 +35,8 @@ export const DiscoverTable = ({ history }: Props) => {
       query: { filterManager },
     },
   } = services;
-  const { data$, refetch$, indexPattern, savedSearch } = useDiscoverContext();
-  const [fetchState, setFetchState] = useState<SearchData>({
-    status: data$.getValue().status,
-    rows: [],
-  });
 
+  const { refetch$, indexPattern, savedSearch } = useDiscoverContext();
   const { columns, sort } = useSelector((state) => state.discover);
   const dispatch = useDispatch();
   const onAddColumn = (col: string) => dispatch(addColumn({ column: col }));
@@ -70,20 +66,6 @@ export const DiscoverTable = ({ history }: Props) => {
     [indexPattern, uiSettings]
   );
 
-  const { rows } = fetchState || {};
-
-  useEffect(() => {
-    const subscription = data$.subscribe((next) => {
-      if (next.status === ResultStatus.LOADING) return;
-      if (next.status !== fetchState.status || (next.rows && next.rows !== fetchState.rows)) {
-        setFetchState({ ...fetchState, ...next });
-      }
-    });
-    return () => {
-      subscription.unsubscribe();
-    };
-  }, [data$, fetchState]);
-
   if (indexPattern === undefined) {
     // TODO: handle better
     return null;
@@ -106,7 +88,6 @@ export const DiscoverTable = ({ history }: Props) => {
       sort={sort}
       rows={rows}
       displayTimeColumn={displayTimeColumn}
-      services={services}
       title={savedSearch?.id ? savedSearch.title : ''}
       description={savedSearch?.id ? savedSearch.description : ''}
     />


### PR DESCRIPTION
### Description
* This PR adds a new rows state to the DiscoverCanvas component and updated it whenever the data$ observable emitted new row data.
* The DiscoverTable component was then refactored to accept rows as a prop, making it dependent on the parent component to provide the correct set of data. This ensures that the table renders correctly based on the current data and doesn't rely on its internal state, which could be outdated.

### Issues Resolved
closes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5181

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/427069ee-0311-4f92-ae7f-029f2e79cf7a


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
