### PR TITLE
[BUG][Discover] Allow default columns settings

### DIFF
--- a/src/plugins/discover/public/application/utils/state_management/discover_slice.tsx
+++ b/src/plugins/discover/public/application/utils/state_management/discover_slice.tsx
@@ -11,7 +11,7 @@ import { RootState, DefaultViewState } from '../../../../../data_explorer/public
 import { buildColumns } from '../columns';
 import * as utils from './common';
 import { SortOrder } from '../../../saved_searches/types';
-import { PLUGIN_ID } from '../../../../common';
+import { DEFAULT_COLUMNS_SETTING, PLUGIN_ID } from '../../../../common';
 
 export interface DiscoverState {
   /**
@@ -57,6 +57,7 @@ const initialState: DiscoverState = {
 
 export const getPreloadedState = async ({
   getSavedSearchById,
+  uiSettings: config,
 }: DiscoverServices): Promise<DefaultViewState<DiscoverState>> => {
   const preloadedState: DefaultViewState<DiscoverState> = {
     state: {
@@ -86,6 +87,8 @@ export const getPreloadedState = async ({
 
       savedSearchInstance.destroy(); // this instance is no longer needed, will create another one later
     }
+  } else if (config.get(DEFAULT_COLUMNS_SETTING)) {
+    preloadedState.state.columns = config.get(DEFAULT_COLUMNS_SETTING);
   }
 
   return preloadedState;

--- a/src/plugins/discover/public/application/view_components/utils/filter_columns.test.ts
+++ b/src/plugins/discover/public/application/view_components/utils/filter_columns.test.ts
@@ -12,23 +12,22 @@ describe('filterColumns', () => {
       getAll: () => [{ name: 'a' }, { name: 'c' }, { name: 'd' }],
     },
   } as IndexPattern;
-  const defaultColumns = ['_defaultColumn'];
 
   it('should return columns that exist in the index pattern fields', () => {
     const columns = ['a', 'b'];
-    const result = filterColumns(columns, indexPatternMock, defaultColumns);
+    const result = filterColumns(columns, indexPatternMock, ['a']);
     expect(result).toEqual(['a']);
   });
 
   it('should return defaultColumns if no columns exist in the index pattern fields', () => {
     const columns = ['b', 'e'];
-    const result = filterColumns(columns, indexPatternMock, defaultColumns);
-    expect(result).toEqual(defaultColumns);
+    const result = filterColumns(columns, indexPatternMock, ['e']);
+    expect(result).toEqual(['_source']);
   });
 
-  it('should return defaultColumns if no columns and indexPattern is null', () => {
+  it('should return defaultColumns if no columns and indexPattern is undefined', () => {
     const columns = ['b', 'e'];
-    const result = filterColumns(columns, null, defaultColumns);
-    expect(result).toEqual(defaultColumns);
+    const result = filterColumns(columns, undefined, ['a']);
+    expect(result).toEqual(['_source']);
   });
 });

--- a/src/plugins/discover/public/application/view_components/utils/filter_columns.ts
+++ b/src/plugins/discover/public/application/view_components/utils/filter_columns.ts
@@ -20,6 +20,8 @@ export function filterColumns(
   defaultColumns: string[]
 ) {
   const fieldsName = indexPattern?.fields.getAll().map((fld) => fld.name) || [];
-  const filteredColumns = columns.filter((column) => fieldsName.includes(column));
-  return filteredColumns.length > 0 ? filteredColumns : defaultColumns;
+  // combine columns and defaultColumns without duplicates
+  const combinedColumns = [...new Set([...columns, ...defaultColumns])];
+  const filteredColumns = combinedColumns.filter((column) => fieldsName.includes(column));
+  return filteredColumns.length > 0 ? filteredColumns : ['_source'];
 }


### PR DESCRIPTION
### Description
This is a missing functionality. In this PR we enables the following:
* When user sets up `Default columns` in advanced settings, discover should display default columns if the selected idp has the columns.
* If selected idp has no such columns, display `_source` column.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5246


## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/2185f139-b600-4a17-964b-42314774181b


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
