### PR TITLE
Chore (ui-shared-deps): Clean up direct usage of OUI theme JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Console] Remove unused ul element and its custom styling ([#3993](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3993))
 - Remove unused Sass in `tile_map` plugin ([#4110](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4110))
 - [Home] Remove unused tutorials ([#5212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5212))
+- [UiSharedDeps] Standardize theme JSON imports to be light/dark-mode aware ([#5662](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5662))
 
 ### 🔩 Tests
 

--- a/src/plugins/expressions/public/react_expression_renderer.tsx
+++ b/src/plugins/expressions/public/react_expression_renderer.tsx
@@ -34,7 +34,7 @@ import { Observable, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import useShallowCompareEffect from 'react-use/lib/useShallowCompareEffect';
 import { EuiLoadingChart, EuiProgress } from '@elastic/eui';
-import theme from '@elastic/eui/dist/eui_theme_light.json';
+import { euiThemeVars } from '@osd/ui-shared-deps/theme';
 import { IExpressionLoaderParams, ExpressionRenderError } from './types';
 import { ExpressionAstExpression, IInterpreterRenderHandlers } from '../common';
 import { ExpressionLoader } from './loader';
@@ -191,8 +191,9 @@ export const ReactExpressionRenderer = ({
 
   const expressionStyles: React.CSSProperties = {};
 
+  // TODO: refactor to SCSS instead of getting values from theme: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5661
   if (padding) {
-    expressionStyles.padding = theme.paddingSizes[padding];
+    expressionStyles.padding = euiThemeVars.paddingSizes[padding];
   }
 
   return (

--- a/src/plugins/index_pattern_management/public/components/create_button/create_button.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_button/create_button.tsx
@@ -28,8 +28,6 @@
  * under the License.
  */
 
-// @ts-ignore
-import { euiColorAccent } from '@elastic/eui/dist/eui_theme_light.json';
 import React, { Component, Fragment } from 'react';
 
 import {
@@ -148,7 +146,7 @@ export class CreateButton extends Component<Props, State> {
 
   private renderBetaBadge = () => {
     return (
-      <EuiBadge color={euiColorAccent}>
+      <EuiBadge color="accent">
         <FormattedMessage
           id="indexPatternManagement.indexPatternList.createButton.betaLabel"
           defaultMessage="Beta"

--- a/src/plugins/opensearch_dashboards_react/public/code_editor/editor_theme.ts
+++ b/src/plugins/opensearch_dashboards_react/public/code_editor/editor_theme.ts
@@ -122,6 +122,7 @@ export function createTheme(
   };
 }
 
+// TODO: Refactor to use packages/osd-ui-shared-deps/theme.ts: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5661
 const DARK_THEME = createTheme(darkTheme, '#343551');
 const LIGHT_THEME = createTheme(lightTheme, '#E3E4ED');
 

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/tooltip.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/tooltip.js
@@ -34,13 +34,13 @@ import $ from 'jquery';
 
 import { Binder } from '../../lib/binder';
 import { positionTooltip } from './position_tooltip';
-import theme from '@elastic/eui/dist/eui_theme_light.json';
+import { euiThemeVars } from '@osd/ui-shared-deps/theme';
 
 let allContents = [];
 
-const tooltipColumnPadding = parseInt(theme.euiSizeXS || 0, 10) * 2;
-const tooltipTableMargin = parseInt(theme.euiSizeS || 0, 10) * 2;
-const tooltipMaxWidth = parseInt(theme.euiSizeXL || 0, 10) * 10;
+const tooltipColumnPadding = parseInt(euiThemeVars.euiSizeXS || 0, 10) * 2;
+const tooltipTableMargin = parseInt(euiThemeVars.euiSizeS || 0, 10) * 2;
+const tooltipMaxWidth = parseInt(euiThemeVars.euiSizeXL || 0, 10) * 10;
 
 /**
  * Add tooltip and listeners to visualization elements


### PR DESCRIPTION
### Description

As part of https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5652, I looked into the various ways we consume OUI themes. One thing I realized is that, when using the JSON files to fetch SASS variables, we should always do it via `ui-shared-deps`, which is dark/light-mode aware. This change fixes the imports, although further refactoring is deferred to the linked issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5661

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
