### PR TITLE
Add datasource picker component and use it in devtools and tutorial page when multiple datasource is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Chrome] Introduce registerCollapsibleNavHeader to allow plugins to customize the rendering of nav menu header ([#5244](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5244))
 - [Custom Branding] Relative URL should be allowed for logos ([#5572](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5572))
 - [Discover] Enhanced the data source selector with added sorting functionality ([#5609](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5609))
+- [Multiple Datasource] Add datasource picker component and use it in devtools and tutorial page when multiple datasource is enabled ([#5756](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5756))
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/data_source_management/opensearch_dashboards.json
+++ b/src/plugins/data_source_management/opensearch_dashboards.json
@@ -6,5 +6,5 @@
   "requiredPlugins": ["management", "dataSource", "indexPatternManagement"],
   "optionalPlugins": [],
   "requiredBundles": ["opensearchDashboardsReact"],
-  "extraPublicDirs": ["public/components/utils"]
+  "extraPublicDirs": ["public/components/utils", "public/components/data_source_picker/data_source_picker"]
 }

--- a/src/plugins/data_source_management/public/components/data_source_picker/data_source_picker.js
+++ b/src/plugins/data_source_management/public/components/data_source_picker/data_source_picker.js
@@ -57,7 +57,7 @@ export class DataSourcePicker extends React.Component {
       });
   }
 
-  onChang(e) {
+  onChange(e) {
     if (!this._isMounted) return;
     this.setState({
       selectedOption: e,
@@ -77,8 +77,10 @@ export class DataSourcePicker extends React.Component {
         singleSelection={{ asPlainText: true }}
         options={this.state.dataSources}
         selectedOptions={this.state.selectedOption}
-        onChange={(e) => this.onChang(e)}
-        prepend="Data source"
+        onChange={(e) => this.onChange(e)}
+        prepend={i18n.translate('dataSourceComboBoxPrepend', {
+          defaultMessage: 'Data source',
+        })}
         compressed
         isDisabled={this.props.disabled}
       />

--- a/src/plugins/data_source_management/public/components/data_source_picker/data_source_picker.js
+++ b/src/plugins/data_source_management/public/components/data_source_picker/data_source_picker.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { getDataSources } from '../utils';
+import { i18n } from '@osd/i18n';
+import { EuiComboBox } from '@elastic/eui';
+
+export const LocalCluster = {
+  label: i18n.translate('dataSource.localCluster', {
+    defaultMessage: 'Local cluster',
+  }),
+  id: '',
+};
+
+export class DataSourcePicker extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      dataSources: [],
+      selectedOption: [LocalCluster],
+    };
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  async componentDidMount() {
+    this._isMounted = true;
+    getDataSources(this.props.savedObjectsClient)
+      .then((fetchedDataSources) => {
+        if (fetchedDataSources?.length) {
+          const dataSourceOptions = fetchedDataSources.map((dataSource) => ({
+            id: dataSource.id,
+            label: dataSource.title,
+          }));
+
+          dataSourceOptions.push(LocalCluster);
+
+          if (!this._isMounted) return;
+          this.setState({
+            ...this.state,
+            dataSources: dataSourceOptions,
+          });
+        }
+      })
+      .catch(() => {
+        this.props.notifications.addWarning(
+          i18n.translate('dataSource.fetchDataSourceError', {
+            defaultMessage: 'Unable to fetch existing data sources',
+          })
+        );
+      });
+  }
+
+  onChang(e) {
+    if (!this._isMounted) return;
+    this.setState({
+      selectedOption: e,
+    });
+    this.props.onSelectedDataSource(e);
+  }
+
+  render() {
+    return (
+      <EuiComboBox
+        aria-label={i18n.translate('dataSourceComboBoxAriaLabel', {
+          defaultMessage: 'Select a data source',
+        })}
+        placeholder={i18n.translate('dataSourceComboBoxPlaceholder', {
+          defaultMessage: 'Select a data source',
+        })}
+        singleSelection={{ asPlainText: true }}
+        options={this.state.dataSources}
+        selectedOptions={this.state.selectedOption}
+        onChange={(e) => this.onChang(e)}
+        prepend="Data source"
+        compressed
+        isDisabled={this.props.disabled}
+      />
+    );
+  }
+}

--- a/src/plugins/home/public/application/components/tutorial_directory.js
+++ b/src/plugins/home/public/application/components/tutorial_directory.js
@@ -35,7 +35,7 @@ import { Synopsis } from './synopsis';
 import { SampleDataSetCards } from './sample_data_set_cards';
 import { getServices } from '../opensearch_dashboards_services';
 // eslint-disable-next-line @osd/eslint/no-restricted-paths
-import { getDataSources } from '../../../../data_source_management/public/components/utils';
+import { DataSourcePicker } from '../../../../data_source_management/public/components/data_source_picker/data_source_picker';
 
 import {
   EuiPage,
@@ -48,7 +48,6 @@ import {
   EuiSpacer,
   EuiTitle,
   EuiPageBody,
-  EuiComboBox,
 } from '@elastic/eui';
 
 import { getTutorials } from '../load_tutorials';
@@ -61,9 +60,6 @@ const SAMPLE_DATA_TAB_ID = 'sampleData';
 const homeTitle = i18n.translate('home.breadcrumbs.homeTitle', { defaultMessage: 'Home' });
 const addDataTitle = i18n.translate('home.breadcrumbs.addDataTitle', {
   defaultMessage: 'Add data',
-});
-const localCluster = i18n.translate('home.dataSource.localCluster', {
-  defaultMessage: 'Local Cluster',
 });
 
 class TutorialDirectoryUi extends React.Component {
@@ -88,7 +84,6 @@ class TutorialDirectoryUi extends React.Component {
       tutorialCards: [],
       notices: getServices().tutorialService.getDirectoryNotices(),
       isDataSourceEnabled: !!getServices().dataSource,
-      selectedOption: [{ label: localCluster }],
     };
   }
 
@@ -160,31 +155,6 @@ class TutorialDirectoryUi extends React.Component {
       return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
     });
 
-    if (this.state.isDataSourceEnabled) {
-      getDataSources(getServices().savedObjectsClient)
-        .then((fetchedDataSources) => {
-          if (fetchedDataSources?.length) {
-            const dataSourceOptions = fetchedDataSources.map((dataSource) => ({
-              id: dataSource.id,
-              label: dataSource.title,
-            }));
-
-            dataSourceOptions.push({ label: localCluster });
-            this.setState({
-              // eslint-disable-line react/no-did-mount-set-state
-              dataSources: dataSourceOptions,
-            });
-          }
-        })
-        .catch(() => {
-          getServices().toastNotifications.addWarning(
-            i18n.translate('home.dataSource.fetchDataSourceError', {
-              defaultMessage: 'Unable to fetch existing data sources',
-            })
-          );
-        });
-    }
-
     this.setState({
       // eslint-disable-line react/no-did-mount-set-state
       tutorialCards: tutorialCards,
@@ -195,12 +165,6 @@ class TutorialDirectoryUi extends React.Component {
     this.setState({
       selectedTabId: id,
     });
-  };
-
-  onSelectedDataSourceChange = (e) => {
-    this.setState({ selectedOption: e });
-    const dataSourceId = e[0] ? e[0].id : undefined;
-    this.setState({ selectedDataSourceId: dataSourceId });
   };
 
   renderTabs = () => {
@@ -255,25 +219,21 @@ class TutorialDirectoryUi extends React.Component {
     );
   };
 
+  onSelectedDataSourceChange = (e) => {
+    const dataSourceId = e[0] ? e[0].id : undefined;
+    this.setState({ selectedDataSourceId: dataSourceId });
+  };
+
   renderDataSourceSelector = () => {
-    const { isDataSourceEnabled, dataSources, selectedOption } = this.state;
+    const { isDataSourceEnabled } = this.state;
 
     return isDataSourceEnabled ? (
       <div className="sampledataSourcePicker">
-        <EuiComboBox
-          aria-label={i18n.translate('sampleData.DataSourceComboBoxAriaLabel', {
-            defaultMessage: 'Select a Data Source',
-          })}
-          placeholder={i18n.translate('sampleData.DataSourceComboBoxPlaceholder', {
-            defaultMessage: 'Select a Data Source',
-          })}
-          singleSelection={{ asPlainText: true }}
-          options={dataSources}
-          selectedOptions={selectedOption}
-          onChange={this.onSelectedDataSourceChange}
-          prepend="DataSource"
-          compressed
-          isDisabled={!isDataSourceEnabled}
+        <DataSourcePicker
+          savedObjectsClient={getServices().savedObjectsClient}
+          notifications={getServices().toastNotifications}
+          onSelectedDataSource={this.onSelectedDataSourceChange}
+          disabled={!isDataSourceEnabled}
         />
       </div>
     ) : null;


### PR DESCRIPTION
### Description

This resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5717. 
The datasource picker has different behavior in devtools and tutorial page when multiple datasource is enabled, it should be one component to ensure the behavior is the same. 

This change adds datasource picker component and use it in devtools and tutorial page when multiple datasource is enabled to unify the behavior: the default option for the picker when first opening the page with the picker should be `Local cluster`. After removing the option, it should display `Select a data source`. Also, the prepend should be `Data source` instead of `DataSource`

### Issues Resolved

fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5717

## Screenshot


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/920260dd-885d-4774-83a5-2174c64e67f9



## Testing the changes
1. If data_source.enabled is false, then data source picker doesn't show up in devtools nor add sample data page. 
2. Change data_source.enabled to true will turn on multiple datasource
3. Go to devtools page, the datasource picker should appear on top right, with `Local cluster` chosen as the default option. Choose the local data source, query data should be successful, choose remote data source,  query data should be successful
4. Go to add sample data page, the datasource picker should appear, with `Local cluster` chosen as the default option. Choose the local data source, add sample data should be successful, choose remote data source,  add sample data should be successful

### Check List

- [ ] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
