### PR TITLE
[Tests-refactor] Remove angular code from plugin_functional and update tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### 🔩 Tests
 
 - [Tests] Add BWC tests for 2.9 and 2.10 ([#4762](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4762))
+- [Tests-refactor] Remove angular code from plugin_functional and update tests ([#5221](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5221))
 
 ## [1.3.12 - 2023-08-10](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/1.3.12)
 

--- a/test/plugin_functional/plugins/doc_views_plugin/public/plugin.tsx
+++ b/test/plugin_functional/plugins/doc_views_plugin/public/plugin.tsx
@@ -28,18 +28,9 @@
  * under the License.
  */
 
-import angular from 'angular';
 import React from 'react';
 import { Plugin, CoreSetup } from 'opensearch-dashboards/public';
 import { DiscoverSetup } from '../../../../../src/plugins/discover/public';
-
-angular.module('myDocView', []).directive('myHit', () => ({
-  restrict: 'E',
-  scope: {
-    hit: '=hit',
-  },
-  template: '<h1 data-test-subj="angular-docview">{{hit._index}}</h1>',
-}));
 
 function MyHit(props: { index: string }) {
   return <h1 data-test-subj="react-docview">{props.index}</h1>;
@@ -47,17 +38,6 @@ function MyHit(props: { index: string }) {
 
 export class DocViewsPlugin implements Plugin<void, void> {
   public setup(core: CoreSetup, { discover }: { discover: DiscoverSetup }) {
-    discover.docViews.addDocView({
-      directive: {
-        controller: function MyController($injector: any) {
-          $injector.loadNewModules(['myDocView']);
-        },
-        template: `<my-hit hit="hit"></my-hit>`,
-      },
-      order: 1,
-      title: 'Angular doc view',
-    });
-
     discover.docViews.addDocView({
       component: (props) => {
         return <MyHit index={props.hit._index as string} />;

--- a/test/plugin_functional/test_suites/doc_views/doc_views.ts
+++ b/test/plugin_functional/test_suites/doc_views/doc_views.ts
@@ -44,17 +44,8 @@ export default function ({ getService, getPageObjects }: PluginFunctionalProvide
 
     it('should show custom doc views', async () => {
       await testSubjects.click('docTableExpandToggleColumn');
-      const angularTab = await find.byButtonText('Angular doc view');
       const reactTab = await find.byButtonText('React doc view');
-      expect(await angularTab.isDisplayed()).to.be(true);
       expect(await reactTab.isDisplayed()).to.be(true);
-    });
-
-    it('should render angular doc view', async () => {
-      const angularTab = await find.byButtonText('Angular doc view');
-      await angularTab.click();
-      const angularContent = await testSubjects.find('angular-docview');
-      expect(await angularContent.getVisibleText()).to.be('logstash-2015.09.22');
     });
 
     it('should render react doc view', async () => {


### PR DESCRIPTION
### Description
* remove angular-based view from DocViewsPlugin
* remove the test case that validates the display and content of the angular doc view

### Issue Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5020

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
