### PR TITLE
[Discover] Fix overflow of the expanded document

### DIFF
--- a/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
+++ b/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
@@ -2,6 +2,11 @@
   border-top: none !important;
 }
 
+// stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
+.euiFlexItem.osdDocTable__detailsIconContainer {
+  margin-right: 0;
+}
+
 .osd-table td.osdDocTableCell__toggleDetails {
   padding: 5px 0 0 4px;
 }

--- a/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
+++ b/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
@@ -2,8 +2,8 @@
   border-top: none !important;
 }
 
-.osdDocTableCell__toggleDetails {
-  padding: 7px 0 0 4px;
+.osd-table td.osdDocTableCell__toggleDetails {
+  padding: 5px 0 0 4px;
 }
 
 /**

--- a/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
@@ -132,8 +132,8 @@ export const TableRow = ({
   const expandedTableRow = (
     <tr key={'x' + row._id}>
       <td className="osdDocTable__detailsParent" colSpan={columnIds.length + 1}>
-        <EuiFlexGroup>
-          <EuiFlexItem grow={false}>
+        <EuiFlexGroup gutterSize="m" alignItems="center">
+          <EuiFlexItem grow={false} className="osdDocTable__detailsIconContainer">
             <EuiIcon type="folderOpen" />
           </EuiFlexItem>
           <EuiFlexItem>
@@ -150,7 +150,7 @@ export const TableRow = ({
             <DocViewerLinks hit={row} indexPattern={indexPattern} columns={columns} />
           </EuiFlexItem>
         </EuiFlexGroup>
-        <EuiFlexGroup>
+        <EuiFlexGroup gutterSize="m">
           <EuiFlexItem>
             <DocViewer
               hit={row}

--- a/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_rows.tsx
@@ -131,7 +131,7 @@ export const TableRow = ({
 
   const expandedTableRow = (
     <tr key={'x' + row._id}>
-      <td className="osdDocTable__detailsParent" colSpan={columnIds.length + 2}>
+      <td className="osdDocTable__detailsParent" colSpan={columnIds.length + 1}>
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
             <EuiIcon type="folderOpen" />


### PR DESCRIPTION
[Discover] Fix overflow of the expanded document

Also
* Fix vertical alignment of expand details button
* Fix colspan of details cells due to bad cherry-pick

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
