### PR TITLE
Add border for header navigation on right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG] Add platform "darwin-arm64" to unit test ([#5290](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5290))
 - [BUG][Dev Tool] Add dev tool documentation link to dev tool's help menu [#5166](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5166)
 - Fix navigation issue across dashboards ([#5435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5435))
+- Fix missing border for header navigation control on right ([#5450](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5450))
 
 ### 🚞 Infrastructure
 

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -4164,6 +4164,7 @@ exports[`Header handles visibility and lock changes 1`] = `
                         "thrownError": null,
                       }
                     }
+                    side="right"
                   />
                 </div>
               </EuiHeaderSectionItem>
@@ -9636,6 +9637,7 @@ exports[`Header renders condensed header 1`] = `
                         "thrownError": null,
                       }
                     }
+                    side="right"
                   />
                 </div>
               </EuiHeaderSectionItem>

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -228,7 +228,7 @@ export function Header({
               </EuiHeaderSectionItem>
 
               <EuiHeaderSectionItem border="left">
-                <HeaderNavControls navControls$={observables.navControlsRight$} />
+                <HeaderNavControls side="right" navControls$={observables.navControlsRight$} />
               </EuiHeaderSectionItem>
 
               <EuiHeaderSectionItem border="left">


### PR DESCRIPTION
### Description

Add border for header navigation control on right


### Issues Resolved
#5449

## Screenshot

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/113890546/a7c2a5cc-87a8-4289-a02c-6cec0193f5e9)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
