### PR TITLE
[OSCI] removed KUI usage in visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Dashboard] Restructure the `Dashboard` plugin folder to be more cohesive with the project ([#4575](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4575))
 - Refactor logo usage to centralize and optimize assets and improve tests ([#4702](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4702))
 - [Home] Remove unused tutorials ([#5212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5212))
+- Remove KUI usage in `disabled_lab_visualization` ([#5462](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5462))
 
 ### 🔩 Tests
 

--- a/src/plugins/visualizations/public/embeddable/disabled_lab_visualization.tsx
+++ b/src/plugins/visualizations/public/embeddable/disabled_lab_visualization.tsx
@@ -29,28 +29,35 @@
  */
 
 import { FormattedMessage } from '@osd/i18n/react';
-import React from 'react';
+import { EuiEmptyPrompt, EuiLink } from '@elastic/eui';
+import React, { Fragment } from 'react';
 
 export function DisabledLabVisualization({ title }: { title: string }) {
   return (
     <div className="visDisabledLabVisualization">
-      <div
-        className="kuiVerticalRhythm visDisabledLabVisualization__icon kuiIcon fa-flask"
-        aria-hidden="true"
+      <EuiEmptyPrompt
+        iconType="database"
+        titleSize="s"
+        data-test-subj="visDisabledLabVisualization"
+        title={
+          <FormattedMessage
+            id="visualizations.disabledLabVisualizationTitle"
+            defaultMessage="{title} is an experimental visualization."
+            values={{ title: <em className="visDisabledLabVisualizationtitle">{title}</em> }}
+          />
+        }
+        body={
+          <Fragment>
+            <p>
+              Enable experimental visualizations within{' '}
+              <EuiLink href="https://github.com/app/management/opensearch-dashboards/settings">
+                Advanced Settings
+              </EuiLink>
+              .
+            </p>
+          </Fragment>
+        }
       />
-      <div className="kuiVerticalRhythm">
-        <FormattedMessage
-          id="visualizations.disabledLabVisualizationTitle"
-          defaultMessage="{title} is a lab visualization."
-          values={{ title: <em className="visDisabledLabVisualization__title">{title}</em> }}
-        />
-      </div>
-      <div className="kuiVerticalRhythm">
-        <FormattedMessage
-          id="visualizations.disabledLabVisualizationMessage"
-          defaultMessage="Please turn on lab-mode in the advanced settings to see lab visualizations."
-        />
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Description

Removed KUI classes in the `DisabledLabVisualization` component
Changed placeholder text and icon should be with `OuiEmptyPrompt`
Updated text to "[vispanel title] is an experimental visualization. Enable experimental visualizations within [Advanced Settings](https://github.com/app/management/opensearch-dashboards/settings)."

### Issues Resolved

#3386 

## Screenshot

<img width="821" alt="visDisabled" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/63242227/f1881a92-4d1e-41eb-8697-6a30367df9ec">

## Testing the changes

[How to view the `DisabledVabVisualization` component](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3855#issuecomment-1599741428)

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff