### PR TITLE
Revert back to old discover table without using Angular

### DIFF
--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -143,8 +143,6 @@ export const DataGridTable = ({
     ];
   }, []);
 
-  console.log('sortOrders', sortingColumns);
-
   const legacyDiscoverTable = useMemo(
     () => (
       <LegacyDiscoverTable
@@ -163,15 +161,15 @@ export const DataGridTable = ({
     ),
     [
       displayedTableColumns,
-      dataGridTableColumnsVisibility,
-      leadingControlColumns,
-      pagination,
-      renderCellValue,
-      rowCount,
-      sorting,
-      isToolbarVisible,
-      rowHeightsOptions,
       adjustedColumns,
+      indexPattern,
+      onAddColumn,
+      onColumnSort,
+      onFilter,
+      onRemoveColumn,
+      onReorderColumn,
+      rows,
+      sortingColumns,
     ]
   );
 
@@ -204,7 +202,6 @@ export const DataGridTable = ({
     ]
   );
 
-  console.log('adjustColumns higher level', adjustedColumns);
   return (
     <DiscoverGridContextProvider
       value={{

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -222,7 +222,7 @@ export const DataGridTable = ({
         <EuiPanel hasBorder={false} hasShadow={true} paddingSize="s" style={{ margin: '8px' }}>
           {getDataGridTableSetting(storage) ? dataGridTable : legacyDiscoverTable}
         </EuiPanel>
-        {inspectedHit && (
+        {getDataGridTableSetting(storage) && inspectedHit && (
           <DataGridFlyout
             indexPattern={indexPattern}
             hit={inspectedHit}

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -138,6 +138,11 @@ export const DataGridTable = ({
     ];
   }, []);
 
+  // console.log("sorting in data grid", sort)
+  // console.log("onsort", onSort)
+
+  console.log('displayedTableColumns', displayedTableColumns);
+
   const table = useMemo(
     () => (
       // <EuiDataGrid
@@ -157,6 +162,8 @@ export const DataGridTable = ({
         displayedTableColumns={displayedTableColumns}
         rows={rows}
         indexPattern={indexPattern}
+        sortOrder={sort}
+        onChangeSortOrder={onSort}
       />
     ),
     [

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -11,7 +11,6 @@ import { buildDataGridColumns, computeVisibleColumns } from './data_grid_table_c
 import { DocViewInspectButton } from './data_grid_table_docview_inspect_button';
 import { DataGridFlyout } from './data_grid_table_flyout';
 import { DiscoverGridContextProvider } from './data_grid_table_context';
-import { toolbarVisibility } from './constants';
 import { DocViewFilterFn, OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { usePagination } from '../utils/use_pagination';
 import { SortOrder } from '../../../saved_searches/types';
@@ -19,7 +18,9 @@ import { buildColumns } from '../../utils/columns';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { DiscoverServices } from '../../../build_services';
 import { SAMPLE_SIZE_SETTING } from '../../../../common';
-import { DefaultDiscoverTable } from '../default_discover_table/default_discover_table';
+import { LegacyDiscoverTable } from '../default_discover_table/default_discover_table';
+import { toolbarVisibility } from './constants';
+import { getDataGridTableSetting } from '../utils/local_storage';
 
 export interface DataGridTableProps {
   columns: string[];
@@ -38,6 +39,7 @@ export interface DataGridTableProps {
   isToolbarVisible?: boolean;
   isContextView?: boolean;
   isLoading?: boolean;
+  storage: any;
 }
 
 export const DataGridTable = ({
@@ -57,6 +59,7 @@ export const DataGridTable = ({
   isToolbarVisible = true,
   isContextView = false,
   isLoading = false,
+  storage,
 }: DataGridTableProps) => {
   const { services } = useOpenSearchDashboards<DiscoverServices>();
 
@@ -140,24 +143,11 @@ export const DataGridTable = ({
     ];
   }, []);
 
-  console.log("sortOrders", sortingColumns)
+  console.log('sortOrders', sortingColumns);
 
-  const table = useMemo(
+  const legacyDiscoverTable = useMemo(
     () => (
-      // <EuiDataGrid
-      //   aria-labelledby="aria-labelledby"
-      //   columns={dataGridTableColumns}
-      //   columnVisibility={dataGridTableColumnsVisibility}
-      //   leadingControlColumns={leadingControlColumns}
-      //   data-test-subj="docTable"
-      //   pagination={pagination}
-      //   renderCellValue={renderCellValue}
-      //   rowCount={rowCount}
-      //   sorting={sorting}
-      //   toolbarVisibility={isToolbarVisible ? toolbarVisibility : false}
-      //   rowHeightsOptions={rowHeightsOptions}
-      // />
-      <DefaultDiscoverTable
+      <LegacyDiscoverTable
         displayedTableColumns={displayedTableColumns}
         columns={adjustedColumns}
         rows={rows}
@@ -185,34 +175,34 @@ export const DataGridTable = ({
     ]
   );
 
-  // const dataGridTable = useMemo(
-  //   () => (
-  //     <EuiDataGrid
-  //       aria-labelledby="aria-labelledby"
-  //       columns={displayedTableColumns}
-  //       columnVisibility={dataGridTableColumnsVisibility}
-  //       leadingControlColumns={leadingControlColumns}
-  //       data-test-subj="docTable"
-  //       pagination={pagination}
-  //       renderCellValue={renderCellValue}
-  //       rowCount={rowCount}
-  //       sorting={sorting}
-  //       toolbarVisibility={isToolbarVisible ? toolbarVisibility : false}
-  //       rowHeightsOptions={rowHeightsOptions}
-  //     />
-  //   ),
-  //   [
-  //     displayedTableColumns,
-  //     dataGridTableColumnsVisibility,
-  //     leadingControlColumns,
-  //     pagination,
-  //     renderCellValue,
-  //     rowCount,
-  //     sorting,
-  //     isToolbarVisible,
-  //     rowHeightsOptions,
-  //   ]
-  // );
+  const dataGridTable = useMemo(
+    () => (
+      <EuiDataGrid
+        aria-labelledby="aria-labelledby"
+        columns={displayedTableColumns}
+        columnVisibility={dataGridTableColumnsVisibility}
+        leadingControlColumns={leadingControlColumns}
+        data-test-subj="docTable"
+        pagination={pagination}
+        renderCellValue={renderCellValue}
+        rowCount={rowCount}
+        sorting={sorting}
+        toolbarVisibility={isToolbarVisible ? toolbarVisibility : false}
+        rowHeightsOptions={rowHeightsOptions}
+      />
+    ),
+    [
+      displayedTableColumns,
+      dataGridTableColumnsVisibility,
+      leadingControlColumns,
+      pagination,
+      renderCellValue,
+      rowCount,
+      sorting,
+      isToolbarVisible,
+      rowHeightsOptions,
+    ]
+  );
 
   console.log('adjustColumns higher level', adjustedColumns);
   return (
@@ -233,7 +223,7 @@ export const DataGridTable = ({
         data-test-subj="discoverTable"
       >
         <EuiPanel hasBorder={false} hasShadow={true} paddingSize="s" style={{ margin: '8px' }}>
-          {table}
+          {getDataGridTableSetting(storage) ? dataGridTable : legacyDiscoverTable}
         </EuiPanel>
         {inspectedHit && (
           <DataGridFlyout

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -153,7 +153,7 @@ export const DataGridTable = ({
       //   toolbarVisibility={isToolbarVisible ? toolbarVisibility : false}
       //   rowHeightsOptions={rowHeightsOptions}
       // />
-      <DefaultDiscoverTable 
+      <DefaultDiscoverTable
         displayedTableColumns={displayedTableColumns}
         rows={rows}
         indexPattern={indexPattern}
@@ -189,10 +189,8 @@ export const DataGridTable = ({
         data-description={description}
         data-test-subj="discoverTable"
       >
-        <EuiPanel hasBorder={false} hasShadow={false} paddingSize="s" color="transparent">
-        
-            {table}
-        
+        <EuiPanel hasBorder={false} hasShadow={true} paddingSize="s" style={{ margin: '8px' }}>
+          {table}
         </EuiPanel>
         {inspectedHit && (
           <DataGridFlyout

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -19,6 +19,7 @@ import { buildColumns } from '../../utils/columns';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { DiscoverServices } from '../../../build_services';
 import { SAMPLE_SIZE_SETTING } from '../../../../common';
+import { DefaultDiscoverTable } from '../default_discover_table/default_discover_table';
 
 export interface DataGridTableProps {
   columns: string[];
@@ -95,7 +96,7 @@ export const DataGridTable = ({
     rows,
   ]);
 
-  const dataGridTableColumns = useMemo(
+  const displayedTableColumns = useMemo(
     () =>
       buildDataGridColumns(
         adjustedColumns,
@@ -139,22 +140,27 @@ export const DataGridTable = ({
 
   const table = useMemo(
     () => (
-      <EuiDataGrid
-        aria-labelledby="aria-labelledby"
-        columns={dataGridTableColumns}
-        columnVisibility={dataGridTableColumnsVisibility}
-        leadingControlColumns={leadingControlColumns}
-        data-test-subj="docTable"
-        pagination={pagination}
-        renderCellValue={renderCellValue}
-        rowCount={rowCount}
-        sorting={sorting}
-        toolbarVisibility={isToolbarVisible ? toolbarVisibility : false}
-        rowHeightsOptions={rowHeightsOptions}
+      // <EuiDataGrid
+      //   aria-labelledby="aria-labelledby"
+      //   columns={dataGridTableColumns}
+      //   columnVisibility={dataGridTableColumnsVisibility}
+      //   leadingControlColumns={leadingControlColumns}
+      //   data-test-subj="docTable"
+      //   pagination={pagination}
+      //   renderCellValue={renderCellValue}
+      //   rowCount={rowCount}
+      //   sorting={sorting}
+      //   toolbarVisibility={isToolbarVisible ? toolbarVisibility : false}
+      //   rowHeightsOptions={rowHeightsOptions}
+      // />
+      <DefaultDiscoverTable 
+        displayedTableColumns={displayedTableColumns}
+        rows={rows}
+        indexPattern={indexPattern}
       />
     ),
     [
-      dataGridTableColumns,
+      displayedTableColumns,
       dataGridTableColumnsVisibility,
       leadingControlColumns,
       pagination,
@@ -184,9 +190,9 @@ export const DataGridTable = ({
         data-test-subj="discoverTable"
       >
         <EuiPanel hasBorder={false} hasShadow={false} paddingSize="s" color="transparent">
-          <EuiPanel paddingSize="s" style={{ height: '100%' }}>
+        
             {table}
-          </EuiPanel>
+        
         </EuiPanel>
         {inspectedHit && (
           <DataGridFlyout

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -27,6 +27,7 @@ export interface DataGridTableProps {
   onAddColumn: (column: string) => void;
   onFilter: DocViewFilterFn;
   onRemoveColumn: (column: string) => void;
+  onReorderColumn: (col: string, source: number, destination: number) => void;
   onSort: (sort: SortOrder[]) => void;
   rows: OpenSearchSearchHit[];
   onSetColumns: (columns: string[]) => void;
@@ -45,6 +46,7 @@ export const DataGridTable = ({
   onAddColumn,
   onFilter,
   onRemoveColumn,
+  onReorderColumn,
   onSetColumns,
   onSort,
   sort,
@@ -164,6 +166,8 @@ export const DataGridTable = ({
         indexPattern={indexPattern}
         sortOrder={sort}
         onChangeSortOrder={onSort}
+        onRemoveColumn={onRemoveColumn}
+        onReorderColumn={onReorderColumn}
       />
     ),
     [

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -140,6 +140,8 @@ export const DataGridTable = ({
     ];
   }, []);
 
+  console.log("sortOrders", sortingColumns)
+
   const table = useMemo(
     () => (
       // <EuiDataGrid
@@ -160,8 +162,8 @@ export const DataGridTable = ({
         columns={adjustedColumns}
         rows={rows}
         indexPattern={indexPattern}
-        sortOrder={sort}
-        onChangeSortOrder={onSort}
+        sortOrder={sortingColumns}
+        onChangeSortOrder={onColumnSort}
         onRemoveColumn={onRemoveColumn}
         onReorderColumn={onReorderColumn}
         onAddColumn={onAddColumn}
@@ -183,34 +185,34 @@ export const DataGridTable = ({
     ]
   );
 
-  const dataGridTable = useMemo(
-    () => (
-      <EuiDataGrid
-        aria-labelledby="aria-labelledby"
-        columns={displayedTableColumns}
-        columnVisibility={dataGridTableColumnsVisibility}
-        leadingControlColumns={leadingControlColumns}
-        data-test-subj="docTable"
-        pagination={pagination}
-        renderCellValue={renderCellValue}
-        rowCount={rowCount}
-        sorting={sorting}
-        toolbarVisibility={isToolbarVisible ? toolbarVisibility : false}
-        rowHeightsOptions={rowHeightsOptions}
-      />
-    ),
-    [
-      displayedTableColumns,
-      dataGridTableColumnsVisibility,
-      leadingControlColumns,
-      pagination,
-      renderCellValue,
-      rowCount,
-      sorting,
-      isToolbarVisible,
-      rowHeightsOptions,
-    ]
-  );
+  // const dataGridTable = useMemo(
+  //   () => (
+  //     <EuiDataGrid
+  //       aria-labelledby="aria-labelledby"
+  //       columns={displayedTableColumns}
+  //       columnVisibility={dataGridTableColumnsVisibility}
+  //       leadingControlColumns={leadingControlColumns}
+  //       data-test-subj="docTable"
+  //       pagination={pagination}
+  //       renderCellValue={renderCellValue}
+  //       rowCount={rowCount}
+  //       sorting={sorting}
+  //       toolbarVisibility={isToolbarVisible ? toolbarVisibility : false}
+  //       rowHeightsOptions={rowHeightsOptions}
+  //     />
+  //   ),
+  //   [
+  //     displayedTableColumns,
+  //     dataGridTableColumnsVisibility,
+  //     leadingControlColumns,
+  //     pagination,
+  //     renderCellValue,
+  //     rowCount,
+  //     sorting,
+  //     isToolbarVisible,
+  //     rowHeightsOptions,
+  //   ]
+  // );
 
   console.log('adjustColumns higher level', adjustedColumns);
   return (
@@ -232,7 +234,6 @@ export const DataGridTable = ({
       >
         <EuiPanel hasBorder={false} hasShadow={true} paddingSize="s" style={{ margin: '8px' }}>
           {table}
-          {dataGridTable}
         </EuiPanel>
         {inspectedHit && (
           <DataGridFlyout

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -140,11 +140,6 @@ export const DataGridTable = ({
     ];
   }, []);
 
-  // console.log("sorting in data grid", sort)
-  // console.log("onsort", onSort)
-
-  console.log('displayedTableColumns', displayedTableColumns);
-
   const table = useMemo(
     () => (
       // <EuiDataGrid
@@ -162,12 +157,46 @@ export const DataGridTable = ({
       // />
       <DefaultDiscoverTable
         displayedTableColumns={displayedTableColumns}
+        columns={adjustedColumns}
         rows={rows}
         indexPattern={indexPattern}
         sortOrder={sort}
         onChangeSortOrder={onSort}
         onRemoveColumn={onRemoveColumn}
         onReorderColumn={onReorderColumn}
+        onAddColumn={onAddColumn}
+        onFilter={onFilter}
+        onClose={() => setInspectedHit(undefined)}
+      />
+    ),
+    [
+      displayedTableColumns,
+      dataGridTableColumnsVisibility,
+      leadingControlColumns,
+      pagination,
+      renderCellValue,
+      rowCount,
+      sorting,
+      isToolbarVisible,
+      rowHeightsOptions,
+      adjustedColumns,
+    ]
+  );
+
+  const dataGridTable = useMemo(
+    () => (
+      <EuiDataGrid
+        aria-labelledby="aria-labelledby"
+        columns={displayedTableColumns}
+        columnVisibility={dataGridTableColumnsVisibility}
+        leadingControlColumns={leadingControlColumns}
+        data-test-subj="docTable"
+        pagination={pagination}
+        renderCellValue={renderCellValue}
+        rowCount={rowCount}
+        sorting={sorting}
+        toolbarVisibility={isToolbarVisible ? toolbarVisibility : false}
+        rowHeightsOptions={rowHeightsOptions}
       />
     ),
     [
@@ -183,6 +212,7 @@ export const DataGridTable = ({
     ]
   );
 
+  console.log('adjustColumns higher level', adjustedColumns);
   return (
     <DiscoverGridContextProvider
       value={{
@@ -202,6 +232,7 @@ export const DataGridTable = ({
       >
         <EuiPanel hasBorder={false} hasShadow={true} paddingSize="s" style={{ margin: '8px' }}>
           {table}
+          {dataGridTable}
         </EuiPanel>
         {inspectedHit && (
           <DataGridFlyout

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.tsx
@@ -17,7 +17,7 @@ import { stringify } from '@osd/std';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 
-function fetchSourceTypeDataCell(
+export function fetchSourceTypeDataCell(
   idxPattern: IndexPattern,
   row: Record<string, unknown>,
   columnId: string,

--- a/src/plugins/discover/public/application/components/default_discover_table/_doc_table.scss
+++ b/src/plugins/discover/public/application/components/default_discover_table/_doc_table.scss
@@ -1,0 +1,159 @@
+/**
+ * 1. Stack content vertically so the table can scroll when its constrained by a fixed container height.
+ */
+ doc-table {
+    @include euiScrollBar;
+  
+    overflow: auto;
+    flex: 1 1 100%;
+    flex-direction: column; /* 1 */
+  
+    th {
+      text-align: left;
+      font-weight: bold;
+    }
+  
+    .spinner {
+      position: absolute;
+      top: 40%;
+      left: 0;
+      right: 0;
+      z-index: $euiZLevel1;
+      opacity: 0.5;
+    }
+  }
+  
+  .osdDocTable__container.loading {
+    opacity: 0.5;
+  }
+  
+  .osdDocTable {
+    font-size: $euiFontSizeXS;
+  
+    th {
+      white-space: nowrap;
+      padding-right: $euiSizeS;
+  
+      .fa {
+        font-size: 1.1em;
+      }
+    }
+  }
+  
+  .osd-table,
+  .osdDocTable {
+    /**
+    *  Style OpenSearch document _source in table view <dt>key:<dt><dd>value</dd>
+    *  Use alpha so this will stand out against non-white backgrounds, e.g. the highlighted
+    *  row in the Context Log.
+    */
+  
+    dl.source {
+      margin-bottom: 0;
+      line-height: 2em;
+      word-break: break-word;
+  
+      dt,
+      dd {
+        display: inline;
+      }
+  
+      dt {
+        background-color: transparentize(shade($euiColorPrimary, 20%), 0.9);
+        color: $euiTextColor;
+        padding: ($euiSizeXS / 2) $euiSizeXS;
+        margin-right: $euiSizeXS;
+        word-break: normal;
+        border-radius: $euiBorderRadius;
+      }
+    }
+  }
+  
+  .osdDocTable__row {
+    td {
+      position: relative;
+  
+      &:hover {
+        .osdDocTableRowFilterButton {
+          opacity: 1;
+        }
+      }
+    }
+  }
+  
+  .osdDocTable__row--highlight {
+    td,
+    .osdDocTableRowFilterButton {
+      background-color: tintOrShade($euiColorPrimary, 90%, 70%);
+    }
+  }
+  
+  .osdDocTable__bar {
+    margin: $euiSizeXS $euiSizeXS 0;
+  }
+  
+  .osdDocTable__bar--footer {
+    position: relative;
+    margin: -($euiSize * 3) $euiSizeXS 0;
+  }
+  
+  .osdDocTable__padBottom {
+    padding-bottom: $euiSizeXL;
+  }
+  
+  .osdDocTable__error {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 1 0 100%;
+    text-align: center;
+  }
+  
+  .truncate-by-height {
+    overflow: hidden;
+  }
+  
+  .table {
+    // Nesting
+    .table {
+      background-color: $euiColorEmptyShade;
+    }
+  }
+  
+  .osd-table {
+    // sub tables should not have a leading border
+    .table .table {
+      margin-bottom: 0;
+  
+      tr:first-child > td {
+        border-top: none;
+      }
+  
+      td.field-name {
+        font-weight: $euiFontWeightBold;
+      }
+    }
+  }
+  
+  table {
+    th {
+      i.fa-sort {
+        color: $euiColorLightShade;
+      }
+  
+      button.fa-sort-asc,
+      button.fa-sort-down,
+      i.fa-sort-asc,
+      i.fa-sort-down {
+        color: $euiColorPrimary;
+      }
+  
+      button.fa-sort-desc,
+      button.fa-sort-up,
+      i.fa-sort-desc,
+      i.fa-sort-up {
+        color: $euiColorPrimary;
+      }
+    }
+  }
+  

--- a/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
+++ b/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
@@ -3,10 +3,8 @@
     padding: 4px 0 0 !important;
   }
   
-  .osdDocTableCell__filter {
-    position: absolute;
-    white-space: nowrap;
-    right: 0;
+  .osdDocTableCell__filter { //TODO: make them appear at top right corner
+    
   }
   
   /**

--- a/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
+++ b/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
@@ -1,7 +1,4 @@
-.osdDocTableCell__dataField {
-    white-space: pre-wrap;
-  }
-  
+
   .osdDocTableCell__toggleDetails {
     padding: 4px 0 0 !important;
   }
@@ -18,18 +15,22 @@
    * 3. Show on focus to enable keyboard accessibility.
    */
   
-  .osdDocTableRowFilterButton {
-    appearance: none;
-    background-color: $euiColorEmptyShade;
-    border: none;
-    padding: 0 $euiSizeXS;
-    font-size: $euiFontSizeS;
-    line-height: 1; /* 1 */
-    display: inline-block;
-    opacity: 0; /* 2 */
-  
-    &:focus {
-      opacity: 1; /* 3 */
+  .osdDocTableCell {
+    white-space: pre-wrap;
+
+    &__filterButton {
+      opacity: 0;
+      transition: opacity $euiAnimSpeedFast;
+
+      @include ouiBreakpoint("xs", "s", "m") {
+        opacity: 1;
+      }
+    }
+
+    &:hover &__filterButton,
+    &:focus &__filterButton {
+        opacity: 1;
     }
   }
+
   

--- a/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
+++ b/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
@@ -1,0 +1,35 @@
+.osdDocTableCell__dataField {
+    white-space: pre-wrap;
+  }
+  
+  .osdDocTableCell__toggleDetails {
+    padding: 4px 0 0 !important;
+  }
+  
+  .osdDocTableCell__filter {
+    position: absolute;
+    white-space: nowrap;
+    right: 0;
+  }
+  
+  /**
+   * 1. Align icon with text in cell.
+   * 2. Use opacity to make this element accessible to screen readers and keyboard.
+   * 3. Show on focus to enable keyboard accessibility.
+   */
+  
+  .osdDocTableRowFilterButton {
+    appearance: none;
+    background-color: $euiColorEmptyShade;
+    border: none;
+    padding: 0 $euiSizeXS;
+    font-size: $euiFontSizeS;
+    line-height: 1; /* 1 */
+    display: inline-block;
+    opacity: 0; /* 2 */
+  
+    &:focus {
+      opacity: 1; /* 3 */
+    }
+  }
+  

--- a/src/plugins/discover/public/application/components/default_discover_table/_table_header.scss
+++ b/src/plugins/discover/public/application/components/default_discover_table/_table_header.scss
@@ -1,0 +1,18 @@
+.osdDocTableHeader {
+    white-space: nowrap;
+    text-align: left;
+}
+  
+.osdDocTableHeader button {
+    margin-left: $euiSizeXS;
+}
+  
+.osdDocTableHeader__move,
+.osdDocTableHeader__sortChange {
+    opacity: 0;
+  
+    &:focus,
+    th:hover & {
+      opacity: 1;
+    }
+}

--- a/src/plugins/discover/public/application/components/default_discover_table/_table_header.scss
+++ b/src/plugins/discover/public/application/components/default_discover_table/_table_header.scss
@@ -16,3 +16,19 @@
       opacity: 1;
     }
 }
+
+.docTableHeaderField {
+    &__actionButton {
+        opacity: 0;
+        transition: opacity $euiAnimSpeedFast;
+
+        @include ouiBreakpoint("xs", "s", "m") {
+        opacity: 1;
+      }
+    }
+
+    &:hover &__actionButton,
+    &:focus &__actionButton {
+        opacity: 1;
+    }
+}

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -59,13 +59,12 @@ export const LegacyDiscoverTable = ({
           />
         </thead>
         <tbody>
-          {rows.map((row: OpenSearchSearchHit, index: number) => {
+          {rows.map((row: OpenSearchSearchHit) => {
             return (
               <TableRow
                 key={row._id}
                 row={row}
-                rowIndex={index}
-                displayedTableColumns={displayedTableColumns}
+                columnIds={displayedTableColumns.map((column) => column.id)}
                 columns={columns}
                 indexPattern={indexPattern}
                 onRemoveColumn={onRemoveColumn}

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -6,7 +6,7 @@
 import './_doc_table.scss';
 
 import React, { useState, useMemo, useCallback } from 'react';
-import { EuiDataGridColumn } from '@elastic/eui';
+import { EuiDataGridColumn, EuiDataGridSorting } from '@elastic/eui';
 import { TableHeader } from './table_header';
 import { DocViewFilterFn, OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { TableRow } from './table_rows';
@@ -18,8 +18,11 @@ export interface DefaultDiscoverTableProps {
   columns: string[];
   rows: OpenSearchSearchHit[];
   indexPattern: IndexPattern;
-  sortOrder: SortOrder[];
-  onChangeSortOrder: (sort: SortOrder[]) => void;
+  sortOrder: {
+    id: string;
+    direction: "asc" | "desc";
+}[];
+  onChangeSortOrder: (cols: EuiDataGridSorting['columns']) => void;
   onRemoveColumn: (column: string) => void;
   onReorderColumn: (col: string, source: number, destination: number) => void;
   onAddColumn: (column: string) => void;

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -13,18 +13,11 @@ import { TableRow } from './table_rows';
 export const DefaultDiscoverTable = ({
   displayedTableColumns,
   rows,
-  // dataGridTableColumnsVisibility,
-  // leadingControlColumns,
-  // pagination,
-  // renderCellValue,
-  // rowCount,
-  // sorting,
-  // isToolbarVisible,
-  // toolbarVisibility,
-  // rowHeightsOptions,
   indexPattern,
   sortOrder,
   onChangeSortOrder,
+  onRemoveColumn,
+  onReorderColumn,
 }) => {
   // console.log("sorting", sorting)
   return (
@@ -38,8 +31,8 @@ export const DefaultDiscoverTable = ({
             indexPattern={indexPattern}
             // isShortDots,
             onChangeSortOrder={onChangeSortOrder}
-            onMoveColumn={() => {}}
-            onRemoveColumn={() => {}}
+            onReorderColumn={onReorderColumn}
+            onRemoveColumn={onRemoveColumn}
             sortOrder={sortOrder}
           />
         </thead>

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -23,7 +23,10 @@ export const DefaultDiscoverTable = ({
   // toolbarVisibility,
   // rowHeightsOptions,
   indexPattern,
+  sortOrder,
+  onChangeSortOrder,
 }) => {
+  // console.log("sorting", sorting)
   return (
     indexPattern && (
       <table data-test-subj="docTable" className="osd-table table">
@@ -34,10 +37,10 @@ export const DefaultDiscoverTable = ({
             // hideTimeColumn,
             indexPattern={indexPattern}
             // isShortDots,
-            onChangeSortOrder={() => {}}
+            onChangeSortOrder={onChangeSortOrder}
             onMoveColumn={() => {}}
             onRemoveColumn={() => {}}
-            sortOrder={[]}
+            sortOrder={sortOrder}
           />
         </thead>
         <tbody>

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -8,29 +8,37 @@ import './_doc_table.scss';
 import React, { useState, useMemo, useCallback } from 'react';
 import { EuiDataGridColumn } from '@elastic/eui';
 import { TableHeader } from './table_header';
-import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
+import { DocViewFilterFn, OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { TableRow } from './table_rows';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { SortOrder } from '../../../saved_searches/types';
 
 export interface DefaultDiscoverTableProps {
   displayedTableColumns: EuiDataGridColumn[];
+  columns: string[];
   rows: OpenSearchSearchHit[];
   indexPattern: IndexPattern;
   sortOrder: SortOrder[];
   onChangeSortOrder: (sort: SortOrder[]) => void;
   onRemoveColumn: (column: string) => void;
   onReorderColumn: (col: string, source: number, destination: number) => void;
+  onAddColumn: (column: string) => void;
+  onFilter: DocViewFilterFn;
+  onClose: () => void;
 }
 
 export const DefaultDiscoverTable = ({
   displayedTableColumns,
+  columns,
   rows,
   indexPattern,
   sortOrder,
   onChangeSortOrder,
   onRemoveColumn,
   onReorderColumn,
+  onAddColumn,
+  onFilter,
+  onClose,
 }: DefaultDiscoverTableProps) => {
   // console.log("sorting", sorting)
   return (
@@ -56,8 +64,13 @@ export const DefaultDiscoverTable = ({
                 key={row._id}
                 row={row}
                 rowIndex={index}
-                columns={displayedTableColumns}
+                displayedTableColumns={displayedTableColumns}
+                columns={columns}
                 indexPattern={indexPattern}
+                onRemoveColumn={onRemoveColumn}
+                onAddColumn={onAddColumn}
+                onFilter={onFilter}
+                onClose={onClose}
               />
             );
           })}

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -43,7 +43,6 @@ export const LegacyDiscoverTable = ({
   onFilter,
   onClose,
 }: DefaultDiscoverTableProps) => {
-  // console.log("sorting", sorting)
   return (
     indexPattern && (
       <table data-test-subj="docTable" className="osd-table table">

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import './_doc_table.scss'
+
+import React, { useState, useMemo, useCallback } from 'react';
+import { TableHeader } from './table_header';
+import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
+import { TableRow } from './table_rows';
+
+export const DefaultDiscoverTable = ({
+    displayedTableColumns,
+    rows,
+    // dataGridTableColumnsVisibility,
+    // leadingControlColumns,
+    // pagination,
+    // renderCellValue,
+    // rowCount,
+    // sorting,
+    // isToolbarVisible,
+    // toolbarVisibility,
+    // rowHeightsOptions,
+    indexPattern
+}) => {
+
+    return (indexPattern && (
+        <table data-test-subj="docTable" className="osd-table table">
+            <thead>
+                <TableHeader 
+                    displayedTableColumns={displayedTableColumns}
+                    defaultSortOrder={''}
+                    //hideTimeColumn,
+                    indexPattern={indexPattern}
+                    //isShortDots,
+                    onChangeSortOrder={()=>{}}
+                    onMoveColumn={()=>{}}
+                    onRemoveColumn={()=>{}}
+                    sortOrder={[]}
+                />
+            </thead>
+            <tbody>
+                {rows.map((row: OpenSearchSearchHit)=>{
+                    return (
+                    <TableRow 
+                        key={row._id}
+                        row={row}
+                        columns={displayedTableColumns}
+                        indexPattern={indexPattern}
+                    />)
+                })}
+            </tbody>
+        </table>
+    ))
+}

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import './_doc_table.scss'
+import './_doc_table.scss';
 
 import React, { useState, useMemo, useCallback } from 'react';
 import { TableHeader } from './table_header';
@@ -11,46 +11,48 @@ import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { TableRow } from './table_rows';
 
 export const DefaultDiscoverTable = ({
-    displayedTableColumns,
-    rows,
-    // dataGridTableColumnsVisibility,
-    // leadingControlColumns,
-    // pagination,
-    // renderCellValue,
-    // rowCount,
-    // sorting,
-    // isToolbarVisible,
-    // toolbarVisibility,
-    // rowHeightsOptions,
-    indexPattern
+  displayedTableColumns,
+  rows,
+  // dataGridTableColumnsVisibility,
+  // leadingControlColumns,
+  // pagination,
+  // renderCellValue,
+  // rowCount,
+  // sorting,
+  // isToolbarVisible,
+  // toolbarVisibility,
+  // rowHeightsOptions,
+  indexPattern,
 }) => {
-
-    return (indexPattern && (
-        <table data-test-subj="docTable" className="osd-table table">
-            <thead>
-                <TableHeader 
-                    displayedTableColumns={displayedTableColumns}
-                    defaultSortOrder={''}
-                    //hideTimeColumn,
-                    indexPattern={indexPattern}
-                    //isShortDots,
-                    onChangeSortOrder={()=>{}}
-                    onMoveColumn={()=>{}}
-                    onRemoveColumn={()=>{}}
-                    sortOrder={[]}
-                />
-            </thead>
-            <tbody>
-                {rows.map((row: OpenSearchSearchHit)=>{
-                    return (
-                    <TableRow 
-                        key={row._id}
-                        row={row}
-                        columns={displayedTableColumns}
-                        indexPattern={indexPattern}
-                    />)
-                })}
-            </tbody>
-        </table>
-    ))
-}
+  return (
+    indexPattern && (
+      <table data-test-subj="docTable" className="osd-table table">
+        <thead>
+          <TableHeader
+            displayedTableColumns={displayedTableColumns}
+            defaultSortOrder={''}
+            // hideTimeColumn,
+            indexPattern={indexPattern}
+            // isShortDots,
+            onChangeSortOrder={() => {}}
+            onMoveColumn={() => {}}
+            onRemoveColumn={() => {}}
+            sortOrder={[]}
+          />
+        </thead>
+        <tbody>
+          {rows.map((row: OpenSearchSearchHit) => {
+            return (
+              <TableRow
+                key={row._id}
+                row={row}
+                columns={displayedTableColumns}
+                indexPattern={indexPattern}
+              />
+            );
+          })}
+        </tbody>
+      </table>
+    )
+  );
+};

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -18,10 +18,10 @@ export interface DefaultDiscoverTableProps {
   columns: string[];
   rows: OpenSearchSearchHit[];
   indexPattern: IndexPattern;
-  sortOrder: {
+  sortOrder: Array<{
     id: string;
-    direction: "asc" | "desc";
-}[];
+    direction: 'asc' | 'desc';
+  }>;
   onChangeSortOrder: (cols: EuiDataGridSorting['columns']) => void;
   onRemoveColumn: (column: string) => void;
   onReorderColumn: (col: string, source: number, destination: number) => void;
@@ -30,7 +30,7 @@ export interface DefaultDiscoverTableProps {
   onClose: () => void;
 }
 
-export const DefaultDiscoverTable = ({
+export const LegacyDiscoverTable = ({
   displayedTableColumns,
   columns,
   rows,

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -6,9 +6,22 @@
 import './_doc_table.scss';
 
 import React, { useState, useMemo, useCallback } from 'react';
+import { EuiDataGridColumn } from '@elastic/eui';
 import { TableHeader } from './table_header';
 import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { TableRow } from './table_rows';
+import { IndexPattern } from '../../../opensearch_dashboards_services';
+import { SortOrder } from '../../../saved_searches/types';
+
+export interface DefaultDiscoverTableProps {
+  displayedTableColumns: EuiDataGridColumn[];
+  rows: OpenSearchSearchHit[];
+  indexPattern: IndexPattern;
+  sortOrder: SortOrder[];
+  onChangeSortOrder: (sort: SortOrder[]) => void;
+  onRemoveColumn: (column: string) => void;
+  onReorderColumn: (col: string, source: number, destination: number) => void;
+}
 
 export const DefaultDiscoverTable = ({
   displayedTableColumns,
@@ -18,7 +31,7 @@ export const DefaultDiscoverTable = ({
   onChangeSortOrder,
   onRemoveColumn,
   onReorderColumn,
-}) => {
+}: DefaultDiscoverTableProps) => {
   // console.log("sorting", sorting)
   return (
     indexPattern && (
@@ -37,11 +50,12 @@ export const DefaultDiscoverTable = ({
           />
         </thead>
         <tbody>
-          {rows.map((row: OpenSearchSearchHit) => {
+          {rows.map((row: OpenSearchSearchHit, index: number) => {
             return (
               <TableRow
                 key={row._id}
                 row={row}
+                rowIndex={index}
                 columns={displayedTableColumns}
                 indexPattern={indexPattern}
               />

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -5,13 +5,12 @@
 
 import './_doc_table.scss';
 
-import React, { useState, useMemo, useCallback } from 'react';
+import React from 'react';
 import { EuiDataGridColumn, EuiDataGridSorting } from '@elastic/eui';
 import { TableHeader } from './table_header';
 import { DocViewFilterFn, OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { TableRow } from './table_rows';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
-import { SortOrder } from '../../../saved_searches/types';
 
 export interface DefaultDiscoverTableProps {
   displayedTableColumns: EuiDataGridColumn[];

--- a/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
@@ -40,11 +40,8 @@ export const TableCell = ({ column, row, rowIndex, indexPattern }: TableCellProp
   // const flattenedRow = flattenedRows
   //   ? (flattenedRows[rowIndex] as Record<string, unknown>)
   //   : undefined;
-  // console.log("column", column)
-  // console.log("row", row)
 
   const fieldInfo = indexPattern.fields.getByName(column.id);
-  // console.log("fieldInfo", fieldInfo)
 
   if (typeof singleRow === 'undefined') {
     return (
@@ -147,7 +144,7 @@ export const TableCell = ({ column, row, rowIndex, indexPattern }: TableCellProp
         className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
       >
         <span dangerouslySetInnerHTML={{ __html: sanitizedCellValue }} />
-        <span>
+        <span className="osdDocTableCell__filter">
           {fieldInfo?.filterable ? filterForButton() : null}
           {fieldInfo?.filterable ? filterOutButton() : null}
         </span>

--- a/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
@@ -12,7 +12,6 @@
 import './_table_cell.scss';
 
 import React from 'react';
-import dompurify from 'dompurify';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { DocViewFilterFn } from '../../doc_views/doc_views_types';
@@ -22,29 +21,22 @@ export interface TableCellProps {
   onFilter: DocViewFilterFn;
   filterable?: boolean;
   fieldMapping?: any;
-  formattedValue: any;
+  sanitizedCellValue: string;
 }
 
 export const TableCell = ({
   columnId,
   onFilter,
-  filterable,
   fieldMapping,
-  formattedValue,
+  sanitizedCellValue,
 }: TableCellProps) => {
-  if (typeof formattedValue === 'undefined') {
-    return (
-      <td
-        data-test-subj="docTableField"
-        className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
-      >
-        <span>-</span>
-      </td>
-    );
-  } else {
-    const sanitizedCellValue = dompurify.sanitize(formattedValue);
-
-    const filters = (
+  return (
+    // eslint-disable-next-line react/no-danger
+    <td
+      data-test-subj="docTableField"
+      className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
+    >
+      <span dangerouslySetInnerHTML={{ __html: sanitizedCellValue }} />
       <span className="osdDocTableCell__filter">
         <EuiToolTip
           content={i18n.translate('discover.filterForValue', {
@@ -77,17 +69,6 @@ export const TableCell = ({
           />
         </EuiToolTip>
       </span>
-    );
-
-    return (
-      // eslint-disable-next-line react/no-danger
-      <td
-        data-test-subj="docTableField"
-        className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
-      >
-        <span dangerouslySetInnerHTML={{ __html: sanitizedCellValue }} />
-        {filterable && filters}
-      </td>
-    );
-  }
+    </td>
+  );
 };

--- a/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
@@ -11,74 +11,27 @@
 
 import './_table_cell.scss';
 
-import React, { useState, useMemo, useCallback } from 'react';
+import React from 'react';
 import dompurify from 'dompurify';
-import {
-  EuiButton,
-  EuiButtonEmpty,
-  EuiButtonIcon,
-  EuiDataGridColumn,
-  EuiToolTip,
-} from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
-import { indexPatternField } from '../../../../../opensearch_ui_shared/static/forms/helpers/field_validators/index_pattern_field';
-import { fetchSourceTypeDataCell } from '../data_grid/data_grid_table_cell_value';
-import { DocViewFilterFn, OpenSearchSearchHit } from '../../doc_views/doc_views_types';
-import { IndexPattern } from '../../../opensearch_dashboards_services';
-import { useDataGridContext } from '../data_grid/data_grid_table_context';
+import { DocViewFilterFn } from '../../doc_views/doc_views_types';
 
 export interface TableCellProps {
-  column: EuiDataGridColumn;
-  row: OpenSearchSearchHit;
-  rowIndex: number;
-  indexPattern: IndexPattern;
-  flattened: Record<string, any>;
+  columnId: string;
   onFilter: DocViewFilterFn;
+  filterable?: boolean;
+  fieldMapping?: any;
+  formattedValue: any;
 }
 
 export const TableCell = ({
-  column,
-  row,
-  rowIndex,
-  indexPattern,
-  flattened,
+  columnId,
   onFilter,
+  filterable,
+  fieldMapping,
+  formattedValue,
 }: TableCellProps) => {
-  const singleRow = row as Record<string, unknown>;
-  // const flattenedRows = dataRows ? dataRows.map((hit) => idxPattern.flattenHit(hit)) : [];
-  // const flattenedRow = flattenedRows
-  //   ? (flattenedRows[rowIndex] as Record<string, unknown>)
-  //   : undefined;
-
-  const fieldInfo = indexPattern.fields.getByName(column.id);
-  const fieldMapping = flattened[column.id];
-
-  if (typeof singleRow === 'undefined') {
-    return (
-      <td
-        data-test-subj="docTableField"
-        className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
-      >
-        <span>-</span>
-      </td>
-    );
-  }
-
-  // TODO: when the cell is a object
-  // if (!fieldInfo?.type && typeof flattenedRow?.[columnId] === 'object') {
-  //   return <span>{stringify(flattenedRow[columnId])}</span>;
-  // }
-
-  if (fieldInfo?.type === '_source') {
-    return (
-      <td className="eui-textBreakAll eui-textBreakWord" data-test-subj="docTableField">
-        {fetchSourceTypeDataCell(indexPattern, singleRow, column.id, false)}
-      </td>
-    );
-  }
-
-  const formattedValue = indexPattern.formatField(singleRow, column.id);
-
   if (typeof formattedValue === 'undefined') {
     return (
       <td
@@ -99,7 +52,7 @@ export const TableCell = ({
           })}
         >
           <EuiButtonIcon
-            onClick={() => onFilter(column.id, fieldMapping, '+')}
+            onClick={() => onFilter(columnId, fieldMapping, '+')}
             iconType="plusInCircle"
             aria-label={i18n.translate('discover.filterForValueLabel', {
               defaultMessage: 'Filter for value',
@@ -114,7 +67,7 @@ export const TableCell = ({
           })}
         >
           <EuiButtonIcon
-            onClick={() => onFilter(column.id, fieldMapping, '-')}
+            onClick={() => onFilter(columnId, fieldMapping, '-')}
             iconType="minusInCircle"
             aria-label={i18n.translate('discover.filterOutValueLabel', {
               defaultMessage: 'Filter out value',
@@ -133,7 +86,7 @@ export const TableCell = ({
         className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
       >
         <span dangerouslySetInnerHTML={{ __html: sanitizedCellValue }} />
-        {fieldInfo?.filterable && filters}
+        {filterable && filters}
       </td>
     );
   }

--- a/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
@@ -13,22 +13,44 @@ import './_table_cell.scss';
 
 import React, { useState, useMemo, useCallback } from 'react';
 import dompurify from 'dompurify';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiDataGridColumn,
+  EuiToolTip,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
 import { indexPatternField } from '../../../../../opensearch_ui_shared/static/forms/helpers/field_validators/index_pattern_field';
 import { fetchSourceTypeDataCell } from '../data_grid/data_grid_table_cell_value';
+import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
+import { IndexPattern } from '../../../opensearch_dashboards_services';
+import { useDataGridContext } from '../data_grid/data_grid_table_context';
 
-export const TableCell = ({ column, row, indexPattern }) => {
+export interface TableCellProps {
+  column: EuiDataGridColumn;
+  row: OpenSearchSearchHit;
+  rowIndex: number;
+  indexPattern: IndexPattern;
+}
+
+export const TableCell = ({ column, row, rowIndex, indexPattern }: TableCellProps) => {
   const singleRow = row as Record<string, unknown>;
   // const flattenedRows = dataRows ? dataRows.map((hit) => idxPattern.flattenHit(hit)) : [];
   // const flattenedRow = flattenedRows
   //   ? (flattenedRows[rowIndex] as Record<string, unknown>)
   //   : undefined;
+  // console.log("column", column)
+  // console.log("row", row)
+
   const fieldInfo = indexPattern.fields.getByName(column.id);
+  // console.log("fieldInfo", fieldInfo)
 
   if (typeof singleRow === 'undefined') {
     return (
       <td
         data-test-subj="docTableField"
-        className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord"
+        className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
       >
         <span>-</span>
       </td>
@@ -49,24 +71,86 @@ export const TableCell = ({ column, row, indexPattern }) => {
   }
 
   const formattedValue = indexPattern.formatField(singleRow, column.id);
+  // const filterFor = column.cellActions ? column.cellActions[0]
+
   if (typeof formattedValue === 'undefined') {
     return (
       <td
         data-test-subj="docTableField"
-        className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord"
+        className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
       >
         <span>-</span>
       </td>
     );
   } else {
     const sanitizedCellValue = dompurify.sanitize(formattedValue);
+    const { onFilter } = useDataGridContext();
+
+    const filterForButton = () => {
+      const filterForValueText = i18n.translate('discover.filterForValue', {
+        defaultMessage: 'Filter for value',
+      });
+      const filterForValueLabel = i18n.translate('discover.filterForValueLabel', {
+        defaultMessage: 'Filter for value: {value}',
+        values: { value: column.id },
+      });
+      return (
+        <EuiToolTip content={filterForValueText}>
+          <EuiButtonIcon
+            onClick={() => {
+              const flattened = indexPattern.flattenHit(row);
+
+              if (flattened) {
+                onFilter(column.id, flattened[column.id], '+');
+              }
+            }}
+            iconType="plusInCircle"
+            aria-label={filterForValueLabel}
+            data-test-subj="filterForValue"
+            className="osdDocTableCell__filterButton"
+          />
+        </EuiToolTip>
+      );
+    };
+
+    const filterOutButton = () => {
+      const filterOutValueText = i18n.translate('discover.filterOutValue', {
+        defaultMessage: 'Filter out value',
+      });
+      const filterOutValueLabel = i18n.translate('discover.filterOutValueLabel', {
+        defaultMessage: 'Filter out value: {value}',
+        values: { value: column.id },
+      });
+      return (
+        <EuiToolTip content={filterOutValueText}>
+          <EuiButtonIcon
+            onClick={() => {
+              const flattened = indexPattern.flattenHit(row);
+
+              if (flattened) {
+                onFilter(column.id, flattened[column.id], '-');
+              }
+            }}
+            iconType="minusInCircle"
+            aria-label={filterOutValueLabel}
+            data-test-subj="filterOutValue"
+            className="osdDocTableCell__filterButton"
+          />
+        </EuiToolTip>
+      );
+    };
+
     return (
       // eslint-disable-next-line react/no-danger
       <td
         data-test-subj="docTableField"
-        className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord"
+        className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
       >
         <span dangerouslySetInnerHTML={{ __html: sanitizedCellValue }} />
+        <span>
+          {fieldInfo?.filterable ? filterForButton() : null}
+          {fieldInfo?.filterable ? filterOutButton() : null}
+        </span>
       </td>
     );
   }

--- a/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
@@ -9,59 +9,65 @@
  * GitHub history for details.
  */
 
-import './_table_cell.scss'
+import './_table_cell.scss';
 
 import React, { useState, useMemo, useCallback } from 'react';
+import dompurify from 'dompurify';
 import { indexPatternField } from '../../../../../opensearch_ui_shared/static/forms/helpers/field_validators/index_pattern_field';
 import { fetchSourceTypeDataCell } from '../data_grid/data_grid_table_cell_value';
-import dompurify from 'dompurify';
 
-export const TableCell = ({
-    column,
-    row,
-    indexPattern
-}) => {
-    const singleRow = row as Record<string, unknown>;
-    //const flattenedRows = dataRows ? dataRows.map((hit) => idxPattern.flattenHit(hit)) : [];
-    // const flattenedRow = flattenedRows
-    //   ? (flattenedRows[rowIndex] as Record<string, unknown>)
-    //   : undefined;
-    const fieldInfo = indexPattern.fields.getByName(column.id);
-  
-    if (typeof singleRow === 'undefined') {
-      return <td data-test-subj="docTableField" className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord">
+export const TableCell = ({ column, row, indexPattern }) => {
+  const singleRow = row as Record<string, unknown>;
+  // const flattenedRows = dataRows ? dataRows.map((hit) => idxPattern.flattenHit(hit)) : [];
+  // const flattenedRow = flattenedRows
+  //   ? (flattenedRows[rowIndex] as Record<string, unknown>)
+  //   : undefined;
+  const fieldInfo = indexPattern.fields.getByName(column.id);
+
+  if (typeof singleRow === 'undefined') {
+    return (
+      <td
+        data-test-subj="docTableField"
+        className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord"
+      >
         <span>-</span>
-      </td>;
-    }
+      </td>
+    );
+  }
 
-    // TODO: when the cell is a object
-    // if (!fieldInfo?.type && typeof flattenedRow?.[columnId] === 'object') {
-    //   return <span>{stringify(flattenedRow[columnId])}</span>;
-    // }
-  
-    if (fieldInfo?.type === '_source') {
-      return (
-        <td className="eui-textBreakAll eui-textBreakWord" data-test-subj="docTableField">
-            {fetchSourceTypeDataCell(indexPattern, singleRow, column.id, false)}
-        </td>
-      )
-    }
-  
-    const formattedValue = indexPattern.formatField(singleRow, column.id);
-    if (typeof formattedValue === 'undefined') {
-      return (
-        <td data-test-subj="docTableField" className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord">
-            <span>-</span>
-        </td>
-      )
-    } else {
-      const sanitizedCellValue = dompurify.sanitize(formattedValue);
-      return (
-        // eslint-disable-next-line react/no-danger
-        <td data-test-subj="docTableField" className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord">
-            <span dangerouslySetInnerHTML={{ __html: sanitizedCellValue }} />
-        </td>
-      );
-    }
-   
-}
+  // TODO: when the cell is a object
+  // if (!fieldInfo?.type && typeof flattenedRow?.[columnId] === 'object') {
+  //   return <span>{stringify(flattenedRow[columnId])}</span>;
+  // }
+
+  if (fieldInfo?.type === '_source') {
+    return (
+      <td className="eui-textBreakAll eui-textBreakWord" data-test-subj="docTableField">
+        {fetchSourceTypeDataCell(indexPattern, singleRow, column.id, false)}
+      </td>
+    );
+  }
+
+  const formattedValue = indexPattern.formatField(singleRow, column.id);
+  if (typeof formattedValue === 'undefined') {
+    return (
+      <td
+        data-test-subj="docTableField"
+        className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord"
+      >
+        <span>-</span>
+      </td>
+    );
+  } else {
+    const sanitizedCellValue = dompurify.sanitize(formattedValue);
+    return (
+      // eslint-disable-next-line react/no-danger
+      <td
+        data-test-subj="docTableField"
+        className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord"
+      >
+        <span dangerouslySetInnerHTML={{ __html: sanitizedCellValue }} />
+      </td>
+    );
+  }
+};

--- a/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import './_table_cell.scss'
+
+import React, { useState, useMemo, useCallback } from 'react';
+import { indexPatternField } from '../../../../../opensearch_ui_shared/static/forms/helpers/field_validators/index_pattern_field';
+import { fetchSourceTypeDataCell } from '../data_grid/data_grid_table_cell_value';
+import dompurify from 'dompurify';
+
+export const TableCell = ({
+    column,
+    row,
+    indexPattern
+}) => {
+    const singleRow = row as Record<string, unknown>;
+    //const flattenedRows = dataRows ? dataRows.map((hit) => idxPattern.flattenHit(hit)) : [];
+    // const flattenedRow = flattenedRows
+    //   ? (flattenedRows[rowIndex] as Record<string, unknown>)
+    //   : undefined;
+    const fieldInfo = indexPattern.fields.getByName(column.id);
+  
+    if (typeof singleRow === 'undefined') {
+      return <td data-test-subj="docTableField" className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord">
+        <span>-</span>
+      </td>;
+    }
+
+    // TODO: when the cell is a object
+    // if (!fieldInfo?.type && typeof flattenedRow?.[columnId] === 'object') {
+    //   return <span>{stringify(flattenedRow[columnId])}</span>;
+    // }
+  
+    if (fieldInfo?.type === '_source') {
+      return (
+        <td className="eui-textBreakAll eui-textBreakWord" data-test-subj="docTableField">
+            {fetchSourceTypeDataCell(indexPattern, singleRow, column.id, false)}
+        </td>
+      )
+    }
+  
+    const formattedValue = indexPattern.formatField(singleRow, column.id);
+    if (typeof formattedValue === 'undefined') {
+      return (
+        <td data-test-subj="docTableField" className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord">
+            <span>-</span>
+        </td>
+      )
+    } else {
+      const sanitizedCellValue = dompurify.sanitize(formattedValue);
+      return (
+        // eslint-disable-next-line react/no-danger
+        <td data-test-subj="docTableField" className="osdDocTableCell__dataField eui-textBreakAll eui-textBreakWord">
+            <span dangerouslySetInnerHTML={{ __html: sanitizedCellValue }} />
+        </td>
+      );
+    }
+   
+}

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
@@ -27,6 +27,7 @@ interface Props {
   onChangeSortOrder?: (cols: EuiDataGridSorting['columns']) => void;
   onMoveColumn?: (name: string, index: number) => void;
   onRemoveColumn?: (name: string) => void;
+  onReorderColumn?: (col: string, source: number, destination: number) => void;
   sortOrder: Array<{
     id: string;
     direction: 'desc' | 'asc';
@@ -34,7 +35,6 @@ interface Props {
 }
 
 export function TableHeader({
-  // columns,
   displayedTableColumns,
   defaultSortOrder,
   // hideTimeColumn,

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
@@ -12,7 +12,7 @@
 import './_table_header.scss';
 
 import React from 'react';
-import { EuiDataGridColumn } from '@elastic/eui';
+import { EuiDataGridColumn, EuiDataGridSorting } from '@elastic/eui';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { SortOrder, getDefaultSort } from '../../view_components/utils/get_default_sort';
 import { TableHeaderColumn } from './table_header_column';
@@ -24,10 +24,13 @@ interface Props {
   // hideTimeColumn: boolean;
   indexPattern: IndexPattern;
   // isShortDots: boolean;
-  onChangeSortOrder?: (sortOrder: SortOrder[]) => void;
+  onChangeSortOrder?: (cols: EuiDataGridSorting['columns']) => void;
   onMoveColumn?: (name: string, index: number) => void;
   onRemoveColumn?: (name: string) => void;
-  sortOrder: SortOrder[];
+  sortOrder: {
+    id: string;
+    direction: "desc" | "asc";
+}[];
 }
 
 export function TableHeader({
@@ -72,9 +75,10 @@ export function TableHeader({
               displayName={col.display}
               isRemoveable={col.actions && col.actions.showHide ? true : false}
               isSortable={col.isSortable}
-              name={col.display}
+              name={col.display as string}
               sortOrder={
-                sortOrder.length ? sortOrder : getDefaultSort(indexPattern, defaultSortOrder)
+                sortOrder.length ? sortOrder : []
+                //getDefaultSort(indexPattern, defaultSortOrder).map(([id, direction]) => ({ id, direction }))
               }
               onReorderColumn={onReorderColumn}
               onRemoveColumn={onRemoveColumn}

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
@@ -9,21 +9,21 @@
  * GitHub history for details.
  */
 
-import './_table_header.scss'
+import './_table_header.scss';
 
 import React from 'react';
+import { AnyAsyncThunk } from '@reduxjs/toolkit/dist/matchers';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { SortOrder, getDefaultSort } from '../../view_components/utils/get_default_sort';
-import { AnyAsyncThunk } from '@reduxjs/toolkit/dist/matchers';
 import { TableHeaderColumn } from './table_header_column';
 
 interface Props {
-  displayedTableColumns:any;
-  //columns: string[];
+  displayedTableColumns: any;
+  // columns: string[];
   defaultSortOrder: string;
-  //hideTimeColumn: boolean;
+  // hideTimeColumn: boolean;
   indexPattern: IndexPattern;
-  //isShortDots: boolean;
+  // isShortDots: boolean;
   onChangeSortOrder?: (sortOrder: SortOrder[]) => void;
   onMoveColumn?: (name: string, index: number) => void;
   onRemoveColumn?: (name: string) => void;
@@ -31,30 +31,30 @@ interface Props {
 }
 
 export function TableHeader({
-  //columns,
+  // columns,
   displayedTableColumns,
   defaultSortOrder,
-  //hideTimeColumn,
+  // hideTimeColumn,
   indexPattern,
-  //isShortDots,
+  // isShortDots,
   onChangeSortOrder,
   onMoveColumn,
   onRemoveColumn,
   sortOrder,
 }: Props) {
-  //const displayedColumns = getDisplayedColumns(columns, indexPattern, hideTimeColumn, isShortDots);
-  console.log("displayedTableColumns", displayedTableColumns)
+  // const displayedColumns = getDisplayedColumns(columns, indexPattern, hideTimeColumn, isShortDots);
+  console.log('displayedTableColumns', displayedTableColumns);
   return (
     <tr data-test-subj="docTableHeader" className="osdDocTableHeader">
       <th style={{ width: '24px' }} />
-      {displayedTableColumns.map((col:any) => {
+      {displayedTableColumns.map((col: any) => {
         return (
           <TableHeaderColumn
             key={col.id}
-            colLeftIdx={-1} //TODO
-            colRightIdx={-1} //TODO
+            colLeftIdx={-1} // TODO
+            colRightIdx={-1} // TODO
             displayName={col.display}
-            isRemoveable={false} //TODO
+            isRemoveable={false} // TODO
             isSortable={col.isSortable}
             name={col.schema}
             sortOrder={

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
@@ -27,10 +27,10 @@ interface Props {
   onChangeSortOrder?: (cols: EuiDataGridSorting['columns']) => void;
   onMoveColumn?: (name: string, index: number) => void;
   onRemoveColumn?: (name: string) => void;
-  sortOrder: {
+  sortOrder: Array<{
     id: string;
-    direction: "desc" | "asc";
-}[];
+    direction: 'desc' | 'asc';
+  }>;
 }
 
 export function TableHeader({
@@ -45,9 +45,6 @@ export function TableHeader({
   onRemoveColumn,
   sortOrder,
 }: Props) {
-  // const displayedColumns = getDisplayedColumns(columns, indexPattern, hideTimeColumn, isShortDots);
-  // console.log('displayedTableColumns', displayedTableColumns);
-
   const timeColName = indexPattern.timeFieldName;
   return (
     <tr data-test-subj="docTableHeader" className="osdDocTableHeader">
@@ -78,7 +75,7 @@ export function TableHeader({
               name={col.display as string}
               sortOrder={
                 sortOrder.length ? sortOrder : []
-                //getDefaultSort(indexPattern, defaultSortOrder).map(([id, direction]) => ({ id, direction }))
+                // getDefaultSort(indexPattern, defaultSortOrder).map(([id, direction]) => ({ id, direction }))
               }
               onReorderColumn={onReorderColumn}
               onRemoveColumn={onRemoveColumn}

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
@@ -38,7 +38,7 @@ export function TableHeader({
   indexPattern,
   // isShortDots,
   onChangeSortOrder,
-  onMoveColumn,
+  onReorderColumn,
   onRemoveColumn,
   sortOrder,
 }: Props) {
@@ -57,9 +57,11 @@ export function TableHeader({
             ? -1
             : idx + 1;
         console.log('index', colLeftIdx, colRightIdx);
+
         return (
           <TableHeaderColumn
             key={col.id}
+            currentIdx={idx}
             colLeftIdx={colLeftIdx}
             colRightIdx={colRightIdx}
             displayName={col.display}
@@ -69,7 +71,7 @@ export function TableHeader({
             sortOrder={
               sortOrder.length ? sortOrder : getDefaultSort(indexPattern, defaultSortOrder)
             }
-            onMoveColumn={onMoveColumn}
+            onReorderColumn={onReorderColumn}
             onRemoveColumn={onRemoveColumn}
             onChangeSortOrder={onChangeSortOrder}
           />

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import './_table_header.scss'
+
+import React from 'react';
+import { IndexPattern } from '../../../opensearch_dashboards_services';
+import { SortOrder, getDefaultSort } from '../../view_components/utils/get_default_sort';
+import { AnyAsyncThunk } from '@reduxjs/toolkit/dist/matchers';
+import { TableHeaderColumn } from './table_header_column';
+
+interface Props {
+  displayedTableColumns:any;
+  //columns: string[];
+  defaultSortOrder: string;
+  //hideTimeColumn: boolean;
+  indexPattern: IndexPattern;
+  //isShortDots: boolean;
+  onChangeSortOrder?: (sortOrder: SortOrder[]) => void;
+  onMoveColumn?: (name: string, index: number) => void;
+  onRemoveColumn?: (name: string) => void;
+  sortOrder: SortOrder[];
+}
+
+export function TableHeader({
+  //columns,
+  displayedTableColumns,
+  defaultSortOrder,
+  //hideTimeColumn,
+  indexPattern,
+  //isShortDots,
+  onChangeSortOrder,
+  onMoveColumn,
+  onRemoveColumn,
+  sortOrder,
+}: Props) {
+  //const displayedColumns = getDisplayedColumns(columns, indexPattern, hideTimeColumn, isShortDots);
+  console.log("displayedTableColumns", displayedTableColumns)
+  return (
+    <tr data-test-subj="docTableHeader" className="osdDocTableHeader">
+      <th style={{ width: '24px' }} />
+      {displayedTableColumns.map((col:any) => {
+        return (
+          <TableHeaderColumn
+            key={col.id}
+            colLeftIdx={-1} //TODO
+            colRightIdx={-1} //TODO
+            displayName={col.display}
+            isRemoveable={false} //TODO
+            isSortable={col.isSortable}
+            name={col.schema}
+            sortOrder={
+              sortOrder.length ? sortOrder : getDefaultSort(indexPattern, defaultSortOrder)
+            }
+            onMoveColumn={onMoveColumn}
+            onRemoveColumn={onRemoveColumn}
+            onChangeSortOrder={onChangeSortOrder}
+          />
+        );
+      })}
+    </tr>
+  );
+}

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
@@ -12,13 +12,13 @@
 import './_table_header.scss';
 
 import React from 'react';
-import { AnyAsyncThunk } from '@reduxjs/toolkit/dist/matchers';
+import { EuiDataGridColumn } from '@elastic/eui';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { SortOrder, getDefaultSort } from '../../view_components/utils/get_default_sort';
 import { TableHeaderColumn } from './table_header_column';
 
 interface Props {
-  displayedTableColumns: any;
+  displayedTableColumns: EuiDataGridColumn[];
   // columns: string[];
   defaultSortOrder: string;
   // hideTimeColumn: boolean;
@@ -44,39 +44,45 @@ export function TableHeader({
 }: Props) {
   // const displayedColumns = getDisplayedColumns(columns, indexPattern, hideTimeColumn, isShortDots);
   // console.log('displayedTableColumns', displayedTableColumns);
-  console.log('timefield name', indexPattern.timeFieldName);
+
   const timeColName = indexPattern.timeFieldName;
   return (
     <tr data-test-subj="docTableHeader" className="osdDocTableHeader">
       <th style={{ width: '24px' }} />
-      {displayedTableColumns.map((col: any, idx, cols) => {
-        const colLeftIdx =
-          !col.actions.showMoveLeft || idx - 1 <= 0 || col.id === timeColName ? -1 : idx - 1;
-        const colRightIdx =
-          !col.actions.showMoveRight || idx + 1 >= cols.length || col.id === timeColName
-            ? -1
-            : idx + 1;
-        console.log('index', colLeftIdx, colRightIdx);
+      {displayedTableColumns.map(
+        (col: EuiDataGridColumn, idx: number, cols: EuiDataGridColumn[]) => {
+          const colLeftIdx =
+            !col.actions || !col.actions!.showMoveLeft || idx - 1 <= 0 || col.id === timeColName
+              ? -1
+              : idx - 1;
+          const colRightIdx =
+            !col.actions ||
+            !col.actions!.showMoveRight ||
+            idx + 1 >= cols.length ||
+            col.id === timeColName
+              ? -1
+              : idx + 1;
 
-        return (
-          <TableHeaderColumn
-            key={col.id}
-            currentIdx={idx}
-            colLeftIdx={colLeftIdx}
-            colRightIdx={colRightIdx}
-            displayName={col.display}
-            isRemoveable={col.actions.showHide}
-            isSortable={col.isSortable}
-            name={col.display}
-            sortOrder={
-              sortOrder.length ? sortOrder : getDefaultSort(indexPattern, defaultSortOrder)
-            }
-            onReorderColumn={onReorderColumn}
-            onRemoveColumn={onRemoveColumn}
-            onChangeSortOrder={onChangeSortOrder}
-          />
-        );
-      })}
+          return (
+            <TableHeaderColumn
+              key={col.id + idx}
+              currentIdx={idx}
+              colLeftIdx={colLeftIdx}
+              colRightIdx={colRightIdx}
+              displayName={col.display}
+              isRemoveable={col.actions && col.actions.showHide ? true : false}
+              isSortable={col.isSortable}
+              name={col.display}
+              sortOrder={
+                sortOrder.length ? sortOrder : getDefaultSort(indexPattern, defaultSortOrder)
+              }
+              onReorderColumn={onReorderColumn}
+              onRemoveColumn={onRemoveColumn}
+              onChangeSortOrder={onChangeSortOrder}
+            />
+          );
+        }
+      )}
     </tr>
   );
 }

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
@@ -43,18 +43,27 @@ export function TableHeader({
   sortOrder,
 }: Props) {
   // const displayedColumns = getDisplayedColumns(columns, indexPattern, hideTimeColumn, isShortDots);
-  console.log('displayedTableColumns', displayedTableColumns);
+  // console.log('displayedTableColumns', displayedTableColumns);
+  console.log('timefield name', indexPattern.timeFieldName);
+  const timeColName = indexPattern.timeFieldName;
   return (
     <tr data-test-subj="docTableHeader" className="osdDocTableHeader">
       <th style={{ width: '24px' }} />
-      {displayedTableColumns.map((col: any) => {
+      {displayedTableColumns.map((col: any, idx, cols) => {
+        const colLeftIdx =
+          !col.actions.showMoveLeft || idx - 1 <= 0 || col.id === timeColName ? -1 : idx - 1;
+        const colRightIdx =
+          !col.actions.showMoveRight || idx + 1 >= cols.length || col.id === timeColName
+            ? -1
+            : idx + 1;
+        console.log('index', colLeftIdx, colRightIdx);
         return (
           <TableHeaderColumn
             key={col.id}
-            colLeftIdx={-1} // TODO
-            colRightIdx={-1} // TODO
+            colLeftIdx={colLeftIdx}
+            colRightIdx={colRightIdx}
             displayName={col.display}
-            isRemoveable={true} // TODO
+            isRemoveable={col.actions.showHide}
             isSortable={col.isSortable}
             name={col.display}
             sortOrder={

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header.tsx
@@ -54,9 +54,9 @@ export function TableHeader({
             colLeftIdx={-1} // TODO
             colRightIdx={-1} // TODO
             displayName={col.display}
-            isRemoveable={false} // TODO
+            isRemoveable={true} // TODO
             isSortable={col.isSortable}
-            name={col.schema}
+            name={col.display}
             sortOrder={
               sortOrder.length ? sortOrder : getDefaultSort(indexPattern, defaultSortOrder)
             }

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
@@ -13,8 +13,7 @@ import './_table_header.scss';
 
 import React, { ReactNode } from 'react';
 import { i18n } from '@osd/i18n';
-import { EuiButtonIcon, EuiDataGridSorting, EuiFieldText, EuiIcon, EuiToolTip } from '@elastic/eui';
-import { SortOrder } from '../../view_components/utils/get_default_sort';
+import { EuiButtonIcon, EuiDataGridSorting, EuiToolTip } from '@elastic/eui';
 
 interface Props {
   currentIdx: number;
@@ -26,11 +25,12 @@ interface Props {
   name: string;
   onChangeSortOrder?: (cols: EuiDataGridSorting['columns']) => void;
   onMoveColumn?: (name: string, idx: number) => void;
+  onReorderColumn?: (col: string, source: number, destination: number) => void;
   onRemoveColumn?: (name: string) => void;
-  sortOrder: {
+  sortOrder: Array<{
     id: string;
-    direction: "desc" | "asc";
-}[];
+    direction: 'desc' | 'asc';
+  }>;
 }
 
 const sortDirectionToIcon: Record<string, string> = {
@@ -52,14 +52,15 @@ export function TableHeaderColumn({
   onRemoveColumn,
   sortOrder,
 }: Props) {
-  //const [, sortDirection = ''] = sortOrder.find((sortPair) => name === sortPair.id) || [];
   const currentSortWithoutColumn = sortOrder.filter((pair) => pair.id !== name);
   const currentColumnSort = sortOrder.find((pair) => pair.id === name);
   const currentColumnSortDirection = (currentColumnSort && currentColumnSort.direction) || '';
 
   const btnSortIcon = sortDirectionToIcon[currentColumnSortDirection];
   const btnSortClassName =
-  currentColumnSortDirection !== '' ? btnSortIcon : `osdDocTableHeader__sortChange ${btnSortIcon}`;
+    currentColumnSortDirection !== ''
+      ? btnSortIcon
+      : `osdDocTableHeader__sortChange ${btnSortIcon}`;
 
   const handleChangeSortOrder = () => {
     if (!onChangeSortOrder) return;
@@ -67,31 +68,31 @@ export function TableHeaderColumn({
     let currentSortOrder;
     let newSortOrder: {
       id: string;
-      direction: "desc" | "asc";
-  };
+      direction: 'desc' | 'asc';
+    };
     // Cycle goes Unsorted -> Asc -> Desc -> Unsorted
     if (currentColumnSort === undefined) {
       newSortOrder = {
         id: name,
-        direction: "asc"
-      }
-      currentSortOrder = [...currentSortWithoutColumn, newSortOrder]
+        direction: 'asc',
+      };
+      currentSortOrder = [...currentSortWithoutColumn, newSortOrder];
       onChangeSortOrder(currentSortOrder);
     } else if (currentColumnSortDirection === 'asc') {
       newSortOrder = {
         id: name,
-        direction: "desc"
-      }
-      currentSortOrder = [...currentSortWithoutColumn, newSortOrder]
+        direction: 'desc',
+      };
+      currentSortOrder = [...currentSortWithoutColumn, newSortOrder];
       onChangeSortOrder(currentSortOrder);
     } else if (currentColumnSortDirection === 'desc' && currentSortWithoutColumn.length === 0) {
       // If we're at the end of the cycle and this is the only existing sort, we switch
       // back to ascending sort instead of removing it.
       newSortOrder = {
         id: name,
-        direction: "asc"
-      }
-      currentSortOrder = [...currentSortWithoutColumn, newSortOrder]
+        direction: 'asc',
+      };
+      currentSortOrder = [...currentSortWithoutColumn, newSortOrder];
       onChangeSortOrder(currentSortOrder);
     } else {
       onChangeSortOrder(currentSortWithoutColumn);
@@ -142,7 +143,7 @@ export function TableHeaderColumn({
       onClick: handleChangeSortOrder,
       testSubject: `docTableHeaderFieldSort_${name}`,
       tooltip: getSortButtonAriaLabel(),
-      iconType: "sortable"
+      iconType: 'sortable',
     },
     // Remove Button
     {

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
@@ -9,9 +9,11 @@
  * GitHub history for details.
  */
 
+import './_table_header.scss';
+
 import React from 'react';
 import { i18n } from '@osd/i18n';
-import { EuiToolTip } from '@elastic/eui';
+import { EuiFieldText, EuiIcon, EuiToolTip } from '@elastic/eui';
 import { SortOrder } from '../../view_components/utils/get_default_sort';
 
 interface Props {
@@ -115,6 +117,7 @@ export function TableHeaderColumn({
       onClick: handleChangeSortOrder,
       testSubject: `docTableHeaderFieldSort_${name}`,
       tooltip: getSortButtonAriaLabel(),
+      iconType: 'sortable',
     },
     // Remove Button
     {
@@ -129,10 +132,11 @@ export function TableHeaderColumn({
       tooltip: i18n.translate('discover.docTable.tableHeader.removeColumnButtonTooltip', {
         defaultMessage: 'Remove Column',
       }),
+      iconType: 'cross',
     },
     // Move Left Button
     {
-      active: colLeftIdx >= 0 && typeof onMoveColumn === 'function',
+      active: (colLeftIdx >= 0 && typeof onMoveColumn === 'function') || true,
       ariaLabel: i18n.translate('discover.docTable.tableHeader.moveColumnLeftButtonAriaLabel', {
         defaultMessage: 'Move {columnName} column to the left',
         values: { columnName: name },
@@ -143,10 +147,11 @@ export function TableHeaderColumn({
       tooltip: i18n.translate('discover.docTable.tableHeader.moveColumnLeftButtonTooltip', {
         defaultMessage: 'Move column to the left',
       }),
+      iconType: 'sortLeft',
     },
     // Move Right Button
     {
-      active: colRightIdx >= 0 && typeof onMoveColumn === 'function',
+      active: (colRightIdx >= 0 && typeof onMoveColumn === 'function') || true,
       ariaLabel: i18n.translate('discover.docTable.tableHeader.moveColumnRightButtonAriaLabel', {
         defaultMessage: 'Move {columnName} column to the right',
         values: { columnName: name },
@@ -157,8 +162,11 @@ export function TableHeaderColumn({
       tooltip: i18n.translate('discover.docTable.tableHeader.moveColumnRightButtonTooltip', {
         defaultMessage: 'Move column to the right',
       }),
+      iconType: 'sortRight',
     },
   ];
+
+  console.log('column head buttons', buttons);
 
   return (
     <th data-test-subj="docTableHeaderField">
@@ -172,7 +180,8 @@ export function TableHeaderColumn({
               content={button.tooltip}
               key={`button-${idx}`}
             >
-              <button
+              <EuiIcon
+                type={`${button.iconType}`}
                 aria-label={button.ariaLabel}
                 className={button.className}
                 data-test-subj={button.testSubject}

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
@@ -13,7 +13,7 @@ import './_table_header.scss';
 
 import React from 'react';
 import { i18n } from '@osd/i18n';
-import { EuiFieldText, EuiIcon, EuiToolTip } from '@elastic/eui';
+import { EuiButtonIcon, EuiFieldText, EuiIcon, EuiToolTip } from '@elastic/eui';
 import { SortOrder } from '../../view_components/utils/get_default_sort';
 
 interface Props {
@@ -136,7 +136,7 @@ export function TableHeaderColumn({
     },
     // Move Left Button
     {
-      active: (colLeftIdx >= 0 && typeof onMoveColumn === 'function') || true,
+      active: colLeftIdx >= 0 && typeof onMoveColumn === 'function',
       ariaLabel: i18n.translate('discover.docTable.tableHeader.moveColumnLeftButtonAriaLabel', {
         defaultMessage: 'Move {columnName} column to the left',
         values: { columnName: name },
@@ -151,7 +151,7 @@ export function TableHeaderColumn({
     },
     // Move Right Button
     {
-      active: (colRightIdx >= 0 && typeof onMoveColumn === 'function') || true,
+      active: colRightIdx >= 0 && typeof onMoveColumn === 'function',
       ariaLabel: i18n.translate('discover.docTable.tableHeader.moveColumnRightButtonAriaLabel', {
         defaultMessage: 'Move {columnName} column to the right',
         values: { columnName: name },
@@ -169,7 +169,7 @@ export function TableHeaderColumn({
   console.log('column head buttons', buttons);
 
   return (
-    <th data-test-subj="docTableHeaderField">
+    <th data-test-subj="docTableHeaderField" className="docTableHeaderField">
       <span data-test-subj={`docTableHeader-${name}`}>
         {displayName}
         {buttons
@@ -177,13 +177,14 @@ export function TableHeaderColumn({
           .map((button, idx) => (
             <EuiToolTip
               id={`docTableHeader-${name}-tt`}
+              delay="long"
               content={button.tooltip}
               key={`button-${idx}`}
             >
-              <EuiIcon
-                type={`${button.iconType}`}
+              <EuiButtonIcon
+                iconType={`${button.iconType}`}
                 aria-label={button.ariaLabel}
-                className={button.className}
+                className="docTableHeaderField__actionButton"
                 data-test-subj={button.testSubject}
                 onClick={button.onClick}
               />

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
@@ -11,18 +11,19 @@
 
 import './_table_header.scss';
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { i18n } from '@osd/i18n';
 import { EuiButtonIcon, EuiFieldText, EuiIcon, EuiToolTip } from '@elastic/eui';
 import { SortOrder } from '../../view_components/utils/get_default_sort';
 
 interface Props {
+  currentIdx: number;
   colLeftIdx: number; // idx of the column to the left, -1 if moving is not possible
   colRightIdx: number; // idx of the column to the right, -1 if moving is not possible
-  displayName: string;
+  displayName: ReactNode;
   isRemoveable: boolean;
   isSortable: boolean;
-  name: string;
+  name?: string | ReactNode;
   onChangeSortOrder?: (sortOrder: SortOrder[]) => void;
   onMoveColumn?: (name: string, idx: number) => void;
   onRemoveColumn?: (name: string) => void;

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
@@ -36,6 +36,7 @@ const sortDirectionToIcon: Record<string, string> = {
 };
 
 export function TableHeaderColumn({
+  currentIdx,
   colLeftIdx,
   colRightIdx,
   displayName,
@@ -43,7 +44,7 @@ export function TableHeaderColumn({
   isSortable,
   name,
   onChangeSortOrder,
-  onMoveColumn,
+  onReorderColumn,
   onRemoveColumn,
   sortOrder,
 }: Props) {
@@ -136,13 +137,13 @@ export function TableHeaderColumn({
     },
     // Move Left Button
     {
-      active: colLeftIdx >= 0 && typeof onMoveColumn === 'function',
+      active: colLeftIdx >= 0 && typeof onReorderColumn === 'function',
       ariaLabel: i18n.translate('discover.docTable.tableHeader.moveColumnLeftButtonAriaLabel', {
         defaultMessage: 'Move {columnName} column to the left',
         values: { columnName: name },
       }),
       className: 'fa fa-angle-double-left osdDocTableHeader__move',
-      onClick: () => onMoveColumn && onMoveColumn(name, colLeftIdx),
+      onClick: () => onReorderColumn && onReorderColumn(name, currentIdx, colLeftIdx),
       testSubject: `docTableMoveLeftHeader-${name}`,
       tooltip: i18n.translate('discover.docTable.tableHeader.moveColumnLeftButtonTooltip', {
         defaultMessage: 'Move column to the left',
@@ -151,13 +152,13 @@ export function TableHeaderColumn({
     },
     // Move Right Button
     {
-      active: colRightIdx >= 0 && typeof onMoveColumn === 'function',
+      active: colRightIdx >= 0 && typeof onReorderColumn === 'function',
       ariaLabel: i18n.translate('discover.docTable.tableHeader.moveColumnRightButtonAriaLabel', {
         defaultMessage: 'Move {columnName} column to the right',
         values: { columnName: name },
       }),
       className: 'fa fa-angle-double-right osdDocTableHeader__move',
-      onClick: () => onMoveColumn && onMoveColumn(name, colRightIdx),
+      onClick: () => onReorderColumn && onReorderColumn(name, currentIdx, colRightIdx),
       testSubject: `docTableMoveRightHeader-${name}`,
       tooltip: i18n.translate('discover.docTable.tableHeader.moveColumnRightButtonTooltip', {
         defaultMessage: 'Move column to the right',

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
@@ -167,8 +167,6 @@ export function TableHeaderColumn({
     },
   ];
 
-  console.log('column head buttons', buttons);
-
   return (
     <th data-test-subj="docTableHeaderField" className="docTableHeaderField">
       <span data-test-subj={`docTableHeader-${name}`}>
@@ -178,7 +176,6 @@ export function TableHeaderColumn({
           .map((button, idx) => (
             <EuiToolTip
               id={`docTableHeader-${name}-tt`}
-              delay="long"
               content={button.tooltip}
               key={`button-${idx}`}
             >

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
@@ -1,0 +1,186 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import { EuiToolTip } from '@elastic/eui';
+import { SortOrder } from '../../view_components/utils/get_default_sort';
+
+interface Props {
+  colLeftIdx: number; // idx of the column to the left, -1 if moving is not possible
+  colRightIdx: number; // idx of the column to the right, -1 if moving is not possible
+  displayName: string;
+  isRemoveable: boolean;
+  isSortable: boolean;
+  name: string;
+  onChangeSortOrder?: (sortOrder: SortOrder[]) => void;
+  onMoveColumn?: (name: string, idx: number) => void;
+  onRemoveColumn?: (name: string) => void;
+  sortOrder: SortOrder[];
+}
+
+const sortDirectionToIcon: Record<string, string> = {
+  desc: 'fa fa-sort-down',
+  asc: 'fa fa-sort-up',
+  '': 'fa fa-sort',
+};
+
+export function TableHeaderColumn({
+  colLeftIdx,
+  colRightIdx,
+  displayName,
+  isRemoveable,
+  isSortable,
+  name,
+  onChangeSortOrder,
+  onMoveColumn,
+  onRemoveColumn,
+  sortOrder,
+}: Props) {
+  const [, sortDirection = ''] = sortOrder.find((sortPair) => name === sortPair[0]) || [];
+  const currentSortWithoutColumn = sortOrder.filter((pair) => pair[0] !== name);
+  const currentColumnSort = sortOrder.find((pair) => pair[0] === name);
+  const currentColumnSortDirection = (currentColumnSort && currentColumnSort[1]) || '';
+
+  const btnSortIcon = sortDirectionToIcon[sortDirection];
+  const btnSortClassName =
+    sortDirection !== '' ? btnSortIcon : `osdDocTableHeader__sortChange ${btnSortIcon}`;
+
+  const handleChangeSortOrder = () => {
+    if (!onChangeSortOrder) return;
+
+    // Cycle goes Unsorted -> Asc -> Desc -> Unsorted
+    if (currentColumnSort === undefined) {
+      onChangeSortOrder([...currentSortWithoutColumn, [name, 'asc']]);
+    } else if (currentColumnSortDirection === 'asc') {
+      onChangeSortOrder([...currentSortWithoutColumn, [name, 'desc']]);
+    } else if (currentColumnSortDirection === 'desc' && currentSortWithoutColumn.length === 0) {
+      // If we're at the end of the cycle and this is the only existing sort, we switch
+      // back to ascending sort instead of removing it.
+      onChangeSortOrder([[name, 'asc']]);
+    } else {
+      onChangeSortOrder(currentSortWithoutColumn);
+    }
+  };
+
+  const getSortButtonAriaLabel = () => {
+    const sortAscendingMessage = i18n.translate(
+      'discover.docTable.tableHeader.sortByColumnAscendingAriaLabel',
+      {
+        defaultMessage: 'Sort {columnName} ascending',
+        values: { columnName: name },
+      }
+    );
+    const sortDescendingMessage = i18n.translate(
+      'discover.docTable.tableHeader.sortByColumnDescendingAriaLabel',
+      {
+        defaultMessage: 'Sort {columnName} descending',
+        values: { columnName: name },
+      }
+    );
+    const stopSortingMessage = i18n.translate(
+      'discover.docTable.tableHeader.sortByColumnUnsortedAriaLabel',
+      {
+        defaultMessage: 'Stop sorting on {columnName}',
+        values: { columnName: name },
+      }
+    );
+
+    if (currentColumnSort === undefined) {
+      return sortAscendingMessage;
+    } else if (sortDirection === 'asc') {
+      return sortDescendingMessage;
+    } else if (sortDirection === 'desc' && currentSortWithoutColumn.length === 0) {
+      return sortAscendingMessage;
+    } else {
+      return stopSortingMessage;
+    }
+  };
+
+  // action buttons displayed on the right side of the column name
+  const buttons = [
+    // Sort Button
+    {
+      active: isSortable && typeof onChangeSortOrder === 'function',
+      ariaLabel: getSortButtonAriaLabel(),
+      className: btnSortClassName,
+      onClick: handleChangeSortOrder,
+      testSubject: `docTableHeaderFieldSort_${name}`,
+      tooltip: getSortButtonAriaLabel(),
+    },
+    // Remove Button
+    {
+      active: isRemoveable && typeof onRemoveColumn === 'function',
+      ariaLabel: i18n.translate('discover.docTable.tableHeader.removeColumnButtonAriaLabel', {
+        defaultMessage: 'Remove {columnName} column',
+        values: { columnName: name },
+      }),
+      className: 'fa fa-remove osdDocTableHeader__move',
+      onClick: () => onRemoveColumn && onRemoveColumn(name),
+      testSubject: `docTableRemoveHeader-${name}`,
+      tooltip: i18n.translate('discover.docTable.tableHeader.removeColumnButtonTooltip', {
+        defaultMessage: 'Remove Column',
+      }),
+    },
+    // Move Left Button
+    {
+      active: colLeftIdx >= 0 && typeof onMoveColumn === 'function',
+      ariaLabel: i18n.translate('discover.docTable.tableHeader.moveColumnLeftButtonAriaLabel', {
+        defaultMessage: 'Move {columnName} column to the left',
+        values: { columnName: name },
+      }),
+      className: 'fa fa-angle-double-left osdDocTableHeader__move',
+      onClick: () => onMoveColumn && onMoveColumn(name, colLeftIdx),
+      testSubject: `docTableMoveLeftHeader-${name}`,
+      tooltip: i18n.translate('discover.docTable.tableHeader.moveColumnLeftButtonTooltip', {
+        defaultMessage: 'Move column to the left',
+      }),
+    },
+    // Move Right Button
+    {
+      active: colRightIdx >= 0 && typeof onMoveColumn === 'function',
+      ariaLabel: i18n.translate('discover.docTable.tableHeader.moveColumnRightButtonAriaLabel', {
+        defaultMessage: 'Move {columnName} column to the right',
+        values: { columnName: name },
+      }),
+      className: 'fa fa-angle-double-right osdDocTableHeader__move',
+      onClick: () => onMoveColumn && onMoveColumn(name, colRightIdx),
+      testSubject: `docTableMoveRightHeader-${name}`,
+      tooltip: i18n.translate('discover.docTable.tableHeader.moveColumnRightButtonTooltip', {
+        defaultMessage: 'Move column to the right',
+      }),
+    },
+  ];
+
+  return (
+    <th data-test-subj="docTableHeaderField">
+      <span data-test-subj={`docTableHeader-${name}`}>
+        {displayName}
+        {buttons
+          .filter((button) => button.active)
+          .map((button, idx) => (
+            <EuiToolTip
+              id={`docTableHeader-${name}-tt`}
+              content={button.tooltip}
+              key={`button-${idx}`}
+            >
+              <button
+                aria-label={button.ariaLabel}
+                className={button.className}
+                data-test-subj={button.testSubject}
+                onClick={button.onClick}
+              />
+            </EuiToolTip>
+          ))}
+      </span>
+    </th>
+  );
+}

--- a/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
@@ -10,66 +10,84 @@
  */
 
 import React, { useState, useMemo, useCallback } from 'react';
-import { TableCell } from './table_cell';
 import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
+import { AnyAction } from '@reduxjs/toolkit';
+import { fatalErrorsServiceMock } from 'src/core/public/mocks';
+import { TableCell } from './table_cell';
+import { DocViewerLinks } from '../doc_viewer_links/doc_viewer_links';
+import { DocViewer } from '../doc_viewer/doc_viewer';
 
-export const TableRow = ({
-    row,
-    columns,
-    indexPattern
-}) => {
-    const [isExpanded, setIsExpanded] = useState(false);
-    console.log("row", row)
-    const tableRow = (
-        <tr>  
-        <td data-test-subj="docTableExpandToggleColumn" className="osdDocTableCell__toggleDetails">
-            <EuiButtonIcon
-                color="text"
-                onClick={() => setIsExpanded(!isExpanded)}
-                iconType={isExpanded?"arrowDown":"arrowRight"}
-                aria-label="Next"
-                data-test-subj="docTableExpandToggleColumn" 
-                className="osdDocTableCell__toggleDetails"
-            />
-        </td>
-            {columns.map((column) => {
-                return (
-                        <TableCell
-                            key={row._id+column.id}
-                            column={column}
-                            row={row}
-                            indexPattern={indexPattern}
-                        />
-                )
-            })}
+export const TableRow = ({ row, columns, indexPattern }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  console.log('row', row);
+  const tableRow = (
+    <tr>
+      <td data-test-subj="docTableExpandToggleColumn" className="osdDocTableCell__toggleDetails">
+        <EuiButtonIcon
+          color="text"
+          onClick={() => setIsExpanded(!isExpanded)}
+          iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
+          aria-label="Next"
+          data-test-subj="docTableExpandToggleColumn"
+          className="osdDocTableCell__toggleDetails"
+        />
+      </td>
+      {columns.map((column) => {
+        return (
+          <TableCell
+            key={row._id + column.id}
+            column={column}
+            row={row}
+            indexPattern={indexPattern}
+          />
+        );
+      })}
     </tr>
-    );
-    console.log("columns size", columns)
+  );
+  console.log('columns size', columns);
+  const columnFields: string[] = columns.map((column: any) => column.id);
 
-    const expandedTableRow = (
-        <tr>
-            <td style={{'borderTop':'none', 'background':'red'}} colSpan={columns.length + 2}>
-                <EuiFlexGroup>
-                   <EuiFlexItem>  
-                        <EuiIcon type="folderOpen"/> <span>{columns.size}</span>
-                    </EuiFlexItem>
-                    <EuiFlexItem>
-                        <h4
-                            data-test-subj="docTableRowDetailsTitle"
-                            className="euiTitle euiTitle--xsmall"
-                            i18n-id="discover.docTable.tableRow.detailHeading"
-                            i18n-default-message="Expanded document"
-                        >Expanded document</h4>
-                    </EuiFlexItem>
-                </EuiFlexGroup>
-            </td>
-        </tr>
-    );
+  const expandedTableRow = (
+    <tr>
+      <td
+        style={{ borderTop: 'none', background: 'white', padding: '5px' }}
+        colSpan={columns.length + 2}
+      >
+        <EuiFlexGroup>
+          <EuiFlexItem grow={false}>
+            <EuiIcon type="folderOpen" /> <span>{columns.size}</span>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <h4
+              data-test-subj="docTableRowDetailsTitle"
+              className="euiTitle euiTitle--xsmall"
+              i18n-id="discover.docTable.tableRow.detailHeading"
+              i18n-default-message="Expanded document"
+            >
+              Expanded document
+            </h4>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            {DocViewerLinks({ columns: columnFields, hit: row, indexPattern })}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            {DocViewer({
+              columns: columnFields,
+              hit: row,
+              indexPattern,
+            })}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </td>
+    </tr>
+  );
 
-    return (
-        <>
-        {tableRow}
-        {isExpanded&&expandedTableRow}
-        </>
-    )
-}
+  return (
+    <>
+      {tableRow}
+      {isExpanded && expandedTableRow}
+    </>
+  );
+};

--- a/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
@@ -10,14 +10,23 @@
  */
 
 import React, { useState, useMemo, useCallback } from 'react';
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiDataGridColumn, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
 import { AnyAction } from '@reduxjs/toolkit';
 import { fatalErrorsServiceMock } from 'src/core/public/mocks';
 import { TableCell } from './table_cell';
 import { DocViewerLinks } from '../doc_viewer_links/doc_viewer_links';
 import { DocViewer } from '../doc_viewer/doc_viewer';
+import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
+import { IndexPattern } from '../../../opensearch_dashboards_services';
 
-export const TableRow = ({ row, columns, indexPattern }) => {
+export interface TableRowProps {
+  row: OpenSearchSearchHit;
+  rowIndex: number;
+  columns: EuiDataGridColumn[];
+  indexPattern: IndexPattern;
+}
+
+export const TableRow = ({ row, rowIndex, columns, indexPattern }: TableRowProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   console.log('row', row);
   const tableRow = (
@@ -38,6 +47,7 @@ export const TableRow = ({ row, columns, indexPattern }) => {
             key={row._id + column.id}
             column={column}
             row={row}
+            rowIndex={rowIndex}
             indexPattern={indexPattern}
           />
         );

--- a/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
@@ -42,6 +42,7 @@ export const TableRow = ({
   onFilter,
   onClose,
 }: TableRowProps) => {
+  const flattened = indexPattern.flattenHit(row);
   const [isExpanded, setIsExpanded] = useState(false);
   const tableRow = (
     <tr>
@@ -63,12 +64,13 @@ export const TableRow = ({
             row={row}
             rowIndex={rowIndex}
             indexPattern={indexPattern}
+            flattened={flattened}
+            onFilter={onFilter}
           />
         );
       })}
     </tr>
   );
-  const columnFields: string[] = displayedTableColumns.map((column: any) => column.id);
 
   const expandedTableRow = (
     <tr>

--- a/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+import { TableCell } from './table_cell';
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
+
+export const TableRow = ({
+    row,
+    columns,
+    indexPattern
+}) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    console.log("row", row)
+    const tableRow = (
+        <tr>  
+        <td data-test-subj="docTableExpandToggleColumn" className="osdDocTableCell__toggleDetails">
+            <EuiButtonIcon
+                color="text"
+                onClick={() => setIsExpanded(!isExpanded)}
+                iconType={isExpanded?"arrowDown":"arrowRight"}
+                aria-label="Next"
+                data-test-subj="docTableExpandToggleColumn" 
+                className="osdDocTableCell__toggleDetails"
+            />
+        </td>
+            {columns.map((column) => {
+                return (
+                        <TableCell
+                            key={row._id+column.id}
+                            column={column}
+                            row={row}
+                            indexPattern={indexPattern}
+                        />
+                )
+            })}
+    </tr>
+    );
+    console.log("columns size", columns)
+
+    const expandedTableRow = (
+        <tr>
+            <td style={{'borderTop':'none', 'background':'red'}} colSpan={columns.length + 2}>
+                <EuiFlexGroup>
+                   <EuiFlexItem>  
+                        <EuiIcon type="folderOpen"/> <span>{columns.size}</span>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                        <h4
+                            data-test-subj="docTableRowDetailsTitle"
+                            className="euiTitle euiTitle--xsmall"
+                            i18n-id="discover.docTable.tableRow.detailHeading"
+                            i18n-default-message="Expanded document"
+                        >Expanded document</h4>
+                    </EuiFlexItem>
+                </EuiFlexGroup>
+            </td>
+        </tr>
+    );
+
+    return (
+        <>
+        {tableRow}
+        {isExpanded&&expandedTableRow}
+        </>
+    )
+}

--- a/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
@@ -99,7 +99,7 @@ export const TableRow = ({
       >
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <EuiIcon type="folderOpen" /> <span>{columnIds.length}</span>
+            <EuiIcon type="folderOpen" />
           </EuiFlexItem>
           <EuiFlexItem>
             <h4

--- a/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
@@ -11,6 +11,7 @@
 
 import React, { useState } from 'react';
 import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
+import dompurify from 'dompurify';
 import { TableCell } from './table_cell';
 import { DocViewerLinks } from '../doc_viewer_links/doc_viewer_links';
 import { DocViewer } from '../doc_viewer/doc_viewer';
@@ -77,14 +78,39 @@ export const TableRow = ({
         }
 
         const formattedValue = indexPattern.formatField(row, columnId);
+
+        if (typeof formattedValue === 'undefined') {
+          return (
+            <td
+              data-test-subj="docTableField"
+              className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
+            >
+              <span>-</span>
+            </td>
+          );
+        }
+
+        const sanitizedCellValue = dompurify.sanitize(formattedValue);
+
+        if (!fieldInfo?.filterable) {
+          return (
+            // eslint-disable-next-line react/no-danger
+            <td
+              data-test-subj="docTableField"
+              className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
+            >
+              <span dangerouslySetInnerHTML={{ __html: sanitizedCellValue }} />
+            </td>
+          );
+        }
+
         return (
           <TableCell
             key={row._id + columnId}
             columnId={columnId}
             onFilter={onFilter}
-            filterable={fieldInfo?.filterable}
             fieldMapping={fieldMapping}
-            formattedValue={formattedValue}
+            sanitizedCellValue={sanitizedCellValue}
           />
         );
       })}

--- a/src/plugins/discover/public/application/components/doc_views/context_app.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/context_app.tsx
@@ -101,6 +101,7 @@ export function ContextApp({
           onAddColumn={() => {}}
           onFilter={onAddFilter}
           onRemoveColumn={() => {}}
+          onReorderColumn={() => {}}
           onSetColumns={() => {}}
           onSort={() => {}}
           sort={sort}

--- a/src/plugins/discover/public/application/components/table/table.tsx
+++ b/src/plugins/discover/public/application/components/table/table.tsx
@@ -69,8 +69,6 @@ export function DocViewTable({
             const toggleColumn =
               onRemoveColumn && onAddColumn && Array.isArray(columns)
                 ? () => {
-                    console.log('columns', columns);
-                    console.log('field', field);
                     if (columns.includes(field)) {
                       onRemoveColumn(field);
                     } else {

--- a/src/plugins/discover/public/application/components/table/table.tsx
+++ b/src/plugins/discover/public/application/components/table/table.tsx
@@ -69,6 +69,8 @@ export function DocViewTable({
             const toggleColumn =
               onRemoveColumn && onAddColumn && Array.isArray(columns)
                 ? () => {
+                    console.log('columns', columns);
+                    console.log('field', field);
                     if (columns.includes(field)) {
                       onRemoveColumn(field);
                     } else {

--- a/src/plugins/discover/public/application/components/top_nav/show_table_feedbacks_panel.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/show_table_feedbacks_panel.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { I18nStart } from '../../../../../../core/public';
+import { OpenSearchDashboardsContextProvider } from '../../../../../opensearch_dashboards_react/public';
+import { DiscoverViewServices } from '../../../build_services';
+import { setDataGridTableSetting } from '../utils/local_storage';
+import { TableFeedbacksPanel } from './table_feedbacks_panel';
+let isFeedbackPanelOpen = false;
+
+export function showTableFeedbacksPanel({
+  I18nContext,
+  services,
+}: {
+  I18nContext: I18nStart['Context'];
+  services: DiscoverViewServices;
+}) {
+  if (isFeedbackPanelOpen) {
+    return;
+  }
+
+  isFeedbackPanelOpen = true;
+  const container = document.createElement('div');
+  const onClose = () => {
+    ReactDOM.unmountComponentAtNode(container);
+    document.body.removeChild(container);
+    isFeedbackPanelOpen = false;
+  };
+
+  const onTurnOff = async () => {
+    // Save the new setting to localStorage
+    setDataGridTableSetting(false, services.storage);
+    onClose();
+    window.location.reload();
+  };
+
+  document.body.appendChild(container);
+  const element = (
+    <OpenSearchDashboardsContextProvider services={services}>
+      <I18nContext>
+        <TableFeedbacksPanel onClose={onClose} onTurnOff={onTurnOff} />
+      </I18nContext>
+    </OpenSearchDashboardsContextProvider>
+  );
+  ReactDOM.render(element, container);
+}

--- a/src/plugins/discover/public/application/components/top_nav/table_feedbacks_panel.test.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/table_feedbacks_panel.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { TableFeedbacksPanel } from './table_feedbacks_panel';
+
+describe('TableFeedbacksPanel', () => {
+  let onCloseMock: jest.Mock;
+  let onTurnOffMock: jest.Mock;
+  let wrapper: ShallowWrapper;
+
+  beforeEach(() => {
+    onCloseMock = jest.fn();
+    onTurnOffMock = jest.fn();
+    wrapper = shallow(<TableFeedbacksPanel onClose={onCloseMock} onTurnOff={onTurnOffMock} />);
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('calls onClose when the Cancel button is clicked', () => {
+    wrapper.find('EuiButtonEmpty').simulate('click');
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it('calls onTurnOff when the Turn off new features button is clicked', () => {
+    wrapper.find('EuiButton').simulate('click');
+    expect(onTurnOffMock).toHaveBeenCalled();
+  });
+});

--- a/src/plugins/discover/public/application/components/top_nav/table_feedbacks_panel.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/table_feedbacks_panel.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiButton,
+  EuiText,
+  EuiButtonEmpty,
+} from '@elastic/eui';
+
+interface TableFeedbacksPanelProps {
+  onClose: () => void;
+  onTurnOff: () => Promise<void>;
+}
+
+export const TableFeedbacksPanel = ({ onClose, onTurnOff }: TableFeedbacksPanelProps) => (
+  <EuiModal onClose={onClose} maxWidth={600}>
+    <EuiModalHeader>
+      <EuiModalHeaderTitle>
+        <h4>Share your thoughts on the latest Discover features</h4>
+      </EuiModalHeaderTitle>
+    </EuiModalHeader>
+
+    <EuiModalBody>
+      <EuiText>
+        <p>
+          Event tables: Documents are now expanded through a flyout. Density, column order, and
+          sorting controls have been improved.{' '}
+          <a href="https://survey.opensearch.org">Provide feedbacks</a>.
+        </p>
+      </EuiText>
+    </EuiModalBody>
+
+    <EuiModalFooter>
+      <EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
+      <EuiButton onClick={onTurnOff} fill>
+        Turn off new features
+      </EuiButton>
+    </EuiModalFooter>
+  </EuiModal>
+);

--- a/src/plugins/discover/public/application/components/utils/local_storage.ts
+++ b/src/plugins/discover/public/application/components/utils/local_storage.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Storage } from '../../../../../opensearch_dashboards_utils/public';
+
+export const DATA_GRID_TABLE_KEY = 'discover:dataGridTable';
+
+export const getDataGridTableSetting = (storage: Storage): boolean => {
+  const storedValue = storage.get(DATA_GRID_TABLE_KEY);
+  return storedValue !== null ? JSON.parse(storedValue) : false;
+};
+
+export const setDataGridTableSetting = (value: boolean, storage: Storage) => {
+  storage.set(DATA_GRID_TABLE_KEY, JSON.stringify(value));
+};

--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import { DiscoverViewServices } from '../../../build_services';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { DataGridTable } from '../../components/data_grid/data_grid_table';
@@ -37,6 +37,7 @@ export const DiscoverTable = ({ rows }: Props) => {
     },
     capabilities,
     indexPatterns,
+    storage,
   } = services;
 
   const { refetch$, indexPattern, savedSearch } = useDiscoverContext();
@@ -66,7 +67,7 @@ export const DiscoverTable = ({ rows }: Props) => {
 
   const onSetColumns = (cols: string[]) => dispatch(setColumns({ columns: cols }));
   const onSetSort = (s: SortOrder[]) => {
-    console.log("sorting now!")
+    console.log('sorting now!');
     dispatch(setSort(s));
     refetch$.next();
   };
@@ -115,6 +116,7 @@ export const DiscoverTable = ({ rows }: Props) => {
       displayTimeColumn={displayTimeColumn}
       title={savedSearch?.id ? savedSearch.title : ''}
       description={savedSearch?.id ? savedSearch.description : ''}
+      storage={storage}
     />
   );
 };

--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -11,6 +11,7 @@ import { useDiscoverContext } from '../context';
 import {
   addColumn,
   removeColumn,
+  reorderColumn,
   setColumns,
   setSort,
   useDispatch,
@@ -55,6 +56,14 @@ export const DiscoverTable = ({ rows }: Props) => {
 
     dispatch(removeColumn(col));
   };
+
+  const onReorderColumn = (col: string, source: number, destination: number) => {
+    if (indexPattern && capabilities.discover?.save) {
+      popularizeField(indexPattern, col, indexPatterns);
+    }
+    dispatch(reorderColumn({ source: source - 1, destination: destination - 1 }));
+  };
+
   const onSetColumns = (cols: string[]) => dispatch(setColumns({ columns: cols }));
   const onSetSort = (s: SortOrder[]) => {
     dispatch(setSort(s));
@@ -97,6 +106,7 @@ export const DiscoverTable = ({ rows }: Props) => {
       onAddColumn={onAddColumn}
       onFilter={onAddFilter as DocViewFilterFn}
       onRemoveColumn={onRemoveColumn}
+      onReorderColumn={onReorderColumn}
       onSetColumns={onSetColumns}
       onSort={onSetSort}
       sort={sort}

--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -66,6 +66,7 @@ export const DiscoverTable = ({ rows }: Props) => {
 
   const onSetColumns = (cols: string[]) => dispatch(setColumns({ columns: cols }));
   const onSetSort = (s: SortOrder[]) => {
+    console.log("sorting now!")
     dispatch(setSort(s));
     refetch$.next();
   };

--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -67,7 +67,6 @@ export const DiscoverTable = ({ rows }: Props) => {
 
   const onSetColumns = (cols: string[]) => dispatch(setColumns({ columns: cols }));
   const onSetSort = (s: SortOrder[]) => {
-    console.log('sorting now!');
     dispatch(setSort(s));
     refetch$.next();
   };

--- a/src/plugins/discover/public/build_services.ts
+++ b/src/plugins/discover/public/build_services.ts
@@ -58,6 +58,7 @@ import { OpenSearchDashboardsLegacyStart } from '../../opensearch_dashboards_leg
 import { UrlForwardingStart } from '../../url_forwarding/public';
 import { NavigationPublicPluginStart } from '../../navigation/public';
 import { DataExplorerServices } from '../../data_explorer/public';
+import { Storage } from '../../opensearch_dashboards_utils/public';
 
 export interface DiscoverServices {
   addBasePath: (path: string) => string;
@@ -82,6 +83,7 @@ export interface DiscoverServices {
   getSavedSearchUrlById: (id: string) => Promise<string>;
   uiSettings: IUiSettingsClient;
   visualizations: VisualizationsStart;
+  storage: Storage;
 }
 
 export function buildServices(
@@ -97,6 +99,7 @@ export function buildServices(
     overlays: core.overlays,
   };
   const savedObjectService = createSavedSearchesLoader(services);
+  const storage = new Storage(localStorage);
 
   return {
     addBasePath: core.http.basePath.prepend,
@@ -123,6 +126,7 @@ export function buildServices(
     toastNotifications: core.notifications.toasts,
     uiSettings: core.uiSettings,
     visualizations: plugins.visualizations,
+    storage,
   };
 }
 

--- a/src/plugins/discover/public/embeddable/search_embeddable.tsx
+++ b/src/plugins/discover/public/embeddable/search_embeddable.tsx
@@ -80,6 +80,7 @@ export interface SearchProps {
   onRemoveColumn?: (column: string) => void;
   onAddColumn?: (column: string) => void;
   onMoveColumn?: (column: string, index: number) => void;
+  onReorderColumn?: (col: string, source: number, destination: number) => void;
   onFilter?: (field: IFieldType, value: string[], operator: string) => void;
   rows?: any[];
   indexPattern?: IndexPattern;

--- a/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
+++ b/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
@@ -34,6 +34,7 @@ export function SearchEmbeddableComponent({ searchProps }: SearchEmbeddableProps
     onAddColumn: searchProps.onAddColumn,
     onFilter: searchProps.onFilter,
     onRemoveColumn: searchProps.onRemoveColumn,
+    onReorderColumn: searchProps.onReorderColumn,
     onSort: searchProps.onSort,
     rows: searchProps.rows,
     onSetColumns: searchProps.onSetColumns,

--- a/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
+++ b/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
@@ -12,6 +12,7 @@ import {
   DataGridTableProps,
 } from '../application/components/data_grid/data_grid_table';
 import { VisualizationNoResults } from '../../../visualizations/public';
+import { getServices } from '../opensearch_dashboards_services';
 import './search_embeddable.scss';
 
 interface SearchEmbeddableProps {
@@ -26,6 +27,7 @@ export const DataGridTableMemoized = React.memo((props: DataGridTableProps) => (
 ));
 
 export function SearchEmbeddableComponent({ searchProps }: SearchEmbeddableProps) {
+  const { storage } = getServices();
   const discoverEmbeddableProps = {
     columns: searchProps.columns,
     indexPattern: searchProps.indexPattern,
@@ -41,6 +43,7 @@ export function SearchEmbeddableComponent({ searchProps }: SearchEmbeddableProps
     totalHitCount: searchProps.totalHitCount,
     title: searchProps.title,
     description: searchProps.description,
+    storage,
   } as DiscoverEmbeddableProps;
 
   return (


### PR DESCRIPTION
### Description
This is the PR that reverts back to old discover table without using Angular. The table will not be using `<OuiDataGrid>` nor `<OuiBasicTable>`.

### Issues Resolved


## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
