### PR TITLE
Vertically align the text in QueryStringInputUI with other elements on the page

### DIFF
--- a/src/plugins/data/public/ui/query_string_input/_query_bar.scss
+++ b/src/plugins/data/public/ui/query_string_input/_query_bar.scss
@@ -33,9 +33,8 @@
 
   // Unlike most inputs within layout control groups, the text area still needs a border.
   // These adjusts help it sit above the control groups shadow to line up correctly.
-  padding: $euiSizeS;
-  padding-top: $euiSizeS + 3px;
-  transform: translateY(-1px) translateX(-1px);
+  padding: ($euiSizeS + 2px) $euiSizeS $euiSizeS;
+  transform: translateY(-2px) translateX(-1px);
 
   &:not(:focus):not(:invalid) {
     @include euiYScrollWithShadows;


### PR DESCRIPTION
Before:
![Screen Shot 2024-02-01 at 19 32 53](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/3527403/968a3471-3b70-4024-aa0e-680c0b8474dc)

After:
![Screen Shot 2024-02-01 at 19 30 41](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/3527403/015c05bc-6832-4673-92c3-1e9fab9a842a)



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
