### PR TITLE
[Worksapce][Feature] Update application category and retire dashboard management section

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -3,7 +3,7 @@ name: Run cypress tests
 # trigger on every PR for all branches
 on:
   pull_request:
-    branches: ['**']
+    branches: [ '**' ]
     paths-ignore:
       - '**/*.md'
   workflow_dispatch:
@@ -33,7 +33,7 @@ env:
   FTR_PATH: 'ftr'
   START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch'
   OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot -E cluster.routing.allocation.disk.threshold_enabled=false'
-  SPEC: ${{ inputs.specs != '' && inputs.specs || 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js,' }}
+  SPEC: ${{ inputs.specs != '' && inputs.specs || 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js,' }} 
   CYPRESS_BROWSER: 'chromium'
   CYPRESS_VISBUILDER_ENABLED: true
   CYPRESS_DATASOURCE_MANAGEMENT_ENABLED: false
@@ -137,7 +137,7 @@ jobs:
           name: ftr-cypress-screenshots
           path: ${{ env.FTR_PATH }}/cypress/screenshots
           retention-days: 1
-
+      
       - uses: actions/upload-artifact@v3
         if: always()
         with:
@@ -165,7 +165,7 @@ jobs:
         with:
           issue-number: ${{ inputs.pr_number }}
           comment-author: 'github-actions[bot]'
-          body-includes: '${{ env.COMMENT_TAG }}'
+          body-includes: "${{ env.COMMENT_TAG }}"
 
       - name: Add comment on the PR
         uses: peter-evans/create-or-update-comment@v3

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -3,7 +3,7 @@ name: Run cypress tests
 # trigger on every PR for all branches
 on:
   pull_request:
-    branches: [ '**' ]
+    branches: ['**']
     paths-ignore:
       - '**/*.md'
   workflow_dispatch:
@@ -33,7 +33,7 @@ env:
   FTR_PATH: 'ftr'
   START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch'
   OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot -E cluster.routing.allocation.disk.threshold_enabled=false'
-  SPEC: ${{ inputs.specs != '' && inputs.specs || 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js,' }} 
+  SPEC: ${{ inputs.specs != '' && inputs.specs || 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js,' }}
   CYPRESS_BROWSER: 'chromium'
   CYPRESS_VISBUILDER_ENABLED: true
   CYPRESS_DATASOURCE_MANAGEMENT_ENABLED: false
@@ -137,7 +137,7 @@ jobs:
           name: ftr-cypress-screenshots
           path: ${{ env.FTR_PATH }}/cypress/screenshots
           retention-days: 1
-      
+
       - uses: actions/upload-artifact@v3
         if: always()
         with:
@@ -165,7 +165,7 @@ jobs:
         with:
           issue-number: ${{ inputs.pr_number }}
           comment-author: 'github-actions[bot]'
-          body-includes: "${{ env.COMMENT_TAG }}"
+          body-includes: '${{ env.COMMENT_TAG }}'
 
       - name: Add comment on the PR
         uses: peter-evans/create-or-update-comment@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Theme] Use themes' definitions to render the initial view ([#4936](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4936))
 - [Theme] Make `next` theme the default ([#4854](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4854))
 - [Discover] Update embeddable for saved searches ([#5081](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5081))
+- [Workspace] Update application category and retire dashboard management section ([#5281](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5281))
 
 ### 🐛 Bug Fixes
 

--- a/cypress/integration/with-security/check_advanced_settings.js
+++ b/cypress/integration/with-security/check_advanced_settings.js
@@ -13,7 +13,7 @@ const loginPage = new LoginPage(cy);
 
 describe('verify the advanced settings are saved', () => {
   beforeEach(() => {
-    miscUtils.visitPage('app/management/opensearch-dashboards/settings');
+    miscUtils.visitPage('app/settings');
     loginPage.enterUserName('admin');
     loginPage.enterPassword('admin');
     loginPage.submit();

--- a/cypress/integration/with-security/helpers/generate_data.js
+++ b/cypress/integration/with-security/helpers/generate_data.js
@@ -13,7 +13,7 @@ const loginPage = new LoginPage(cy);
 
 describe('Generating BWC test data with security', () => {
   beforeEach(() => {
-    miscUtils.visitPage('app/management/opensearch-dashboards/settings');
+    miscUtils.visitPage('app/settings');
     loginPage.enterUserName('admin');
     loginPage.enterPassword('admin');
     loginPage.submit();
@@ -29,7 +29,7 @@ describe('Generating BWC test data with security', () => {
   });
 
   it('adds advanced settings', () => {
-    miscUtils.visitPage('app/management/opensearch-dashboards/settings');
+    miscUtils.visitPage('app/settings');
     cy.get('[data-test-subj="advancedSetting-editField-theme:darkMode"]').click();
     cy.get('[data-test-subj="advancedSetting-editField-timeline:max_buckets"]').type(
       '{selectAll}4'

--- a/cypress/integration/without-security/check_advanced_settings.js
+++ b/cypress/integration/without-security/check_advanced_settings.js
@@ -9,7 +9,7 @@ const miscUtils = new MiscUtils(cy);
 
 describe('verify the advanced settings are saved', () => {
   beforeEach(() => {
-    miscUtils.visitPage('app/management/opensearch-dashboards/settings');
+    miscUtils.visitPage('app/settings');
   });
 
   it('the dark mode is on', () => {

--- a/cypress/integration/without-security/helpers/generate_data.js
+++ b/cypress/integration/without-security/helpers/generate_data.js
@@ -12,7 +12,7 @@ describe('Generating BWC test data without security', () => {
     miscUtils.visitPage('app');
   });
   it('adds advanced settings', () => {
-    miscUtils.visitPage('app/management/opensearch-dashboards/settings');
+    miscUtils.visitPage('app/settings');
     cy.get('[data-test-subj="advancedSetting-editField-theme:darkMode"]').click();
     cy.get('[data-test-subj="advancedSetting-editField-timeline:max_buckets"]').type(
       '{selectAll}4'

--- a/src/core/public/core_app/errors/url_overflow.test.ts
+++ b/src/core/public/core_app/errors/url_overflow.test.ts
@@ -102,7 +102,7 @@ describe('url overflow detection', () => {
         </code>
          option in 
         <a
-          href="/test-123/app/management/opensearch-dashboards/settings"
+          href="/test-123/app/settings"
         >
           advanced settings
         </a>

--- a/src/core/public/core_app/errors/url_overflow.tsx
+++ b/src/core/public/core_app/errors/url_overflow.tsx
@@ -92,7 +92,7 @@ export const setupUrlOverflowDetection = ({ basePath, history, toasts, uiSetting
             values={{
               storeInSessionStorageParam: <code>state:storeInSessionStorage</code>,
               advancedSettingsLink: (
-                <a href={basePath.prepend('/app/management/opensearch-dashboards/settings')}>
+                <a href={basePath.prepend('/app/settings')}>
                   <FormattedMessage
                     id="core.ui.errorUrlOverflow.bigUrlWarningNotificationMessage.advancedSettingsLinkText"
                     defaultMessage="advanced settings"

--- a/src/core/public/core_app/errors/url_overflow_ui.tsx
+++ b/src/core/public/core_app/errors/url_overflow_ui.tsx
@@ -54,7 +54,7 @@ export const UrlOverflowUi: React.FC<{ basePath: IBasePath }> = ({ basePath }) =
             values={{
               storeInSessionStorageConfig: <code>state:storeInSessionStorage</code>,
               opensearchDashboardsSettingsLink: (
-                <a href={basePath.prepend('/app/management/opensearch-dashboards/settings')}>
+                <a href={basePath.prepend('/app/settings')}>
                   <FormattedMessage
                     id="core.ui.errorUrlOverflow.optionsToFixError.enableOptionText.advancedSettingsLinkText"
                     defaultMessage="Advanced Settings"

--- a/src/core/server/ui_settings/saved_objects/ui_settings.ts
+++ b/src/core/server/ui_settings/saved_objects/ui_settings.ts
@@ -47,7 +47,7 @@ export const uiSettingsType: SavedObjectsType = {
     importableAndExportable: true,
     getInAppUrl() {
       return {
-        path: `/app/management/opensearch-dashboards/settings`,
+        path: `/app/settings`,
         uiCapabilitiesPath: 'advancedSettings.show',
       };
     },

--- a/src/core/utils/default_app_categories.ts
+++ b/src/core/utils/default_app_categories.ts
@@ -35,8 +35,8 @@ import { AppCategory } from '../types';
 export const DEFAULT_APP_CATEGORIES: Record<string, AppCategory> = Object.freeze({
   opensearchDashboards: {
     id: 'opensearchDashboards',
-    label: i18n.translate('core.ui.opensearchDashboardsNavList.label', {
-      defaultMessage: 'OpenSearch Dashboards',
+    label: i18n.translate('core.ui.libraryNavList.label', {
+      defaultMessage: 'Library',
     }),
     euiIconType: 'inputOutput',
     order: 1000,

--- a/src/plugins/advanced_settings/public/management_app/components/page_wrapper/__snapshots__/page_wrapper.test.tsx.snap
+++ b/src/plugins/advanced_settings/public/management_app/components/page_wrapper/__snapshots__/page_wrapper.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageWrapper should render normally 1`] = `
+<div>
+  <div
+    class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPageContent euiPageContent--horizontalCenter"
+    role="main"
+    style="max-width: 75%; margin-top: 20px;"
+  >
+    Foo
+  </div>
+</div>
+`;

--- a/src/plugins/advanced_settings/public/management_app/components/page_wrapper/index.ts
+++ b/src/plugins/advanced_settings/public/management_app/components/page_wrapper/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { PageWrapper } from './page_wrapper';

--- a/src/plugins/advanced_settings/public/management_app/components/page_wrapper/page_wrapper.test.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/page_wrapper/page_wrapper.test.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PageWrapper } from './page_wrapper';
+
+describe('PageWrapper', () => {
+  it('should render normally', async () => {
+    const { findByText, container } = render(<PageWrapper>Foo</PageWrapper>);
+    await findByText('Foo');
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/plugins/advanced_settings/public/management_app/components/page_wrapper/page_wrapper.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/page_wrapper/page_wrapper.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiPageContent } from '@elastic/eui';
+import React from 'react';
+
+export const PageWrapper = (props: { children?: React.ReactChild }) => {
+  return (
+    <EuiPageContent
+      style={{ maxWidth: '75%', marginTop: '20px' }}
+      hasShadow={false}
+      hasBorder={false}
+      panelPaddingSize="none"
+      horizontalPosition="center"
+      color="transparent"
+      {...props}
+    />
+  );
+};

--- a/src/plugins/advanced_settings/public/management_app/mount_management_section.tsx
+++ b/src/plugins/advanced_settings/public/management_app/mount_management_section.tsx
@@ -34,18 +34,24 @@ import { Router, Switch, Route } from 'react-router-dom';
 
 import { i18n } from '@osd/i18n';
 import { I18nProvider } from '@osd/i18n/react';
-import { StartServicesAccessor } from 'src/core/public';
+import {
+  AppMountParameters,
+  ChromeBreadcrumb,
+  ScopedHistory,
+  StartServicesAccessor,
+} from 'src/core/public';
 
 import { AdvancedSettings } from './advanced_settings';
-import { ManagementAppMountParams } from '../../../management/public';
 import { ComponentRegistry } from '../types';
+import { reactRouterNavigate } from '../../../opensearch_dashboards_react/public';
+import { PageWrapper } from './components/page_wrapper';
 
 import './index.scss';
 
 const title = i18n.translate('advancedSettings.advancedSettingsLabel', {
   defaultMessage: 'Advanced settings',
 });
-const crumb = [{ text: title }];
+const crumb: ChromeBreadcrumb[] = [{ text: title }];
 
 const readOnlyBadge = {
   text: i18n.translate('advancedSettings.badge.readOnly.text', {
@@ -57,13 +63,18 @@ const readOnlyBadge = {
   iconType: 'glasses',
 };
 
-export async function mountManagementSection(
+export async function mountAdvancedSettingsManagementSection(
   getStartServices: StartServicesAccessor,
-  params: ManagementAppMountParams,
+  params: AppMountParameters,
   componentRegistry: ComponentRegistry['start']
 ) {
-  params.setBreadcrumbs(crumb);
   const [{ uiSettings, notifications, docLinks, application, chrome }] = await getStartServices();
+  chrome.setBreadcrumbs([
+    ...crumb.map((item) => ({
+      ...item,
+      ...(item.href ? reactRouterNavigate(params.history, item.href) : {}),
+    })),
+  ]);
 
   const canSave = application.capabilities.advancedSettings.save as boolean;
 
@@ -72,21 +83,23 @@ export async function mountManagementSection(
   }
 
   ReactDOM.render(
-    <I18nProvider>
-      <Router history={params.history}>
-        <Switch>
-          <Route path={['/:query', '/']}>
-            <AdvancedSettings
-              enableSaving={canSave}
-              toasts={notifications.toasts}
-              dockLinks={docLinks.links}
-              uiSettings={uiSettings}
-              componentRegistry={componentRegistry}
-            />
-          </Route>
-        </Switch>
-      </Router>
-    </I18nProvider>,
+    <PageWrapper>
+      <I18nProvider>
+        <Router history={params.history}>
+          <Switch>
+            <Route path={['/:query', '/']}>
+              <AdvancedSettings
+                enableSaving={canSave}
+                toasts={notifications.toasts}
+                dockLinks={docLinks.links}
+                uiSettings={uiSettings}
+                componentRegistry={componentRegistry}
+              />
+            </Route>
+          </Switch>
+        </Router>
+      </I18nProvider>
+    </PageWrapper>,
     params.element
   );
   return () => {

--- a/src/plugins/advanced_settings/public/plugin.ts
+++ b/src/plugins/advanced_settings/public/plugin.ts
@@ -29,10 +29,11 @@
  */
 
 import { i18n } from '@osd/i18n';
-import { CoreSetup, Plugin } from 'opensearch-dashboards/public';
+import { AppMountParameters, CoreSetup, Plugin } from 'opensearch-dashboards/public';
 import { FeatureCatalogueCategory } from '../../home/public';
 import { ComponentRegistry } from './component_registry';
 import { AdvancedSettingsSetup, AdvancedSettingsStart, AdvancedSettingsPluginSetup } from './types';
+import { DEFAULT_APP_CATEGORIES } from '../../../core/public';
 
 const component = new ComponentRegistry();
 
@@ -42,18 +43,21 @@ const title = i18n.translate('advancedSettings.advancedSettingsLabel', {
 
 export class AdvancedSettingsPlugin
   implements Plugin<AdvancedSettingsSetup, AdvancedSettingsStart, AdvancedSettingsPluginSetup> {
-  public setup(core: CoreSetup, { management, home }: AdvancedSettingsPluginSetup) {
-    const opensearchDashboardsSection = management.sections.section.opensearchDashboards;
-
-    opensearchDashboardsSection.registerApp({
+  public setup(core: CoreSetup, { home }: AdvancedSettingsPluginSetup) {
+    core.application.register({
       id: 'settings',
       title,
-      order: 3,
-      async mount(params) {
-        const { mountManagementSection } = await import(
+      order: 99,
+      category: DEFAULT_APP_CATEGORIES.management,
+      async mount(params: AppMountParameters) {
+        const { mountAdvancedSettingsManagementSection } = await import(
           './management_app/mount_management_section'
         );
-        return mountManagementSection(core.getStartServices, params, component.start);
+        return mountAdvancedSettingsManagementSection(
+          core.getStartServices,
+          params,
+          component.start
+        );
       },
     });
 
@@ -66,7 +70,7 @@ export class AdvancedSettingsPlugin
             'Customize your OpenSearch Dashboards experience — change the date format, turn on dark mode, and more.',
         }),
         icon: 'gear',
-        path: '/app/management/opensearch-dashboards/settings',
+        path: '/app/settings',
         showOnHomePage: false,
         category: FeatureCatalogueCategory.ADMIN,
       });

--- a/src/plugins/dashboard/server/saved_objects/dashboard.ts
+++ b/src/plugins/dashboard/server/saved_objects/dashboard.ts
@@ -43,9 +43,7 @@ export const dashboardSavedObjectType: SavedObjectsType = {
       return obj.attributes.title;
     },
     getEditUrl(obj) {
-      return `/management/opensearch-dashboards/objects/savedDashboards/${encodeURIComponent(
-        obj.id
-      )}`;
+      return `/objects/savedDashboards/${encodeURIComponent(obj.id)}`;
     },
     getInAppUrl(obj) {
       return {

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
@@ -418,11 +418,7 @@ export class IndexPatternsService {
     );
 
     if (!savedObject.version) {
-      throw new SavedObjectNotFound(
-        savedObjectType,
-        id,
-        'management/opensearch-dashboards/indexPatterns'
-      );
+      throw new SavedObjectNotFound(savedObjectType, id, 'indexPatterns');
     }
 
     const spec = this.savedObjectToSpec(savedObject);

--- a/src/plugins/data/public/index_patterns/index_patterns/redirect_no_index_pattern.tsx
+++ b/src/plugins/data/public/index_patterns/index_patterns/redirect_no_index_pattern.tsx
@@ -42,9 +42,7 @@ export const onRedirectNoIndexPattern = (
   overlays: CoreStart['overlays']
 ) => () => {
   const canManageIndexPatterns = capabilities.management.opensearchDashboards.indexPatterns;
-  const redirectTarget = canManageIndexPatterns
-    ? '/management/opensearch-dashboards/indexPatterns'
-    : '/home';
+  const redirectTarget = canManageIndexPatterns ? '/indexPatterns' : '/home';
   let timeoutId: NodeJS.Timeout | undefined;
 
   if (timeoutId) {
@@ -72,8 +70,8 @@ export const onRedirectNoIndexPattern = (
   if (redirectTarget === '/home') {
     navigateToApp('home');
   } else {
-    navigateToApp('management', {
-      path: `/opensearch-dashboards/indexPatterns?bannerMessage=${bannerMessage}`,
+    navigateToApp('indexPatterns', {
+      path: `?bannerMessage=${bannerMessage}`,
     });
   }
 

--- a/src/plugins/data/public/search/errors/painless_error.tsx
+++ b/src/plugins/data/public/search/errors/painless_error.tsx
@@ -53,9 +53,7 @@ export class PainlessError extends OsdError {
 
   public getErrorMessage(application: ApplicationStart) {
     function onClick() {
-      application.navigateToApp('management', {
-        path: `/opensearch-dashboards/indexPatterns`,
-      });
+      application.navigateToApp('indexPatterns');
     }
 
     return (

--- a/src/plugins/data/server/saved_objects/index_patterns.ts
+++ b/src/plugins/data/server/saved_objects/index_patterns.ts
@@ -43,15 +43,11 @@ export const indexPatternSavedObjectType: SavedObjectsType = {
       return obj.attributes.title;
     },
     getEditUrl(obj) {
-      return `/management/opensearch-dashboards/indexPatterns/patterns/${encodeURIComponent(
-        obj.id
-      )}`;
+      return `/indexPatterns/patterns/${encodeURIComponent(obj.id)}`;
     },
     getInAppUrl(obj) {
       return {
-        path: `/app/management/opensearch-dashboards/indexPatterns/patterns/${encodeURIComponent(
-          obj.id
-        )}`,
+        path: `/app/indexPatterns/patterns/${encodeURIComponent(obj.id)}`,
         uiCapabilitiesPath: 'management.opensearchDashboards.indexPatterns',
       };
     },

--- a/src/plugins/data_source/server/saved_objects/data_source.ts
+++ b/src/plugins/data_source/server/saved_objects/data_source.ts
@@ -17,11 +17,11 @@ export const dataSource: SavedObjectsType = {
       return obj.attributes.title;
     },
     getEditUrl(obj) {
-      return `/management/opensearch-dashboards/dataSources/${encodeURIComponent(obj.id)}`;
+      return `/dataSources/${encodeURIComponent(obj.id)}`;
     },
     getInAppUrl(obj) {
       return {
-        path: `/app/management/opensearch-dashboards/dataSources/${encodeURIComponent(obj.id)}`,
+        path: `/app/dataSources/${encodeURIComponent(obj.id)}`,
         uiCapabilitiesPath: 'management.opensearchDashboards.dataSources',
       };
     },

--- a/src/plugins/data_source_management/opensearch_dashboards.json
+++ b/src/plugins/data_source_management/opensearch_dashboards.json
@@ -3,7 +3,7 @@
   "version": "opensearchDashboards",
   "server": false,
   "ui": true,
-  "requiredPlugins": ["management", "dataSource", "indexPatternManagement"],
+  "requiredPlugins": ["dataSource", "indexPatternManagement"],
   "optionalPlugins": [],
   "requiredBundles": ["opensearchDashboardsReact"],
   "extraPublicDirs": ["public/components/utils"]

--- a/src/plugins/data_source_management/public/components/data_source_column/data_source_column.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_column/data_source_column.tsx
@@ -56,11 +56,7 @@ export class DataSourceColumn implements IndexPatternTableColumn<DataSourceMap> 
         ?.map((dataSource) => {
           return {
             ...dataSource,
-            relativeUrl: basePath.prepend(
-              `/app/management/opensearch-dashboards/dataSources/${encodeURIComponent(
-                dataSource.id
-              )}`
-            ),
+            relativeUrl: basePath.prepend(`/app/dataSources/${encodeURIComponent(dataSource.id)}`),
           };
         })
         ?.reduce(

--- a/src/plugins/data_source_management/public/components/page_wrapper/__snapshots__/page_wrapper.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/page_wrapper/__snapshots__/page_wrapper.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageWrapper should render normally 1`] = `
+<div>
+  <div
+    class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPageContent euiPageContent--horizontalCenter"
+    role="main"
+    style="max-width: 75%; margin-top: 20px;"
+  >
+    Foo
+  </div>
+</div>
+`;

--- a/src/plugins/data_source_management/public/components/page_wrapper/index.ts
+++ b/src/plugins/data_source_management/public/components/page_wrapper/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { PageWrapper } from './page_wrapper';

--- a/src/plugins/data_source_management/public/components/page_wrapper/page_wrapper.test.tsx
+++ b/src/plugins/data_source_management/public/components/page_wrapper/page_wrapper.test.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PageWrapper } from './page_wrapper';
+
+describe('PageWrapper', () => {
+  it('should render normally', async () => {
+    const { findByText, container } = render(<PageWrapper>Foo</PageWrapper>);
+    await findByText('Foo');
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/plugins/data_source_management/public/components/page_wrapper/page_wrapper.tsx
+++ b/src/plugins/data_source_management/public/components/page_wrapper/page_wrapper.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiPageContent } from '@elastic/eui';
+import React from 'react';
+
+export const PageWrapper = (props: { children?: React.ReactChild }) => {
+  return (
+    <EuiPageContent
+      style={{ maxWidth: '75%', marginTop: '20px' }}
+      hasShadow={false}
+      hasBorder={false}
+      panelPaddingSize="none"
+      horizontalPosition="center"
+      color="transparent"
+      {...props}
+    />
+  );
+};

--- a/src/plugins/data_source_management/public/management_app/index.ts
+++ b/src/plugins/data_source_management/public/management_app/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { mountManagementSection } from './mount_management_section';
+export { mountDataSourcesManagementSection } from './mount_management_section';

--- a/src/plugins/data_source_management/public/management_app/mount_management_section.tsx
+++ b/src/plugins/data_source_management/public/management_app/mount_management_section.tsx
@@ -3,32 +3,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { StartServicesAccessor } from 'src/core/public';
+import {
+  AppMountParameters,
+  ChromeBreadcrumb,
+  ScopedHistory,
+  StartServicesAccessor,
+} from 'src/core/public';
 
 import { I18nProvider } from '@osd/i18n/react';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Route, Router, Switch } from 'react-router-dom';
-import { DataPublicPluginStart } from 'src/plugins/data/public';
-import { ManagementAppMountParams } from '../../../management/public';
-
 import { OpenSearchDashboardsContextProvider } from '../../../opensearch_dashboards_react/public';
 import { CreateDataSourceWizardWithRouter } from '../components/create_data_source_wizard';
 import { DataSourceTableWithRouter } from '../components/data_source_table';
-import { DataSourceManagementContext } from '../types';
+import { DataSourceManagementContext, DataSourceManagementStartDependencies } from '../types';
 import { EditDataSourceWithRouter } from '../components/edit_data_source';
+import { PageWrapper } from '../components/page_wrapper';
+import { reactRouterNavigate } from '../../../opensearch_dashboards_react/public';
 
-export interface DataSourceManagementStartDependencies {
-  data: DataPublicPluginStart;
-}
-
-export async function mountManagementSection(
+export async function mountDataSourcesManagementSection(
   getStartServices: StartServicesAccessor<DataSourceManagementStartDependencies>,
-  params: ManagementAppMountParams
+  params: AppMountParameters
 ) {
   const [
     { chrome, application, savedObjects, uiSettings, notifications, overlays, http, docLinks },
   ] = await getStartServices();
+
+  const setBreadcrumbsScoped = (crumbs: ChromeBreadcrumb[] = []) => {
+    const wrapBreadcrumb = (item: ChromeBreadcrumb, scopedHistory: ScopedHistory) => ({
+      ...item,
+      ...(item.href ? reactRouterNavigate(scopedHistory, item.href) : {}),
+    });
+
+    chrome.setBreadcrumbs([...crumbs.map((item) => wrapBreadcrumb(item, params.history))]);
+  };
 
   const deps: DataSourceManagementContext = {
     chrome,
@@ -39,27 +48,29 @@ export async function mountManagementSection(
     overlays,
     http,
     docLinks,
-    setBreadcrumbs: params.setBreadcrumbs,
+    setBreadcrumbs: setBreadcrumbsScoped,
   };
 
   ReactDOM.render(
-    <OpenSearchDashboardsContextProvider services={deps}>
-      <I18nProvider>
-        <Router history={params.history}>
-          <Switch>
-            <Route path={['/create']}>
-              <CreateDataSourceWizardWithRouter />
-            </Route>
-            <Route path={['/:id']}>
-              <EditDataSourceWithRouter />
-            </Route>
-            <Route path={['/']}>
-              <DataSourceTableWithRouter />
-            </Route>
-          </Switch>
-        </Router>
-      </I18nProvider>
-    </OpenSearchDashboardsContextProvider>,
+    <PageWrapper>
+      <OpenSearchDashboardsContextProvider services={deps}>
+        <I18nProvider>
+          <Router history={params.history}>
+            <Switch>
+              <Route path={['/create']}>
+                <CreateDataSourceWizardWithRouter />
+              </Route>
+              <Route path={['/:id']}>
+                <EditDataSourceWithRouter />
+              </Route>
+              <Route path={['/']}>
+                <DataSourceTableWithRouter />
+              </Route>
+            </Switch>
+          </Router>
+        </I18nProvider>
+      </OpenSearchDashboardsContextProvider>
+    </PageWrapper>,
     params.element
   );
 

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -3,13 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CoreSetup, CoreStart, Plugin } from '../../../core/public';
+import {
+  AppMountParameters,
+  CoreSetup,
+  CoreStart,
+  DEFAULT_APP_CATEGORIES,
+  Plugin,
+  StartServicesAccessor,
+} from '../../../core/public';
 
 import { PLUGIN_NAME } from '../common';
 
 import { ManagementSetup } from '../../management/public';
 import { IndexPatternManagementSetup } from '../../index_pattern_management/public';
 import { DataSourceColumn } from './components/data_source_column/data_source_column';
+import { DataSourceManagementStartDependencies } from './types';
 
 export interface DataSourceManagementSetupDependencies {
   management: ManagementSetup;
@@ -20,16 +28,7 @@ const DSM_APP_ID = 'dataSources';
 
 export class DataSourceManagementPlugin
   implements Plugin<void, void, DataSourceManagementSetupDependencies> {
-  public setup(
-    core: CoreSetup,
-    { management, indexPatternManagement }: DataSourceManagementSetupDependencies
-  ) {
-    const opensearchDashboardsSection = management.sections.section.opensearchDashboards;
-
-    if (!opensearchDashboardsSection) {
-      throw new Error('`opensearchDashboards` management section not found.');
-    }
-
+  public setup(core: CoreSetup, { indexPatternManagement }: DataSourceManagementSetupDependencies) {
     const savedObjectPromise = core
       .getStartServices()
       .then(([coreStart]) => coreStart.savedObjects);
@@ -37,14 +36,18 @@ export class DataSourceManagementPlugin
     const column = new DataSourceColumn(savedObjectPromise, httpPromise);
     indexPatternManagement.columns.register(column);
 
-    opensearchDashboardsSection.registerApp({
+    core.application.register({
       id: DSM_APP_ID,
       title: PLUGIN_NAME,
       order: 1,
-      mount: async (params) => {
-        const { mountManagementSection } = await import('./management_app');
+      category: DEFAULT_APP_CATEGORIES.opensearchDashboards,
+      mount: async (params: AppMountParameters) => {
+        const { mountDataSourcesManagementSection } = await import('./management_app');
 
-        return mountManagementSection(core.getStartServices, params);
+        return mountDataSourcesManagementSection(
+          core.getStartServices as StartServicesAccessor<DataSourceManagementStartDependencies>,
+          params
+        );
       },
     });
   }

--- a/src/plugins/data_source_management/public/types.ts
+++ b/src/plugins/data_source_management/public/types.ts
@@ -14,6 +14,7 @@ import {
   HttpSetup,
 } from 'src/core/public';
 import { ManagementAppMountParams } from 'src/plugins/management/public';
+import { DataPublicPluginStart } from 'src/plugins/data/public';
 import { SavedObjectAttributes } from 'src/core/types';
 import { i18n } from '@osd/i18n';
 import { SigV4ServiceName } from '../../data_source/common/data_sources';
@@ -114,4 +115,8 @@ export interface SigV4Content extends SavedObjectAttributes {
   secretKey: string;
   region: string;
   service?: SigV4ServiceName;
+}
+
+export interface DataSourceManagementStartDependencies {
+  data: DataPublicPluginStart;
 }

--- a/src/plugins/discover/public/application/components/top_nav/__snapshots__/open_search_panel.test.tsx.snap
+++ b/src/plugins/discover/public/application/components/top_nav/__snapshots__/open_search_panel.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`render 1`] = `
       >
         <EuiButton
           fill={true}
-          href="/app/management/opensearch-dashboards/objects?_a=(tab:search)"
+          href="/app/objects?_a=(tab:search)"
           onClick={[Function]}
         >
           <FormattedMessage

--- a/src/plugins/discover/public/application/components/top_nav/open_search_panel.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/open_search_panel.tsx
@@ -105,7 +105,7 @@ export function OpenSearchPanel({ onClose, makeUrl }: Props) {
               fill
               onClick={onClose}
               href={addBasePath(
-                `/app/management/opensearch-dashboards/objects?_a=${rison.encode({
+                `/app/objects?_a=${rison.encode({
                   tab: SAVED_OBJECT_TYPE,
                 })}`
               )}

--- a/src/plugins/discover/server/saved_objects/search.ts
+++ b/src/plugins/discover/server/saved_objects/search.ts
@@ -43,9 +43,7 @@ export const searchSavedObjectType: SavedObjectsType = {
       return obj.attributes.title;
     },
     getEditUrl(obj) {
-      return `/management/opensearch-dashboards/objects/savedSearches/${encodeURIComponent(
-        obj.id
-      )}`;
+      return `/objects/savedSearches/${encodeURIComponent(obj.id)}`;
     },
     getInAppUrl(obj) {
       return {

--- a/src/plugins/home/public/application/components/new_theme_modal.tsx
+++ b/src/plugins/home/public/application/components/new_theme_modal.tsx
@@ -56,9 +56,7 @@ export const NewThemeModal: FC<Props> = ({ addBasePath, onClose }) => {
             modes. You or your administrator can change to the previous theme by visiting {advancedSettingsLink}."
               values={{
                 advancedSettingsLink: (
-                  <EuiLink
-                    href={addBasePath('/app/management/opensearch-dashboards/settings#appearance')}
-                  >
+                  <EuiLink href={addBasePath('/app/settings#appearance')}>
                     <FormattedMessage
                       id="home.newThemeModal.previewDescription.advancedSettingsLinkText"
                       defaultMessage="Advanced Settings"

--- a/src/plugins/index_pattern_management/opensearch_dashboards.json
+++ b/src/plugins/index_pattern_management/opensearch_dashboards.json
@@ -4,6 +4,6 @@
   "server": true,
   "ui": true,
   "optionalPlugins": ["dataSource"],
-  "requiredPlugins": ["management", "data", "urlForwarding"],
+  "requiredPlugins": ["data", "urlForwarding"],
   "requiredBundles": ["opensearchDashboardsReact", "opensearchDashboardsUtils"]
 }

--- a/src/plugins/index_pattern_management/public/management_app/mount_management_section.tsx
+++ b/src/plugins/index_pattern_management/public/management_app/mount_management_section.tsx
@@ -75,7 +75,7 @@ export async function mountManagementSection(
     { data, dataSource },
     indexPatternManagementStart,
   ] = await getStartServices();
-  const canSave = Boolean(application.capabilities.indexPatterns.save);
+  const canSave = Boolean(application.capabilities.indexPatterns?.save);
   const dataSourceEnabled = !!dataSource;
 
   if (!canSave) {

--- a/src/plugins/index_pattern_management/public/plugin.ts
+++ b/src/plugins/index_pattern_management/public/plugin.ts
@@ -35,8 +35,6 @@ import {
   CoreStart,
   Plugin,
   AppMountParameters,
-  ChromeBreadcrumb,
-  ScopedHistory,
 } from 'src/core/public';
 import { DataPublicPluginStart } from 'src/plugins/data/public';
 import { DataSourcePluginStart } from 'src/plugins/data_source/public';
@@ -47,9 +45,7 @@ import {
   IndexPatternManagementServiceStart,
 } from './service';
 
-import { ManagementAppMountParams } from '../../management/public';
 import { DEFAULT_APP_CATEGORIES } from '../../../core/public';
-import { reactRouterNavigate } from '../../opensearch_dashboards_react/public';
 
 export interface IndexPatternManagementSetupDependencies {
   urlForwarding: UrlForwardingSetup;

--- a/src/plugins/opensearch_dashboards_overview/public/components/getting_started/__snapshots__/getting_started.test.tsx.snap
+++ b/src/plugins/opensearch_dashboards_overview/public/components/getting_started/__snapshots__/getting_started.test.tsx.snap
@@ -171,7 +171,7 @@ exports[`GettingStarted dark mode on 1`] = `
         <RedirectAppLinks>
           <EuiButton
             fill={true}
-            href="/app/management/opensearch-dashboards/indexPatterns"
+            href="/app/indexPatterns"
             iconType="indexOpen"
           >
             <FormattedMessage
@@ -366,7 +366,7 @@ exports[`GettingStarted render 1`] = `
         <RedirectAppLinks>
           <EuiButton
             fill={true}
-            href="/app/management/opensearch-dashboards/indexPatterns"
+            href="/app/indexPatterns"
             iconType="indexOpen"
           >
             <FormattedMessage

--- a/src/plugins/opensearch_dashboards_overview/public/components/getting_started/getting_started.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/components/getting_started/getting_started.tsx
@@ -114,11 +114,7 @@ export const GettingStarted: FC<Props> = ({ addBasePath, isDarkTheme, apps }) =>
             <EuiSpacer size="xl" />
 
             <RedirectAppLinks application={application}>
-              <EuiButton
-                fill
-                iconType="indexOpen"
-                href={addBasePath('/app/management/opensearch-dashboards/indexPatterns')}
-              >
+              <EuiButton fill iconType="indexOpen" href={addBasePath('/app/indexPatterns')}>
                 <FormattedMessage
                   defaultMessage="Add your data"
                   id="opensearchDashboardsOverview.gettingStarted.addDataButtonLabel"

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_footer/overview_page_footer.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_footer/overview_page_footer.tsx
@@ -62,7 +62,7 @@ export const OverviewPageFooter: FC<Props> = ({ addBasePath, path }) => {
         <EuiButtonEmpty
           className="osdOverviewPageFooter__button"
           flush="both"
-          href={addBasePath('/app/management/opensearch-dashboards/settings#defaultRoute')}
+          href={addBasePath('/app/settings#defaultRoute')}
           iconType="home"
           size="xs"
         >

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.test.tsx
@@ -200,7 +200,7 @@ describe('OverviewPageHeader toolbar items - Management', () => {
 
     return component.find({
       className: 'osdOverviewPageHeader__actionButton',
-      href: '/app/management',
+      href: '/app/settings',
     });
   };
 

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
@@ -136,7 +136,7 @@ export const OverviewPageHeader: FC<Props> = ({
                         className="osdOverviewPageHeader__actionButton"
                         flush="both"
                         iconType="gear"
-                        href={addBasePath('/app/management')}
+                        href={addBasePath('/app/settings')}
                       >
                         {i18n.translate(
                           'opensearch-dashboards-react.osdOverviewPageHeader.stackManagementButtonLabel',

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
@@ -315,7 +315,7 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
                   listingLimitValue: this.props.listingLimit,
                   listingLimitText: <strong>listingLimit</strong>,
                   advancedSettingsLink: (
-                    <EuiLink href="#/management/opensearch-dashboards/settings">
+                    <EuiLink href="#/settings">
                       <FormattedMessage
                         id="opensearch-dashboards-react.tableListView.listing.listingLimitExceeded.advancedSettingsLinkText"
                         defaultMessage="Advanced Settings"

--- a/src/plugins/saved_objects_management/README.md
+++ b/src/plugins/saved_objects_management/README.md
@@ -1,20 +1,20 @@
 # Saved objects management
 
-Provides a UI (via the `management` plugin) to find and manage all saved objects in one place (you can see the primary page by navigating to `/app/management/opensearch-dashboards/objects`). Not to be confused with the `savedObjects` plugin, which provides all the core capabilities of saved objects.
+Provides a UI (via the `management` plugin) to find and manage all saved objects in one place (you can see the primary page by navigating to `/app/objects`). Not to be confused with the `savedObjects` plugin, which provides all the core capabilities of saved objects.
 
 From the primary UI page, this plugin allows you to:
 1. Search/view/delete saved objects and their relationships
 2. Import/export saved objects
 3. Inspect/edit raw saved object values without validation
 
-For 3., this plugin can also be used to provide a route/page for editing, such as `/app/management/opensearch-dashboards/objects/savedVisualizations/{visualizationId}`, although plugins are also free to provide or host alternate routes for this purpose (see index patterns, for instance, which provide their own integration and UI via the `management` plugin directly).
+For 3., this plugin can also be used to provide a route/page for editing, such as `/app/objects/savedVisualizations/{visualizationId}`, although plugins are also free to provide or host alternate routes for this purpose (see index patterns, for instance, which provide their own integration and UI via the `management` plugin directly).
 
 ## Making a new saved object type manageable
 
 1. Create a new `SavedObjectsType` or add the `management` property to an existing one. (See [`SavedObjectsTypeManagementDefinition`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/e1380f14deb98cc7cce55c3b82c2d501826a78c3/src/core/server/saved_objects/types.ts#L247-L285) for explanation of its properties)
 2. Register saved object type via `core.savedObjects.registerType(...)` as part of plugin server setup method
 3. Implement a way to save the object (e.g. via `savedObjectsClient.create(...)` or a `savedObjectLoader`)
-4. After these steps, you should be able to save objects and view/search for them in Saved Objects management (`/app/management/opensearch-dashboards/objects`)
+4. After these steps, you should be able to save objects and view/search for them in Saved Objects management (`/app/objects`)
 
 ## Enabling edit links from saved objects management
 
@@ -25,7 +25,7 @@ For 3., this plugin can also be used to provide a route/page for editing, such a
 
 ## Using saved objects management to inspect/edit new plugin objects
 
-You'll notice that when clicking on the "Inspect" button from the saved objects management table, you'll usually be routed to something like `/app/management/opensearch-dashboards/objects/savedVisualizations/` (where the route itself is determined by the `management.getEditUrl` method of the `SavedObjectsType`). But to register a similar route for a new saved object type, you'll need to create a new `savedObjectLoader` and register it with the management plugin.
+You'll notice that when clicking on the "Inspect" button from the saved objects management table, you'll usually be routed to something like `/app/objects/savedVisualizations/` (where the route itself is determined by the `management.getEditUrl` method of the `SavedObjectsType`). But to register a similar route for a new saved object type, you'll need to create a new `savedObjectLoader` and register it with the management plugin.
 
 ### Creating `savedObjectLoader`
 

--- a/src/plugins/saved_objects_management/public/constants.ts
+++ b/src/plugins/saved_objects_management/public/constants.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+
+export const MANAGE_LIBRARY_TITLE_WORDINGS = i18n.translate(
+  'savedObjectsManagement.manageLibrary',
+  {
+    defaultMessage: 'Manage library',
+  }
+);
+
+export const ALL_LIBRARY_OBJECTS_TITLE_WORDINGS = i18n.translate(
+  'savedObjectsManagement.objectsTable.header.allLibraryObjectsTitle',
+  {
+    defaultMessage: 'Library objects in Analytics',
+  }
+);
+
+export const SAVED_OBJECT_MANAGEMENT_TITLE_WORDINGS = i18n.translate(
+  'savedObjectsManagement.objectsTable.header.savedObjectsTitle',
+  {
+    defaultMessage: 'Saved Objects',
+  }
+);
+
+export const SAVED_SEARCHES_WORDINGS = i18n.translate(
+  'savedObjectsManagement.SearchesManagementSectionLabel',
+  {
+    defaultMessage: 'Saved searches',
+  }
+);
+
+export const SAVED_QUERIES_WORDINGS = i18n.translate(
+  'savedObjectsManagement.QueriesManagementSectionLabel',
+  {
+    defaultMessage: 'Saved filters',
+  }
+);

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
@@ -314,10 +314,10 @@ exports[`SavedObjectsTable should render normally 1`] = `
           Object {
             "id": "1",
             "meta": Object {
-              "editUrl": "#/management/opensearch-dashboards/indexPatterns/patterns/1",
+              "editUrl": "#/indexPatterns/patterns/1",
               "icon": "indexPatternApp",
               "inAppUrl": Object {
-                "path": "/management/opensearch-dashboards/indexPatterns/patterns/1",
+                "path": "/indexPatterns/patterns/1",
                 "uiCapabilitiesPath": "management.opensearchDashboards.indexPatterns",
               },
               "title": "MyIndexPattern*",
@@ -327,7 +327,7 @@ exports[`SavedObjectsTable should render normally 1`] = `
           Object {
             "id": "2",
             "meta": Object {
-              "editUrl": "/management/opensearch-dashboards/objects/savedSearches/2",
+              "editUrl": "/objects/savedSearches/2",
               "icon": "search",
               "inAppUrl": Object {
                 "path": "/discover/2",
@@ -340,7 +340,7 @@ exports[`SavedObjectsTable should render normally 1`] = `
           Object {
             "id": "3",
             "meta": Object {
-              "editUrl": "/management/opensearch-dashboards/objects/savedDashboards/3",
+              "editUrl": "/objects/savedDashboards/3",
               "icon": "dashboardApp",
               "inAppUrl": Object {
                 "path": "/dashboard/3",
@@ -353,7 +353,7 @@ exports[`SavedObjectsTable should render normally 1`] = `
           Object {
             "id": "4",
             "meta": Object {
-              "editUrl": "/management/opensearch-dashboards/objects/savedVisualizations/4",
+              "editUrl": "/objects/savedVisualizations/4",
               "icon": "visualizeApp",
               "inAppUrl": Object {
                 "path": "/edit/4",

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/header.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/header.test.tsx.snap
@@ -10,13 +10,7 @@ exports[`Header should render normally 1`] = `
       grow={false}
     >
       <EuiTitle>
-        <h1>
-          <FormattedMessage
-            defaultMessage="Saved Objects"
-            id="savedObjectsManagement.objectsTable.header.savedObjectsTitle"
-            values={Object {}}
-          />
-        </h1>
+        <h1 />
       </EuiTitle>
     </EuiFlexItem>
     <EuiFlexItem

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/relationships.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/relationships.test.tsx.snap
@@ -711,7 +711,7 @@ exports[`Relationships should render augment-vis objects normally 1`] = `
             Object {
               "id": "1",
               "meta": Object {
-                "editUrl": "/management/opensearch-dashboards/objects/savedVisualizations/1",
+                "editUrl": "/objects/savedVisualizations/1",
                 "icon": "visualizeApp",
                 "inAppUrl": Object {
                   "path": "/edit/1",
@@ -845,7 +845,7 @@ exports[`Relationships should render dashboards normally 1`] = `
             Object {
               "id": "1",
               "meta": Object {
-                "editUrl": "/management/opensearch-dashboards/objects/savedVisualizations/1",
+                "editUrl": "/objects/savedVisualizations/1",
                 "icon": "visualizeApp",
                 "inAppUrl": Object {
                   "path": "/app/visualize#/edit/1",
@@ -859,7 +859,7 @@ exports[`Relationships should render dashboards normally 1`] = `
             Object {
               "id": "2",
               "meta": Object {
-                "editUrl": "/management/opensearch-dashboards/objects/savedVisualizations/2",
+                "editUrl": "/objects/savedVisualizations/2",
                 "icon": "visualizeApp",
                 "inAppUrl": Object {
                   "path": "/app/visualize#/edit/2",
@@ -1028,7 +1028,7 @@ exports[`Relationships should render index patterns normally 1`] = `
             Object {
               "id": "1",
               "meta": Object {
-                "editUrl": "/management/opensearch-dashboards/objects/savedSearches/1",
+                "editUrl": "/objects/savedSearches/1",
                 "icon": "search",
                 "inAppUrl": Object {
                   "path": "/app/discover#//1",
@@ -1042,7 +1042,7 @@ exports[`Relationships should render index patterns normally 1`] = `
             Object {
               "id": "2",
               "meta": Object {
-                "editUrl": "/management/opensearch-dashboards/objects/savedVisualizations/2",
+                "editUrl": "/objects/savedVisualizations/2",
                 "icon": "visualizeApp",
                 "inAppUrl": Object {
                   "path": "/app/visualize#/edit/2",
@@ -1181,10 +1181,10 @@ exports[`Relationships should render searches normally 1`] = `
             Object {
               "id": "1",
               "meta": Object {
-                "editUrl": "/management/opensearch-dashboards/indexPatterns/patterns/1",
+                "editUrl": "/indexPatterns/patterns/1",
                 "icon": "indexPatternApp",
                 "inAppUrl": Object {
-                  "path": "/app/management/opensearch-dashboards/indexPatterns/patterns/1",
+                  "path": "/app/indexPatterns/patterns/1",
                   "uiCapabilitiesPath": "management.opensearchDashboards.indexPatterns",
                 },
                 "title": "My Index Pattern",
@@ -1195,7 +1195,7 @@ exports[`Relationships should render searches normally 1`] = `
             Object {
               "id": "2",
               "meta": Object {
-                "editUrl": "/management/opensearch-dashboards/objects/savedVisualizations/2",
+                "editUrl": "/objects/savedVisualizations/2",
                 "icon": "visualizeApp",
                 "inAppUrl": Object {
                   "path": "/app/visualize#/edit/2",
@@ -1334,7 +1334,7 @@ exports[`Relationships should render visualizations normally 1`] = `
             Object {
               "id": "1",
               "meta": Object {
-                "editUrl": "/management/opensearch-dashboards/objects/savedDashboards/1",
+                "editUrl": "/objects/savedDashboards/1",
                 "icon": "dashboardApp",
                 "inAppUrl": Object {
                   "path": "/app/opensearch-dashboards#/dashboard/1",
@@ -1348,7 +1348,7 @@ exports[`Relationships should render visualizations normally 1`] = `
             Object {
               "id": "2",
               "meta": Object {
-                "editUrl": "/management/opensearch-dashboards/objects/savedDashboards/2",
+                "editUrl": "/objects/savedDashboards/2",
                 "icon": "dashboardApp",
                 "inAppUrl": Object {
                   "path": "/app/opensearch-dashboards#/dashboard/2",

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/table.test.tsx.snap
@@ -184,10 +184,10 @@ exports[`Table prevents saved objects from being deleted 1`] = `
             "attributes": Object {},
             "id": "1",
             "meta": Object {
-              "editUrl": "#/management/opensearch-dashboards/indexPatterns/patterns/1",
+              "editUrl": "#/indexPatterns/patterns/1",
               "icon": "indexPatternApp",
               "inAppUrl": Object {
-                "path": "/management/opensearch-dashboards/indexPatterns/patterns/1",
+                "path": "/indexPatterns/patterns/1",
                 "uiCapabilitiesPath": "management.opensearchDashboards.indexPatterns",
               },
               "title": "MyIndexPattern*",
@@ -409,10 +409,10 @@ exports[`Table should render normally 1`] = `
             "attributes": Object {},
             "id": "1",
             "meta": Object {
-              "editUrl": "#/management/opensearch-dashboards/indexPatterns/patterns/1",
+              "editUrl": "#/indexPatterns/patterns/1",
               "icon": "indexPatternApp",
               "inAppUrl": Object {
-                "path": "/management/opensearch-dashboards/indexPatterns/patterns/1",
+                "path": "/indexPatterns/patterns/1",
                 "uiCapabilitiesPath": "management.opensearchDashboards.indexPatterns",
               },
               "title": "MyIndexPattern*",

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
@@ -45,22 +45,19 @@ export const Header = ({
   onImport,
   onRefresh,
   filteredCount,
+  title,
 }: {
   onExportAll: () => void;
   onImport: () => void;
   onRefresh: () => void;
   filteredCount: number;
+  title: string;
 }) => (
   <Fragment>
     <EuiFlexGroup justifyContent="spaceBetween" alignItems="baseline">
       <EuiFlexItem grow={false}>
         <EuiTitle>
-          <h1>
-            <FormattedMessage
-              id="savedObjectsManagement.objectsTable.header.savedObjectsTitle"
-              defaultMessage="Saved Objects"
-            />
-          </h1>
+          <h1>{title}</h1>
         </EuiTitle>
       </EuiFlexItem>
 

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.test.tsx
@@ -53,7 +53,7 @@ describe('Relationships', () => {
           id: '1',
           relationship: 'parent',
           meta: {
-            editUrl: '/management/opensearch-dashboards/objects/savedSearches/1',
+            editUrl: '/objects/savedSearches/1',
             icon: 'search',
             inAppUrl: {
               path: '/app/discover#//1',
@@ -67,7 +67,7 @@ describe('Relationships', () => {
           id: '2',
           relationship: 'parent',
           meta: {
-            editUrl: '/management/opensearch-dashboards/objects/savedVisualizations/2',
+            editUrl: '/objects/savedVisualizations/2',
             icon: 'visualizeApp',
             inAppUrl: {
               path: '/app/visualize#/edit/2',
@@ -85,9 +85,9 @@ describe('Relationships', () => {
         meta: {
           title: 'MyIndexPattern*',
           icon: 'indexPatternApp',
-          editUrl: '#/management/opensearch-dashboards/indexPatterns/patterns/1',
+          editUrl: '#/indexPatterns/patterns/1',
           inAppUrl: {
-            path: '/management/opensearch-dashboards/indexPatterns/patterns/1',
+            path: '/indexPatterns/patterns/1',
             uiCapabilitiesPath: 'management.opensearchDashboards.indexPatterns',
           },
         },
@@ -120,10 +120,10 @@ describe('Relationships', () => {
           id: '1',
           relationship: 'child',
           meta: {
-            editUrl: '/management/opensearch-dashboards/indexPatterns/patterns/1',
+            editUrl: '/indexPatterns/patterns/1',
             icon: 'indexPatternApp',
             inAppUrl: {
-              path: '/app/management/opensearch-dashboards/indexPatterns/patterns/1',
+              path: '/app/indexPatterns/patterns/1',
               uiCapabilitiesPath: 'management.opensearchDashboards.indexPatterns',
             },
             title: 'My Index Pattern',
@@ -134,7 +134,7 @@ describe('Relationships', () => {
           id: '2',
           relationship: 'parent',
           meta: {
-            editUrl: '/management/opensearch-dashboards/objects/savedVisualizations/2',
+            editUrl: '/objects/savedVisualizations/2',
             icon: 'visualizeApp',
             inAppUrl: {
               path: '/app/visualize#/edit/2',
@@ -152,7 +152,7 @@ describe('Relationships', () => {
         meta: {
           title: 'MySearch',
           icon: 'search',
-          editUrl: '/management/opensearch-dashboards/objects/savedSearches/1',
+          editUrl: '/objects/savedSearches/1',
           inAppUrl: {
             path: '/discover/1',
             uiCapabilitiesPath: 'discover.show',
@@ -187,7 +187,7 @@ describe('Relationships', () => {
           id: '1',
           relationship: 'parent',
           meta: {
-            editUrl: '/management/opensearch-dashboards/objects/savedDashboards/1',
+            editUrl: '/objects/savedDashboards/1',
             icon: 'dashboardApp',
             inAppUrl: {
               path: '/app/opensearch-dashboards#/dashboard/1',
@@ -201,7 +201,7 @@ describe('Relationships', () => {
           id: '2',
           relationship: 'parent',
           meta: {
-            editUrl: '/management/opensearch-dashboards/objects/savedDashboards/2',
+            editUrl: '/objects/savedDashboards/2',
             icon: 'dashboardApp',
             inAppUrl: {
               path: '/app/opensearch-dashboards#/dashboard/2',
@@ -219,7 +219,7 @@ describe('Relationships', () => {
         meta: {
           title: 'MyViz',
           icon: 'visualizeApp',
-          editUrl: '/management/opensearch-dashboards/objects/savedVisualizations/1',
+          editUrl: '/objects/savedVisualizations/1',
           inAppUrl: {
             path: '/edit/1',
             uiCapabilitiesPath: 'visualize.show',
@@ -256,7 +256,7 @@ describe('Relationships', () => {
           meta: {
             title: 'MyViz',
             icon: 'visualizeApp',
-            editUrl: '/management/opensearch-dashboards/objects/savedVisualizations/1',
+            editUrl: '/objects/savedVisualizations/1',
             inAppUrl: {
               path: '/edit/1',
               uiCapabilitiesPath: 'visualize.show',
@@ -272,7 +272,7 @@ describe('Relationships', () => {
         meta: {
           title: 'MyAugmentVisObject',
           icon: 'savedObject',
-          editUrl: '/management/opensearch-dashboards/objects/savedAugmentVis/1',
+          editUrl: '/objects/savedAugmentVis/1',
         },
       },
       close: jest.fn(),
@@ -303,7 +303,7 @@ describe('Relationships', () => {
           id: '1',
           relationship: 'child',
           meta: {
-            editUrl: '/management/opensearch-dashboards/objects/savedVisualizations/1',
+            editUrl: '/objects/savedVisualizations/1',
             icon: 'visualizeApp',
             inAppUrl: {
               path: '/app/visualize#/edit/1',
@@ -317,7 +317,7 @@ describe('Relationships', () => {
           id: '2',
           relationship: 'child',
           meta: {
-            editUrl: '/management/opensearch-dashboards/objects/savedVisualizations/2',
+            editUrl: '/objects/savedVisualizations/2',
             icon: 'visualizeApp',
             inAppUrl: {
               path: '/app/visualize#/edit/2',
@@ -335,7 +335,7 @@ describe('Relationships', () => {
         meta: {
           title: 'MyDashboard',
           icon: 'dashboardApp',
-          editUrl: '/management/opensearch-dashboards/objects/savedDashboards/1',
+          editUrl: '/objects/savedDashboards/1',
           inAppUrl: {
             path: '/dashboard/1',
             uiCapabilitiesPath: 'dashboard.show',
@@ -375,7 +375,7 @@ describe('Relationships', () => {
         meta: {
           title: 'MyDashboard',
           icon: 'dashboardApp',
-          editUrl: '/management/opensearch-dashboards/objects/savedDashboards/1',
+          editUrl: '/objects/savedDashboards/1',
           inAppUrl: {
             path: '/dashboard/1',
             uiCapabilitiesPath: 'dashboard.show',

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.test.tsx
@@ -51,9 +51,9 @@ const defaultProps: TableProps = {
       meta: {
         title: `MyIndexPattern*`,
         icon: 'indexPatternApp',
-        editUrl: '#/management/opensearch-dashboards/indexPatterns/patterns/1',
+        editUrl: '#/indexPatterns/patterns/1',
         inAppUrl: {
-          path: '/management/opensearch-dashboards/indexPatterns/patterns/1',
+          path: '/indexPatterns/patterns/1',
           uiCapabilitiesPath: 'management.opensearchDashboards.indexPatterns',
         },
       },
@@ -91,9 +91,9 @@ const defaultProps: TableProps = {
       meta: {
         title: `MyIndexPattern*`,
         icon: 'indexPatternApp',
-        editUrl: '#/management/opensearch-dashboards/indexPatterns/patterns/1',
+        editUrl: '#/indexPatterns/patterns/1',
         inAppUrl: {
-          path: '/management/opensearch-dashboards/indexPatterns/patterns/1',
+          path: '/indexPatterns/patterns/1',
           uiCapabilitiesPath: 'management.opensearchDashboards.indexPatterns',
         },
       },

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
@@ -172,9 +172,9 @@ describe('SavedObjectsTable', () => {
           meta: {
             title: `MyIndexPattern*`,
             icon: 'indexPatternApp',
-            editUrl: '#/management/opensearch-dashboards/indexPatterns/patterns/1',
+            editUrl: '#/indexPatterns/patterns/1',
             inAppUrl: {
-              path: '/management/opensearch-dashboards/indexPatterns/patterns/1',
+              path: '/indexPatterns/patterns/1',
               uiCapabilitiesPath: 'management.opensearchDashboards.indexPatterns',
             },
           },
@@ -185,7 +185,7 @@ describe('SavedObjectsTable', () => {
           meta: {
             title: `MySearch`,
             icon: 'search',
-            editUrl: '/management/opensearch-dashboards/objects/savedSearches/2',
+            editUrl: '/objects/savedSearches/2',
             inAppUrl: {
               path: '/discover/2',
               uiCapabilitiesPath: 'discover.show',
@@ -198,7 +198,7 @@ describe('SavedObjectsTable', () => {
           meta: {
             title: `MyDashboard`,
             icon: 'dashboardApp',
-            editUrl: '/management/opensearch-dashboards/objects/savedDashboards/3',
+            editUrl: '/objects/savedDashboards/3',
             inAppUrl: {
               path: '/dashboard/3',
               uiCapabilitiesPath: 'dashboard.show',
@@ -211,7 +211,7 @@ describe('SavedObjectsTable', () => {
           meta: {
             title: `MyViz`,
             icon: 'visualizeApp',
-            editUrl: '/management/opensearch-dashboards/objects/savedVisualizations/4',
+            editUrl: '/objects/savedVisualizations/4',
             inAppUrl: {
               path: '/edit/4',
               uiCapabilitiesPath: 'visualize.show',
@@ -460,7 +460,7 @@ describe('SavedObjectsTable', () => {
         meta: {
           title: `MySearch`,
           icon: 'search',
-          editUrl: '/management/opensearch-dashboards/objects/savedSearches/2',
+          editUrl: '/objects/savedSearches/2',
           inAppUrl: {
             path: '/discover/2',
             uiCapabilitiesPath: 'discover.show',
@@ -475,7 +475,7 @@ describe('SavedObjectsTable', () => {
         type: 'search',
         meta: {
           title: 'MySearch',
-          editUrl: '/management/opensearch-dashboards/objects/savedSearches/2',
+          editUrl: '/objects/savedSearches/2',
           icon: 'search',
           inAppUrl: {
             path: '/discover/2',

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -114,6 +114,7 @@ export interface SavedObjectsTableProps {
   goInspectObject: (obj: SavedObjectWithMetadata) => void;
   canGoInApp: (obj: SavedObjectWithMetadata) => boolean;
   dateFormat: string;
+  title: string;
 }
 
 export interface SavedObjectsTableState {
@@ -543,9 +544,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
       return null;
     }
     const { applications } = this.props;
-    const newIndexPatternUrl = applications.getUrlForApp('management', {
-      path: 'opensearch-dashboards/indexPatterns',
-    });
+    const newIndexPatternUrl = applications.getUrlForApp('indexPatterns');
 
     return (
       <Flyout
@@ -857,6 +856,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
           onImport={this.showImportFlyout}
           onRefresh={this.refreshObjects}
           filteredCount={filteredItemCount}
+          title={this.props.title}
         />
         <EuiSpacer size="xs" />
         <RedirectAppLinks application={applications}>

--- a/src/plugins/saved_objects_management/public/management_section/page_wrapper/__snapshots__/page_wrapper.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/page_wrapper/__snapshots__/page_wrapper.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageWrapper should render normally 1`] = `
+<div>
+  <div
+    class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPageContent euiPageContent--horizontalCenter"
+    role="main"
+    style="max-width: 75%; margin-top: 20px;"
+  >
+    Foo
+  </div>
+</div>
+`;

--- a/src/plugins/saved_objects_management/public/management_section/page_wrapper/index.ts
+++ b/src/plugins/saved_objects_management/public/management_section/page_wrapper/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { PageWrapper } from './page_wrapper';

--- a/src/plugins/saved_objects_management/public/management_section/page_wrapper/page_wrapper.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/page_wrapper/page_wrapper.test.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PageWrapper } from './page_wrapper';
+
+describe('PageWrapper', () => {
+  it('should render normally', async () => {
+    const { findByText, container } = render(<PageWrapper>Foo</PageWrapper>);
+    await findByText('Foo');
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/plugins/saved_objects_management/public/management_section/page_wrapper/page_wrapper.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/page_wrapper/page_wrapper.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiPageContent } from '@elastic/eui';
+import React from 'react';
+
+export const PageWrapper = (props: { children?: React.ReactChild }) => {
+  return (
+    <EuiPageContent
+      style={{ maxWidth: '75%', marginTop: '20px' }}
+      hasShadow={false}
+      hasBorder={false}
+      panelPaddingSize="none"
+      horizontalPosition="center"
+      color="transparent"
+      {...props}
+    />
+  );
+};

--- a/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
@@ -30,13 +30,13 @@
 
 import React, { useEffect } from 'react';
 import { get } from 'lodash';
-import { i18n } from '@osd/i18n';
 import { CoreStart, ChromeBreadcrumb } from 'src/core/public';
 import { DataPublicPluginStart } from '../../../data/public';
 import {
   ISavedObjectsManagementServiceRegistry,
   SavedObjectsManagementActionServiceStart,
   SavedObjectsManagementColumnServiceStart,
+  SavedObjectsManagementNamespaceServiceStart,
 } from '../services';
 import { SavedObjectsTable } from './objects_table';
 
@@ -49,6 +49,7 @@ const SavedObjectsTablePage = ({
   columnRegistry,
   namespaceRegistry,
   setBreadcrumbs,
+  title,
 }: {
   coreStart: CoreStart;
   dataStart: DataPublicPluginStart;
@@ -58,6 +59,7 @@ const SavedObjectsTablePage = ({
   columnRegistry: SavedObjectsManagementColumnServiceStart;
   namespaceRegistry: SavedObjectsManagementNamespaceServiceStart;
   setBreadcrumbs: (crumbs: ChromeBreadcrumb[]) => void;
+  title: string;
 }) => {
   const capabilities = coreStart.application.capabilities;
   const itemsPerPage = coreStart.uiSettings.get<number>('savedObjects:perPage', 50);
@@ -66,13 +68,11 @@ const SavedObjectsTablePage = ({
   useEffect(() => {
     setBreadcrumbs([
       {
-        text: i18n.translate('savedObjectsManagement.breadcrumb.index', {
-          defaultMessage: 'Saved objects',
-        }),
-        href: '/',
+        text: title,
+        href: undefined,
       },
     ]);
-  }, [setBreadcrumbs]);
+  }, [setBreadcrumbs, title]);
 
   return (
     <SavedObjectsTable
@@ -102,6 +102,7 @@ const SavedObjectsTablePage = ({
         const { inAppUrl } = savedObject.meta;
         return inAppUrl ? Boolean(get(capabilities, inAppUrl.uiCapabilitiesPath)) : false;
       }}
+      title={title}
     />
   );
 };

--- a/src/plugins/saved_objects_management/public/plugin.test.ts
+++ b/src/plugins/saved_objects_management/public/plugin.test.ts
@@ -28,12 +28,23 @@
  * under the License.
  */
 
+const mountManagementSectionMock = jest.fn();
+jest.doMock('./management_section', () => ({
+  mountManagementSection: mountManagementSectionMock,
+}));
+import { waitFor } from '@testing-library/dom';
 import { coreMock } from '../../../core/public/mocks';
 import { homePluginMock } from '../../home/public/mocks';
 import { managementPluginMock } from '../../management/public/mocks';
 import { dataPluginMock } from '../../data/public/mocks';
 import { uiActionsPluginMock } from '../../ui_actions/public/mocks';
 import { SavedObjectsManagementPlugin } from './plugin';
+import {
+  MANAGE_LIBRARY_TITLE_WORDINGS,
+  SAVED_QUERIES_WORDINGS,
+  SAVED_SEARCHES_WORDINGS,
+} from './constants';
+import { DEFAULT_APP_CATEGORIES } from '../../../core/public';
 
 describe('SavedObjectsManagementPlugin', () => {
   let plugin: SavedObjectsManagementPlugin;
@@ -50,18 +61,60 @@ describe('SavedObjectsManagementPlugin', () => {
       const homeSetup = homePluginMock.createSetupContract();
       const managementSetup = managementPluginMock.createSetupContract();
       const uiActionsSetup = uiActionsPluginMock.createSetupContract();
+      const registerMock = jest.fn((params) => params.mount({} as any, {} as any));
 
-      await plugin.setup(coreSetup, {
-        home: homeSetup,
-        management: managementSetup,
-        uiActions: uiActionsSetup,
-      });
+      await plugin.setup(
+        {
+          ...coreSetup,
+          application: {
+            ...coreSetup.application,
+            register: registerMock,
+          },
+        },
+        {
+          home: homeSetup,
+          management: managementSetup,
+          uiActions: uiActionsSetup,
+        }
+      );
 
       expect(homeSetup.featureCatalogue.register).toHaveBeenCalledTimes(1);
       expect(homeSetup.featureCatalogue.register).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 'saved_objects',
         })
+      );
+      expect(registerMock).toBeCalledWith(
+        expect.objectContaining({
+          id: 'objects',
+          title: MANAGE_LIBRARY_TITLE_WORDINGS,
+          order: 10000,
+          category: DEFAULT_APP_CATEGORIES.opensearchDashboards,
+        })
+      );
+      expect(registerMock).toBeCalledWith(
+        expect.objectContaining({
+          id: 'objects_searches',
+          title: SAVED_SEARCHES_WORDINGS,
+          order: 8000,
+          category: DEFAULT_APP_CATEGORIES.opensearchDashboards,
+        })
+      );
+      expect(registerMock).toBeCalledWith(
+        expect.objectContaining({
+          id: 'objects_query',
+          title: SAVED_QUERIES_WORDINGS,
+          order: 8001,
+          category: DEFAULT_APP_CATEGORIES.opensearchDashboards,
+        })
+      );
+      waitFor(
+        () => {
+          expect(mountManagementSectionMock).toBeCalledTimes(3);
+        },
+        {
+          container: document.body,
+        }
       );
     });
   });

--- a/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
+++ b/src/plugins/vis_augmenter/server/saved_objects/augment_vis.ts
@@ -15,9 +15,7 @@ export const augmentVisSavedObjectType: SavedObjectsType = {
       return `augment-vis-${obj?.attributes?.originPlugin}`;
     },
     getEditUrl(obj) {
-      return `/management/opensearch-dashboards/objects/savedAugmentVis/${encodeURIComponent(
-        obj.id
-      )}`;
+      return `/objects/savedAugmentVis/${encodeURIComponent(obj.id)}`;
     },
   },
   mappings: {

--- a/src/plugins/vis_builder/server/saved_objects/vis_builder_app.ts
+++ b/src/plugins/vis_builder/server/saved_objects/vis_builder_app.ts
@@ -20,8 +20,7 @@ export const visBuilderSavedObjectType: SavedObjectsType = {
     defaultSearchField: 'title',
     importableAndExportable: true,
     getTitle: ({ attributes: { title } }: SavedObject<VisBuilderSavedObjectAttributes>) => title,
-    getEditUrl: ({ id }: SavedObject) =>
-      `/management/opensearch-dashboards/objects/savedVisBuilder/${encodeURIComponent(id)}`,
+    getEditUrl: ({ id }: SavedObject) => `/objects/savedVisBuilder/${encodeURIComponent(id)}`,
     getInAppUrl({ id }: SavedObject) {
       return {
         path: `/app/${PLUGIN_ID}${EDIT_PATH}/${encodeURIComponent(id)}`,

--- a/src/plugins/visualizations/server/saved_objects/visualization.ts
+++ b/src/plugins/visualizations/server/saved_objects/visualization.ts
@@ -43,9 +43,7 @@ export const visualizationSavedObjectType: SavedObjectsType = {
       return obj.attributes.title;
     },
     getEditUrl(obj) {
-      return `/management/opensearch-dashboards/objects/savedVisualizations/${encodeURIComponent(
-        obj.id
-      )}`;
+      return `/objects/savedVisualizations/${encodeURIComponent(obj.id)}`;
     },
     getInAppUrl(obj) {
       return {

--- a/test/api_integration/apis/saved_objects_management/find.ts
+++ b/test/api_integration/apis/saved_objects_management/find.ts
@@ -73,8 +73,7 @@ export default function ({ getService }: FtrProviderContext) {
                   score: 0,
                   updated_at: '2017-09-21T18:51:23.794Z',
                   meta: {
-                    editUrl:
-                      '/management/opensearch-dashboards/objects/savedVisualizations/dd7caf20-9efd-11e7-acb3-3dab96693fab',
+                    editUrl: '/objects/savedVisualizations/dd7caf20-9efd-11e7-acb3-3dab96693fab',
                     icon: 'visualizeApp',
                     inAppUrl: {
                       path: '/app/visualize#/edit/dd7caf20-9efd-11e7-acb3-3dab96693fab',
@@ -237,8 +236,7 @@ export default function ({ getService }: FtrProviderContext) {
             expect(resp.body.saved_objects[0].meta).to.eql({
               icon: 'discoverApp',
               title: 'OneRecord',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedSearches/960372e0-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedSearches/960372e0-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'discover.show',
@@ -256,8 +254,7 @@ export default function ({ getService }: FtrProviderContext) {
             expect(resp.body.saved_objects[0].meta).to.eql({
               icon: 'dashboardApp',
               title: 'Dashboard',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedDashboards/b70c7ae0-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedDashboards/b70c7ae0-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/dashboards#/view/b70c7ae0-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'dashboard.show',
@@ -275,8 +272,7 @@ export default function ({ getService }: FtrProviderContext) {
             expect(resp.body.saved_objects[0].meta).to.eql({
               icon: 'visualizeApp',
               title: 'VisualizationFromSavedSearch',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedVisualizations/a42c0580-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedVisualizations/a42c0580-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/visualize#/edit/a42c0580-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'visualize.show',
@@ -286,8 +282,7 @@ export default function ({ getService }: FtrProviderContext) {
             expect(resp.body.saved_objects[1].meta).to.eql({
               icon: 'visualizeApp',
               title: 'Visualization',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedVisualizations/add810b0-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedVisualizations/add810b0-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/visualize#/edit/add810b0-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'visualize.show',
@@ -305,11 +300,9 @@ export default function ({ getService }: FtrProviderContext) {
             expect(resp.body.saved_objects[0].meta).to.eql({
               icon: 'indexPatternApp',
               title: 'saved_objects*',
-              editUrl:
-                '/management/opensearch-dashboards/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
+              editUrl: '/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
-                path:
-                  '/app/management/opensearch-dashboards/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
+                path: '/app/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'management.opensearchDashboards.indexPatterns',
               },
               namespaceType: 'single',

--- a/test/api_integration/apis/saved_objects_management/relationships.ts
+++ b/test/api_integration/apis/saved_objects_management/relationships.ts
@@ -94,11 +94,9 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               title: 'saved_objects*',
               icon: 'indexPatternApp',
-              editUrl:
-                '/management/opensearch-dashboards/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
+              editUrl: '/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
-                path:
-                  '/app/management/opensearch-dashboards/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
+                path: '/app/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'management.opensearchDashboards.indexPatterns',
               },
               namespaceType: 'single',
@@ -111,8 +109,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               title: 'VisualizationFromSavedSearch',
               icon: 'visualizeApp',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedVisualizations/a42c0580-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedVisualizations/a42c0580-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/visualize#/edit/a42c0580-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'visualize.show',
@@ -137,11 +134,9 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'indexPatternApp',
               title: 'saved_objects*',
-              editUrl:
-                '/management/opensearch-dashboards/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
+              editUrl: '/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
-                path:
-                  '/app/management/opensearch-dashboards/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
+                path: '/app/indexPatterns/patterns/8963ca30-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'management.opensearchDashboards.indexPatterns',
               },
               namespaceType: 'single',
@@ -154,8 +149,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'visualizeApp',
               title: 'VisualizationFromSavedSearch',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedVisualizations/a42c0580-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedVisualizations/a42c0580-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/visualize#/edit/a42c0580-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'visualize.show',
@@ -199,8 +193,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'visualizeApp',
               title: 'Visualization',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedVisualizations/add810b0-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedVisualizations/add810b0-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/visualize#/edit/add810b0-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'visualize.show',
@@ -215,8 +208,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'visualizeApp',
               title: 'VisualizationFromSavedSearch',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedVisualizations/a42c0580-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedVisualizations/a42c0580-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/visualize#/edit/a42c0580-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'visualize.show',
@@ -239,8 +231,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'visualizeApp',
               title: 'Visualization',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedVisualizations/add810b0-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedVisualizations/add810b0-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/visualize#/edit/add810b0-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'visualize.show',
@@ -255,8 +246,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'visualizeApp',
               title: 'VisualizationFromSavedSearch',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedVisualizations/a42c0580-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedVisualizations/a42c0580-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/visualize#/edit/a42c0580-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'visualize.show',
@@ -300,8 +290,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'discoverApp',
               title: 'OneRecord',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedSearches/960372e0-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedSearches/960372e0-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'discover.show',
@@ -316,8 +305,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'dashboardApp',
               title: 'Dashboard',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedDashboards/b70c7ae0-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedDashboards/b70c7ae0-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/dashboards#/view/b70c7ae0-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'dashboard.show',
@@ -342,8 +330,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'discoverApp',
               title: 'OneRecord',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedSearches/960372e0-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedSearches/960372e0-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'discover.show',
@@ -386,8 +373,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'discoverApp',
               title: 'OneRecord',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedSearches/960372e0-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedSearches/960372e0-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'discover.show',
@@ -402,8 +388,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'visualizeApp',
               title: 'Visualization',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedVisualizations/add810b0-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedVisualizations/add810b0-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/visualize#/edit/add810b0-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'visualize.show',
@@ -428,8 +413,7 @@ export default function ({ getService }: FtrProviderContext) {
             meta: {
               icon: 'discoverApp',
               title: 'OneRecord',
-              editUrl:
-                '/management/opensearch-dashboards/objects/savedSearches/960372e0-3224-11e8-a572-ffca06da1357',
+              editUrl: '/objects/savedSearches/960372e0-3224-11e8-a572-ffca06da1357',
               inAppUrl: {
                 path: '/app/discover#/view/960372e0-3224-11e8-a572-ffca06da1357',
                 uiCapabilitiesPath: 'discover.show',

--- a/test/functional/apps/dashboard/create_and_add_embeddables.js
+++ b/test/functional/apps/dashboard/create_and_add_embeddables.js
@@ -112,8 +112,7 @@ export default function ({ getService, getPageObjects }) {
 
       describe('is false', () => {
         before(async () => {
-          await PageObjects.header.clickStackManagement();
-          await PageObjects.settings.clickOpenSearchDashboardsSettings();
+          await PageObjects.common.navigateToApp('settings');
           await PageObjects.settings.toggleAdvancedSettingCheckbox(VISUALIZE_ENABLE_LABS_SETTING);
         });
 
@@ -127,8 +126,7 @@ export default function ({ getService, getPageObjects }) {
         });
 
         after(async () => {
-          await PageObjects.header.clickStackManagement();
-          await PageObjects.settings.clickOpenSearchDashboardsSettings();
+          await PageObjects.settings.navigateTo();
           await PageObjects.settings.clearAdvancedSettings(VISUALIZE_ENABLE_LABS_SETTING);
           await PageObjects.header.clickDashboard();
         });

--- a/test/functional/apps/dashboard/time_zones.js
+++ b/test/functional/apps/dashboard/time_zones.js
@@ -51,7 +51,6 @@ export default function ({ getService, getPageObjects }) {
       await opensearchDashboardsServer.uiSettings.replace({
         defaultIndex: '0bf35f60-3dc9-11e8-8660-4d65aa086b3c',
       });
-      await PageObjects.settings.navigateTo();
       await PageObjects.settings.clickOpenSearchDashboardsSavedObjects();
       await PageObjects.savedObjects.importFile(
         path.join(__dirname, 'exports', 'timezonetest_6_2_4.json')
@@ -75,7 +74,6 @@ export default function ({ getService, getPageObjects }) {
 
     it('Changing timezone changes dashboard timestamp and shows the same data', async () => {
       await PageObjects.settings.navigateTo();
-      await PageObjects.settings.clickOpenSearchDashboardsSettings();
       await PageObjects.settings.setAdvancedSettingsSelect('dateFormat:tz', 'Etc/GMT+5');
       await PageObjects.common.navigateToApp('dashboard');
       await PageObjects.dashboard.loadSavedDashboard('time zone test');

--- a/test/functional/apps/management/_import_objects.js
+++ b/test/functional/apps/management/_import_objects.js
@@ -46,7 +46,6 @@ export default function ({ getService, getPageObjects }) {
       beforeEach(async function () {
         // delete .kibana index and then wait for OpenSearch Dashboards to re-create it
         await opensearchDashboardsServer.uiSettings.replace({});
-        await PageObjects.settings.navigateTo();
         await opensearchArchiver.load('management');
         await PageObjects.settings.clickOpenSearchDashboardsSavedObjects();
       });
@@ -215,7 +214,6 @@ export default function ({ getService, getPageObjects }) {
       beforeEach(async function () {
         // delete .kibana index and then wait for OpenSearch Dashboards to re-create it
         await opensearchDashboardsServer.uiSettings.replace({});
-        await PageObjects.settings.navigateTo();
         await opensearchArchiver.load('saved_objects_imports');
         await PageObjects.settings.clickOpenSearchDashboardsSavedObjects();
       });

--- a/test/functional/apps/management/_index_pattern_create_delete.js
+++ b/test/functional/apps/management/_index_pattern_create_delete.js
@@ -129,7 +129,7 @@ export default function ({ getService, getPageObjects }) {
         return retry.try(function tryingForTime() {
           return browser.getCurrentUrl().then(function (currentUrl) {
             log.debug('currentUrl = ' + currentUrl);
-            expect(currentUrl).to.contain('management/opensearch-dashboards/indexPatterns');
+            expect(currentUrl).to.contain('indexPatterns');
           });
         });
       });

--- a/test/functional/apps/management/_mgmt_import_saved_objects.js
+++ b/test/functional/apps/management/_mgmt_import_saved_objects.js
@@ -42,7 +42,6 @@ export default function ({ getService, getPageObjects }) {
     beforeEach(async function () {
       await opensearchArchiver.load('empty_opensearch_dashboards');
       await opensearchArchiver.load('discover');
-      await PageObjects.settings.navigateTo();
     });
 
     afterEach(async function () {

--- a/test/functional/apps/management/_opensearch_dashboards_settings.js
+++ b/test/functional/apps/management/_opensearch_dashboards_settings.js
@@ -39,12 +39,10 @@ export default function ({ getService, getPageObjects }) {
     before(async function () {
       // delete .kibana index and then wait for OpenSearch Dashboards to re-create it
       await opensearchDashboardsServer.uiSettings.replace({});
-      await PageObjects.settings.navigateTo();
       await PageObjects.settings.createIndexPattern('logstash-*');
     });
 
     after(async function afterAll() {
-      await PageObjects.settings.navigateTo();
       await PageObjects.settings.clickOpenSearchDashboardsIndexPatterns();
       await PageObjects.settings.removeLogstashIndexPatternIfExist();
     });
@@ -90,7 +88,6 @@ export default function ({ getService, getPageObjects }) {
       });
 
       it('setting to true change is preserved', async function () {
-        await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickOpenSearchDashboardsSettings();
         await PageObjects.settings.toggleAdvancedSettingCheckbox('state:storeInSessionStorage');
         const storeInSessionStorage = await PageObjects.settings.getAdvancedSettingCheckbox(
@@ -113,8 +110,7 @@ export default function ({ getService, getPageObjects }) {
 
       it("changing 'state:storeInSessionStorage' also takes effect without full page reload", async () => {
         await PageObjects.dashboard.preserveCrossAppState();
-        await PageObjects.header.clickStackManagement();
-        await PageObjects.settings.clickOpenSearchDashboardsSettings();
+        await PageObjects.settings.navigateTo();
         await PageObjects.settings.toggleAdvancedSettingCheckbox('state:storeInSessionStorage');
         await PageObjects.header.clickDashboard();
         const [globalState, appState] = await getStateFromUrl();

--- a/test/functional/apps/management/_scripted_fields.js
+++ b/test/functional/apps/management/_scripted_fields.js
@@ -75,13 +75,11 @@ export default function ({ getService, getPageObjects }) {
     });
 
     after(async function afterAll() {
-      await PageObjects.settings.navigateTo();
       await PageObjects.settings.clickOpenSearchDashboardsIndexPatterns();
       await PageObjects.settings.removeLogstashIndexPatternIfExist();
     });
 
     it('should not allow saving of invalid scripts', async function () {
-      await PageObjects.settings.navigateTo();
       await PageObjects.settings.clickOpenSearchDashboardsIndexPatterns();
       await PageObjects.settings.clickIndexPatternLogstash();
       await PageObjects.settings.clickScriptedFieldsTab();
@@ -99,7 +97,6 @@ export default function ({ getService, getPageObjects }) {
       const scriptedPainlessFieldName = 'ram_Pain_reg';
 
       it('should create and edit scripted field', async function () {
-        await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickOpenSearchDashboardsIndexPatterns();
         await PageObjects.settings.clickIndexPatternLogstash();
         const startingCount = parseInt(await PageObjects.settings.getScriptedFieldsTabCount());
@@ -133,7 +130,6 @@ export default function ({ getService, getPageObjects }) {
       const scriptedPainlessFieldName = 'ram_Pain1';
 
       it('should create scripted field', async function () {
-        await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickOpenSearchDashboardsIndexPatterns();
         await PageObjects.settings.clickIndexPatternLogstash();
         const startingCount = parseInt(await PageObjects.settings.getScriptedFieldsTabCount());
@@ -254,7 +250,6 @@ export default function ({ getService, getPageObjects }) {
       const scriptedPainlessFieldName2 = 'painString';
 
       it('should create scripted field', async function () {
-        await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickOpenSearchDashboardsIndexPatterns();
         await PageObjects.settings.clickIndexPatternLogstash();
         const startingCount = parseInt(await PageObjects.settings.getScriptedFieldsTabCount());
@@ -350,7 +345,6 @@ export default function ({ getService, getPageObjects }) {
       const scriptedPainlessFieldName2 = 'painBool';
 
       it('should create scripted field', async function () {
-        await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickOpenSearchDashboardsIndexPatterns();
         await PageObjects.settings.clickIndexPatternLogstash();
         const startingCount = parseInt(await PageObjects.settings.getScriptedFieldsTabCount());
@@ -448,7 +442,6 @@ export default function ({ getService, getPageObjects }) {
       const scriptedPainlessFieldName2 = 'painDate';
 
       it('should create scripted field', async function () {
-        await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickOpenSearchDashboardsIndexPatterns();
         await PageObjects.settings.clickIndexPatternLogstash();
         const startingCount = parseInt(await PageObjects.settings.getScriptedFieldsTabCount());

--- a/test/functional/apps/management/_scripted_fields_filter.js
+++ b/test/functional/apps/management/_scripted_fields_filter.js
@@ -58,7 +58,6 @@ export default function ({ getService, getPageObjects }) {
     const scriptedPainlessFieldName = 'ram_pain1';
 
     it('should filter scripted fields', async function () {
-      await PageObjects.settings.navigateTo();
       await PageObjects.settings.clickOpenSearchDashboardsIndexPatterns();
       await PageObjects.settings.clickIndexPatternLogstash();
       await PageObjects.settings.clickScriptedFieldsTab();

--- a/test/functional/apps/saved_objects_management/edit_saved_object.ts
+++ b/test/functional/apps/saved_objects_management/edit_saved_object.ts
@@ -88,7 +88,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('allows to update the saved object when submitting', async () => {
-      await PageObjects.settings.navigateTo();
       await PageObjects.settings.clickOpenSearchDashboardsSavedObjects();
 
       let objects = await PageObjects.savedObjects.getRowTitles();
@@ -154,7 +153,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         },
       ];
 
-      await PageObjects.settings.navigateTo();
       await PageObjects.settings.clickOpenSearchDashboardsSavedObjects();
 
       const objects = await PageObjects.savedObjects.getRowTitles();

--- a/test/functional/apps/visualize/_custom_branding.ts
+++ b/test/functional/apps/visualize/_custom_branding.ts
@@ -46,7 +46,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('with customized logo for opensearch overview header in dark mode', async () => {
-        await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
+        await PageObjects.settings.navigateTo();
         await PageObjects.settings.toggleAdvancedSettingCheckbox('theme:darkMode');
         await PageObjects.common.navigateToApp('opensearch_dashboards_overview');
         await testSubjects.existOrFail('osdOverviewPageHeaderLogo');
@@ -100,7 +100,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('with customized logo in dark mode', async () => {
-        await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
+        await PageObjects.settings.navigateTo();
         await PageObjects.settings.toggleAdvancedSettingCheckbox('theme:darkMode');
         await PageObjects.common.navigateToApp('home');
         await testSubjects.existOrFail('welcomeCustomLogo');
@@ -179,13 +179,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       describe('in dark mode', async () => {
         before(async function () {
-          await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
+          await PageObjects.settings.navigateTo();
           await PageObjects.settings.toggleAdvancedSettingCheckbox('theme:darkMode');
           await PageObjects.common.navigateToApp('home');
         });
 
         after(async function () {
-          await PageObjects.common.navigateToApp('management/opensearch-dashboards/settings');
+          await PageObjects.settings.navigateTo();
           await PageObjects.settings.clearAdvancedSettings('theme:darkMode');
         });
 
@@ -206,7 +206,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
 
         it('with customized mark logo button that navigates to home page', async () => {
-          await PageObjects.common.navigateToApp('settings');
+          await PageObjects.settings.navigateTo();
           await globalNav.clickHomeButton();
           await PageObjects.header.waitUntilLoadingHasFinished();
           const url = await browser.getCurrentUrl();

--- a/test/functional/apps/visualize/_lab_mode.js
+++ b/test/functional/apps/visualize/_lab_mode.js
@@ -47,8 +47,7 @@ export default function ({ getService, getPageObjects }) {
       log.info('found saved search before toggling enableLabs mode');
 
       // Navigate to advanced setting and disable lab mode
-      await PageObjects.header.clickStackManagement();
-      await PageObjects.settings.clickOpenSearchDashboardsSettings();
+      await PageObjects.settings.navigateTo();
       await PageObjects.settings.toggleAdvancedSettingCheckbox(VISUALIZE_ENABLE_LABS_SETTING);
 
       // Expect the discover still to list that saved visualization in the open list
@@ -61,8 +60,7 @@ export default function ({ getService, getPageObjects }) {
 
     after(async () => {
       await PageObjects.discover.closeLoadSaveSearchPanel();
-      await PageObjects.header.clickStackManagement();
-      await PageObjects.settings.clickOpenSearchDashboardsSettings();
+      await PageObjects.settings.navigateTo();
       await PageObjects.settings.clearAdvancedSettings(VISUALIZE_ENABLE_LABS_SETTING);
     });
   });

--- a/test/functional/apps/visualize/_tag_cloud.js
+++ b/test/functional/apps/visualize/_tag_cloud.js
@@ -160,7 +160,6 @@ export default function ({ getService, getPageObjects }) {
 
     describe('formatted field', function () {
       before(async function () {
-        await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickOpenSearchDashboardsIndexPatterns();
         await PageObjects.settings.clickIndexPatternLogstash();
         await PageObjects.settings.filterField(termsField);
@@ -178,7 +177,6 @@ export default function ({ getService, getPageObjects }) {
 
       after(async function () {
         await filterBar.removeFilter(termsField);
-        await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickOpenSearchDashboardsIndexPatterns();
         await PageObjects.settings.clickIndexPatternLogstash();
         await PageObjects.settings.filterField(termsField);

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -101,10 +101,6 @@ export default async function ({ readConfigFile }) {
       management: {
         pathname: '/app/management',
       },
-      /** @obsolete "management" should be instead of "settings" **/
-      settings: {
-        pathname: '/app/management',
-      },
       console: {
         pathname: '/app/dev_tools',
         hash: '/console',

--- a/test/functional/page_objects/settings_page.ts
+++ b/test/functional/page_objects/settings_page.ts
@@ -51,19 +51,19 @@ export function SettingsPageProvider({ getService, getPageObjects }: FtrProvider
       await find.clickByDisplayedLinkText(text);
     }
     async clickOpenSearchDashboardsSettings() {
-      await testSubjects.click('settings');
+      await PageObjects.common.navigateToApp('settings');
       await PageObjects.header.waitUntilLoadingHasFinished();
       await testSubjects.existOrFail('managementSettingsTitle');
     }
 
     async clickOpenSearchDashboardsSavedObjects() {
-      await testSubjects.click('objects');
+      await PageObjects.common.navigateToApp('objects');
       await PageObjects.savedObjects.waitTableIsLoaded();
     }
 
     async clickOpenSearchDashboardsIndexPatterns() {
       log.debug('clickOpenSearchDashboardsIndexPatterns link');
-      await testSubjects.click('indexPatterns');
+      await PageObjects.common.navigateToApp('indexPatterns');
 
       await PageObjects.header.waitUntilLoadingHasFinished();
     }


### PR DESCRIPTION
### Description

The main change of this PR are:

- Rename `Opensearch Dashboards` category to `Library`.
- Register Advance Settings as standalone application.
- Register Data Source management as standalone application.
- Register Index Pattern management as standalone application.
- Rename `SavedObject management`to `Manage library` as standalone application.
- Retire dashboard management section.


### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5280

## Screenshot
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/42465692/d2cf0eee-2ffc-42c7-b598-f546175e1d70)
Before change

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/42465692/26d32151-205c-4db7-b253-149c06bd4d29)
After change


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
