### PR TITLE
[Multi data source] Add interfaces to register add-on authentication method from plug-in module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Discover] Enhanced the data source selector with added sorting functionality ([#5609](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5609))
 - [Multiple Datasource] Add datasource picker component and use it in devtools and tutorial page when multiple datasource is enabled ([#5756](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5756))
 - [Multiple Datasource] Add datasource picker to import saved object flyout when multiple data source is enabled ([#5781](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5781))
+- [Multiple Datasource] Add interfaces to register add-on authentication method from plug-in module ([#5851](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5851)) 
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/data_source/common/data_sources/types.ts
+++ b/src/plugins/data_source/common/data_sources/types.ts
@@ -11,9 +11,13 @@ export interface DataSourceAttributes extends SavedObjectAttributes {
   endpoint: string;
   auth: {
     type: AuthType;
-    credentials: UsernamePasswordTypedContent | SigV4Content | undefined;
+    credentials: UsernamePasswordTypedContent | SigV4Content | undefined | AuthTypeContent;
   };
   lastUpdatedTime?: string;
+}
+
+export interface AuthTypeContent {
+  [key: string]: string;
 }
 
 /**

--- a/src/plugins/data_source/server/auth_registry/authentication_methods_registry.test.ts
+++ b/src/plugins/data_source/server/auth_registry/authentication_methods_registry.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthenticationMethodRegistery } from './authentication_methods_registry';
+import { AuthMethodType } from '../../server/types';
+import { AuthType } from '../../common/data_sources';
+
+const createAuthenticationMethod = (authMethod: Partial<AuthMethodType>): AuthMethodType => ({
+  name: 'unknown',
+  authType: AuthType.NoAuth,
+  credentialProvider: jest.fn(),
+  ...authMethod,
+});
+
+describe('AuthenticationMethodRegistery', () => {
+  let registry: AuthenticationMethodRegistery;
+
+  beforeEach(() => {
+    registry = new AuthenticationMethodRegistery();
+  });
+
+  it('allows to register authentication method', () => {
+    registry.registerAuthenticationMethod(createAuthenticationMethod({ name: 'typeA' }));
+    registry.registerAuthenticationMethod(createAuthenticationMethod({ name: 'typeB' }));
+    registry.registerAuthenticationMethod(createAuthenticationMethod({ name: 'typeC' }));
+
+    expect(
+      registry
+        .getAllAuthenticationMethods()
+        .map((type) => type.name)
+        .sort()
+    ).toEqual(['typeA', 'typeB', 'typeC']);
+  });
+
+  it('throws when trying to register the same authentication method twice', () => {
+    registry.registerAuthenticationMethod(createAuthenticationMethod({ name: 'typeA' }));
+    registry.registerAuthenticationMethod(createAuthenticationMethod({ name: 'typeB' }));
+    expect(() => {
+      registry.registerAuthenticationMethod(createAuthenticationMethod({ name: 'typeA' }));
+    }).toThrowErrorMatchingInlineSnapshot(`"Authentication method 'typeA' is already registered"`);
+  });
+
+  describe('#getAuthenticationMethod', () => {
+    it(`retrieve a type by it's name`, () => {
+      const typeA = createAuthenticationMethod({ name: 'typeA' });
+      const typeB = createAuthenticationMethod({ name: 'typeB' });
+      registry.registerAuthenticationMethod(typeA);
+      registry.registerAuthenticationMethod(typeB);
+      registry.registerAuthenticationMethod(createAuthenticationMethod({ name: 'typeC' }));
+
+      expect(registry.getAuthenticationMethod('typeA')).toEqual(typeA);
+      expect(registry.getAuthenticationMethod('typeB')).toEqual(typeB);
+      expect(registry.getAuthenticationMethod('unknownType')).toBeUndefined();
+    });
+
+    it('forbids to mutate the registered types', () => {
+      registry.registerAuthenticationMethod(
+        createAuthenticationMethod({
+          name: 'typeA',
+          authType: AuthType.NoAuth,
+        })
+      );
+
+      const typeA = registry.getAuthenticationMethod('typeA')!;
+
+      expect(() => {
+        typeA.authType = AuthType.SigV4;
+      }).toThrow();
+      expect(() => {
+        typeA.name = 'foo';
+      }).toThrow();
+      expect(() => {
+        typeA.credentialProvider = jest.fn();
+      }).toThrow();
+    });
+  });
+
+  describe('#getAllTypes', () => {
+    it('returns all registered types', () => {
+      const typeA = createAuthenticationMethod({ name: 'typeA' });
+      const typeB = createAuthenticationMethod({ name: 'typeB' });
+      const typeC = createAuthenticationMethod({ name: 'typeC' });
+      registry.registerAuthenticationMethod(typeA);
+      registry.registerAuthenticationMethod(typeB);
+
+      const registered = registry.getAllAuthenticationMethods();
+      expect(registered.length).toEqual(2);
+      expect(registered).toContainEqual(typeA);
+      expect(registered).toContainEqual(typeB);
+      expect(registered).not.toContainEqual(typeC);
+    });
+
+    it('does not mutate the registered types when altering the list', () => {
+      registry.registerAuthenticationMethod(createAuthenticationMethod({ name: 'typeA' }));
+      registry.registerAuthenticationMethod(createAuthenticationMethod({ name: 'typeB' }));
+      registry.registerAuthenticationMethod(createAuthenticationMethod({ name: 'typeC' }));
+
+      const types = registry.getAllAuthenticationMethods();
+      types.splice(0, 3);
+
+      expect(registry.getAllAuthenticationMethods().length).toEqual(3);
+    });
+  });
+});

--- a/src/plugins/data_source/server/auth_registry/authentication_methods_registry.ts
+++ b/src/plugins/data_source/server/auth_registry/authentication_methods_registry.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthMethodValues } from '../../server/types';
+
+export type IAuthenticationMethodRegistery = Omit<
+  AuthenticationMethodRegistery,
+  'registerAuthenticationMethod'
+>;
+
+export class AuthenticationMethodRegistery {
+  private readonly authMethods = new Map<string, AuthMethodValues>();
+  /**
+   * Register a authMethods with function to return credentials inside the registry.
+   * Authentication Method can only be registered once. subsequent calls with the same method name will throw an error.
+   */
+  public registerAuthenticationMethod(name: string, authMethodValues: AuthMethodValues) {
+    if (this.authMethods.has(name)) {
+      throw new Error(`Authentication method '${name}' is already registered`);
+    }
+    this.authMethods.set(name, authMethodValues);
+  }
+
+  public getAllAuthenticationMethods() {
+    return [...this.authMethods.values()];
+  }
+
+  public getAuthenticationMethod(name: string) {
+    return this.authMethods.get(name);
+  }
+}

--- a/src/plugins/data_source/server/auth_registry/authentication_methods_registry.ts
+++ b/src/plugins/data_source/server/auth_registry/authentication_methods_registry.ts
@@ -4,7 +4,7 @@
  */
 
 import { deepFreeze } from '@osd/std';
-import { AuthMethodType } from '../../server/types';
+import { AuthenticationMethod } from '../../server/types';
 
 export type IAuthenticationMethodRegistery = Omit<
   AuthenticationMethodRegistery,
@@ -12,16 +12,16 @@ export type IAuthenticationMethodRegistery = Omit<
 >;
 
 export class AuthenticationMethodRegistery {
-  private readonly authMethods = new Map<string, AuthMethodType>();
+  private readonly authMethods = new Map<string, AuthenticationMethod>();
   /**
    * Register a authMethods with function to return credentials inside the registry.
    * Authentication Method can only be registered once. subsequent calls with the same method name will throw an error.
    */
-  public registerAuthenticationMethod(method: AuthMethodType) {
+  public registerAuthenticationMethod(method: AuthenticationMethod) {
     if (this.authMethods.has(method.name)) {
       throw new Error(`Authentication method '${method.name}' is already registered`);
     }
-    this.authMethods.set(method.name, deepFreeze(method) as AuthMethodType);
+    this.authMethods.set(method.name, deepFreeze(method) as AuthenticationMethod);
   }
 
   public getAllAuthenticationMethods() {

--- a/src/plugins/data_source/server/auth_registry/authentication_methods_registry.ts
+++ b/src/plugins/data_source/server/auth_registry/authentication_methods_registry.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthMethodValues } from '../../server/types';
+import { deepFreeze } from '@osd/std';
+import { AuthMethodType } from '../../server/types';
 
 export type IAuthenticationMethodRegistery = Omit<
   AuthenticationMethodRegistery,
@@ -11,16 +12,16 @@ export type IAuthenticationMethodRegistery = Omit<
 >;
 
 export class AuthenticationMethodRegistery {
-  private readonly authMethods = new Map<string, AuthMethodValues>();
+  private readonly authMethods = new Map<string, AuthMethodType>();
   /**
    * Register a authMethods with function to return credentials inside the registry.
    * Authentication Method can only be registered once. subsequent calls with the same method name will throw an error.
    */
-  public registerAuthenticationMethod(name: string, authMethodValues: AuthMethodValues) {
-    if (this.authMethods.has(name)) {
-      throw new Error(`Authentication method '${name}' is already registered`);
+  public registerAuthenticationMethod(method: AuthMethodType) {
+    if (this.authMethods.has(method.name)) {
+      throw new Error(`Authentication method '${method.name}' is already registered`);
     }
-    this.authMethods.set(name, authMethodValues);
+    this.authMethods.set(method.name, deepFreeze(method) as AuthMethodType);
   }
 
   public getAllAuthenticationMethods() {

--- a/src/plugins/data_source/server/auth_registry/index.ts
+++ b/src/plugins/data_source/server/auth_registry/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+  IAuthenticationMethodRegistery,
+  AuthenticationMethodRegistery,
+} from './authentication_methods_registry';

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -23,7 +23,7 @@ import { LoggingAuditor } from './audit/logging_auditor';
 import { CryptographyService, CryptographyServiceSetup } from './cryptography_service';
 import { DataSourceService, DataSourceServiceSetup } from './data_source_service';
 import { DataSourceSavedObjectsClientWrapper, dataSource } from './saved_objects';
-import { AuthMethodType, DataSourcePluginSetup, DataSourcePluginStart } from './types';
+import { AuthenticationMethod, DataSourcePluginSetup, DataSourcePluginStart } from './types';
 import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../common';
 
 // eslint-disable-next-line @osd/eslint/no-restricted-paths
@@ -124,7 +124,7 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
       authRegistryPromise
     );
 
-    const registerCredentialProvider = (method: AuthMethodType) => {
+    const registerCredentialProvider = (method: AuthenticationMethod) => {
       this.logger.debug(`Registered Credential Provider for authType = ${method.name}`);
       if (this.started) {
         throw new Error('cannot call `registerCredentialProvider` after service startup.');

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -23,19 +23,22 @@ import { LoggingAuditor } from './audit/logging_auditor';
 import { CryptographyService, CryptographyServiceSetup } from './cryptography_service';
 import { DataSourceService, DataSourceServiceSetup } from './data_source_service';
 import { DataSourceSavedObjectsClientWrapper, dataSource } from './saved_objects';
-import { DataSourcePluginSetup, DataSourcePluginStart } from './types';
+import { AuthMethodValues, DataSourcePluginSetup, DataSourcePluginStart } from './types';
 import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../common';
 
 // eslint-disable-next-line @osd/eslint/no-restricted-paths
 import { ensureRawRequest } from '../../../../src/core/server/http/router';
 import { createDataSourceError } from './lib/error';
 import { registerTestConnectionRoute } from './routes/test_connection';
+import { AuthenticationMethodRegistery, IAuthenticationMethodRegistery } from './auth_registry';
 
 export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourcePluginStart> {
   private readonly logger: Logger;
   private readonly cryptographyService: CryptographyService;
   private readonly dataSourceService: DataSourceService;
   private readonly config$: Observable<DataSourcePluginConfigType>;
+  private started = false;
+  private authMethodsRegistry = new AuthenticationMethodRegistery();
 
   constructor(private initializerContext: PluginInitializerContext<DataSourcePluginConfigType>) {
     this.logger = this.initializerContext.logger.get();
@@ -44,7 +47,7 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
     this.config$ = this.initializerContext.config.create<DataSourcePluginConfigType>();
   }
 
-  public async setup(core: CoreSetup) {
+  public async setup(core: CoreSetup<DataSourcePluginStart>) {
     this.logger.debug('dataSource: Setup');
 
     // Register data source saved object type
@@ -95,6 +98,12 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
     const auditTrailPromise = core.getStartServices().then(([coreStart]) => coreStart.auditTrail);
 
     const dataSourceService: DataSourceServiceSetup = await this.dataSourceService.setup(config);
+
+    const authRegistryPromise = core.getStartServices().then(([, , selfStart]) => {
+      const dataSourcePluginStart = selfStart as DataSourcePluginStart;
+      return dataSourcePluginStart.getAuthenticationMethodRegistery();
+    });
+
     // Register data source plugin context to route handler context
     core.http.registerRouteHandlerContext(
       'dataSource',
@@ -102,24 +111,41 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
         dataSourceService,
         cryptographyServiceSetup,
         this.logger,
-        auditTrailPromise
+        auditTrailPromise,
+        authRegistryPromise
       )
     );
 
     const router = core.http.createRouter();
-    registerTestConnectionRoute(router, dataSourceService, cryptographyServiceSetup);
+    registerTestConnectionRoute(
+      router,
+      dataSourceService,
+      cryptographyServiceSetup,
+      authRegistryPromise
+    );
+
+    const registerCredentialProvider = (name: string, authMethodValues: AuthMethodValues) => {
+      this.logger.debug(`Registered Credential Provider for authType = ${name}`);
+      if (this.started) {
+        throw new Error('cannot call `registerCredentialProvider` after service startup.');
+      }
+      this.authMethodsRegistry.registerAuthenticationMethod(name, authMethodValues);
+    };
 
     return {
       createDataSourceError: (e: any) => createDataSourceError(e),
       dataSourceEnabled: () => config.enabled,
       defaultClusterEnabled: () => config.defaultCluster,
+      registerCredentialProvider,
     };
   }
 
   public start(core: CoreStart) {
     this.logger.debug('dataSource: Started');
-
-    return {};
+    this.started = true;
+    return {
+      getAuthenticationMethodRegistery: () => this.authMethodsRegistry,
+    };
   }
 
   public stop() {
@@ -130,7 +156,8 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
     dataSourceService: DataSourceServiceSetup,
     cryptography: CryptographyServiceSetup,
     logger: Logger,
-    auditTrailPromise: Promise<AuditorFactory>
+    auditTrailPromise: Promise<AuditorFactory>,
+    authRegistryPromise: Promise<IAuthenticationMethodRegistery>
   ): IContextProvider<RequestHandler<unknown, unknown, unknown>, 'dataSource'> => {
     return (context, req) => {
       return {

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -23,7 +23,7 @@ import { LoggingAuditor } from './audit/logging_auditor';
 import { CryptographyService, CryptographyServiceSetup } from './cryptography_service';
 import { DataSourceService, DataSourceServiceSetup } from './data_source_service';
 import { DataSourceSavedObjectsClientWrapper, dataSource } from './saved_objects';
-import { AuthMethodValues, DataSourcePluginSetup, DataSourcePluginStart } from './types';
+import { AuthMethodType, DataSourcePluginSetup, DataSourcePluginStart } from './types';
 import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../common';
 
 // eslint-disable-next-line @osd/eslint/no-restricted-paths
@@ -124,12 +124,12 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
       authRegistryPromise
     );
 
-    const registerCredentialProvider = (name: string, authMethodValues: AuthMethodValues) => {
-      this.logger.debug(`Registered Credential Provider for authType = ${name}`);
+    const registerCredentialProvider = (method: AuthMethodType) => {
+      this.logger.debug(`Registered Credential Provider for authType = ${method.name}`);
       if (this.started) {
         throw new Error('cannot call `registerCredentialProvider` after service startup.');
       }
-      this.authMethodsRegistry.registerAuthenticationMethod(name, authMethodValues);
+      this.authMethodsRegistry.registerAuthenticationMethod(method);
     };
 
     return {

--- a/src/plugins/data_source/server/routes/test_connection.ts
+++ b/src/plugins/data_source/server/routes/test_connection.ts
@@ -9,11 +9,13 @@ import { AuthType, DataSourceAttributes, SigV4ServiceName } from '../../common/d
 import { DataSourceConnectionValidator } from './data_source_connection_validator';
 import { DataSourceServiceSetup } from '../data_source_service';
 import { CryptographyServiceSetup } from '../cryptography_service';
+import { IAuthenticationMethodRegistery } from '../auth_registry';
 
 export const registerTestConnectionRoute = (
   router: IRouter,
   dataSourceServiceSetup: DataSourceServiceSetup,
-  cryptography: CryptographyServiceSetup
+  cryptography: CryptographyServiceSetup,
+  authRegistryPromise: Promise<IAuthenticationMethodRegistery>
 ) => {
   router.post(
     {

--- a/src/plugins/data_source/server/types.ts
+++ b/src/plugins/data_source/server/types.ts
@@ -46,7 +46,7 @@ export type DataSourceCredentialsProvider = (
   options: DataSourceCredentialsProviderOptions
 ) => Promise<UsernamePasswordTypedContent | SigV4Content>;
 
-export interface AuthMethodType {
+export interface AuthenticationMethod {
   name: string;
   authType: AuthType;
   credentialProvider: DataSourceCredentialsProvider;
@@ -78,7 +78,7 @@ export interface DataSourcePluginSetup {
   createDataSourceError: (err: any) => DataSourceError;
   dataSourceEnabled: () => boolean;
   defaultClusterEnabled: () => boolean;
-  registerCredentialProvider: (method: AuthMethodType) => void;
+  registerCredentialProvider: (method: AuthenticationMethod) => void;
 }
 
 export interface DataSourcePluginStart {

--- a/src/plugins/data_source/server/types.ts
+++ b/src/plugins/data_source/server/types.ts
@@ -7,11 +7,18 @@ import {
   LegacyCallAPIOptions,
   OpenSearchClient,
   SavedObjectsClientContract,
+  OpenSearchDashboardsRequest,
 } from 'src/core/server';
-import { DataSourceAttributes } from '../common/data_sources';
+import {
+  DataSourceAttributes,
+  AuthType,
+  UsernamePasswordTypedContent,
+  SigV4Content,
+} from '../common/data_sources';
 
 import { CryptographyServiceSetup } from './cryptography_service';
 import { DataSourceError } from './lib/error';
+import { IAuthenticationMethodRegistery } from './auth_registry';
 
 export interface LegacyClientCallAPIParams {
   endpoint: string;
@@ -27,6 +34,21 @@ export interface DataSourceClientParams {
   dataSourceId?: string;
   // required when creating test client
   testClientDataSourceAttr?: DataSourceAttributes;
+}
+
+export interface DataSourceCredentialsProviderOptions {
+  dataSourceAttr: DataSourceAttributes;
+  request?: OpenSearchDashboardsRequest;
+  cryptography?: CryptographyServiceSetup;
+}
+
+export type DataSourceCredentialsProvider = (
+  options: DataSourceCredentialsProviderOptions
+) => Promise<UsernamePasswordTypedContent | SigV4Content>;
+
+export interface AuthMethodValues {
+  credentialProvider: DataSourceCredentialsProvider;
+  authType: AuthType;
 }
 
 export interface DataSourcePluginRequestContext {
@@ -55,6 +77,9 @@ export interface DataSourcePluginSetup {
   createDataSourceError: (err: any) => DataSourceError;
   dataSourceEnabled: () => boolean;
   defaultClusterEnabled: () => boolean;
+  registerCredentialProvider: (name: string, authMethodValues: AuthMethodValues) => void;
 }
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface DataSourcePluginStart {}
+
+export interface DataSourcePluginStart {
+  getAuthenticationMethodRegistery: () => IAuthenticationMethodRegistery;
+}

--- a/src/plugins/data_source/server/types.ts
+++ b/src/plugins/data_source/server/types.ts
@@ -46,9 +46,10 @@ export type DataSourceCredentialsProvider = (
   options: DataSourceCredentialsProviderOptions
 ) => Promise<UsernamePasswordTypedContent | SigV4Content>;
 
-export interface AuthMethodValues {
-  credentialProvider: DataSourceCredentialsProvider;
+export interface AuthMethodType {
+  name: string;
   authType: AuthType;
+  credentialProvider: DataSourceCredentialsProvider;
 }
 
 export interface DataSourcePluginRequestContext {
@@ -77,7 +78,7 @@ export interface DataSourcePluginSetup {
   createDataSourceError: (err: any) => DataSourceError;
   dataSourceEnabled: () => boolean;
   defaultClusterEnabled: () => boolean;
-  registerCredentialProvider: (name: string, authMethodValues: AuthMethodValues) => void;
+  registerCredentialProvider: (method: AuthMethodType) => void;
 }
 
 export interface DataSourcePluginStart {

--- a/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.test.ts
+++ b/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.test.ts
@@ -3,22 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  AuthenticationMethodRegistery,
-  AuthenticationMethod,
-} from './authentication_methods_registry';
+import { AuthenticationMethodRegistery } from './authentication_methods_registry';
 import React from 'react';
-
-export const createAuthenticationMethod = (
-  authMethod: Partial<AuthenticationMethod>
-): AuthenticationMethod => ({
-  name: 'unknown',
-  credentialForm: React.createElement('div', {}, 'Hello, world!'),
-  credentialSourceOption: {
-    value: 'unknown',
-  },
-  ...authMethod,
-});
+import { createAuthenticationMethod } from '../mocks';
 
 describe('AuthenticationMethodRegistery', () => {
   let registry: AuthenticationMethodRegistery;

--- a/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.test.ts
+++ b/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.test.ts
@@ -3,16 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthenticationMethodRegistery } from './authentication_methods_registry';
-import { AuthenticationMethod } from '../../server/types';
-import { AuthType } from '../../common/data_sources';
+import {
+  AuthenticationMethodRegistery,
+  AuthenticationMethod,
+} from './authentication_methods_registry';
+import React from 'react';
 
 const createAuthenticationMethod = (
   authMethod: Partial<AuthenticationMethod>
 ): AuthenticationMethod => ({
   name: 'unknown',
-  authType: AuthType.NoAuth,
-  credentialProvider: jest.fn(),
+  credentialForm: React.createElement('div', {}, 'Hello, world!'),
+  credentialSourceOption: {
+    value: 'unknown',
+  },
   ...authMethod,
 });
 
@@ -61,20 +65,18 @@ describe('AuthenticationMethodRegistery', () => {
       registry.registerAuthenticationMethod(
         createAuthenticationMethod({
           name: 'typeA',
-          authType: AuthType.NoAuth,
         })
       );
 
       const typeA = registry.getAuthenticationMethod('typeA')!;
 
       expect(() => {
-        typeA.authType = AuthType.SigV4;
+        typeA.credentialForm = React.createElement('div', {}, 'Welcome!');
       }).toThrow();
       expect(() => {
-        typeA.name = 'foo';
-      }).toThrow();
-      expect(() => {
-        typeA.credentialProvider = jest.fn();
+        typeA.credentialSourceOption = {
+          value: 'typeA',
+        };
       }).toThrow();
     });
   });

--- a/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.test.ts
+++ b/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.test.ts
@@ -9,7 +9,7 @@ import {
 } from './authentication_methods_registry';
 import React from 'react';
 
-const createAuthenticationMethod = (
+export const createAuthenticationMethod = (
   authMethod: Partial<AuthenticationMethod>
 ): AuthenticationMethod => ({
   name: 'unknown',

--- a/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.ts
+++ b/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { deepFreeze } from '@osd/std';
 import { EuiSuperSelectOption } from '@elastic/eui';
-import { AuthTypeContent } from 'src/plugins/data_source/common/data_sources';
 
-export interface AuthMethodUIElements {
+export interface AuthenticationMethod {
+  name: string;
   credentialForm: React.JSX.Element;
   credentialSourceOption: EuiSuperSelectOption<string>;
-  credentialsFormValues: AuthTypeContent;
 }
 
 export type IAuthenticationMethodRegistery = Omit<
@@ -18,16 +18,16 @@ export type IAuthenticationMethodRegistery = Omit<
 >;
 
 export class AuthenticationMethodRegistery {
-  private readonly authMethods = new Map<string, AuthMethodUIElements>();
+  private readonly authMethods = new Map<string, AuthenticationMethod>();
   /**
    * Register a authMethods with function to return credentials inside the registry.
    * Authentication Method can only be registered once. subsequent calls with the same method name will throw an error.
    */
-  public registerAuthenticationMethod(name: string, authMethodUIElements: AuthMethodUIElements) {
-    if (this.authMethods.has(name)) {
-      throw new Error(`Authentication method '${name}' is already registered`);
+  public registerAuthenticationMethod(method: AuthenticationMethod) {
+    if (this.authMethods.has(method.name)) {
+      throw new Error(`Authentication method '${method.name}' is already registered`);
     }
-    this.authMethods.set(name, authMethodUIElements);
+    this.authMethods.set(method.name, deepFreeze(method) as AuthenticationMethod);
   }
 
   public getAllAuthenticationMethods() {

--- a/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.ts
+++ b/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiSuperSelectOption } from '@elastic/eui';
+import { AuthTypeContent } from 'src/plugins/data_source/common/data_sources';
+
+export interface AuthMethodUIElements {
+  credentialForm: React.JSX.Element;
+  credentialSourceOption: EuiSuperSelectOption<string>;
+  credentialsFormValues: AuthTypeContent;
+}
+
+export type IAuthenticationMethodRegistery = Omit<
+  AuthenticationMethodRegistery,
+  'registerAuthenticationMethod'
+>;
+
+export class AuthenticationMethodRegistery {
+  private readonly authMethods = new Map<string, AuthMethodUIElements>();
+  /**
+   * Register a authMethods with function to return credentials inside the registry.
+   * Authentication Method can only be registered once. subsequent calls with the same method name will throw an error.
+   */
+  public registerAuthenticationMethod(name: string, authMethodUIElements: AuthMethodUIElements) {
+    if (this.authMethods.has(name)) {
+      throw new Error(`Authentication method '${name}' is already registered`);
+    }
+    this.authMethods.set(name, authMethodUIElements);
+  }
+
+  public getAllAuthenticationMethods() {
+    return [...this.authMethods.values()];
+  }
+
+  public getAuthenticationMethod(name: string) {
+    return this.authMethods.get(name);
+  }
+}

--- a/src/plugins/data_source_management/public/auth_registry/index.ts
+++ b/src/plugins/data_source_management/public/auth_registry/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+  IAuthenticationMethodRegistery,
+  AuthMethodUIElements,
+  AuthenticationMethodRegistery,
+} from './authentication_methods_registry';

--- a/src/plugins/data_source_management/public/auth_registry/index.ts
+++ b/src/plugins/data_source_management/public/auth_registry/index.ts
@@ -8,5 +8,3 @@ export {
   AuthenticationMethod,
   AuthenticationMethodRegistery,
 } from './authentication_methods_registry';
-
-export { createAuthenticationMethod } from './authentication_methods_registry.test';

--- a/src/plugins/data_source_management/public/auth_registry/index.ts
+++ b/src/plugins/data_source_management/public/auth_registry/index.ts
@@ -8,3 +8,5 @@ export {
   AuthenticationMethod,
   AuthenticationMethodRegistery,
 } from './authentication_methods_registry';
+
+export { createAuthenticationMethod } from './authentication_methods_registry.test';

--- a/src/plugins/data_source_management/public/auth_registry/index.ts
+++ b/src/plugins/data_source_management/public/auth_registry/index.ts
@@ -5,6 +5,6 @@
 
 export {
   IAuthenticationMethodRegistery,
-  AuthMethodUIElements,
+  AuthenticationMethod,
   AuthenticationMethodRegistery,
 } from './authentication_methods_registry';

--- a/src/plugins/data_source_management/public/index.ts
+++ b/src/plugins/data_source_management/public/index.ts
@@ -12,3 +12,4 @@ export function plugin() {
 }
 export { DataSourceManagementPluginStart } from './types';
 export { ClusterSelector } from './components/cluster_selector';
+export { DataSourceManagementPlugin, DataSourceManagementPluginSetup } from './plugin';

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import React from 'react';
 import { throwError } from 'rxjs';
 import { SavedObjectsClientContract } from 'opensearch-dashboards/public';
 import { AuthType } from './types';
@@ -14,6 +15,7 @@ import {
 } from './plugin';
 import { managementPluginMock } from '../../management/public/mocks';
 import { mockManagementPlugin as indexPatternManagementPluginMock } from '../../index_pattern_management/public/mocks';
+import { AuthenticationMethod } from './auth_registry';
 
 /* Mock Types */
 
@@ -225,3 +227,14 @@ export const testDataSourceManagementPlugin = (
   };
   return { setup, doStart };
 };
+
+export const createAuthenticationMethod = (
+  authMethod: Partial<AuthenticationMethod>
+): AuthenticationMethod => ({
+  name: 'unknown',
+  credentialForm: React.createElement('div', {}, 'Hello, world!'),
+  credentialSourceOption: {
+    value: 'unknown',
+  },
+  ...authMethod,
+});

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -7,6 +7,13 @@ import { throwError } from 'rxjs';
 import { SavedObjectsClientContract } from 'opensearch-dashboards/public';
 import { AuthType } from './types';
 import { coreMock } from '../../../core/public/mocks';
+import {
+  DataSourceManagementPlugin,
+  DataSourceManagementPluginSetup,
+  DataSourceManagementPluginStart,
+} from './plugin';
+import { managementPluginMock } from '../../management/public/mocks';
+import { mockManagementPlugin as indexPatternManagementPluginMock } from '../../index_pattern_management/public/mocks';
 
 /* Mock Types */
 
@@ -196,4 +203,25 @@ export const mockErrorResponseForSavedObjectsCalls = (
   (savedObjectsClient[savedObjectsMethodName] as jest.Mock).mockRejectedValue(
     throwError(new Error('Error while fetching data sources'))
   );
+};
+
+export interface TestPluginReturn {
+  setup: DataSourceManagementPluginSetup;
+  doStart: () => DataSourceManagementPluginStart;
+}
+
+export const testDataSourceManagementPlugin = (
+  coreSetup: any,
+  coreStart: any
+): TestPluginReturn => {
+  const plugin = new DataSourceManagementPlugin();
+  const setup = plugin.setup(coreSetup, {
+    management: managementPluginMock.createSetupContract(),
+    indexPatternManagement: indexPatternManagementPluginMock.createSetupContract(),
+  });
+  const doStart = () => {
+    const start = plugin.start(coreStart);
+    return start;
+  };
+  return { setup, doStart };
 };

--- a/src/plugins/data_source_management/public/plugin.test.ts
+++ b/src/plugins/data_source_management/public/plugin.test.ts
@@ -4,8 +4,7 @@
  */
 import { coreMock } from '../../../core/public/mocks';
 import { DataSourceManagementPluginStart } from './plugin';
-import { testDataSourceManagementPlugin } from './mocks';
-import { createAuthenticationMethod } from './auth_registry';
+import { testDataSourceManagementPlugin, createAuthenticationMethod } from './mocks';
 
 describe('#dataSourceManagement', () => {
   let coreSetup: any;

--- a/src/plugins/data_source_management/public/plugin.test.ts
+++ b/src/plugins/data_source_management/public/plugin.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { coreMock } from '../../../core/public/mocks';
+import { DataSourceManagementPluginStart } from './plugin';
+import { testDataSourceManagementPlugin } from './mocks';
+import { createAuthenticationMethod } from './auth_registry';
+
+describe('#dataSourceManagement', () => {
+  let coreSetup: any;
+  let coreStart: any;
+  let mockDataSourceManagementPluginStart: MockedKeys<DataSourceManagementPluginStart>;
+  beforeEach(() => {
+    coreSetup = coreMock.createSetup({ pluginStartContract: mockDataSourceManagementPluginStart });
+    coreStart = coreMock.createStart();
+  });
+  it('can register custom authentication method', () => {
+    const { setup, doStart } = testDataSourceManagementPlugin(coreSetup, coreStart);
+    const typeA = createAuthenticationMethod({ name: 'typeA' });
+    setup.registerAuthenticationMethod(createAuthenticationMethod(typeA));
+    const start = doStart();
+    const registry = start.getAuthenticationMethodRegistery();
+    expect(registry.getAuthenticationMethod('typeA')).toEqual(typeA);
+  });
+});

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -11,7 +11,7 @@ import { ManagementSetup } from '../../management/public';
 import { IndexPatternManagementSetup } from '../../index_pattern_management/public';
 import { DataSourceColumn } from './components/data_source_column/data_source_column';
 import {
-  AuthMethodUIElements,
+  AuthenticationMethod,
   IAuthenticationMethodRegistery,
   AuthenticationMethodRegistery,
 } from './auth_registry';
@@ -22,7 +22,7 @@ export interface DataSourceManagementSetupDependencies {
 }
 
 export interface DataSourceManagementPluginSetup {
-  registerAuthenticationMethod: (name: string, authMethodValues: AuthMethodUIElements) => void;
+  registerAuthenticationMethod: (authMethodValues: AuthenticationMethod) => void;
 }
 
 export interface DataSourceManagementPluginStart {
@@ -69,16 +69,13 @@ export class DataSourceManagementPlugin
       },
     });
 
-    const registerAuthenticationMethod = (
-      name: string,
-      authMethodUIElements: AuthMethodUIElements
-    ) => {
+    const registerAuthenticationMethod = (authMethod: AuthenticationMethod) => {
       if (this.started) {
         throw new Error(
           'cannot call `registerAuthenticationMethod` after data source management startup.'
         );
       }
-      this.authMethodsRegistry.registerAuthenticationMethod(name, authMethodUIElements);
+      this.authMethodsRegistry.registerAuthenticationMethod(authMethod);
     };
 
     return { registerAuthenticationMethod };

--- a/src/plugins/index_pattern_management/public/mocks.ts
+++ b/src/plugins/index_pattern_management/public/mocks.ts
@@ -53,6 +53,9 @@ const createSetupContract = (): IndexPatternManagementSetup => ({
   environment: {
     update: jest.fn(),
   },
+  columns: {
+    register: jest.fn(),
+  },
 });
 
 const createStartContract = (): IndexPatternManagementStart => ({


### PR DESCRIPTION
### Description

This PR adds the interfaces to register authentication method into the registry and get authentication registry. These interfaces are accessible via the setup and start hook in `plugin.ts`. Any core components or plugins that list dataSource and dataSourceManagement as a dependency will have access to these interfaces.

### Issues Resolved

Partially resolves #5692 

### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
