### PR TITLE
Fix a broken link by updating a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We aim to be an exceptional community-driven platform and to foster open partici
 
 You can [contribute to this project](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/CONTRIBUTING.md) by [opening issues](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/new/choose) to give feedback, share ideas, identify bugs, and contribute code.
 
-Set up your [OpenSearch Dashboards development environment](ttps://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/DEVELOPER_GUIDE.md#getting-started-guide) today! The project team looks forward to your contributions.
+Set up your [OpenSearch Dashboards development environment](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/DEVELOPER_GUIDE.md#getting-started-guide) today! The project team looks forward to your contributions.
 
 ## Code Summary
 


### PR DESCRIPTION
### Description

This change fixes a typo (ttps->https) in README.md -- this fixes a broken getting started guide link.

### Issues Resolved

Trivial documentation change, so no issue filed.

## Screenshot

See the working link at this fork's README.md: https://github.com/vinaykakade/OpenSearch-Dashboards/blob/main/README.md

## Testing the changes

Only validated that existing tests pass.

### Check List

- [x] Commits are signed per the DCO using --signoff

Signed-off-by: Vinay Kakade <vinaykakade@gmail.com>