### PR TITLE
[BUG] Fix Discover table panel size auto adjust in Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG] Add platform "darwin-arm64" to unit test ([#5290](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5290))
 - [BUG][Dev Tool] Add dev tool documentation link to dev tool's help menu [#5166](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5166)
 - Fix navigation issue across dashboards ([#5435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5435))
-- [BUG] Fix Discover table panel size auto adjust in Dashboard ([#5441](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5441))
+- [Discover] Fix table panel auto-sizing ([#5441](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5441))
 
 ### 🚞 Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG] Add platform "darwin-arm64" to unit test ([#5290](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5290))
 - [BUG][Dev Tool] Add dev tool documentation link to dev tool's help menu [#5166](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5166)
 - Fix navigation issue across dashboards ([#5435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5435))
+- [BUG] Fix Discover table panel size auto adjust in Dashboard ([#5441](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5441))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -13,7 +13,6 @@ import { DataGridFlyout } from './data_grid_table_flyout';
 import { DiscoverGridContextProvider } from './data_grid_table_context';
 import { toolbarVisibility } from './constants';
 import { DocViewFilterFn, OpenSearchSearchHit } from '../../doc_views/doc_views_types';
-import { DiscoverServices } from '../../../build_services';
 import { usePagination } from '../utils/use_pagination';
 import { SortOrder } from '../../../saved_searches/types';
 import { buildColumns } from '../../utils/columns';

--- a/src/plugins/discover/public/embeddable/search_embeddable.scss
+++ b/src/plugins/discover/public/embeddable/search_embeddable.scss
@@ -1,0 +1,12 @@
+/**
+   * 1. We want the osdDocTable__container to scroll only when embedded in an embeddable panel
+   * 2. Force a better looking scrollbar
+   */
+.embPanel {
+  .osdDocTable__container {
+    @include euiScrollBar; /* 2 */
+
+    flex: 1 1 0; /* 1 */
+    overflow: auto; /* 1 */
+  }
+}

--- a/src/plugins/discover/public/embeddable/search_embeddable.tsx
+++ b/src/plugins/discover/public/embeddable/search_embeddable.tsx
@@ -374,7 +374,9 @@ export class SearchEmbeddable
     const props = {
       searchProps,
     };
-    ReactDOM.render(<SearchEmbeddableComponent {...props} />, node);
+
+    const MemorizedSearchEmbeddableComponent = React.memo(SearchEmbeddableComponent);
+    ReactDOM.render(<MemorizedSearchEmbeddableComponent {...props} />, node);
   }
 
   private async pushContainerStateParamsToProps(searchProps: SearchProps, force: boolean = false) {

--- a/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
+++ b/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
@@ -12,6 +12,7 @@ import {
   DataGridTableProps,
 } from '../application/components/data_grid/data_grid_table';
 import { VisualizationNoResults } from '../../../visualizations/public';
+import './search_embeddable.scss';
 
 interface SearchEmbeddableProps {
   searchProps: SearchProps;
@@ -51,8 +52,10 @@ export function SearchEmbeddableComponent({ searchProps }: SearchEmbeddableProps
         data-test-subj="embeddedSavedSearchDocTable"
       >
         {discoverEmbeddableProps.totalHitCount !== 0 ? (
-          <EuiFlexItem>
-            <DataGridTableMemoized {...discoverEmbeddableProps} />
+          <EuiFlexItem style={{ minHeight: 0 }}>
+            <div className="osdDocTable__container">
+              <DataGridTableMemoized {...discoverEmbeddableProps} />
+            </div>
           </EuiFlexItem>
         ) : (
           <EuiFlexItem>

--- a/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
+++ b/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
@@ -52,10 +52,8 @@ export function SearchEmbeddableComponent({ searchProps }: SearchEmbeddableProps
         data-test-subj="embeddedSavedSearchDocTable"
       >
         {discoverEmbeddableProps.totalHitCount !== 0 ? (
-          <EuiFlexItem style={{ minHeight: 0 }}>
-            <div className="osdDocTable__container">
-              <DataGridTableMemoized {...discoverEmbeddableProps} />
-            </div>
+          <EuiFlexItem style={{ minHeight: 0 }} className="osdDocTable__container">
+            <DataGridTableMemoized {...discoverEmbeddableProps} />
           </EuiFlexItem>
         ) : (
           <EuiFlexItem>


### PR DESCRIPTION
### Description
* Add React.memo on parent comp
* Restore embeddable panel style

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5415


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/5a8ad865-d179-41b7-a49b-e0a269e7a1ed


### Check List

- [ ] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
