### PR TITLE
Routing for surrounding doc link should work without a question mark appending to the end

### DIFF
--- a/src/plugins/discover/public/migrate_state.ts
+++ b/src/plugins/discover/public/migrate_state.ts
@@ -66,7 +66,7 @@ export function migrateUrlState(oldPath: string, newPath = '/'): string {
   let path = newPath;
   const pathPatterns = [
     {
-      pattern: '#/context/:indexPattern/:id?:appState?',
+      pattern: '#/context/:indexPattern/:id',
       extraState: { docView: 'context' },
       path: `context`,
     },

--- a/src/plugins/discover/public/migrate_state.ts
+++ b/src/plugins/discover/public/migrate_state.ts
@@ -71,7 +71,7 @@ export function migrateUrlState(oldPath: string, newPath = '/'): string {
       path: `context`,
     },
     {
-      pattern: '#/doc/:indexPattern/:index\\?:appState?',
+      pattern: '#/doc/:indexPattern/:id',
       extraState: { docView: 'doc' },
       path: `doc`,
     },
@@ -99,6 +99,7 @@ export function migrateUrlState(oldPath: string, newPath = '/'): string {
     case `doc`:
     case `context`:
       path = oldPath;
+      break;
     case `discover`:
     case `savedSearch`:
       const params = matchPath<DiscoverParams>(oldPath, {

--- a/src/plugins/discover/public/migrate_state.ts
+++ b/src/plugins/discover/public/migrate_state.ts
@@ -66,7 +66,7 @@ export function migrateUrlState(oldPath: string, newPath = '/'): string {
   let path = newPath;
   const pathPatterns = [
     {
-      pattern: '#/context/:indexPattern/:id\\?:appState?',
+      pattern: '#/context/:indexPattern/:id?:appState?',
       extraState: { docView: 'context' },
       path: `context`,
     },


### PR DESCRIPTION
### Description
URLs such as /app/discover#/context/<document-id>/<index-id> which is a valid URL for the context page should work.

Previously the link will only work if there is a question mark append to it.

### Issues Resolved

closes #5774 

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/b0a4ba77-9d9d-4764-b4a2-1e4bf9a3de7e



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
