### PR TITLE
[BUG] Make table size adjustable according to table rows and columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Discover] Fix missing index pattern field from breaking Discover [#5626](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5626)
 - [BUG] Remove duplicate sample data as id 90943e30-9a47-11e8-b64d-95841ca0b247 ([5668](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5668))
 - [BUG][Multiple Datasource] Fix datasource testing connection unexpectedly passed with wrong endpoint [#5663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5663)
+- [BUG][Discover] Make table size adjustable according to table rows and columns ([#5514](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5514))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -89,6 +89,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
   }, [dispatch, filteredColumns, indexPattern]);
 
   const timeField = indexPattern?.timeFieldName ? indexPattern.timeFieldName : undefined;
+  const lastColumn = columns ? columns[columns.length - 1] : '';
 
   return (
     <EuiPanel
@@ -118,7 +119,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
               <MemoizedDiscoverChartContainer {...fetchState} />
             </EuiPanel>
           </EuiPanel>
-          <MemoizedDiscoverTable rows={rows} />
+          <MemoizedDiscoverTable key={`table-${rows?.length}-${lastColumn}`} rows={rows} />
         </>
       )}
     </EuiPanel>


### PR DESCRIPTION
## Description
Auto-resized issue is caused by we have a central discover context created useSearch.
When it is updated, both panel and canvas which use useDiscoverContext will render.
The update on panel will trigger useSearch and cause canvas render before update is done.
Therefore when table might not be fully re-rendered and just use the current table space. 
It appears that the main challenge is ensuring that DiscoverTable fully re-renders when the rows changes. 
    
* This PR uses the length of the rows and a combination of last column that uniquely identify the state of the rows as the key.
* The last column name is helpful to make sure add/remove column will trigger fully re-render. For example, since `_source` takes multiple lines so we will see extra empty space at the bottom when we add a column.  Since add/remove column always update last one, by add last column name as a key, we won't see extra space by fully re-render.

We could do more optimization after 2.12. 
* investigate whether we have to call fetch in use_search when add/remove a column
* investigate whether we could not reload panel with canvas
* breaking down histogram and table fetch: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4851

## Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5440

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/263913f9-625b-4707-ab16-761e1642fe51


## Testing the changes


### Check List

- [ ] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
