### PR TITLE
[Fix] Duplicate Icon Rendering in Markdown Visualization Editor

### DIFF
--- a/src/plugins/vis_type_markdown/public/markdown_options.tsx
+++ b/src/plugins/vis_type_markdown/public/markdown_options.tsx
@@ -73,7 +73,6 @@ function MarkdownOptions({ stateParams, setValue }: VisOptionsProps<MarkdownVisP
                     id="visTypeMarkdown.params.helpLinkLabel"
                     defaultMessage="Help"
                   />{' '}
-                  <EuiIcon type="popout" size="s" />
                 </EuiLink>
               </EuiText>
             </EuiFlexItem>


### PR DESCRIPTION
### Description

The revision makes the icon appear only once, aligning with the design of the user interface.

### Issues Resolved

Resolves #5510 

## Screenshot

### Before
![Screenshot 2023-11-19 at 6 03 15 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/65143821/d5920999-f208-48ce-8e94-40699ccac60b)

### After
![Screenshot 2023-11-19 at 6 17 30 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/65143821/dc7b7061-114e-4f40-b395-9995e758c2e3)

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
