### PR TITLE
[BUG][Data Explorer][Discover] Allow filter and query persist when refresh page or paste url to a new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix `visAugmenter` forming empty key-value pairs in its calls to the `SavedObject` API ([#5190](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5190))
 - [Data Explorer][Discover] Automatically load solo added default index pattern ([#5171](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5171))
 - [Data Explorer][Discover] Allow data grid to auto adjust size based on fetched data count ([#5191](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5191))
+- [BUG][Data Explorer][Discover] Allow filter and query persist when refresh page or paste url to a new tab ([#5206](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5206))
 
 
 ### 🚞 Infrastructure

--- a/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
@@ -13,6 +13,7 @@ import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { getTopNavLinks } from '../../components/top_nav/get_top_nav_links';
 import { useDiscoverContext } from '../context';
 import { getRootBreadcrumbs } from '../../helpers/breadcrumbs';
+import { opensearchFilters, connectStorageToQueryState } from '../../../../../data/public';
 
 export interface TopNavProps {
   opts: {
@@ -35,9 +36,15 @@ export const TopNav = ({ opts }: TopNavProps) => {
     },
     data,
     chrome,
+    osdUrlStateStorage,
   } = services;
 
   const topNavLinks = savedSearch ? getTopNavLinks(services, inspectorAdapters, savedSearch) : [];
+
+  connectStorageToQueryState(services.data.query, osdUrlStateStorage, {
+    filters: opensearchFilters.FilterStateStore.APP_STATE,
+    query: true,
+  });
 
   useEffect(() => {
     let isMounted = true;

--- a/src/plugins/discover/public/application/view_components/context/index.tsx
+++ b/src/plugins/discover/public/application/view_components/context/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { DataExplorerServices, ViewProps } from '../../../../../data_explorer/public';
 import {
   OpenSearchDashboardsContextProvider,
@@ -11,7 +11,6 @@ import {
 } from '../../../../../opensearch_dashboards_react/public';
 import { getServices } from '../../../opensearch_dashboards_services';
 import { useSearch, SearchContextValue } from '../utils/use_search';
-import { connectStorageToQueryState, opensearchFilters } from '../../../../../data/public';
 
 const SearchContext = React.createContext<SearchContextValue>({} as SearchContextValue);
 
@@ -23,16 +22,6 @@ export default function DiscoverContext({ children }: React.PropsWithChildren<Vi
     ...deServices,
     ...services,
   });
-
-  const { osdUrlStateStorage } = deServices;
-
-  // Connect the query service to the url state
-  useEffect(() => {
-    connectStorageToQueryState(services.data.query, osdUrlStateStorage, {
-      filters: opensearchFilters.FilterStateStore.APP_STATE,
-      query: true,
-    });
-  }, [osdUrlStateStorage, services.data.query, services.uiSettings]);
 
   return (
     <OpenSearchDashboardsContextProvider services={services}>


### PR DESCRIPTION
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5179 
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5071


## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/4648a28d-5a76-4146-a34e-8d51bd7624fc


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
