### PR TITLE
[2.x Backport] Add @SuZhou-Joe as a maintainer (#5594)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ananzh @kavilla @seanneumann @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @kristenTian @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy
+*   @ananzh @kavilla @seanneumann @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @kristenTian @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Replace `node-sass` with `sass-embedded` ([#5338](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5338))
 - [Version] Bump version to 2.12.0 ([#5294](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5294))
+- Add @SuZhou-Joe as a maintainer. ([#5594](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5594))
 
 ### 🪛 Refactoring
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,6 +20,9 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Tao Liu                   | [Flyingliuhub](https://github.com/Flyingliuhub)     | Amazon      |
 | Zilong Xia                | [ZilongX](https://github.com/ZilongX)               | Amazon      |
 | Matt Provost              | [BSFishy](https://github.com/BSFishy)               | Amazon      |
+| Sirazh Gabdullin          | [curq](https://github.com/curq)                     | External contributor |
+| Bandini Bhopi             | [bandinib-amzn](https://github.com/bandinib-amzn)   | Amazon      |
+| Su Zhou                   | [SuZhou-Joe](https://github.com/SuZhou-Joe)         | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description

Backport https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5594 and update missing backports for MAINTAINERS.md and .github/CODEOWNERS.

### Backport PR
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5594


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
