### PR TITLE
[Manual Backport 2.x ]Update import api to have data source id to allow import saved objects from uploading files to have data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [CVE-2023-45133] Bump all babel dependencies from `7.16.x` to `7.22.9` to fix upstream vulnerability ([#5428](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5428))
 - [CVE-2023-45857] Bump `axios` from `0.27.2` to `1.6.1` ([#5470](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5470))
 - [CVE-2023-26159] Bump `follow-redirects` from `1.15.2` to `1.15.4` ([#5669](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5669))
+- [CVE-2023-52079] Bump `msgpackr` from `1.9.7` to `1.10.1` ([#5803](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5803))
 - [CVE-2020-8203] Bump `cheerio` from `0.22.0` to `1.0.0-rc.1` to fix vulnerable `lodash` dependency ([#5797](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5797))
 
 ### 📈 Features/Enhancements
@@ -34,6 +35,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Custom Branding] Relative URL should be allowed for logos ([#5572](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5572))
 - [Discover] Enhanced the data source selector with added sorting functionality ([#5609](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5609))
 - [Multiple Datasource] Add datasource picker component and use it in devtools and tutorial page when multiple datasource is enabled ([#5756](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5756))
+- [Multiple Datasource] Add datasource picker to import saved object flyout when multiple data source is enabled ([#5781](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5781))
 
 ### 🐛 Bug Fixes
 
@@ -54,6 +56,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Discover] Fix missing index pattern field from breaking Discover [#5626](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5626)
 - [BUG] Remove duplicate sample data as id 90943e30-9a47-11e8-b64d-95841ca0b247 ([5668](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5668))
 - [BUG][Multiple Datasource] Fix datasource testing connection unexpectedly passed with wrong endpoint [#5663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5663)
+- [BUG][Multiple Datasource] Datasource id is required if multiple datasource is enabled and no default cluster supported [#5751](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5751)
 
 ### 🚞 Infrastructure
 
@@ -343,6 +346,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Dashboard De-Angular] Add more unit tests for utils folder ([#4641](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4641))
 - [Dashboard De-Angular] Add unit tests for dashboard_listing and dashboard_top_nav ([#4640](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4640))
 - Optimize `augment-vis` saved obj searching by adding arg to saved obj client ([#4595](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4595))
+- Change SavedObjects' Import API to allow selecting a data source when uploading files ([#5777](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5777))
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [CVE-2023-45133] Bump all babel dependencies from `7.16.x` to `7.22.9` to fix upstream vulnerability ([#5428](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5428))
 - [CVE-2023-45857] Bump `axios` from `0.27.2` to `1.6.1` ([#5470](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5470))
 - [CVE-2023-26159] Bump `follow-redirects` from `1.15.2` to `1.15.4` ([#5669](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5669))
-- [CVE-2023-52079] Bump `msgpackr` from `1.9.7` to `1.10.1` ([#5803](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5803))
 - [CVE-2020-8203] Bump `cheerio` from `0.22.0` to `1.0.0-rc.1` to fix vulnerable `lodash` dependency ([#5797](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5797))
 
 ### 📈 Features/Enhancements
@@ -35,7 +34,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Custom Branding] Relative URL should be allowed for logos ([#5572](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5572))
 - [Discover] Enhanced the data source selector with added sorting functionality ([#5609](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5609))
 - [Multiple Datasource] Add datasource picker component and use it in devtools and tutorial page when multiple datasource is enabled ([#5756](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5756))
-- [Multiple Datasource] Add datasource picker to import saved object flyout when multiple data source is enabled ([#5781](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5781))
 
 ### 🐛 Bug Fixes
 
@@ -56,7 +54,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Discover] Fix missing index pattern field from breaking Discover [#5626](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5626)
 - [BUG] Remove duplicate sample data as id 90943e30-9a47-11e8-b64d-95841ca0b247 ([5668](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5668))
 - [BUG][Multiple Datasource] Fix datasource testing connection unexpectedly passed with wrong endpoint [#5663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5663)
-- [BUG][Multiple Datasource] Datasource id is required if multiple datasource is enabled and no default cluster supported [#5751](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5751)
 
 ### 🚞 Infrastructure
 
@@ -346,7 +343,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Dashboard De-Angular] Add more unit tests for utils folder ([#4641](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4641))
 - [Dashboard De-Angular] Add unit tests for dashboard_listing and dashboard_top_nav ([#4640](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4640))
 - Optimize `augment-vis` saved obj searching by adding arg to saved obj client ([#4595](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4595))
-- Change SavedObjects' Import API to allow selecting a data source when uploading files ([#5777](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5777))
 
 ### 🐛 Bug Fixes
 
@@ -647,6 +643,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add disablePrototypePoisoningProtection configuration to prevent JS client from erroring when cluster utilizes JS reserved words ([#2992](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2992))
 - [Multiple DataSource] Add support for SigV4 authentication ([#3058](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3058))
 - [Multiple DataSource] Refactor test connection to support SigV4 auth type ([#3456](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3456))
+- [Multiple Datasource] Add datasource picker to import saved object flyout when multiple data source is enabled ([#5781](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5781))
 
 ### 🐛 Bug Fixes
 

--- a/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
+++ b/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mockUuidv4 } from './__mocks__';
+import { SavedObjectReference, SavedObjectsImportRetry } from 'opensearch-dashboards/public';
+import { SavedObject } from '../types';
+import { SavedObjectsErrorHelpers } from '..';
+import {
+  checkConflictsForDataSource,
+  ConflictsForDataSourceParams,
+} from './check_conflict_for_data_source';
+
+type SavedObjectType = SavedObject<{ title?: string }>;
+
+/**
+ * Function to create a realistic-looking import object given a type and ID
+ */
+const createObject = (type: string, id: string): SavedObjectType => ({
+  type,
+  id,
+  attributes: { title: 'some-title' },
+  references: (Symbol() as unknown) as SavedObjectReference[],
+});
+
+const getResultMock = {
+  conflict: (type: string, id: string) => {
+    const error = SavedObjectsErrorHelpers.createConflictError(type, id).output.payload;
+    return { type, id, error };
+  },
+  unresolvableConflict: (type: string, id: string) => {
+    const conflictMock = getResultMock.conflict(type, id);
+    const metadata = { isNotOverwritable: true };
+    return { ...conflictMock, error: { ...conflictMock.error, metadata } };
+  },
+  invalidType: (type: string, id: string) => {
+    const error = SavedObjectsErrorHelpers.createUnsupportedTypeError(type).output.payload;
+    return { type, id, error };
+  },
+};
+
+/**
+ * Create a variety of different objects to exercise different import / result scenarios
+ */
+const dataSourceObj = createObject('data-source', 'data-source-id-1'); // -> data-source type, no need to add in the filteredObjects
+const dataSourceObj1 = createObject('type-1', 'ds_id-1'); // -> object with data source id
+const dataSourceObj2 = createObject('type-2', 'ds_id-2'); // -> object with data source id
+const objectsWithDataSource = [dataSourceObj, dataSourceObj1, dataSourceObj2];
+const dataSourceObj1Error = getResultMock.conflict(dataSourceObj1.type, dataSourceObj1.id);
+
+describe('#checkConflictsForDataSource', () => {
+  const setupParams = (partial: {
+    objects: SavedObjectType[];
+    ignoreRegularConflicts?: boolean;
+    retries?: SavedObjectsImportRetry[];
+    createNewCopies?: boolean;
+    dataSourceId?: string;
+  }): ConflictsForDataSourceParams => {
+    return { ...partial };
+  };
+
+  beforeEach(() => {
+    mockUuidv4.mockReset();
+    mockUuidv4.mockReturnValueOnce(`new-object-id`);
+  });
+
+  it('exits early if there are no objects to check', async () => {
+    const params = setupParams({ objects: [] });
+    const checkConflictsForDataSourceResult = await checkConflictsForDataSource(params);
+    expect(checkConflictsForDataSourceResult).toEqual({
+      filteredObjects: [],
+      errors: [],
+      importIdMap: new Map(),
+      pendingOverwrites: new Set(),
+    });
+  });
+
+  it('return obj if it is not data source obj and there is no conflict of the data source id', async () => {
+    const params = setupParams({ objects: objectsWithDataSource, dataSourceId: 'ds' });
+    const checkConflictsForDataSourceResult = await checkConflictsForDataSource(params);
+    expect(checkConflictsForDataSourceResult).toEqual({
+      filteredObjects: [dataSourceObj1, dataSourceObj2],
+      errors: [],
+      importIdMap: new Map(),
+      pendingOverwrites: new Set(),
+    });
+  });
+
+  it('can resolve the data source id conflict when the ds it not match when ignoreRegularConflicts=true', async () => {
+    const params = setupParams({
+      objects: objectsWithDataSource,
+      ignoreRegularConflicts: true,
+      dataSourceId: 'currentDsId',
+    });
+    const checkConflictsForDataSourceResult = await checkConflictsForDataSource(params);
+
+    expect(checkConflictsForDataSourceResult).toEqual(
+      expect.objectContaining({
+        filteredObjects: [
+          {
+            ...dataSourceObj1,
+            id: 'currentDsId_id-1',
+          },
+          {
+            ...dataSourceObj2,
+            id: 'currentDsId_id-2',
+          },
+        ],
+        errors: [],
+        importIdMap: new Map([
+          [
+            `${dataSourceObj1.type}:${dataSourceObj1.id}`,
+            { id: 'currentDsId_id-1', omitOriginId: true },
+          ],
+          [
+            `${dataSourceObj2.type}:${dataSourceObj2.id}`,
+            { id: 'currentDsId_id-2', omitOriginId: true },
+          ],
+        ]),
+        pendingOverwrites: new Set([
+          `${dataSourceObj1.type}:${dataSourceObj1.id}`,
+          `${dataSourceObj2.type}:${dataSourceObj2.id}`,
+        ]),
+      })
+    );
+  });
+
+  it('can push error when do not override with data source conflict', async () => {
+    const params = setupParams({
+      objects: [dataSourceObj1],
+      ignoreRegularConflicts: false,
+      dataSourceId: 'currentDs',
+    });
+    const checkConflictsForDataSourceResult = await checkConflictsForDataSource(params);
+    expect(checkConflictsForDataSourceResult).toEqual({
+      filteredObjects: [],
+      errors: [
+        {
+          ...dataSourceObj1Error,
+          title: dataSourceObj1.attributes.title,
+          meta: { title: dataSourceObj1.attributes.title },
+          error: { type: 'conflict' },
+        },
+      ],
+      importIdMap: new Map(),
+      pendingOverwrites: new Set(),
+    });
+  });
+});

--- a/src/core/server/saved_objects/import/check_conflict_for_data_source.ts
+++ b/src/core/server/saved_objects/import/check_conflict_for_data_source.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObject, SavedObjectsImportError, SavedObjectsImportRetry } from '../types';
+
+export interface ConflictsForDataSourceParams {
+  objects: Array<SavedObject<{ title?: string }>>;
+  ignoreRegularConflicts?: boolean;
+  retries?: SavedObjectsImportRetry[];
+  dataSourceId?: string;
+}
+
+interface ImportIdMapEntry {
+  id?: string;
+  omitOriginId?: boolean;
+}
+
+/**
+ * function to check the conflict when multiple data sources are enabled.
+ * the purpose of this function is to check the conflict of the imported saved objects and data source
+ * @param objects, this the array of saved objects to be verified whether contains the data source conflict
+ * @param ignoreRegularConflicts whether to override
+ * @param retries import operations list
+ * @param dataSourceId the id to identify the data source
+ * @returns {filteredObjects, errors, importIdMap, pendingOverwrites }
+ */
+export async function checkConflictsForDataSource({
+  objects,
+  ignoreRegularConflicts,
+  retries = [],
+  dataSourceId,
+}: ConflictsForDataSourceParams) {
+  const filteredObjects: Array<SavedObject<{ title?: string }>> = [];
+  const errors: SavedObjectsImportError[] = [];
+  const importIdMap = new Map<string, ImportIdMapEntry>();
+  const pendingOverwrites = new Set<string>();
+
+  // exit early if there are no objects to check
+  if (objects.length === 0) {
+    return { filteredObjects, errors, importIdMap, pendingOverwrites };
+  }
+  const retryMap = retries.reduce(
+    (acc, cur) => acc.set(`${cur.type}:${cur.id}`, cur),
+    new Map<string, SavedObjectsImportRetry>()
+  );
+  objects.forEach((object) => {
+    const {
+      type,
+      id,
+      attributes: { title },
+    } = object;
+    const { destinationId } = retryMap.get(`${type}:${id}`) || {};
+
+    if (object.type !== 'data-source') {
+      const parts = id.split('_'); // this is the array to host the split results of the id
+      const previoudDataSourceId = parts.length > 1 ? parts[0] : undefined;
+      const rawId = previoudDataSourceId ? parts[1] : parts[0];
+
+      /**
+       * for import saved object from osd exported
+       * when the imported saved objects with the different dataSourceId comparing to the current dataSourceId
+       */
+
+      if (
+        previoudDataSourceId &&
+        previoudDataSourceId !== dataSourceId &&
+        !ignoreRegularConflicts
+      ) {
+        const error = { type: 'conflict' as 'conflict', ...(destinationId && { destinationId }) };
+        errors.push({ type, id, title, meta: { title }, error });
+      } else if (previoudDataSourceId && previoudDataSourceId === dataSourceId) {
+        filteredObjects.push(object);
+      } else {
+        const omitOriginId = ignoreRegularConflicts;
+        importIdMap.set(`${type}:${id}`, { id: `${dataSourceId}_${rawId}`, omitOriginId });
+        pendingOverwrites.add(`${type}:${id}`);
+        filteredObjects.push({ ...object, id: `${dataSourceId}_${rawId}` });
+      }
+    }
+  });
+
+  return { filteredObjects, errors, importIdMap, pendingOverwrites };
+}

--- a/src/core/server/saved_objects/import/check_origin_conflicts.ts
+++ b/src/core/server/saved_objects/import/check_origin_conflicts.ts
@@ -45,6 +45,7 @@ interface CheckOriginConflictsParams {
   namespace?: string;
   ignoreRegularConflicts?: boolean;
   importIdMap: Map<string, unknown>;
+  dataSourceId?: string;
 }
 
 type CheckOriginConflictParams = Omit<CheckOriginConflictsParams, 'objects'> & {

--- a/src/core/server/saved_objects/import/collect_saved_objects.ts
+++ b/src/core/server/saved_objects/import/collect_saved_objects.ts
@@ -46,6 +46,7 @@ interface CollectSavedObjectsOptions {
   objectLimit: number;
   filter?: (obj: SavedObject) => boolean;
   supportedTypes: string[];
+  dataSourceId?: string;
 }
 
 export async function collectSavedObjects({
@@ -53,6 +54,7 @@ export async function collectSavedObjects({
   objectLimit,
   filter,
   supportedTypes,
+  dataSourceId,
 }: CollectSavedObjectsOptions) {
   const errors: SavedObjectsImportError[] = [];
   const entries: Array<{ type: string; id: string }> = [];

--- a/src/core/server/saved_objects/import/create_saved_objects.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.ts
@@ -39,6 +39,8 @@ interface CreateSavedObjectsParams<T> {
   importIdMap: Map<string, { id?: string; omitOriginId?: boolean }>;
   namespace?: string;
   overwrite?: boolean;
+  dataSourceId?: string;
+  dataSourceTitle?: string;
 }
 interface CreateSavedObjectsResult<T> {
   createdObjects: Array<CreatedObject<T>>;
@@ -56,6 +58,8 @@ export const createSavedObjects = async <T>({
   importIdMap,
   namespace,
   overwrite,
+  dataSourceId,
+  dataSourceTitle,
 }: CreateSavedObjectsParams<T>): Promise<CreateSavedObjectsResult<T>> => {
   // filter out any objects that resulted in errors
   const errorSet = accumulatedErrors.reduce(
@@ -76,7 +80,70 @@ export const createSavedObjects = async <T>({
   );
 
   // filter out the 'version' field of each object, if it exists
+
   const objectsToCreate = filteredObjects.map(({ version, ...object }) => {
+    if (dataSourceId) {
+      // @ts-expect-error
+      if (dataSourceTitle && object.attributes.title) {
+        if (
+          object.type === 'dashboard' ||
+          object.type === 'visualization' ||
+          object.type === 'search'
+        ) {
+          // @ts-expect-error
+          object.attributes.title = object.attributes.title + `_${dataSourceTitle}`;
+        }
+      }
+
+      if (object.type === 'index-pattern') {
+        object.references = [
+          {
+            id: `${dataSourceId}`,
+            type: 'data-source',
+            name: 'dataSource',
+          },
+        ];
+      }
+
+      if (object.type === 'visualization' || object.type === 'search') {
+        // @ts-expect-error
+        const searchSourceString = object.attributes?.kibanaSavedObjectMeta?.searchSourceJSON;
+        // @ts-expect-error
+        const visStateString = object.attributes?.visState;
+
+        if (searchSourceString) {
+          const searchSource = JSON.parse(searchSourceString);
+          if (searchSource.index) {
+            const searchSourceIndex = searchSource.index.includes('_')
+              ? searchSource.index.split('_')[searchSource.index.split('_').length - 1]
+              : searchSource.index;
+            searchSource.index = `${dataSourceId}_` + searchSourceIndex;
+
+            // @ts-expect-error
+            object.attributes.kibanaSavedObjectMeta.searchSourceJSON = JSON.stringify(searchSource);
+          }
+        }
+
+        if (visStateString) {
+          const visState = JSON.parse(visStateString);
+          const controlList = visState.params?.controls;
+          if (controlList) {
+            // @ts-expect-error
+            controlList.map((control) => {
+              if (control.indexPattern) {
+                const controlIndexPattern = control.indexPattern.includes('_')
+                  ? control.indexPattern.split('_')[control.indexPattern.split('_').length - 1]
+                  : control.indexPattern;
+                control.indexPattern = `${dataSourceId}_` + controlIndexPattern;
+              }
+            });
+          }
+          // @ts-expect-error
+          object.attributes.visState = JSON.stringify(visState);
+        }
+      }
+    }
+
     // use the import ID map to ensure that each reference is being created with the correct ID
     const references = object.references?.map((reference) => {
       const { type, id } = reference;
@@ -96,7 +163,6 @@ export const createSavedObjects = async <T>({
     }
     return { ...object, ...(references && { references }) };
   });
-
   const resolvableErrors = ['conflict', 'ambiguous_conflict', 'missing_references'];
   let expectedResults = objectsToCreate;
   if (!accumulatedErrors.some(({ error: { type } }) => resolvableErrors.includes(type))) {

--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -47,6 +47,7 @@ import { validateReferences } from './validate_references';
 import { checkConflicts } from './check_conflicts';
 import { checkOriginConflicts } from './check_origin_conflicts';
 import { createSavedObjects } from './create_saved_objects';
+import { checkConflictsForDataSource } from './check_conflict_for_data_source';
 
 jest.mock('./collect_saved_objects');
 jest.mock('./regenerate_ids');
@@ -54,6 +55,7 @@ jest.mock('./validate_references');
 jest.mock('./check_conflicts');
 jest.mock('./check_origin_conflicts');
 jest.mock('./create_saved_objects');
+jest.mock('./check_conflict_for_data_source');
 
 const getMockFn = <T extends (...args: any[]) => any, U>(fn: (...args: Parameters<T>) => U) =>
   fn as jest.MockedFunction<(...args: Parameters<T>) => U>;
@@ -80,6 +82,12 @@ describe('#importSavedObjectsFromStream', () => {
       importIdMap: new Map(),
       pendingOverwrites: new Set(),
     });
+    getMockFn(checkConflictsForDataSource).mockResolvedValue({
+      errors: [],
+      filteredObjects: [],
+      importIdMap: new Map(),
+      pendingOverwrites: new Set(),
+    });
     getMockFn(createSavedObjects).mockResolvedValue({ errors: [], createdObjects: [] });
   });
 
@@ -89,8 +97,12 @@ describe('#importSavedObjectsFromStream', () => {
   let savedObjectsClient: jest.Mocked<SavedObjectsClientContract>;
   let typeRegistry: jest.Mocked<ISavedObjectTypeRegistry>;
   const namespace = 'some-namespace';
+  const testDataSourceId = 'some-datasource';
 
-  const setupOptions = (createNewCopies: boolean = false): SavedObjectsImportOptions => {
+  const setupOptions = (
+    createNewCopies: boolean = false,
+    dataSourceId: string | undefined = undefined
+  ): SavedObjectsImportOptions => {
     readStream = new Readable();
     savedObjectsClient = savedObjectsClientMock.create();
     typeRegistry = typeRegistryMock.create();
@@ -109,14 +121,17 @@ describe('#importSavedObjectsFromStream', () => {
       typeRegistry,
       namespace,
       createNewCopies,
+      dataSourceId,
     };
   };
-  const createObject = (): SavedObject<{
+  const createObject = (
+    dataSourceId: string | undefined = undefined
+  ): SavedObject<{
     title: string;
   }> => {
     return {
       type: 'foo-type',
-      id: uuidv4(),
+      id: dataSourceId ? `${dataSourceId}_${uuidv4()}` : uuidv4(),
       references: [],
       attributes: { title: 'some-title' },
     };
@@ -225,6 +240,24 @@ describe('#importSavedObjectsFromStream', () => {
         expect(checkOriginConflicts).toHaveBeenCalledWith(checkOriginConflictsParams);
       });
 
+      test('checks data source conflicts', async () => {
+        const options = setupOptions(false, testDataSourceId);
+        const collectedObjects = [createObject()];
+        getMockFn(collectSavedObjects).mockResolvedValue({
+          errors: [],
+          collectedObjects,
+          importIdMap: new Map(),
+        });
+
+        await importSavedObjectsFromStream(options);
+        const checkConflictsForDataSourceParams = {
+          objects: collectedObjects,
+          ignoreRegularConflicts: overwrite,
+          dataSourceId: testDataSourceId,
+        };
+        expect(checkConflictsForDataSource).toHaveBeenCalledWith(checkConflictsForDataSourceParams);
+      });
+
       test('creates saved objects', async () => {
         const options = setupOptions();
         const collectedObjects = [createObject()];
@@ -281,16 +314,18 @@ describe('#importSavedObjectsFromStream', () => {
         });
 
         await importSavedObjectsFromStream(options);
-        expect(regenerateIds).toHaveBeenCalledWith(collectedObjects);
+        expect(regenerateIds).toHaveBeenCalledWith(collectedObjects, undefined);
       });
 
-      test('does not check conflicts or check origin conflicts', async () => {
+      test('does not check conflicts or check origin conflicts or check data source conflict', async () => {
         const options = setupOptions(true);
+
         getMockFn(validateReferences).mockResolvedValue([]);
 
         await importSavedObjectsFromStream(options);
         expect(checkConflicts).not.toHaveBeenCalled();
         expect(checkOriginConflicts).not.toHaveBeenCalled();
+        expect(checkConflictsForDataSource).not.toHaveBeenCalled();
       });
 
       test('creates saved objects', async () => {
@@ -348,10 +383,20 @@ describe('#importSavedObjectsFromStream', () => {
       const obj1 = createObject();
       const tmp = createObject();
       const obj2 = { ...tmp, destinationId: 'some-destinationId', originId: tmp.id };
-      const obj3 = { ...createObject(), destinationId: 'another-destinationId' }; // empty originId
+      const obj3 = { ...createObject(undefined), destinationId: 'another-destinationId' }; // empty originId
       const createdObjects = [obj1, obj2, obj3];
       const error1 = createError();
       const error2 = createError();
+      // add some objects with data source id
+      const dataSourceObj1 = createObject(testDataSourceId);
+      const tmp2 = createObject(testDataSourceId);
+      const dataSourceObj2 = { ...tmp2, destinationId: 'some-destinationId', originId: tmp.id };
+      const dataSourceObj3 = {
+        ...createObject(testDataSourceId),
+        destinationId: 'another-destinationId',
+      };
+      const createdDsObjects = [dataSourceObj1, dataSourceObj2, dataSourceObj3];
+
       // results
       const success1 = {
         type: obj1.type,
@@ -372,8 +417,28 @@ describe('#importSavedObjectsFromStream', () => {
       };
       const errors = [error1, error2];
 
+      const dsSuccess1 = {
+        type: dataSourceObj1.type,
+        id: dataSourceObj1.id,
+        meta: { title: dataSourceObj1.attributes.title, icon: `${dataSourceObj1.type}-icon` },
+      };
+
+      const dsSuccess2 = {
+        type: dataSourceObj2.type,
+        id: dataSourceObj2.id,
+        meta: { title: dataSourceObj2.attributes.title, icon: `${dataSourceObj2.type}-icon` },
+        destinationId: dataSourceObj2.destinationId,
+      };
+
+      const dsSuccess3 = {
+        type: dataSourceObj3.type,
+        id: dataSourceObj3.id,
+        meta: { title: dataSourceObj3.attributes.title, icon: `${dataSourceObj3.type}-icon` },
+        destinationId: dataSourceObj3.destinationId,
+      };
+
       test('with createNewCopies disabled', async () => {
-        const options = setupOptions();
+        const options = setupOptions(false, undefined);
         getMockFn(checkConflicts).mockResolvedValue({
           errors: [],
           filteredObjects: [],
@@ -410,7 +475,7 @@ describe('#importSavedObjectsFromStream', () => {
 
       test('with createNewCopies enabled', async () => {
         // however, we include it here for posterity
-        const options = setupOptions(true);
+        const options = setupOptions(true, undefined);
         getMockFn(createSavedObjects).mockResolvedValue({ errors, createdObjects });
 
         const result = await importSavedObjectsFromStream(options);
@@ -428,10 +493,73 @@ describe('#importSavedObjectsFromStream', () => {
           errors: errorResults,
         });
       });
+
+      test('with createNewCopies disabled and with data source id', async () => {
+        const options = setupOptions(false, testDataSourceId);
+        getMockFn(checkConflictsForDataSource).mockResolvedValue({
+          errors: [],
+          filteredObjects: [],
+          importIdMap: new Map(),
+          pendingOverwrites: new Set([`${dsSuccess2.type}:${dsSuccess2.id}`]),
+        });
+        getMockFn(checkConflicts).mockResolvedValue({
+          errors: [],
+          filteredObjects: [],
+          importIdMap: new Map(),
+          pendingOverwrites: new Set([
+            `${dsSuccess2.type}:${dsSuccess2.id}`, // the dsSuccess2 object was overwritten
+            `${error2.type}:${error2.id}`, // an attempt was made to overwrite the error2 object
+          ]),
+        });
+        getMockFn(createSavedObjects).mockResolvedValue({
+          errors,
+          createdObjects: createdDsObjects,
+        });
+
+        const result = await importSavedObjectsFromStream(options);
+        // successResults only includes the imported object's type, id, and destinationId (if a new one was generated)
+        const successResults = [
+          dsSuccess1,
+          { ...dsSuccess2, overwrite: true },
+          { ...dsSuccess3, createNewCopy: true },
+        ];
+        const errorResults = [
+          { ...error1, meta: { ...error1.meta, icon: `${error1.type}-icon` } },
+          { ...error2, meta: { ...error2.meta, icon: `${error2.type}-icon` }, overwrite: true },
+        ];
+        expect(result).toEqual({
+          success: false,
+          successCount: 3,
+          successResults,
+          errors: errorResults,
+        });
+      });
+
+      test('with createNewCopies enabled and with data source id', async () => {
+        const options = setupOptions(true, testDataSourceId);
+        getMockFn(createSavedObjects).mockResolvedValue({
+          errors,
+          createdObjects: createdDsObjects,
+        });
+
+        const result = await importSavedObjectsFromStream(options);
+        const successDsResults = [dsSuccess1, dsSuccess2, dsSuccess3];
+
+        const errorResults = [
+          { ...error1, meta: { ...error1.meta, icon: `${error1.type}-icon` } },
+          { ...error2, meta: { ...error2.meta, icon: `${error2.type}-icon` } },
+        ];
+        expect(result).toEqual({
+          success: false,
+          successCount: 3,
+          successResults: successDsResults,
+          errors: errorResults,
+        });
+      });
     });
 
     test('accumulates multiple errors', async () => {
-      const options = setupOptions();
+      const options = setupOptions(false, undefined);
       const errors = [createError(), createError(), createError(), createError(), createError()];
       getMockFn(collectSavedObjects).mockResolvedValue({
         errors: [errors[0]],

--- a/src/core/server/saved_objects/import/regenerate_ids.test.ts
+++ b/src/core/server/saved_objects/import/regenerate_ids.test.ts
@@ -39,12 +39,18 @@ describe('#regenerateIds', () => {
     { type: 'baz', id: '3' },
   ] as any) as SavedObject[];
 
+  const dataSourceObjects = ([{ type: 'data-source', id: '1' }] as any) as SavedObject[];
+
+  test('can filter out data source object', () => {
+    expect(regenerateIds(dataSourceObjects, '').size).toBe(0);
+  });
+
   test('returns expected values', () => {
     mockUuidv4
       .mockReturnValueOnce('uuidv4 #1')
       .mockReturnValueOnce('uuidv4 #2')
       .mockReturnValueOnce('uuidv4 #3');
-    expect(regenerateIds(objects)).toMatchInlineSnapshot(`
+    expect(regenerateIds(objects, '')).toMatchInlineSnapshot(`
       Map {
         "foo:1" => Object {
           "id": "uuidv4 #1",

--- a/src/core/server/saved_objects/import/regenerate_ids.ts
+++ b/src/core/server/saved_objects/import/regenerate_ids.ts
@@ -36,9 +36,14 @@ import { SavedObject } from '../types';
  *
  * @param objects The saved objects to generate new IDs for.
  */
-export const regenerateIds = (objects: SavedObject[]) => {
+export const regenerateIds = (objects: SavedObject[], dataSourceId: string | undefined) => {
   const importIdMap = objects.reduce((acc, object) => {
-    return acc.set(`${object.type}:${object.id}`, { id: uuidv4(), omitOriginId: true });
+    return object.type === 'data-source'
+      ? acc
+      : acc.set(`${object.type}:${object.id}`, {
+          id: dataSourceId ? `${dataSourceId}_${uuidv4()}` : uuidv4(),
+          omitOriginId: true,
+        });
   }, new Map<string, { id: string; omitOriginId?: boolean }>());
   return importIdMap;
 };

--- a/src/core/server/saved_objects/import/resolve_import_errors.test.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.test.ts
@@ -369,7 +369,7 @@ describe('#importSavedObjectsFromStream', () => {
         });
 
         await resolveSavedObjectsImportErrors(options);
-        expect(regenerateIds).toHaveBeenCalledWith(collectedObjects);
+        expect(regenerateIds).toHaveBeenCalledWith(collectedObjects, undefined);
       });
 
       test('creates saved objects', async () => {

--- a/src/core/server/saved_objects/import/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.ts
@@ -59,6 +59,8 @@ export async function resolveSavedObjectsImportErrors({
   typeRegistry,
   namespace,
   createNewCopies,
+  dataSourceId,
+  dataSourceTitle,
 }: SavedObjectsResolveImportErrorsOptions): Promise<SavedObjectsImportResponse> {
   // throw a BadRequest error if we see invalid retries
   validateRetries(retries);
@@ -76,6 +78,7 @@ export async function resolveSavedObjectsImportErrors({
       objectLimit,
       filter,
       supportedTypes,
+      dataSourceId,
     }
   );
   errorAccumulator = [...errorAccumulator, ...collectorErrors];
@@ -116,7 +119,7 @@ export async function resolveSavedObjectsImportErrors({
   if (createNewCopies) {
     // In case any missing reference errors were resolved, ensure that we regenerate those object IDs as well
     // This is because a retry to resolve a missing reference error may not necessarily specify a destinationId
-    importIdMap = regenerateIds(objectsToResolve);
+    importIdMap = regenerateIds(objectsToResolve, dataSourceId);
   }
 
   // Check single-namespace objects for conflicts in this namespace, and check multi-namespace objects for conflicts across all namespaces
@@ -126,6 +129,7 @@ export async function resolveSavedObjectsImportErrors({
     namespace,
     retries,
     createNewCopies,
+    dataSourceId,
   };
   const checkConflictsResult = await checkConflicts(checkConflictsParams);
   errorAccumulator = [...errorAccumulator, ...checkConflictsResult.errors];
@@ -157,6 +161,8 @@ export async function resolveSavedObjectsImportErrors({
       importIdMap,
       namespace,
       overwrite,
+      dataSourceId,
+      dataSourceTitle,
     };
     const { createdObjects, errors: bulkCreateErrors } = await createSavedObjects(
       createSavedObjectsParams

--- a/src/core/server/saved_objects/import/types.ts
+++ b/src/core/server/saved_objects/import/types.ts
@@ -187,6 +187,8 @@ export interface SavedObjectsImportOptions {
   namespace?: string;
   /** If true, will create new copies of import objects, each with a random `id` and undefined `originId`. */
   createNewCopies: boolean;
+  dataSourceId?: string;
+  dataSourceTitle?: string;
 }
 
 /**
@@ -208,6 +210,8 @@ export interface SavedObjectsResolveImportErrorsOptions {
   namespace?: string;
   /** If true, will create new copies of import objects, each with a random `id` and undefined `originId`. */
   createNewCopies: boolean;
+  dataSourceId?: string;
+  dataSourceTitle?: string;
 }
 
 export type CreatedObject<T> = SavedObject<T> & { destinationId?: string };

--- a/src/core/server/saved_objects/routes/import.ts
+++ b/src/core/server/saved_objects/routes/import.ts
@@ -60,6 +60,7 @@ export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) 
           {
             overwrite: schema.boolean({ defaultValue: false }),
             createNewCopies: schema.boolean({ defaultValue: false }),
+            dataSourceId: schema.maybe(schema.string({ defaultValue: '' })),
           },
           {
             validate: (object) => {
@@ -75,12 +76,28 @@ export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) 
       },
     },
     router.handleLegacyErrors(async (context, req, res) => {
-      const { overwrite, createNewCopies } = req.query;
+      const { overwrite, createNewCopies, dataSourceId } = req.query;
       const file = req.body.file as FileStream;
       const fileExtension = extname(file.hapi.filename).toLowerCase();
       if (fileExtension !== '.ndjson') {
         return res.badRequest({ body: `Invalid file extension ${fileExtension}` });
       }
+
+      // get datasource from saved object service
+      // dataSource is '' when there is no dataSource pass in the url
+      const dataSource = dataSourceId
+        ? await context.core.savedObjects.client
+            .get('data-source', dataSourceId)
+            .then((response) => {
+              const attributes: any = response?.attributes || {};
+              return {
+                id: response.id,
+                title: attributes.title,
+              };
+            })
+        : '';
+
+      const dataSourceTitle = dataSource ? dataSource.title : '';
 
       let readStream: Readable;
       try {
@@ -98,6 +115,8 @@ export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) 
         objectLimit: maxImportExportSize,
         overwrite,
         createNewCopies,
+        dataSourceId,
+        dataSourceTitle,
       });
 
       return res.ok({ body: result });

--- a/src/core/server/saved_objects/routes/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/routes/resolve_import_errors.ts
@@ -58,6 +58,7 @@ export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedO
       validate: {
         query: schema.object({
           createNewCopies: schema.boolean({ defaultValue: false }),
+          dataSourceId: schema.maybe(schema.string({ defaultValue: '' })),
         }),
         body: schema.object({
           file: schema.stream(),
@@ -89,6 +90,24 @@ export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedO
         return res.badRequest({ body: `Invalid file extension ${fileExtension}` });
       }
 
+      const dataSourceId = req.query.dataSourceId;
+
+      // get datasource from saved object service
+
+      const dataSource = dataSourceId
+        ? await context.core.savedObjects.client
+            .get('data-source', dataSourceId)
+            .then((response) => {
+              const attributes: any = response?.attributes || {};
+              return {
+                id: response.id,
+                title: attributes.title,
+              };
+            })
+        : '';
+
+      const dataSourceTitle = dataSource ? dataSource.title : '';
+
       let readStream: Readable;
       try {
         readStream = await createSavedObjectsStreamFromNdJson(file);
@@ -105,6 +124,8 @@ export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedO
         retries: req.body.retries,
         objectLimit: maxImportExportSize,
         createNewCopies: req.query.createNewCopies,
+        dataSourceId,
+        dataSourceTitle,
       });
 
       return res.ok({ body: result });


### PR DESCRIPTION
### Description
backport PR
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5777
### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
