### PR TITLE
Change sort icon according to current sort conditions

### DIFF
--- a/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
@@ -34,9 +34,9 @@ interface Props {
 }
 
 const sortDirectionToIcon: Record<string, string> = {
-  desc: 'fa fa-sort-down',
-  asc: 'fa fa-sort-up',
-  '': 'fa fa-sort',
+  desc: 'sortDown',
+  asc: 'sortUp',
+  '': 'sortable',
 };
 
 export function TableHeaderColumn({
@@ -143,7 +143,7 @@ export function TableHeaderColumn({
       onClick: handleChangeSortOrder,
       testSubject: `docTableHeaderFieldSort_${name}`,
       tooltip: getSortButtonAriaLabel(),
-      iconType: 'sortable',
+      iconType: btnSortIcon,
     },
     // Remove Button
     {


### PR DESCRIPTION
### Description

Change sort icon according to current sort condition. 

up arrow when it is sorted ascending;
down arrow when it is sorted descending;
up and down arrow when it is not sorted.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/d13eff16-2ada-45c6-925e-a04e88b0da66




## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
