### PR TITLE
[Manual Backport 2.9] Fix dashboard to dashboard navigation error

### DIFF
--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -235,6 +235,7 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
       <I18nProvider>
         <OpenSearchDashboardsContextProvider services={this.options}>
           <DashboardViewport
+            key={this.id}
             renderEmpty={this.renderEmpty}
             container={this}
             PanelComponent={this.embeddablePanel}


### PR DESCRIPTION
### Description

Fix navigation error when loading one dashboard directly from another dashboard for branch 2.9. Added a id to trigger re-rendering of the dashboard viewport.

### Issues Resolved
resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4694
resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4819
