### PR TITLE
[BUG][Fuctional Test] Make setDefaultAbsoluteRange more robust and update doc views tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Data Explorer][Discover] Allow data grid to auto adjust size based on fetched data count ([#5191](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5191))
 - [BUG] Fix wrong test due to time conversion ([#5174](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5174))
 - [BUG][Data Explorer][Discover] Allow filter and query persist when refresh page or paste url to a new tab ([#5206](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5206))
+- [BUG][Fuctional Test] Make setDefaultAbsoluteRange more robust and update doc views tests ([#5242](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5242))
 
 ### 🚞 Infrastructure
 

--- a/test/functional/page_objects/time_picker.ts
+++ b/test/functional/page_objects/time_picker.ts
@@ -131,32 +131,6 @@ export function TimePickerProvider({ getService, getPageObjects }: FtrProviderCo
       await testSubjects.exists('superDatePickerstartDatePopoverButton');
     }
 
-    // Helper function to set input value and verify
-    private async setInputValueWithRetry(testSubjectId: string, value: string) {
-      const MAX_ATTEMPTS = 3;
-
-      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-        // try to set the value
-        await this.inputValue(testSubjectId, value);
-        await sleep(500);
-
-        // verify if the value was correctly set
-        const actualValue = await (await testSubjects.find(testSubjectId)).getAttribute('value');
-        if (actualValue === value) {
-          return;
-        }
-
-        // if it's the last attempt and value wasn't set correctly, throw an error
-        if (attempt === MAX_ATTEMPTS - 1) {
-          throw new Error(
-            `Failed to set ${testSubjectId} to ${value} after ${MAX_ATTEMPTS} attempts.`
-          );
-        }
-
-        await sleep(500); // wait before retrying
-      }
-    }
-
     /**
      * @param {String} fromTime MMM D, YYYY @ HH:mm:ss.SSS
      * @param {String} toTime MMM D, YYYY @ HH:mm:ss.SSS
@@ -164,16 +138,13 @@ export function TimePickerProvider({ getService, getPageObjects }: FtrProviderCo
     public async setAbsoluteRange(fromTime: string, toTime: string) {
       log.debug(`Setting absolute range to ${fromTime} to ${toTime}`);
       await this.showStartEndTimes();
-      // make sure to close this verify panel
-      await browser.pressKeys(browser.keys.ESCAPE);
-      await sleep(500);
 
       // set to time
       await testSubjects.click('superDatePickerendDatePopoverButton');
       let panel = await this.getTimePickerPanel();
       await testSubjects.click('superDatePickerAbsoluteTab');
       await testSubjects.click('superDatePickerAbsoluteDateInput');
-      await this.setInputValueWithRetry('superDatePickerAbsoluteDateInput', toTime);
+      await this.inputValue('superDatePickerAbsoluteDateInput', toTime);
       await browser.pressKeys(browser.keys.ESCAPE); // close popover because sometimes browser can't find start input
 
       // set from time
@@ -182,8 +153,7 @@ export function TimePickerProvider({ getService, getPageObjects }: FtrProviderCo
       panel = await this.getTimePickerPanel();
       await testSubjects.click('superDatePickerAbsoluteTab');
       await testSubjects.click('superDatePickerAbsoluteDateInput');
-      await this.setInputValueWithRetry('superDatePickerAbsoluteDateInput', fromTime);
-      await browser.pressKeys(browser.keys.ESCAPE);
+      await this.inputValue('superDatePickerAbsoluteDateInput', fromTime);
 
       const superDatePickerApplyButtonExists = await testSubjects.exists(
         'superDatePickerApplyTimeButton'
@@ -339,6 +309,83 @@ export function TimePickerProvider({ getService, getPageObjects }: FtrProviderCo
       const fromTime = 'Apr 9, 2018 @ 00:00:00.000';
       const toTime = 'Apr 13, 2018 @ 00:00:00.000';
       await this.setAbsoluteRange(fromTime, toTime);
+    }
+
+    // Helper function to set input value and verify
+    private async setInputValueWithRetry(testSubjectId: string, value: string) {
+      const MAX_ATTEMPTS = 3;
+
+      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        // try to set the value
+        await this.inputValue(testSubjectId, value);
+        await sleep(500);
+
+        // verify if the value was correctly set
+        const actualValue = await (await testSubjects.find(testSubjectId)).getAttribute('value');
+        if (actualValue === value) {
+          return;
+        }
+
+        // if it's the last attempt and value wasn't set correctly, throw an error
+        if (attempt === MAX_ATTEMPTS - 1) {
+          throw new Error(
+            `Failed to set ${testSubjectId} to ${value} after ${MAX_ATTEMPTS} attempts.`
+          );
+        }
+
+        await sleep(500); // wait before retrying
+      }
+    }
+
+    // TODO: This is a temporary method added due to observed issues with panels
+    // not closing in time and incorrect time settings on Discover page. Once these bugs are resolved
+    // and the interactions become more reliable, we should consider removing this method and related helper functions.
+    // Tracking issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5241
+    /**
+     * @param {String} fromTime MMM D, YYYY @ HH:mm:ss.SSS
+     * @param {String} toTime MMM D, YYYY @ HH:mm:ss.SSS
+     */
+    public async setDefaultRangeForDiscover() {
+      const fromTime = this.defaultStartTime;
+      const toTime = this.defaultEndTime;
+      log.debug(`Setting absolute range to ${fromTime} to ${toTime}`);
+
+      await this.showStartEndTimes();
+      // make sure to close this verify panel
+      await browser.pressKeys(browser.keys.ESCAPE);
+      await sleep(500);
+
+      // set to time
+      await testSubjects.click('superDatePickerendDatePopoverButton');
+      let panel = await this.getTimePickerPanel();
+      await testSubjects.click('superDatePickerAbsoluteTab');
+      await testSubjects.click('superDatePickerAbsoluteDateInput');
+      await this.setInputValueWithRetry('superDatePickerAbsoluteDateInput', toTime);
+      await browser.pressKeys(browser.keys.ESCAPE); // close popover because sometimes browser can't find start input
+
+      // set from time
+      await testSubjects.click('superDatePickerstartDatePopoverButton');
+      await this.waitPanelIsGone(panel);
+      panel = await this.getTimePickerPanel();
+      await testSubjects.click('superDatePickerAbsoluteTab');
+      await testSubjects.click('superDatePickerAbsoluteDateInput');
+      await this.setInputValueWithRetry('superDatePickerAbsoluteDateInput', fromTime);
+      await browser.pressKeys(browser.keys.ESCAPE);
+
+      const superDatePickerApplyButtonExists = await testSubjects.exists(
+        'superDatePickerApplyTimeButton'
+      );
+      if (superDatePickerApplyButtonExists) {
+        // Timepicker is in top nav
+        // Click super date picker apply button to apply time range
+        await testSubjects.click('superDatePickerApplyTimeButton');
+      } else {
+        // Timepicker is embedded in query bar
+        // click query bar submit button to apply time range
+        await testSubjects.click('querySubmitButton');
+      }
+      await this.waitPanelIsGone(panel);
+      await header.awaitGlobalLoadingIndicatorHidden();
     }
   }
 

--- a/test/plugin_functional/test_suites/doc_views/doc_views.ts
+++ b/test/plugin_functional/test_suites/doc_views/doc_views.ts
@@ -39,7 +39,9 @@ export default function ({ getService, getPageObjects }: PluginFunctionalProvide
   describe('custom doc views', function () {
     before(async () => {
       await PageObjects.common.navigateToApp('discover');
-      await PageObjects.timePicker.setDefaultAbsoluteRange();
+      // TODO: change back to setDefaultRange() once we resolve
+      // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5241
+      await PageObjects.timePicker.setDefaultRangeForDiscover();
     });
 
     it('should show custom doc views', async () => {

--- a/test/plugin_functional/test_suites/doc_views/doc_views.ts
+++ b/test/plugin_functional/test_suites/doc_views/doc_views.ts
@@ -43,7 +43,7 @@ export default function ({ getService, getPageObjects }: PluginFunctionalProvide
     });
 
     it('should show custom doc views', async () => {
-      await testSubjects.click('docTableExpandToggleColumn');
+      await testSubjects.click('docTableExpandToggleColumn-0');
       const reactTab = await find.byButtonText('React doc view');
       expect(await reactTab.isDisplayed()).to.be(true);
     });

--- a/test/plugin_functional/test_suites/doc_views_links/doc_views_links.ts
+++ b/test/plugin_functional/test_suites/doc_views_links/doc_views_links.ts
@@ -38,7 +38,9 @@ export default function ({ getService, getPageObjects }: PluginFunctionalProvide
   describe('custom doc views links', function () {
     beforeEach(async () => {
       await PageObjects.common.navigateToApp('discover');
-      await PageObjects.timePicker.setDefaultAbsoluteRange();
+      // TODO: change back to setDefaultRange() once we resolve
+      // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5241
+      await PageObjects.timePicker.setDefaultRangeForDiscover();
       await testSubjects.click('docTableExpandToggleColumn-0');
     });
 

--- a/test/plugin_functional/test_suites/doc_views_links/doc_views_links.ts
+++ b/test/plugin_functional/test_suites/doc_views_links/doc_views_links.ts
@@ -11,36 +11,81 @@ export default function ({ getService, getPageObjects }: PluginFunctionalProvide
   const find = getService('find');
   const browser = getService('browser');
   const PageObjects = getPageObjects(['common', 'discover', 'timePicker']);
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const waitFor = async (conditionFunction, timeoutMs = 10000, intervalMs = 100) => {
+    const start = Date.now();
+
+    let lastError;
+    while (Date.now() - start < timeoutMs) {
+      try {
+        if (await conditionFunction()) {
+          return;
+        }
+      } catch (error) {
+        lastError = error;
+      }
+
+      await sleep(intervalMs);
+    }
+
+    throw new Error(
+      `waitFor condition did not become true within ${timeoutMs}ms. Last error: ${
+        lastError && lastError.message
+      }`
+    );
+  };
 
   describe('custom doc views links', function () {
     beforeEach(async () => {
       await PageObjects.common.navigateToApp('discover');
       await PageObjects.timePicker.setDefaultAbsoluteRange();
-      await testSubjects.click('docTableExpandToggleColumn');
+      await testSubjects.click('docTableExpandToggleColumn-0');
     });
 
-    it('should show href and generateCb doc views link', async () => {
+    it('should show href and generateCb doc views link and not show generateCbHidden doc views link', async () => {
       const hrefLink = await find.byLinkText('href doc view link');
       const generateCbLink = await find.byLinkText('generateCb doc view link');
-
       expect(await hrefLink.isDisplayed()).to.be(true);
       expect(await generateCbLink.isDisplayed()).to.be(true);
-    });
-
-    it('should not render generateCbHidden doc views link', async () => {
       expect(await find.existsByLinkText('generateCbHidden doc view link')).to.eql(false);
     });
 
     it('should render href doc view link', async () => {
       const hrefLink = await find.byLinkText('href doc view link');
+      const originalTabCount = (await browser.getAllWindowHandles()).length;
       await hrefLink.click();
-      expect(await browser.getCurrentUrl()).to.eql('http://some-url/');
+
+      // wait until a new tab is opened
+      await waitFor(async () => (await browser.getAllWindowHandles()).length > originalTabCount);
+
+      // switch to the originalTabCount in case previous tab is not closed in time
+      await browser.switchTab(originalTabCount);
+
+      const currentUrl = await browser.getCurrentUrl();
+      expect(currentUrl).to.eql('http://some-url/');
+
+      // close new tab and switch back to original tab
+      await browser.closeCurrentWindow();
+      await browser.switchTab(0);
     });
 
     it('should render generateCb doc view link', async () => {
       const generateCbLink = await find.byLinkText('generateCb doc view link');
+      const originalTabCount = (await browser.getAllWindowHandles()).length;
       await generateCbLink.click();
-      expect(await browser.getCurrentUrl()).to.eql('http://some-url/');
+
+      // wait until a new tab is opened
+      await waitFor(async () => (await browser.getAllWindowHandles()).length > originalTabCount);
+
+      // switch to the originalTabCount in case previous tab is not closed in time
+      await browser.switchTab(originalTabCount);
+
+      const currentUrl = await browser.getCurrentUrl();
+      expect(currentUrl).to.eql('http://some-url/');
+
+      // close new tab and switch back to original tab
+      await browser.closeCurrentWindow();
+      await browser.switchTab(0);
     });
   });
 }


### PR DESCRIPTION
### Description
* add a helper function setInputValueWithRetry for setAbsoluteRange to retry time range setup
* update doc_views test to click docTableExpandToggleColumn-0
* update doc_views_link to check new tab

### Issue Resolve
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5241


## Screenshot

* `test_suites/doc_views`

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/534be03d-7b8c-4f8d-bbe8-193e93afd797

* `test_suites/doc_views_links`

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/0093c9df-082e-4a17-b785-a285240801c9


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
