### PR TITLE
hide shorten url button

### DIFF
--- a/src/plugins/share/public/components/url_panel_content.tsx
+++ b/src/plugins/share/public/components/url_panel_content.tsx
@@ -86,6 +86,7 @@ interface State {
 export class UrlPanelContent extends Component<Props, State> {
   private mounted?: boolean;
   private shortUrlCache?: string;
+  shouldRenderShortUrl: boolean = true;
 
   constructor(props: Props) {
     super(props);
@@ -106,7 +107,16 @@ export class UrlPanelContent extends Component<Props, State> {
     this.mounted = false;
   }
 
-  public componentDidMount() {
+  public async componentDidMount() {
+    try {
+      await shortenUrl(this.getSnapshotUrl(), {
+        basePath: this.props.basePath,
+        post: this.props.post,
+      });
+    } catch (err) {
+      this.shouldRenderShortUrl = false;
+    }
+
     this.mounted = true;
     this.setUrl();
 
@@ -393,7 +403,8 @@ export class UrlPanelContent extends Component<Props, State> {
   private renderShortUrlSwitch = () => {
     if (
       this.state.exportUrlAs === ExportUrlAsType.EXPORT_URL_AS_SAVED_OBJECT ||
-      !this.props.allowShortUrl
+      !this.props.allowShortUrl ||
+      !this.shouldRenderShortUrl
     ) {
       return;
     }


### PR DESCRIPTION
### Description
This solution hides the "shorten URL" switch from user that who doesn't have permission to perform the action. 
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/128170204/55fc8b3e-1f13-4ffb-8f59-e8ae171bf3c3)


### Issues Resolved
(https://github.com/opensearch-project/security-dashboards-plugin/issues/891)


## Testing the changes

Manual testing was performed according to scenario from task: [#8914](https://github.com/opensearch-project/security-dashboards-plugin/issues/891)
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
