### PR TITLE
[Fix] typo in 2.11.0 release note header

### DIFF
--- a/release-notes/opensearch-dashboards.release-notes-2.11.0.md
+++ b/release-notes/opensearch-dashboards.release-notes-2.11.0.md
@@ -1,4 +1,4 @@
-## Version 2.10.0 Release Notes
+## Version 2.11.0 Release Notes
 
 ### 🛡 Security
 


### PR DESCRIPTION
### Description

First line of release note shows `2.10.0` and not `2.11.0`.

### Issues Resolved

rel #5252 

## Screenshot

_N/A_

## Testing the changes

_not subject for that, since it's only markdown related._

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
