### PR TITLE
Add pagination to discover embeddable

### DIFF
--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -41,6 +41,7 @@ export interface DataGridTableProps {
   isContextView?: boolean;
   isLoading?: boolean;
   storage: Storage;
+  showPagination?: boolean;
 }
 
 export const DataGridTable = ({
@@ -61,6 +62,7 @@ export const DataGridTable = ({
   isContextView = false,
   isLoading = false,
   storage,
+  showPagination,
 }: DataGridTableProps) => {
   const { services } = useOpenSearchDashboards<DiscoverServices>();
 
@@ -161,6 +163,7 @@ export const DataGridTable = ({
         onFilter={onFilter}
         onClose={() => setInspectedHit(undefined)}
         sampleSize={pageSizeLimit}
+        showPagination={showPagination}
       />
     ),
     [
@@ -175,6 +178,7 @@ export const DataGridTable = ({
       onAddColumn,
       onFilter,
       pageSizeLimit,
+      showPagination,
     ]
   );
 

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -12,6 +12,9 @@ import {
   EuiDataGridColumn,
   EuiDataGridSorting,
   EuiProgress,
+  EuiPagination,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { TableHeader } from './table_header';
@@ -35,6 +38,7 @@ export interface DefaultDiscoverTableProps {
   onFilter: DocViewFilterFn;
   onClose: () => void;
   sampleSize: number;
+  showPagination?: boolean;
 }
 
 export const LegacyDiscoverTable = ({
@@ -50,8 +54,17 @@ export const LegacyDiscoverTable = ({
   onFilter,
   onClose,
   sampleSize,
+  showPagination,
 }: DefaultDiscoverTableProps) => {
+  const pageSize = 50;
   const [renderedRowCount, setRenderedRowCount] = useState(50); // Start with 50 rows
+  const [displayedRows, setDisplayedRows] = useState(
+    showPagination ? rows.slice(0, pageSize) : rows.slice(0, renderedRowCount)
+  );
+  const [currentRowCounts, setCurrentRowCounts] = useState({
+    startRow: 0,
+    endRow: pageSize,
+  });
   const observerRef = useRef<IntersectionObserver | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
@@ -81,9 +94,48 @@ export const LegacyDiscoverTable = ({
     };
   }, []);
 
+  const [activePage, setActivePage] = useState(0);
+  const PAGE_COUNT = Math.ceil(rows.length / pageSize);
+
+  const goToPage = (pageNumber: number) => {
+    const startRow = pageNumber * pageSize;
+    const endRow =
+      rows.length < pageNumber * pageSize + pageSize
+        ? rows.length
+        : pageNumber * pageSize + pageSize;
+    setCurrentRowCounts({
+      startRow,
+      endRow,
+    });
+    setDisplayedRows(rows.slice(startRow, endRow));
+    setActivePage(pageNumber);
+  };
+
   return (
     indexPattern && (
       <>
+        {showPagination ? (
+          <EuiFlexGroup>
+            <EuiFlexItem grow={false}>
+              <EuiPagination
+                pageCount={PAGE_COUNT}
+                activePage={activePage}
+                onPageClick={(currentPage) => goToPage(currentPage)}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <FormattedMessage
+                id="discover.docTable.pagerControl.pagesCountLabel"
+                defaultMessage="{startItem}&ndash;{endItem} of {totalItems}"
+                values={{
+                  startItem: currentRowCounts.startRow,
+                  endItem: currentRowCounts.endRow,
+                  totalItems: rows.length,
+                }}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ) : null}
         <table data-test-subj="docTable" className="osd-table table">
           <thead>
             <TableHeader
@@ -99,7 +151,7 @@ export const LegacyDiscoverTable = ({
             />
           </thead>
           <tbody>
-            {rows.slice(0, renderedRowCount).map((row: OpenSearchSearchHit, index: number) => {
+            {displayedRows.map((row: OpenSearchSearchHit, index: number) => {
               return (
                 <TableRow
                   key={index}

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -173,7 +173,7 @@ export const LegacyDiscoverTable = ({
             <EuiProgress size="xs" color="accent" />
           </div>
         )}
-        {rows.length === sampleSize && (
+        {!showPagination && rows.length === sampleSize && (
           <EuiCallOut className="dscTable__footer" data-test-subj="discoverDocTableFooter">
             <FormattedMessage
               id="discover.howToSeeOtherMatchingDocumentsDescription"

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -58,9 +58,7 @@ export const LegacyDiscoverTable = ({
 }: DefaultDiscoverTableProps) => {
   const pageSize = 50;
   const [renderedRowCount, setRenderedRowCount] = useState(50); // Start with 50 rows
-  const [displayedRows, setDisplayedRows] = useState(
-    showPagination ? rows.slice(0, pageSize) : rows.slice(0, renderedRowCount)
-  );
+  const [displayedRows, setDisplayedRows] = useState(rows.slice(0, pageSize));
   const [currentRowCounts, setCurrentRowCounts] = useState({
     startRow: 0,
     endRow: pageSize,
@@ -151,24 +149,26 @@ export const LegacyDiscoverTable = ({
             />
           </thead>
           <tbody>
-            {displayedRows.map((row: OpenSearchSearchHit, index: number) => {
-              return (
-                <TableRow
-                  key={index}
-                  row={row}
-                  columnIds={displayedTableColumns.map((column) => column.id)}
-                  columns={columns}
-                  indexPattern={indexPattern}
-                  onRemoveColumn={onRemoveColumn}
-                  onAddColumn={onAddColumn}
-                  onFilter={onFilter}
-                  onClose={onClose}
-                />
-              );
-            })}
+            {(showPagination ? displayedRows : rows.slice(0, renderedRowCount)).map(
+              (row: OpenSearchSearchHit, index: number) => {
+                return (
+                  <TableRow
+                    key={index}
+                    row={row}
+                    columnIds={displayedTableColumns.map((column) => column.id)}
+                    columns={columns}
+                    indexPattern={indexPattern}
+                    onRemoveColumn={onRemoveColumn}
+                    onAddColumn={onAddColumn}
+                    onFilter={onFilter}
+                    onClose={onClose}
+                  />
+                );
+              }
+            )}
           </tbody>
         </table>
-        {renderedRowCount < rows.length && (
+        {!showPagination && renderedRowCount < rows.length && (
           <div ref={sentinelRef}>
             <EuiProgress size="xs" color="accent" />
           </div>

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -93,7 +93,7 @@ export const LegacyDiscoverTable = ({
   }, []);
 
   const [activePage, setActivePage] = useState(0);
-  const PAGE_COUNT = Math.ceil(rows.length / pageSize);
+  const pageCount = Math.ceil(rows.length / pageSize);
 
   const goToPage = (pageNumber: number) => {
     const startRow = pageNumber * pageSize;
@@ -116,7 +116,7 @@ export const LegacyDiscoverTable = ({
           <EuiFlexGroup>
             <EuiFlexItem grow={false}>
               <EuiPagination
-                pageCount={PAGE_COUNT}
+                pageCount={pageCount}
                 activePage={activePage}
                 onPageClick={(currentPage) => goToPage(currentPage)}
               />

--- a/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
+++ b/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
@@ -20,6 +20,7 @@ interface SearchEmbeddableProps {
 }
 export interface DiscoverEmbeddableProps extends DataGridTableProps {
   totalHitCount: number;
+  showPagination: boolean;
 }
 
 export const DataGridTableMemoized = React.memo((props: DataGridTableProps) => (
@@ -45,6 +46,7 @@ export function SearchEmbeddableComponent({ searchProps }: SearchEmbeddableProps
     title: searchProps.title,
     description: searchProps.description,
     storage,
+    showPagination: true,
   } as DiscoverEmbeddableProps;
 
   return (

--- a/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
+++ b/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
@@ -20,7 +20,6 @@ interface SearchEmbeddableProps {
 }
 export interface DiscoverEmbeddableProps extends DataGridTableProps {
   totalHitCount: number;
-  showPagination: boolean;
 }
 
 export const DataGridTableMemoized = React.memo((props: DataGridTableProps) => (


### PR DESCRIPTION
### Description
Add pagination to discover embeddable that is shown on the dashboard.

According to 2.9 legacy discover:
- always have pagination on discover embeddable on dashboard; default row number is 50 rows per table
- no pagination on discover table on the discover page, it is always infinite scrolling

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/9bd88ddb-4563-4fdc-afb1-d695d73d54fd



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
