### PR TITLE
[Chore] `--security` for snapshot and OSD server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add an achievement badger to the PR ([#3721](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3721))
 - [CI] Enable inputs for manually triggered Cypress test jobs ([#5134](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5134))
 - [CI] Replace usage of deprecated `set-output` in workflows ([#5340](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5340))
+- [Chore] Add `--security` for `opensearch snapshot` and `opensearch_dashboards` to configure local setup with the security plugin ([#5451](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5451))
 
 ### 📝 Documentation
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -252,10 +252,11 @@ Options:
       -E                Additional key=value settings to pass to OpenSearch
       --download-only   Download the snapshot but don't actually start it
       --ssl             Sets up SSL on OpenSearch
+      --security        Installs and sets up OpenSearch Security plugin on the cluster
       --P               OpenSearch plugin artifact URL to install it on the cluster.
 
 ```bash
-$ yarn opensearch snapshot --version 2.2.0 -E cluster.name=test -E path.data=/tmp/opensearch-data --P org.opensearch.plugin:test-plugin:2.2.0.0 --P file:/home/user/opensearch-test-plugin-2.2.0.0.zip
+$ yarn opensearch snapshot --version 2.2.0 -E cluster.name=test -E path.data=/tmp/opensearch-data --P org.opensearch.plugin:test-plugin:2.2.0.0 --P file:/home/user/opensearch-test-plugin-2.2.0.0.zip --security
 ```
 
 #### Read Only capabilities
@@ -280,6 +281,18 @@ This method can also be used to develop against the [full distribution of OpenSe
 ### Configure OpenSearch Dashboards for security
 
 _This step is only mandatory if you have the [`security` plugin](https://github.com/opensearch-project/security) installed on your OpenSearch cluster with https/authentication enabled._
+
+> 1. Run `export initialAdminPassword=<initial admin password>` since it's needed by the configuration script
+> 2. Run `yarn opensearch snapshot --security`
+> 3. Wait a few seconds while the plugin is installed, configured, and OpenSearch starts up.
+
+Then within another window. You can start:
+
+> 1. Run `export OPENSEARCH_USERNAME=admin`
+> 2. Run `export OPENSEARCH_PASSWORD=<initial admin password>`
+> 3. Optional: Run `export OPENSEARCH_SECURITY_READONLY_ROLE=<read only role>`
+> 4. Run `yarn start:security`
+> 5. Navigate to OpenSearch Dashboards and login with the above username and password.
 
 Once the bootstrap of OpenSearch Dashboards is finished, you need to apply some
 changes to the default [`opensearch_dashboards.yml`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/config/opensearch_dashboards.yml#L25-L72) in order to connect to OpenSearch.

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "build": "scripts/use_node scripts/build --all-platforms",
     "start": "scripts/use_node scripts/opensearch_dashboards --dev",
     "start:docker": "scripts/use_node scripts/opensearch_dashboards --dev --opensearch.hosts=$OPENSEARCH_HOSTS --opensearch.ignoreVersionMismatch=true --server.host=$SERVER_HOST",
+    "start:security": "scripts/use_node scripts/opensearch_dashboards --dev --security",
     "debug": "scripts/use_node --nolazy --inspect scripts/opensearch_dashboards --dev",
     "debug-break": "scripts/use_node --nolazy --inspect-brk scripts/opensearch_dashboards --dev",
     "lint": "yarn run lint:es && yarn run lint:style",

--- a/packages/osd-opensearch/src/cli_commands/snapshot.js
+++ b/packages/osd-opensearch/src/cli_commands/snapshot.js
@@ -49,6 +49,7 @@ exports.help = (defaults = {}) => {
       -E                Additional key=value settings to pass to OpenSearch
       --download-only   Download the snapshot but don't actually start it
       --ssl             Sets up SSL on OpenSearch
+      --security        Installs and sets up the OpenSearch Security plugin on the cluster
       --P               OpenSearch plugin artifact URL to install it on the cluster. We can use the flag multiple times
                         to install multiple plugins on the cluster snapshot. The argument value can be url to zip file, maven coordinates of the plugin 
                         or for local zip files, use file:<followed by the absolute or relative path to the plugin zip file>.
@@ -74,6 +75,8 @@ exports.run = async (defaults = {}) => {
 
     boolean: ['download-only'],
 
+    boolean: ['security'],
+
     default: defaults,
   });
 
@@ -89,6 +92,10 @@ exports.run = async (defaults = {}) => {
 
     if (options.opensearchPlugins) {
       await cluster.installOpenSearchPlugins(installPath, options.opensearchPlugins);
+    }
+
+    if (options.security) {
+      await cluster.setupSecurity(installPath, options.version ?? defaults.version);
     }
 
     options.bundledJDK = true;

--- a/packages/osd-opensearch/src/paths.js
+++ b/packages/osd-opensearch/src/paths.js
@@ -35,6 +35,10 @@ function maybeUseBat(bin) {
   return os.platform().startsWith('win') ? `${bin}.bat` : bin;
 }
 
+function maybeUseBatOrShell(bin) {
+  return os.platform().startsWith('win') ? `${bin}.bat` : `${bin}.sh`;
+}
+
 const tempDir = os.tmpdir();
 
 exports.BASE_PATH = path.resolve(tempDir, 'osd-opensearch');
@@ -45,3 +49,6 @@ exports.OPENSEARCH_CONFIG = 'config/opensearch.yml';
 
 exports.OPENSEARCH_KEYSTORE_BIN = maybeUseBat('./bin/opensearch-keystore');
 exports.OPENSEARCH_PLUGIN = maybeUseBat('./bin/opensearch-plugin');
+exports.OPENSEARCH_SECURITY_INSTALL = maybeUseBatOrShell(
+  './plugins/opensearch-security/tools/install_demo_configuration'
+);


### PR DESCRIPTION
Add the ability to run:
```
yarn opensearch snapshot --security
```
which will start the OpenSearch cluster with the security plugin.

And add the ability to run:
```
yarn start:security
```
which will start the OpenSearch Dashboards server if the security plugin is available.

This is only intended for demo and local purposes.

Issue:
n/a

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
