### PR TITLE
[Fix] Change panel header & update snapshot

### DIFF
--- a/src/plugins/discover/public/application/components/top_nav/__snapshots__/open_search_panel.test.tsx.snap
+++ b/src/plugins/discover/public/application/components/top_nav/__snapshots__/open_search_panel.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`render 1`] = `
     >
       <h2>
         <FormattedMessage
-          defaultMessage="Open search"
+          defaultMessage="OpenSearch"
           id="discover.topNav.openSearchPanel.openSearchTitle"
           values={Object {}}
         />

--- a/src/plugins/discover/public/application/components/top_nav/open_search_panel.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/open_search_panel.tsx
@@ -67,7 +67,7 @@ export function OpenSearchPanel({ onClose, makeUrl }: Props) {
           <h2>
             <FormattedMessage
               id="discover.topNav.openSearchPanel.openSearchTitle"
-              defaultMessage="Open search"
+              defaultMessage="OpenSearch"
             />
           </h2>
         </EuiTitle>


### PR DESCRIPTION
### Description

In the Discover page ("Open" tab), changed the panel header from "Open search" to "OpenSearch".

### Issues Resolved

- closes #5145 
- add snapshots to #5152 

## Screenshot

### Before
<img width="1491" alt="Screenshot 2023-10-16 at 12 02 31 AM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/65143821/1dc814f0-dd61-45cf-85e4-1273de7cd336">

### After
<img width="1490" alt="Screenshot 2023-10-16 at 12 00 51 AM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/65143821/362b2add-d448-4520-81cd-5b3556565a71">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass 
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
