### PR TITLE
[CI][Cypress][Bug] use default `SOURCE` inputs for checkout

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -28,8 +28,6 @@ on:
         type: string
 
 env:
-  SOURCE_REPO: ${{ github.repository }}
-  SOURCE_BRANCH: "${{ github.base_ref }}"
   TEST_REPO: ${{ inputs.test_repo != '' && inputs.test_repo || 'opensearch-project/opensearch-dashboards-functional-test' }}
   TEST_BRANCH: "${{ inputs.test_branch != '' && inputs.test_branch || github.base_ref }}"
   FTR_PATH: 'ftr'


### PR DESCRIPTION
### Description

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5134

Incorrectly uses the source of the code to pull down to BASE REF,
which would likely be `main` or `2.x`, etc.

It should be pulling down the PR branch. Cypress tests at the time
of merging were failing due to unrelated issue of disk allocation.

Not setting the env variables causes the workflow to rely on the default
values which is a return back to the original implementation and if the
env is set then it will be not empty.

### Issues Resolved

n/a

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
