### PR TITLE
[Discover] Fixes DataTable rendering in discover

### DIFF
--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -16,7 +16,6 @@ import {
   useDispatch,
   useSelector,
 } from '../../utils/state_management';
-import { useSearch } from '../utils/use_search';
 import { IndexPatternField, opensearchFilters } from '../../../../../data/public';
 import { DocViewFilterFn } from '../../doc_views/doc_views_types';
 import { SortOrder } from '../../../saved_searches/types';
@@ -24,7 +23,7 @@ import { DOC_HIDE_TIME_COLUMN_SETTING } from '../../../../common';
 import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 
 interface Props {
-  rows: OpenSearchSearchHit[];
+  rows?: OpenSearchSearchHit[];
 }
 
 export const DiscoverTable = ({ rows }: Props) => {

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { EuiPanel } from '@elastic/eui';
 import { TopNav } from './top_nav';
 import { ViewProps } from '../../../../../data_explorer/public';
@@ -89,9 +89,6 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
 
   const timeField = indexPattern?.timeFieldName ? indexPattern.timeFieldName : undefined;
 
-  const MemoizedDiscoverTable = React.memo(DiscoverTable);
-  const MemoizedDiscoverChartContainer = React.memo(DiscoverChartContainer);
-
   return (
     <EuiPanel
       hasBorder={false}
@@ -126,3 +123,6 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
     </EuiPanel>
   );
 }
+
+const MemoizedDiscoverTable = React.memo(DiscoverTable);
+const MemoizedDiscoverChartContainer = React.memo(DiscoverChartContainer);


### PR DESCRIPTION
### Description

Fixes a memoization issue with the datatable component that caused unnecessary and expensive rerenders.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
