### PR TITLE
[feat/2.11/os-assistant] Add stay connected link

### DIFF
--- a/src/plugins/home/public/application/components/homepage/hero_section/get_started.tsx
+++ b/src/plugins/home/public/application/components/homepage/hero_section/get_started.tsx
@@ -71,6 +71,7 @@ export const GetStartedSection: React.FC<{ olly?: boolean }> = ({ olly = true })
       <EuiFlexItem key={prompt} grow={false}>
         <EuiPanel
           color="subdued"
+          paddingSize="s"
           onClick={() =>
             navigate('observability-logs', {
               path: `#/explorer?datasourceName=${encodeURIComponent(
@@ -97,7 +98,7 @@ export const GetStartedSection: React.FC<{ olly?: boolean }> = ({ olly = true })
   function renderCategories() {
     return (
       <>
-        <EuiTitle size="m">
+        <EuiTitle size="s">
           <h3>
             <FormattedMessage id="home.getStarted.examples" defaultMessage="Suggested questions" />
           </h3>
@@ -109,16 +110,27 @@ export const GetStartedSection: React.FC<{ olly?: boolean }> = ({ olly = true })
     );
   }
 
+  const links = [
+    {
+      text: i18n.translate('home.getStarted.learnMore', { defaultMessage: 'Learn more' }),
+      url: 'https://opensearch.org/platform/observability/index.html',
+    },
+  ];
+
+  if (olly) {
+    links.push({
+      text: i18n.translate('home.getStarted.stayConnected', { defaultMessage: 'Stay connected' }),
+      url: 'https://opensearch.org/slack.html',
+    });
+  }
+
   return (
     <HeroSection
       title={i18n.translate('home.getStarted.title', {
         defaultMessage: 'Try the Query Assistant',
       })}
       description={description}
-      link={{
-        text: i18n.translate('home.getStarted.learnMore', { defaultMessage: 'Learn more' }),
-        url: 'https://opensearch.org/platform/observability/index.html',
-      }}
+      links={links}
       actionButton={actionButton}
       content={
         olly ? (

--- a/src/plugins/home/public/application/components/homepage/hero_section/hero_section.tsx
+++ b/src/plugins/home/public/application/components/homepage/hero_section/hero_section.tsx
@@ -17,10 +17,10 @@ import {
 interface Props {
   title: string;
   description: React.ReactNode;
-  link: {
+  links: Array<{
     text: string;
     url: string;
-  };
+  }>;
   actionButton: React.ReactNode;
   content: React.ReactNode;
   illustration: React.ReactNode;
@@ -29,14 +29,14 @@ interface Props {
 export const HeroSection: React.FC<Props> = ({
   title,
   description,
-  link,
+  links,
   actionButton,
   content,
   illustration,
 }) => {
   return (
     <EuiPanel paddingSize="m">
-      <EuiFlexGroup direction="row" alignItems="center" className="home-hero-group">
+      <EuiFlexGroup direction="row" alignItems="flexStart" className="home-hero-group">
         <EuiFlexItem grow={10}>{illustration}</EuiFlexItem>
         <EuiFlexItem grow={9} className="home-hero-descriptionSection">
           <EuiTitle size="l" className="home-hero-title">
@@ -44,13 +44,16 @@ export const HeroSection: React.FC<Props> = ({
           </EuiTitle>
           <EuiText>{description}</EuiText>
           <EuiSpacer size="m" />
-          <EuiFlexGroup direction="row" alignItems="center" responsive={false}>
-            <EuiFlexItem grow={false}>{actionButton}</EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiLink key={link.url} href={link.url} external={true}>
-                {link.text}
-              </EuiLink>
-            </EuiFlexItem>
+          {actionButton}
+          <EuiSpacer size="m" />
+          <EuiFlexGroup direction="row" responsive={false} gutterSize="l">
+            {links.map((link) => (
+              <EuiFlexItem grow={false} key={link.url}>
+                <EuiLink href={link.url} external={true}>
+                  {link.text}
+                </EuiLink>
+              </EuiFlexItem>
+            ))}
           </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem grow={10}>{content}</EuiFlexItem>


### PR DESCRIPTION
Mainly adding stay connected link to olly homepage, but also some minor styling things, mainly: 1) align hero section to top and 2) make suggested questions title smaller.