### PR TITLE
Adds validation for invalid hostname in multi data source

### DIFF
--- a/src/plugins/data_source/server/util/endpoint_validator.ts
+++ b/src/plugins/data_source/server/util/endpoint_validator.ts
@@ -5,8 +5,20 @@
 
 import dns from 'dns-sync';
 import IPCIDR from 'ip-cidr';
+// eslint-disable-next-line @osd/eslint/no-restricted-paths
+import { config } from '../../../../core/server/http';
 
 export function isValidURL(endpoint: string, deniedIPs?: string[]) {
+  // Validate hostname e.g. https://abc.com<><><><img>
+  const httpSchema = config.schema;
+  const obj = {
+    host: endpoint,
+  };
+  try {
+    httpSchema.validate(obj);
+  } catch (err) {
+    return false;
+  }
   // Check the format of URL, URL has be in the format as
   // scheme://server/path/resource otherwise an TypeError
   // would be thrown.


### PR DESCRIPTION
### Description

Adds validation for invalid hostname in multi data source to prevent possible Denial of Service attack.

## Screenshot

**Before Fix:**
<img width="1918" alt="Screenshot 2023-10-18 at 4 30 58 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/63824432/464a4d4c-7b41-4ba3-80ff-479dd11ad24b">

**After Fix:**
<img width="1917" alt="Screenshot 2023-10-18 at 4 34 25 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/63824432/9b63dc1d-a31a-4dcd-b5c7-c4d0eec701df">


**Response of `api/saved_objects/data-source` with invalid endpoint**:
```
{"statusCode":400,"error":"Bad Request","message":"\"endpoint\" attribute is not valid or allowed: Bad Request"}
```

## Testing the changes

**Steps to Reproduce issue:**

1. Go to create data source screen: 
2. Enter details as follows:
```
Title: test.
Description: test
Endpoint URL: https://search-test-2-xsecwmknog2wrmfphvor4dkuo4.eu-central-1.es.amazonaws.com<><><><img>.
Authentication Method: No Authentication
```
3. Click on Create data source.

Before this fix: Dashboards hangs up.
After this fix: It will validate endpoint and prevent dashboards from hanging up.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
