### PR TITLE
[Home] video opens to new tab

### DIFF
--- a/src/plugins/home/public/application/components/homepage/hero_section/get_started.tsx
+++ b/src/plugins/home/public/application/components/homepage/hero_section/get_started.tsx
@@ -141,6 +141,8 @@ export const GetStartedSection: React.FC<{ olly?: boolean }> = ({ olly = true })
         heroConfig.img ? (
           <div className="home-hero-illustrationContainer">
             <EuiButtonIcon
+              target="_blank"
+              rel="noopener noreferrer"
               href={heroConfig.img.link}
               aria-labelledby="home-hero-illustrationPlay"
               className="home-hero-illustrationButton"


### PR DESCRIPTION
Forces the new video link button to open on a new tab instead of navigating away.
