### PR TITLE
[OSCI][Fix] ScopedHistory out of navigation scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Fix navigation issue across dashboards ([#5435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5435))
 - [Discover] Fix table panel auto-sizing ([#5441](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5441))
+- [Fix] ScopedHistory out of navigation scope ([#5498](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5498))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_storage.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/osd_url_storage.ts
@@ -213,7 +213,12 @@ export const createOsdUrlControls = (
   return {
     listen: (cb: () => void) =>
       history.listen(() => {
-        cb();
+        try {
+          cb();
+        } catch {
+          // TODO: Do something when ScopedHistory
+          // instance has fell out of navigation scope
+        }
       }),
     update: (newUrl: string, replace = false) => updateUrl(newUrl, replace),
     updateAsync: (updater: UrlUpdaterFnType, replace = false) => {


### PR DESCRIPTION
### Description

Catch the error due to race conditions when the window reloads before the history comes. Name of error is ScopedHistory fell out of navigation scope.

### Issues Resolved

Fix #5476 

## Screenshot


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/88635563/2e87ce91-7873-45fc-91bd-945c32680509

<img width="551" alt="image" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/88635563/400fb84e-216f-473f-a59d-27b8b45d1ec1">

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
