### PR TITLE
Block out new homepage

### DIFF
--- a/src/plugins/home/public/application/components/_index.scss
+++ b/src/plugins/home/public/application/components/_index.scss
@@ -12,3 +12,4 @@
 @import "synopsis";
 @import "welcome";
 @import "tutorial/tutorial";
+@import "homepage";

--- a/src/plugins/home/public/application/components/home_app.js
+++ b/src/plugins/home/public/application/components/home_app.js
@@ -35,6 +35,7 @@ import { Home } from './home';
 import { FeatureDirectory } from './feature_directory';
 import { TutorialDirectory } from './tutorial_directory';
 import { Tutorial } from './tutorial/tutorial';
+import { Homepage } from './homepage';
 import { HashRouter as Router, Switch, Route } from 'react-router-dom';
 import { getTutorial } from '../load_tutorials';
 import { replaceTemplateStrings } from './tutorial/replace_template_strings';
@@ -91,6 +92,9 @@ export function HomeApp({ directories, solutions }) {
           <Route path="/tutorial_directory/:tab?" render={renderTutorialDirectory} />
           <Route exact path="/feature_directory">
             <FeatureDirectory addBasePath={addBasePath} directories={directories} />
+          </Route>
+          <Route exact path="/homepage">
+            <Homepage />
           </Route>
           <Route exact path="/">
             <Home

--- a/src/plugins/home/public/application/components/homepage/_index.scss
+++ b/src/plugins/home/public/application/components/homepage/_index.scss
@@ -1,1 +1,6 @@
 @import "hero_section/hero_section";
+@import "section/section";
+
+.home-homepage-pageBody {
+  padding: 0 $euiSizeL;
+}

--- a/src/plugins/home/public/application/components/homepage/_index.scss
+++ b/src/plugins/home/public/application/components/homepage/_index.scss
@@ -1,0 +1,1 @@
+@import "hero_section/hero_section";

--- a/src/plugins/home/public/application/components/homepage/hero_section/_hero_section.scss
+++ b/src/plugins/home/public/application/components/homepage/hero_section/_hero_section.scss
@@ -2,7 +2,6 @@
   color: $euiColorPrimary;
 }
 
