### PR TITLE
[MD] Support local cluster by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG] Remove duplicate sample data as id 90943e30-9a47-11e8-b64d-95841ca0b247 ([5668](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5668))
 - [BUG][Multiple Datasource] Fix datasource testing connection unexpectedly passed with wrong endpoint [#5663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5663)
 - [BUG][Multiple Datasource] Datasource id is required if multiple datasource is enabled and no default cluster supported [#5751](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5751)
-- [BUG][Multiple Datasource] Dy default turn on default cluster [#5811](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5811)
 
 ### 🚞 Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG] Remove duplicate sample data as id 90943e30-9a47-11e8-b64d-95841ca0b247 ([5668](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5668))
 - [BUG][Multiple Datasource] Fix datasource testing connection unexpectedly passed with wrong endpoint [#5663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5663)
 - [BUG][Multiple Datasource] Datasource id is required if multiple datasource is enabled and no default cluster supported [#5751](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5751)
+- [BUG][Multiple Datasource] Dy default turn on default cluster [#5811](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5811)
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/data_source/config.ts
+++ b/src/plugins/data_source/config.ts
@@ -13,7 +13,7 @@ const WRAPPING_KEY_SIZE: number = 32;
 
 export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: false }),
-  defaultCluster: schema.boolean({ defaultValue: false }),
+  defaultCluster: schema.boolean({ defaultValue: true }),
   encryption: schema.object({
     wrappingKeyName: schema.string({
       minLength: KEY_NAME_MIN_LENGTH,


### PR DESCRIPTION
### Description

When MD enabled, local cluster should be enabled by default

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5754

## Screenshot
![Screenshot 2024-02-05 at 6 34 05 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/139305463/8438bb98-4ef7-4dbe-b671-159f60e2c6f6)

## Testing the changes
Tested when 
1. data_source.enabled = true
2. data_source.defaultCluster get comment out

We still able to add sample data successfully in local cluster

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
