### PR TITLE
Bug 5861

### DIFF
--- a/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
+++ b/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
@@ -72,7 +72,6 @@ describe('#checkConflictsForDataSource', () => {
       filteredObjects: [],
       errors: [],
       importIdMap: new Map(),
-      pendingOverwrites: new Set(),
     });
   });
 
@@ -83,7 +82,6 @@ describe('#checkConflictsForDataSource', () => {
       filteredObjects: [dataSourceObj1, dataSourceObj2],
       errors: [],
       importIdMap: new Map(),
-      pendingOverwrites: new Set(),
     });
   });
 
@@ -118,10 +116,6 @@ describe('#checkConflictsForDataSource', () => {
             { id: 'currentDsId_id-2', omitOriginId: true },
           ],
         ]),
-        pendingOverwrites: new Set([
-          `${dataSourceObj1.type}:${dataSourceObj1.id}`,
-          `${dataSourceObj2.type}:${dataSourceObj2.id}`,
-        ]),
       })
     );
   });
@@ -144,7 +138,6 @@ describe('#checkConflictsForDataSource', () => {
         },
       ],
       importIdMap: new Map(),
-      pendingOverwrites: new Set(),
     });
   });
 });

--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -437,7 +437,7 @@ describe('#importSavedObjectsFromStream', () => {
       };
 
       test('with createNewCopies disabled', async () => {
-        const options = setupOptions(false, undefined);
+        const options = setupOptions();
         getMockFn(checkConflicts).mockResolvedValue({
           errors: [],
           filteredObjects: [],
@@ -557,7 +557,7 @@ describe('#importSavedObjectsFromStream', () => {
     });
 
     test('accumulates multiple errors', async () => {
-      const options = setupOptions(false, undefined);
+      const options = setupOptions();
       const errors = [createError(), createError(), createError(), createError(), createError()];
       getMockFn(collectSavedObjects).mockResolvedValue({
         errors: [errors[0]],

--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -247,6 +247,12 @@ describe('#importSavedObjectsFromStream', () => {
           collectedObjects,
           importIdMap: new Map(),
         });
+        getMockFn(checkConflicts).mockResolvedValue({
+          errors: [],
+          filteredObjects: collectedObjects,
+          importIdMap: new Map([['bar', { id: 'newId1' }]]),
+          pendingOverwrites: new Set(),
+        });
 
         await importSavedObjectsFromStream(options);
         const checkConflictsForDataSourceParams = {

--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -86,7 +86,6 @@ describe('#importSavedObjectsFromStream', () => {
       errors: [],
       filteredObjects: [],
       importIdMap: new Map(),
-      pendingOverwrites: new Set(),
     });
     getMockFn(createSavedObjects).mockResolvedValue({ errors: [], createdObjects: [] });
   });
@@ -500,7 +499,6 @@ describe('#importSavedObjectsFromStream', () => {
           errors: [],
           filteredObjects: [],
           importIdMap: new Map(),
-          pendingOverwrites: new Set([`${dsSuccess2.type}:${dsSuccess2.id}`]),
         });
         getMockFn(checkConflicts).mockResolvedValue({
           errors: [],

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -94,22 +94,6 @@ export async function importSavedObjectsFromStream({
       ignoreRegularConflicts: overwrite,
     };
 
-    // resolve when data source exist, pass the filtered objects to next check conflict
-    if (dataSourceId) {
-      const checkConflictsForDataSourceResult = await checkConflictsForDataSource({
-        objects: collectSavedObjectsResult.collectedObjects,
-        ignoreRegularConflicts: overwrite,
-        dataSourceId,
-      });
-
-      checkConflictsParams.objects = checkConflictsForDataSourceResult.filteredObjects;
-
-      pendingOverwrites = new Set([
-        ...pendingOverwrites,
-        ...checkConflictsForDataSourceResult.pendingOverwrites,
-      ]);
-    }
-
     const checkConflictsResult = await checkConflicts(checkConflictsParams);
     errorAccumulator = [...errorAccumulator, ...checkConflictsResult.errors];
     importIdMap = new Map([...importIdMap, ...checkConflictsResult.importIdMap]);
@@ -124,6 +108,19 @@ export async function importSavedObjectsFromStream({
       ignoreRegularConflicts: overwrite,
       importIdMap,
     };
+
+    /**
+     * If dataSourceId exist,
+     */
+    if (dataSourceId) {
+      const checkConflictsForDataSourceResult = await checkConflictsForDataSource({
+        objects: checkConflictsResult.filteredObjects,
+        ignoreRegularConflicts: overwrite,
+        dataSourceId,
+      });
+      checkOriginConflictsParams.objects = checkConflictsForDataSourceResult.filteredObjects;
+    }
+
     const checkOriginConflictsResult = await checkOriginConflicts(checkOriginConflictsParams);
     errorAccumulator = [...errorAccumulator, ...checkOriginConflictsResult.errors];
     importIdMap = new Map([...importIdMap, ...checkOriginConflictsResult.importIdMap]);


### PR DESCRIPTION
### Description

Adjust the order of checkConflicts, checkConflictForDataSource and checkOriginConflict.
The root cause of [issue 5861](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5861
) is when check conflict with data source, if there is no data source conflict, the object will be added in `pendingOverwrites` without checking wether the object found or not, which is told by checkConflict results, in errors array

We do not need to mutate the  `pendingOverwrites` in checkConflictForDataSource since checkConflicts already handled


### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5861

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

![bug-fix-5861](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/112784385/bdcb0bd9-064b-4a80-a5cc-e49c93a6c0b0)


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