-.home-hero-askTrinity {
-  display: inline;
-  font-weight: bold;
+.home-getStarted-chatIcon {
+  padding-left: $euiSizeS;
 }

--- a/src/plugins/home/public/application/components/homepage/hero_section/_hero_section.scss
+++ b/src/plugins/home/public/application/components/homepage/hero_section/_hero_section.scss
@@ -1,0 +1,8 @@
+.home-hero-title {
+  color: $euiColorPrimary;
+}
+
+.home-hero-askTrinity {
+  display: inline;
+  font-weight: bold;
+}

--- a/src/plugins/home/public/application/components/homepage/hero_section/get_started.tsx
+++ b/src/plugins/home/public/application/components/homepage/hero_section/get_started.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
+import {
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFieldText,
+  EuiIcon,
+  EuiButton,
+  EuiTitle,
+  EuiSpacer,
+} from '@elastic/eui';
+import { HeroSection } from './hero_section';
+
+export const GetStartedSection: React.FC = () => {
+  function renderOptions(options: string[]) {
+    return (
+      <EuiFlexGroup wrap direction="column" gutterSize="s">
+        {options.map((option, i) => (
+          <EuiFlexItem key={i} grow={false}>
+            <EuiPanel color="subdued">&quot;{option}&quot;</EuiPanel>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+    );
+  }
+
+  function renderCategory(size: 1 | 2, title: string, options: string[]) {
+    return (
+      <EuiFlexItem grow={size}>
+        <EuiFlexGroup direction="column" gutterSize="none">
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="m">
+              <h3>{title}</h3>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem>{renderOptions(options)}</EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    );
+  }
+
+  function renderCategories() {
+    return (
+      <>
+        <EuiFlexGroup wrap direction="row">
+          {renderCategory(
+            2,
+            i18n.translate('home.getStarted.observability', { defaultMessage: 'Observability' }),
+            [
+              i18n.translate('home.getStarted.monitor', {
+                defaultMessage: 'Help me monitor my applications infrastructure',
+              }),
+              i18n.translate('home.getStarted.import', {
+                defaultMessage: 'Help me import my Prometheus Data',
+              }),
+              i18n.translate('home.getStarted.question', {
+                defaultMessage: 'Some question here',
+              }),
+              i18n.translate('home.getStarted.question2', {
+                defaultMessage: 'Some other question here',
+              }),
+            ]
+          )}
+          {renderCategory(
+            1,
+            i18n.translate('home.getStarted.more', { defaultMessage: 'General' }),
+            [
+              i18n.translate('home.getStarted.ingest', {
+                defaultMessage: 'Help me understand the indexes in my system',
+              }),
+              i18n.translate('home.getStarted.visualize', {
+                defaultMessage: 'Help me optimize my OpenSearch setup',
+              }),
+            ]
+          )}
+        </EuiFlexGroup>
+        <EuiSpacer />
+        {renderFooter()}
+      </>
+    );
+  }
+
+  function renderFooter() {
+    return (
+      <EuiPanel color="subdued">
+        <EuiFlexGroup wrap direction="row" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiIcon type="chatRight" size="l" />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFlexGroup direction="row" alignItems="center">
+              <EuiFlexItem>
+                <EuiFieldText
+                  fullWidth
+                  placeholder={i18n.translate('home.getStarted.placeholder', {
+                    defaultMessage: 'Ask anything',
+                  })}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton size="s" iconSide="right" iconType="returnKey" fill={true} minWidth={0}>
+                  <FormattedMessage id="home.getStarted.go" defaultMessage="Go" />
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    );
+  }
+
+  return (
+    <HeroSection
+      title={i18n.translate('home.getStarted.title', { defaultMessage: 'Get started' })}
+      description={i18n.translate('home.getStarted.description', {
+        defaultMessage:
+          'Explore OpenSearch capabilities with the OpenSearch Assistant. Start with a suggested prompt, or ask anything.',
+      })}
+      links={[
+        {
+          text: i18n.translate('home.getStarted.learnMore', { defaultMessage: 'Learn more' }),
+          url: 'https://google.com',
+        },
+      ]}
+      categories={renderCategories()}
+    />
+  );
+};

--- a/src/plugins/home/public/application/components/homepage/hero_section/get_started.tsx
+++ b/src/plugins/home/public/application/components/homepage/hero_section/get_started.tsx
@@ -19,29 +19,40 @@ import {
 import { HeroSection } from './hero_section';
 
 export const GetStartedSection: React.FC = () => {
-  function renderOptions(options: string[]) {
+  function renderOptions(options1: string[], options2?: string[]) {
     return (
-      <EuiFlexGroup wrap direction="column" gutterSize="s">
-        {options.map((option, i) => (
-          <EuiFlexItem key={i} grow={false}>
-            <EuiPanel color="subdued">&quot;{option}&quot;</EuiPanel>
+      <EuiFlexGroup wrap direction="row" gutterSize="s">
+        <EuiFlexItem>
+          <EuiFlexGroup direction="column" gutterSize="s">
+            {options1.map((option, i) => (
+              <EuiFlexItem key={i} grow={false}>
+                <EuiPanel color="subdued">&quot;{option}&quot;</EuiPanel>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        {options2 && (
+          <EuiFlexItem>
+            <EuiFlexGroup direction="column" gutterSize="s">
+              {options2.map((option, i) => (
+                <EuiFlexItem key={i} grow={false}>
+                  <EuiPanel color="subdued">&quot;{option}&quot;</EuiPanel>
+                </EuiFlexItem>
+              ))}
+            </EuiFlexGroup>
           </EuiFlexItem>
-        ))}
+        )}
       </EuiFlexGroup>
     );
   }
 
-  function renderCategory(size: 1 | 2, title: string, options: string[]) {
+  function renderCategory(size: 1 | 2, title: string, options1: string[], options2?: string[]) {
     return (
       <EuiFlexItem grow={size}>
-        <EuiFlexGroup direction="column" gutterSize="none">
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="m">
-              <h3>{title}</h3>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem>{renderOptions(options)}</EuiFlexItem>
-        </EuiFlexGroup>
+        <EuiTitle size="m">
+          <h3>{title}</h3>
+        </EuiTitle>
+        {renderOptions(options1, options2)}
       </EuiFlexItem>
     );
   }
@@ -55,16 +66,18 @@ export const GetStartedSection: React.FC = () => {
             i18n.translate('home.getStarted.observability', { defaultMessage: 'Observability' }),
             [
               i18n.translate('home.getStarted.monitor', {
-                defaultMessage: 'Help me monitor my applications infrastructure',
+                defaultMessage: 'Help me optimize the observability deployment for my new service',
               }),
               i18n.translate('home.getStarted.import', {
-                defaultMessage: 'Help me import my Prometheus Data',
+                defaultMessage: 'Help me investigate a service incident',
               }),
+            ],
+            [
               i18n.translate('home.getStarted.question', {
-                defaultMessage: 'Some question here',
+                defaultMessage: 'Help me understand why my service latency increased this week?',
               }),
               i18n.translate('home.getStarted.question2', {
-                defaultMessage: 'Some other question here',
+                defaultMessage: 'How are my service level indicators?',
               }),
             ]
           )}

--- a/src/plugins/home/public/application/components/homepage/hero_section/get_started.tsx
+++ b/src/plugins/home/public/application/components/homepage/hero_section/get_started.tsx
@@ -104,7 +104,7 @@ export const GetStartedSection: React.FC = () => {
     return (
       <EuiPanel color="subdued">
         <EuiFlexGroup wrap direction="row" alignItems="center">
-          <EuiFlexItem grow={false}>
+          <EuiFlexItem grow={false} className="home-getStarted-chatIcon">
             <EuiIcon type="chatRight" size="l" />
           </EuiFlexItem>
           <EuiFlexItem>

--- a/src/plugins/home/public/application/components/homepage/hero_section/hero_section.tsx
+++ b/src/plugins/home/public/application/components/homepage/hero_section/hero_section.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+  EuiText,
+  EuiLink,
+  EuiSpacer,
+} from '@elastic/eui';
+
+interface Props {
+  title: string;
+  description: string;
+  links: Array<{
+    text: string;
+    url: string;
+  }>;
+  categories: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+export const HeroSection: React.FC<Props> = ({ title, description, links, categories, footer }) => {
+  return (
+    <EuiPanel>
+      <EuiFlexGroup direction="row">
+        <EuiFlexItem grow={1}>
+          <EuiTitle size="l" className="home-hero-title">
+            <h2>{title}</h2>
+          </EuiTitle>
+          <EuiText>{description}</EuiText>
+          {links.map((link) => (
+            <EuiLink key={link.url} href={link.url} external={true}>
+              {link.text}
+            </EuiLink>
+          ))}
+        </EuiFlexItem>
+        <EuiFlexItem grow={3}>{categories}</EuiFlexItem>
+      </EuiFlexGroup>
+      {footer && <EuiSpacer />}
+      {footer}
+    </EuiPanel>
+  );
+};

--- a/src/plugins/home/public/application/components/homepage/hero_section/index.ts
+++ b/src/plugins/home/public/application/components/homepage/hero_section/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { GetStartedSection } from './get_started';

--- a/src/plugins/home/public/application/components/homepage/homepage.tsx
+++ b/src/plugins/home/public/application/components/homepage/homepage.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiPageTemplate, EuiSpacer } from '@elastic/eui';
+import { GetStartedSection } from './hero_section';
+import { BasicsSection, DataSection } from './section';
+
+export const Homepage: React.FC = () => {
+  return (
+    <EuiPageTemplate
+      restrictWidth={1600}
+      pageContentProps={{
+        color: 'transparent',
+      }}
+    >
+      <GetStartedSection />
+      <EuiSpacer />
+      <DataSection />
+      <EuiSpacer />
+      <BasicsSection />
+    </EuiPageTemplate>
+  );
+};

--- a/src/plugins/home/public/application/components/homepage/homepage.tsx
+++ b/src/plugins/home/public/application/components/homepage/homepage.tsx
@@ -4,22 +4,40 @@
  */
 
 import React from 'react';
-import { EuiPageTemplate, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { EuiPageTemplate, EuiSpacer, EuiButtonEmpty } from '@elastic/eui';
 import { GetStartedSection } from './hero_section';
 import { BasicsSection, DataSection } from './section';
 
 export const Homepage: React.FC = () => {
+  const sideItems: React.ReactNode[] = [
+    <EuiButtonEmpty iconType="indexOpen">Add data</EuiButtonEmpty>,
+    <EuiButtonEmpty iconType="gear">Manage</EuiButtonEmpty>,
+    <EuiButtonEmpty iconType="wrench">Dev tools</EuiButtonEmpty>,
+  ];
+
   return (
     <EuiPageTemplate
       restrictWidth={1600}
+      pageHeader={{
+        pageTitle: i18n.translate('home.title', { defaultMessage: 'Home' }),
+        rightSideItems: sideItems,
+        alignItems: 'center',
+      }}
       pageContentProps={{
         color: 'transparent',
+        hasBorder: false,
+        hasShadow: false,
+      }}
+      pageContentBodyProps={{
+        paddingSize: 'none',
+        className: 'home-homepage-pageBody',
       }}
     >
       <GetStartedSection />
-      <EuiSpacer />
+      <EuiSpacer size="s" />
       <DataSection />
-      <EuiSpacer />
+      <EuiSpacer size="s" />
       <BasicsSection />
     </EuiPageTemplate>
   );

--- a/src/plugins/home/public/application/components/homepage/homepage.tsx
+++ b/src/plugins/home/public/application/components/homepage/homepage.tsx
@@ -35,9 +35,9 @@ export const Homepage: React.FC = () => {
       }}
     >
       <GetStartedSection />
-      <EuiSpacer size="s" />
+      <EuiSpacer size="xs" />
       <DataSection />
-      <EuiSpacer size="s" />
+      <EuiSpacer size="xs" />
       <BasicsSection />
     </EuiPageTemplate>
   );

--- a/src/plugins/home/public/application/components/homepage/index.ts
+++ b/src/plugins/home/public/application/components/homepage/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { Homepage } from './homepage';

--- a/src/plugins/home/public/application/components/homepage/section/_section.scss
+++ b/src/plugins/home/public/application/components/homepage/section/_section.scss
@@ -1,0 +1,3 @@
+.home-basics-listGroup {
+  margin-left: -$euiSizeM * 4;
+}

--- a/src/plugins/home/public/application/components/homepage/section/basics.tsx
+++ b/src/plugins/home/public/application/components/homepage/section/basics.tsx
@@ -21,19 +21,19 @@ export const BasicsSection: React.FC = () => {
       label: i18n.translate('home.basics.gettingStarted.quickstart', {
         defaultMessage: 'OpenSearch Dashboards quickstart',
       }),
-      href: 'https://google.com',
+      href: 'https://opensearch.org/docs/latest/dashboards/quickstart/',
     },
     {
       label: i18n.translate('home.basics.gettingStarted.dataVis', {
         defaultMessage: 'Building data visualizations',
       }),
-      href: 'https://google.com',
+      href: 'https://opensearch.org/docs/latest/dashboards/visualize/viz-index/',
     },
     {
       label: i18n.translate('home.basics.gettingStarted.dashboards', {
         defaultMessage: 'Creating dashboards',
       }),
-      href: 'https://google.com',
+      href: 'https://opensearch.org/docs/latest/dashboards/dashboard/index/',
     },
   ];
 
@@ -42,19 +42,19 @@ export const BasicsSection: React.FC = () => {
       label: i18n.translate('home.basics.dataDiscovery.exploration', {
         defaultMessage: 'Get familiar with Discover',
       }),
-      href: 'https://google.com',
+      href: 'https://opensearch.org/docs/latest/dashboards/discover/index-discover/',
     },
     {
       label: i18n.translate('home.basics.dataDiscovery.sources', {
         defaultMessage: 'Run queries in the Dev Tools Console',
       }),
-      href: 'https://google.com',
+      href: 'https://opensearch.org/docs/latest/dashboards/dev-tools/run-queries/',
     },
     {
       label: i18n.translate('home.basics.dataDiscovery.vis', {
         defaultMessage: 'Working with indexes',
       }),
-      href: 'https://google.com',
+      href: 'https://opensearch.org/docs/latest/dashboards/im-dashboards/index/',
     },
   ];
 
@@ -63,19 +63,19 @@ export const BasicsSection: React.FC = () => {
       label: i18n.translate('home.basics.observability.logExplorer', {
         defaultMessage: 'Get familiar with Log Explorer',
       }),
-      href: 'https://google.com',
+      href: 'https://opensearch.org/docs/latest/observing-your-data/event-analytics/',
     },
     {
       label: i18n.translate('home.basics.observability.prometheus', {
         defaultMessage: 'Explore prometheus metrics',
       }),
-      href: 'https://google.com',
+      href: 'https://opensearch.org/docs/latest/observing-your-data/prometheusmetrics/',
     },
     {
       label: i18n.translate('home.basics.observability.traces', {
         defaultMessage: 'Dive into traces and spans',
       }),
-      href: 'https://google.com',
+      href: 'https://opensearch.org/docs/latest/observing-your-data/trace/ta-dashboards/',
     },
   ];
 
@@ -90,7 +90,7 @@ export const BasicsSection: React.FC = () => {
           })}
           layout="horizontal"
         >
-          <EuiListGroup listItems={gettingStartedLinks} />
+          <EuiListGroup className="home-basics-listGroup" listItems={gettingStartedLinks} />
         </EuiCard>
       </EuiFlexItem>
       <EuiFlexItem>
@@ -102,7 +102,7 @@ export const BasicsSection: React.FC = () => {
           })}
           layout="horizontal"
         >
-          <EuiListGroup listItems={dataDiscoveryLinks} />
+          <EuiListGroup className="home-basics-listGroup" listItems={dataDiscoveryLinks} />
         </EuiCard>
       </EuiFlexItem>
       <EuiFlexItem>
@@ -114,7 +114,7 @@ export const BasicsSection: React.FC = () => {
           })}
           layout="horizontal"
         >
-          <EuiListGroup listItems={observabilityLinks} />
+          <EuiListGroup className="home-basics-listGroup" listItems={observabilityLinks} />
         </EuiCard>
       </EuiFlexItem>
     </EuiFlexGroup>
@@ -129,7 +129,7 @@ export const BasicsSection: React.FC = () => {
       links={[
         {
           text: i18n.translate('home.basics.documentation', { defaultMessage: 'Documentation' }),
-          url: 'https://google.com',
+          url: 'https://opensearch.org/docs/latest/',
         },
       ]}
       categories={categories}

--- a/src/plugins/home/public/application/components/homepage/section/basics.tsx
+++ b/src/plugins/home/public/application/components/homepage/section/basics.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiCard,
+  EuiIcon,
+  EuiListGroup,
+  EuiListGroupItemProps,
+} from '@elastic/eui';
+import { Section } from './section';
+
+export const BasicsSection: React.FC = () => {
+  const gettingStartedLinks: EuiListGroupItemProps[] = [
+    {
+      label: i18n.translate('home.basics.gettingStarted.quickstart', {
+        defaultMessage: 'OpenSearch Dashboards quickstart',
+      }),
+      href: 'https://google.com',
+    },
+    {
+      label: i18n.translate('home.basics.gettingStarted.dataVis', {
+        defaultMessage: 'Building data visualizations',
+      }),
+      href: 'https://google.com',
+    },
+    {
+      label: i18n.translate('home.basics.gettingStarted.dashboards', {
+        defaultMessage: 'Creating dashboards',
+      }),
+      href: 'https://google.com',
+    },
+  ];
+
+  const dataDiscoveryLinks: EuiListGroupItemProps[] = [
+    {
+      label: i18n.translate('home.basics.dataDiscovery.exploration', {
+        defaultMessage: 'Get familiar with Discover',
+      }),
+      href: 'https://google.com',
+    },
+    {
+      label: i18n.translate('home.basics.dataDiscovery.sources', {
+        defaultMessage: 'Run queries in the Dev Tools Console',
+      }),
+      href: 'https://google.com',
+    },
+    {
+      label: i18n.translate('home.basics.dataDiscovery.vis', {
+        defaultMessage: 'Working with indexes',
+      }),
+      href: 'https://google.com',
+    },
+  ];
+
+  const observabilityLinks: EuiListGroupItemProps[] = [
+    {
+      label: i18n.translate('home.basics.observability.logExplorer', {
+        defaultMessage: 'Get familiar with Log Explorer',
+      }),
+      href: 'https://google.com',
+    },
+    {
+      label: i18n.translate('home.basics.observability.prometheus', {
+        defaultMessage: 'Explore prometheus metrics',
+      }),
+      href: 'https://google.com',
+    },
+    {
+      label: i18n.translate('home.basics.observability.traces', {
+        defaultMessage: 'Dive into traces and spans',
+      }),
+      href: 'https://google.com',
+    },
+  ];
+
+  const categories = (
+    <EuiFlexGroup direction="row" alignItems="stretch">
+      <EuiFlexItem>
+        <EuiCard
+          display="plain"
+          icon={<EuiIcon type="logoOpenSearch" size="xl" />}
+          title={i18n.translate('home.basics.gettingStarted.title', {
+            defaultMessage: 'Getting started',
+          })}
+          layout="horizontal"
+        >
+          <EuiListGroup listItems={gettingStartedLinks} />
+        </EuiCard>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiCard
+          display="plain"
+          icon={<EuiIcon type="discoverApp" size="xl" />}
+          title={i18n.translate('home.basics.dataDiscovery.title', {
+            defaultMessage: 'Explore data',
+          })}
+          layout="horizontal"
+        >
+          <EuiListGroup listItems={dataDiscoveryLinks} />
+        </EuiCard>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiCard
+          display="plain"
+          icon={<EuiIcon type="eye" size="xl" />}
+          title={i18n.translate('home.basics.dataDiscovery.title', {
+            defaultMessage: 'Observability',
+          })}
+          layout="horizontal"
+        >
+          <EuiListGroup listItems={observabilityLinks} />
+        </EuiCard>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  return (
+    <Section
+      title={i18n.translate('home.basics.title', { defaultMessage: 'Lean OpenSearch basics' })}
+      description={i18n.translate('home.basics.description', {
+        defaultMessage: 'Core concepts to get you started with OpenSearch',
+      })}
+      links={[
+        {
+          text: i18n.translate('home.basics.documentation', { defaultMessage: 'Documentation' }),
+          url: 'https://google.com',
+        },
+      ]}
+      categories={categories}
+    />
+  );
+};

--- a/src/plugins/home/public/application/components/homepage/section/data.tsx
+++ b/src/plugins/home/public/application/components/homepage/section/data.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
+import { EuiFlexGroup, EuiFlexItem, EuiCard, EuiImage, EuiButton } from '@elastic/eui';
+import { Section } from './section';
+
+export const DataSection: React.FC = () => {
+  const categories = (
+    <EuiFlexGroup direction="row" alignItems="stretch">
+      <EuiFlexItem grow={1}>
+        <EuiCard
+          display="plain"
+          image={<EuiImage src="https://placehold.co/600x250" alt="Placeholder" />}
+          title={i18n.translate('home.data.sampleData.title', {
+            defaultMessage: 'Sample data',
+          })}
+          description={i18n.translate('home.data.sampleData.description', {
+            defaultMessage:
+              'These sample data sets allow you to explore dashboards, visualizations and features without needing to ingest your own data.',
+          })}
+          footer={
+            <EuiButton fullWidth={true}>
+              <FormattedMessage
+                id="home.data.sampleData.button"
+                defaultMessage="Manage sample data"
+              />
+            </EuiButton>
+          }
+          textAlign="left"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={1}>
+        <EuiCard
+          display="plain"
+          image={<EuiImage src="https://placehold.co/600x250" alt="Placeholder" />}
+          title={i18n.translate('home.data.explore.title', {
+            defaultMessage: 'Explore Data',
+          })}
+          description={i18n.translate('home.data.explore.description', {
+            defaultMessage:
+              'Data Explorer makes it simple to query, filter, and visualize your data for intuitive and in-depth data analysis.',
+          })}
+          footer={
+            <EuiButton fullWidth={true}>
+              <FormattedMessage id="home.data.explore.button" defaultMessage="Open Discover" />
+            </EuiButton>
+          }
+          textAlign="left"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={1}>
+        <EuiCard
+          display="plain"
+          image={<EuiImage src="https://placehold.co/600x250" alt="Placeholder" />}
+          title={i18n.translate('home.data.ingest.title', {
+            defaultMessage: 'Ingest data with Data Prepper',
+          })}
+          description={i18n.translate('home.data.ingest.description', {
+            defaultMessage:
+              'Filter, enrich, transform, normalize, and aggregate data for analytics and visualization.',
+          })}
+          footer={
+            <EuiButton fullWidth={true}>
+              <FormattedMessage
+                id="home.data.ingest.button"
+                defaultMessage="Data Prepper Documentation"
+              />
+            </EuiButton>
+          }
+          textAlign="left"
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  return (
+    <Section
+      title={i18n.translate('home.data.title', { defaultMessage: 'Work with data' })}
+      description={i18n.translate('home.data.description', {
+        defaultMessage:
+          'Get started by ingesting data to access rebust and visual data exploration capabilities. Not ready to ingest data yet? Use our sample data to explore and get familiar with OpenSearch capabilities.',
+      })}
+      categories={categories}
+    />
+  );
+};

--- a/src/plugins/home/public/application/components/homepage/section/index.ts
+++ b/src/plugins/home/public/application/components/homepage/section/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { Section } from './section';
+export { BasicsSection } from './basics';
+export { DataSection } from './data';

--- a/src/plugins/home/public/application/components/homepage/section/section.tsx
+++ b/src/plugins/home/public/application/components/homepage/section/section.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiPanel,
+  EuiTitle,
+  EuiText,
+  EuiLink,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonIcon,
+} from '@elastic/eui';
+
+interface Props {
+  title: string;
+  description?: string;
+  links?: Array<{
+    text: string;
+    url: string;
+  }>;
+  categories: React.ReactNode;
+}
+
+export const Section: React.FC<Props> = ({ title, description, links, categories }) => {
+  const hasDescriptionCategory = Boolean(description) || (!!links && links.length > 0);
+  const [collapsed, setCollapsed] = useState(false);
+
+  const toggleCollapsed = () => {
+    setCollapsed(!collapsed);
+  };
+
+  return (
+    <EuiPanel hasBorder={false} hasShadow={false} color="transparent">
+      <EuiFlexGroup direction="row" alignItems="center" gutterSize="s">
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            iconType={collapsed ? 'arrowRight' : 'arrowUp'}
+            onClick={toggleCollapsed}
+            size="s"
+            iconSize="m"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={true}>
+          <EuiTitle size="l">
+            <h3>{title}</h3>
+          </EuiTitle>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      {!collapsed && (
+        <EuiFlexGroup direction="row">
+          {hasDescriptionCategory && (
+            <EuiFlexItem grow={1}>
+              {description && <EuiText>{description}</EuiText>}
+              {links &&
+                links.map((link) => (
+                  <EuiLink key={link.url} href={link.url} external={true}>
+                    {link.text}
+                  </EuiLink>
+                ))}
+            </EuiFlexItem>
+          )}
+          <EuiFlexItem grow={3}>{categories}</EuiFlexItem>
+        </EuiFlexGroup>
+      )}
+    </EuiPanel>
+  );
+};


### PR DESCRIPTION
### Description

Block out new home page implementation. This is implemented in a separate route, since this is not yet feature complete. Additionally, this is mainly to get the page structure out for Olly integration. Page content, links, and functionality is mostly not complete yet.

![Screenshot (165)](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/6763209/0aed97ba-88aa-4376-b42b-8376ead7dadd)

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
