### PR TITLE
Fix save query management popover render error

### DIFF
--- a/src/plugins/data_explorer/public/components/app_container.tsx
+++ b/src/plugins/data_explorer/public/components/app_container.tsx
@@ -22,7 +22,6 @@ export const AppContainer = ({ view, params }: { view?: View; params: AppMountPa
   const { Canvas, Panel, Context } = view;
 
   const MemoizedPanel = memo(Panel);
-  const MemoizedCanvas = memo(Canvas);
 
   // Render the application DOM.
   return (
@@ -47,7 +46,7 @@ export const AppContainer = ({ view, params }: { view?: View; params: AppMountPa
 
                 <EuiResizablePanel initialSize={80} minSize="65%" mode="main" paddingSize="none">
                   <EuiPageBody className="deLayout__canvas">
-                    <MemoizedCanvas {...params} />
+                    <Canvas {...params} />
                   </EuiPageBody>
                 </EuiResizablePanel>
               </>


### PR DESCRIPTION
### Description
The memoization on the canvas cause the saved query management component renders incorrectly. When we loaded a query, we need to repeat the action twice for the UI to correctly load.



### Issues Resolved

resolves #5833 

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/43937633/fa8f7128-72b4-4be0-9ed7-7723dd90889d

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
