### PR TITLE
Revert "[Fix] Add platform "darwin-arm64" to unit test"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Data Explorer][Discover] Allow filter and query persist when refresh page or paste url to a new tab ([#5206](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5206))
 - [Data Explorer] Remove the `X` icon in data source selection field ([#5238](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5238))
 - [BUG][Fuctional Test] Make setDefaultAbsoluteRange more robust and update doc views tests ([#5242](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5242))
-- [BUG] Add platform "darwin-arm64" to unit test ([#5290](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5290))
 - [BUG][Dev Tool] Add dev tool documentation link to dev tool's help menu [#5166](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5166)
 
 ### 🚞 Infrastructure

--- a/src/dev/build/lib/config.test.ts
+++ b/src/dev/build/lib/config.test.ts
@@ -52,7 +52,6 @@ const setup = async ({
   targetAllPlatforms = true,
   targetPlatforms = {
     darwin: false,
-    darwinArm: false,
     linux: false,
     linuxArm: false,
     windows: false,
@@ -61,7 +60,6 @@ const setup = async ({
   targetAllPlatforms?: boolean;
   targetPlatforms?: {
     darwin: boolean;
-    darwinArm: boolean;
     linux: boolean;
     linuxArm: boolean;
     windows: boolean;
@@ -91,7 +89,9 @@ describe('#getNodeRange()', () => {
 describe('#getRepoRelativePath()', () => {
   it('converts an absolute path to relative path, from the root of the repo', async () => {
     const config = await setup();
-    expect(config.getRepoRelativePath(__dirname)).toMatchInlineSnapshot(`"src/dev/build/lib"`);
+    expect(config.getRepoRelativePath(__dirname)).toMatchInlineSnapshot(
+      `"${standardize('src/dev/build/lib', false, true)}"`
+    );
   });
 });
 
@@ -117,7 +117,6 @@ describe('#hasSpecifiedPlatform', () => {
       targetAllPlatforms: false,
       targetPlatforms: {
         darwin: true,
-        darwinArm: false,
         linux: false,
         linuxArm: false,
         windows: false,
@@ -131,7 +130,6 @@ describe('#hasSpecifiedPlatform', () => {
       targetAllPlatforms: false,
       targetPlatforms: {
         darwin: false,
-        darwinArm: false,
         linux: false,
         linuxArm: true,
         windows: false,
@@ -145,7 +143,6 @@ describe('#hasSpecifiedPlatform', () => {
       targetAllPlatforms: false,
       targetPlatforms: {
         darwin: false,
-        darwinArm: false,
         linux: true,
         linuxArm: false,
         windows: false,
@@ -200,7 +197,6 @@ describe('#getTargetPlatforms()', () => {
         .sort()
     ).toMatchInlineSnapshot(`
       Array [
-        "darwin-arm64",
         "darwin-x64",
         "linux-arm64",
         "linux-x64",
@@ -214,7 +210,6 @@ describe('#getTargetPlatforms()', () => {
       targetAllPlatforms: false,
       targetPlatforms: {
         darwin: true,
-        darwinArm: false,
         linux: false,
         linuxArm: false,
         windows: false,
@@ -238,7 +233,6 @@ describe('#getTargetPlatforms()', () => {
       targetAllPlatforms: false,
       targetPlatforms: {
         darwin: false,
-        darwinArm: false,
         linux: true,
         linuxArm: false,
         windows: false,
@@ -262,7 +256,6 @@ describe('#getTargetPlatforms()', () => {
       targetAllPlatforms: false,
       targetPlatforms: {
         darwin: false,
-        darwinArm: false,
         linux: false,
         linuxArm: true,
         windows: false,
@@ -286,7 +279,6 @@ describe('#getTargetPlatforms()', () => {
       targetAllPlatforms: false,
       targetPlatforms: {
         darwin: true,
-        darwinArm: false,
         linux: false,
         linuxArm: true,
         windows: false,
@@ -323,7 +315,7 @@ describe('#getNodePlatforms()', () => {
         .getTargetPlatforms()
         .map((p) => p.getNodeArch())
         .sort()
-    ).toEqual(['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64', 'win32-x64']);
+    ).toEqual(['darwin-x64', 'linux-arm64', 'linux-x64', 'win32-x64']);
   });
 
   it('returns this platform and linux, when targetAllPlatforms = false', async () => {

--- a/src/dev/build/lib/config.ts
+++ b/src/dev/build/lib/config.ts
@@ -155,10 +155,9 @@ export class Config {
 
     const platforms: Platform[] = [];
     if (this.targetPlatforms.darwin) platforms.push(this.getPlatform('darwin', 'x64'));
-    if (this.targetPlatforms.darwinArm) platforms.push(this.getPlatform('darwin', 'arm64'));
     if (this.targetPlatforms.linux) platforms.push(this.getPlatform('linux', 'x64'));
-    if (this.targetPlatforms.linuxArm) platforms.push(this.getPlatform('linux', 'arm64'));
     if (this.targetPlatforms.windows) platforms.push(this.getPlatform('win32', 'x64'));
+    if (this.targetPlatforms.linuxArm) platforms.push(this.getPlatform('linux', 'arm64'));
 
     if (platforms.length > 0) return platforms;
 

--- a/src/dev/build/lib/platform.ts
+++ b/src/dev/build/lib/platform.ts
@@ -33,7 +33,6 @@ export type PlatformArchitecture = 'x64' | 'arm64';
 
 export interface TargetPlatforms {
   darwin: boolean;
-  darwinArm: boolean;
   linuxArm: boolean;
   linux: boolean;
   windows: boolean;
@@ -79,6 +78,5 @@ export const ALL_PLATFORMS = [
   new Platform('linux', 'x64', 'linux-x64'),
   new Platform('linux', 'arm64', 'linux-arm64'),
   new Platform('darwin', 'x64', 'darwin-x64'),
-  new Platform('darwin', 'arm64', 'darwin-arm64'),
   new Platform('win32', 'x64', 'windows-x64'),
 ];

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
@@ -139,15 +139,6 @@ it('downloads node builds for each platform', async () => {
       ],
       Array [
         Object {
-          "destination": "darwin:downloadPath",
-          "log": <ToolingLog>,
-          "retries": 3,
-          "sha256": "darwin:sha256",
-          "url": "darwin:url",
-        },
-      ],
-      Array [
-        Object {
           "destination": "win32:downloadPath",
           "log": <ToolingLog>,
           "retries": 3,
@@ -180,15 +171,6 @@ it('downloads node builds for each platform', async () => {
           "retries": 3,
           "sha256": undefined,
           "url": "https://mirrors.nodejs.org/dist/v14.21.3/node-v14.21.3-darwin-x64.tar.gz",
-        },
-      ],
-      Array [
-        Object {
-          "destination": "/mocked/path/.node_binaries/14.21.3/node-v14.21.3-darwin-arm64.tar.gz",
-          "log": <ToolingLog>,
-          "retries": 3,
-          "sha256": undefined,
-          "url": "https://mirrors.nodejs.org/dist/v14.21.3/node-v14.21.3-darwin-arm64.tar.gz",
         },
       ],
       Array [

--- a/src/dev/build/tasks/nodejs/extract_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/extract_node_builds_task.test.ts
@@ -124,13 +124,6 @@ it('runs expected fs operations', async () => {
           },
         ],
         Array [
-          <absolute path>/.node_binaries/<node version>/node-v<node version>-darwin-arm64.tar.gz,
-          <absolute path>/.node_binaries/<node version>/darwin-arm64,
-          Object {
-            "strip": 1,
-          },
-        ],
-        Array [
           <absolute path>/.node_binaries/14.21.3/node-v14.21.3-linux-x64.tar.gz,
           <absolute path>/.node_binaries/14.21.3/linux-x64,
           Object {
@@ -147,13 +140,6 @@ it('runs expected fs operations', async () => {
         Array [
           <absolute path>/.node_binaries/14.21.3/node-v14.21.3-darwin-x64.tar.gz,
           <absolute path>/.node_binaries/14.21.3/darwin-x64,
-          Object {
-            "strip": 1,
-          },
-        ],
-        Array [
-          <absolute path>/.node_binaries/14.21.3/node-v14.21.3-darwin-arm64.tar.gz,
-          <absolute path>/.node_binaries/14.21.3/darwin-arm64,
           Object {
             "strip": 1,
           },

--- a/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/verify_existing_node_builds_task.test.ts
@@ -120,7 +120,6 @@ it('checks shasums for each downloaded node build', async () => {
         Object {
           "type": "return",
           "value": Object {
-            "darwin:darwin-arm64:downloadName": "valid shasum",
             "darwin:darwin-x64:downloadName": "valid shasum",
             "linux:linux-arm64:downloadName": "valid shasum",
             "linux:linux-x64:downloadName": "valid shasum",
@@ -154,14 +153,6 @@ it('checks shasums for each downloaded node build', async () => {
           Platform {
             "architecture": "x64",
             "buildName": "darwin-x64",
-            "name": "darwin",
-          },
-        ],
-        Array [
-          <Config>,
-          Platform {
-            "architecture": "arm64",
-            "buildName": "darwin-arm64",
             "name": "darwin",
           },
         ],
@@ -202,14 +193,6 @@ it('checks shasums for each downloaded node build', async () => {
         Object {
           "type": "return",
           "value": Object {
-            "downloadName": "darwin:darwin-arm64:downloadName",
-            "downloadPath": "darwin:darwin-arm64:downloadPath",
-            "version": "<node version>",
-          },
-        },
-        Object {
-          "type": "return",
-          "value": Object {
             "downloadName": "win32:win32-x64:downloadName",
             "downloadPath": "win32:win32-x64:downloadPath",
             "version": "<node version>",
@@ -234,19 +217,11 @@ it('checks shasums for each downloaded node build', async () => {
           "sha256",
         ],
         Array [
-          "darwin:darwin-arm64:downloadPath",
-          "sha256",
-        ],
-        Array [
           "win32:win32-x64:downloadPath",
           "sha256",
         ],
       ],
       "results": Array [
-        Object {
-          "type": "return",
-          "value": "valid shasum",
-        },
         Object {
           "type": "return",
           "value": "valid shasum",


### PR DESCRIPTION
Reverts opensearch-project/OpenSearch-Dashboards#5290

I believe this revert is necessary to unblock https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5413 until we can kill node 14 support.