### PR TITLE
Add api registry and allow it to be added into client config in data source plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Add datasource picker to import saved object flyout when multiple data source is enabled ([#5781](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5781))
 - [Multiple Datasource] Add interfaces to register add-on authentication method from plug-in module ([#5851](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5851))
 - [Multiple Datasource] Able to Hide "Local Cluster" option from datasource DropDown ([#5827](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5827))
+- [Multiple Datasource] Add api registry and allow it to be added into client config in data source plugin ([#5895](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5895))
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/data_source/server/client/client_config.ts
+++ b/src/plugins/data_source/server/client/client_config.ts
@@ -15,7 +15,8 @@ import { DataSourcePluginConfigType } from '../../config';
 export function parseClientOptions(
   // TODO: will use client configs, that comes from a merge result of user config and default opensearch client config,
   config: DataSourcePluginConfigType,
-  endpoint: string
+  endpoint: string,
+  registeredSchema: any[]
 ): ClientOptions {
   const clientOptions: ClientOptions = {
     node: endpoint,
@@ -23,6 +24,7 @@ export function parseClientOptions(
       requestCert: true,
       rejectUnauthorized: true,
     },
+    plugins: registeredSchema,
   };
 
   return clientOptions;

--- a/src/plugins/data_source/server/client/configure_client.test.ts
+++ b/src/plugins/data_source/server/client/configure_client.test.ts
@@ -22,6 +22,7 @@ import { opensearchClientMock } from '../../../../core/server/opensearch/client/
 import { cryptographyServiceSetupMock } from '../cryptography_service.mocks';
 import { CryptographyServiceSetup } from '../cryptography_service';
 import { DataSourceClientParams } from '../types';
+import { CustomApiSchemaRegistry } from '../schema_registry';
 
 const DATA_SOURCE_ID = 'a54b76ec86771ee865a0f74a305dfff8';
 
@@ -38,12 +39,14 @@ describe('configureClient', () => {
   let dataSourceClientParams: DataSourceClientParams;
   let usernamePasswordAuthContent: UsernamePasswordTypedContent;
   let sigV4AuthContent: SigV4Content;
+  let customApiSchemaRegistry: CustomApiSchemaRegistry;
 
   beforeEach(() => {
     dsClient = opensearchClientMock.createInternalClient();
     logger = loggingSystemMock.createLogger();
     savedObjectsMock = savedObjectsClientMock.create();
     cryptographyMock = cryptographyServiceSetupMock.create();
+    customApiSchemaRegistry = new CustomApiSchemaRegistry();
 
     config = {
       enabled: true,
@@ -95,6 +98,7 @@ describe('configureClient', () => {
       dataSourceId: DATA_SOURCE_ID,
       savedObjects: savedObjectsMock,
       cryptography: cryptographyMock,
+      customApiSchemaRegistryPromise: Promise.resolve(customApiSchemaRegistry),
     };
 
     ClientMock.mockImplementation(() => dsClient);

--- a/src/plugins/data_source/server/client/configure_client.ts
+++ b/src/plugins/data_source/server/client/configure_client.ts
@@ -27,7 +27,6 @@ import {
   getDataSource,
   generateCacheKey,
 } from './configure_client_utils';
-import { CustomApiSchemaRegistry } from '../schema_registry';
 
 export const configureClient = async (
   {
@@ -71,11 +70,13 @@ export const configureClient = async (
       dataSourceId
     ) as Client;
 
+    const registeredSchema = (await customApiSchemaRegistryPromise).getAll();
+
     return await getQueryClient(
       dataSource,
       openSearchClientPoolSetup.addClientToPool,
       config,
-      customApiSchemaRegistryPromise,
+      registeredSchema,
       cryptography,
       rootClient,
       dataSourceId,
@@ -95,7 +96,7 @@ export const configureClient = async (
  *
  * @param rootClient root client for the given data source.
  * @param dataSourceAttr data source saved object attributes
- * @param customApiSchemaRegistryPromise custom api schema registry promise to be used when initiating client to register api schema
+ * @param registeredSchema registered API schema
  * @param cryptography cryptography service for password encryption / decryption
  * @param config data source config
  * @param addClientToPool function to add client to client pool
@@ -107,7 +108,7 @@ const getQueryClient = async (
   dataSourceAttr: DataSourceAttributes,
   addClientToPool: (endpoint: string, authType: AuthType, client: Client | LegacyClient) => void,
   config: DataSourcePluginConfigType,
-  customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>,
+  registeredSchema: any[],
   cryptography?: CryptographyServiceSetup,
   rootClient?: Client,
   dataSourceId?: string,
@@ -117,7 +118,6 @@ const getQueryClient = async (
     auth: { type },
     endpoint,
   } = dataSourceAttr;
-  const registeredSchema = (await customApiSchemaRegistryPromise).getAll();
   const clientOptions = parseClientOptions(config, endpoint, registeredSchema);
   const cacheKey = generateCacheKey(dataSourceAttr, dataSourceId);
 

--- a/src/plugins/data_source/server/legacy/client_config.ts
+++ b/src/plugins/data_source/server/legacy/client_config.ts
@@ -15,13 +15,15 @@ import { DataSourcePluginConfigType } from '../../config';
 export function parseClientOptions(
   // TODO: will use client configs, that comes from a merge result of user config and default legacy client config,
   config: DataSourcePluginConfigType,
-  endpoint: string
+  endpoint: string,
+  registeredSchema: any[]
 ): ConfigOptions {
   const configOptions: ConfigOptions = {
     host: endpoint,
     ssl: {
       rejectUnauthorized: true,
     },
+    plugins: registeredSchema,
   };
 
   return configOptions;

--- a/src/plugins/data_source/server/legacy/configure_legacy_client.test.ts
+++ b/src/plugins/data_source/server/legacy/configure_legacy_client.test.ts
@@ -15,6 +15,7 @@ import { OpenSearchClientPoolSetup } from '../client';
 import { ConfigOptions } from 'elasticsearch';
 import { ClientMock, parseClientOptionsMock } from './configure_legacy_client.test.mocks';
 import { configureLegacyClient } from './configure_legacy_client';
+import { CustomApiSchemaRegistry } from '../schema_registry';
 
 const DATA_SOURCE_ID = 'a54b76ec86771ee865a0f74a305dfff8';
 
@@ -35,6 +36,7 @@ describe('configureLegacyClient', () => {
   };
   let dataSourceClientParams: DataSourceClientParams;
   let callApiParams: LegacyClientCallAPIParams;
+  const customApiSchemaRegistry = new CustomApiSchemaRegistry();
 
   const mockResponse = { data: 'ping' };
 
@@ -98,6 +100,7 @@ describe('configureLegacyClient', () => {
       dataSourceId: DATA_SOURCE_ID,
       savedObjects: savedObjectsMock,
       cryptography: cryptographyMock,
+      customApiSchemaRegistryPromise: Promise.resolve(customApiSchemaRegistry),
     };
 
     ClientMock.mockImplementation(() => mockOpenSearchClientInstance);

--- a/src/plugins/data_source/server/legacy/configure_legacy_client.ts
+++ b/src/plugins/data_source/server/legacy/configure_legacy_client.ts
@@ -34,9 +34,15 @@ import {
   getDataSource,
   generateCacheKey,
 } from '../client/configure_client_utils';
+import { CustomApiSchemaRegistry } from '../schema_registry';
 
 export const configureLegacyClient = async (
-  { dataSourceId, savedObjects, cryptography }: DataSourceClientParams,
+  {
+    dataSourceId,
+    savedObjects,
+    cryptography,
+    customApiSchemaRegistryPromise,
+  }: DataSourceClientParams,
   callApiParams: LegacyClientCallAPIParams,
   openSearchClientPoolSetup: OpenSearchClientPoolSetup,
   config: DataSourcePluginConfigType,
@@ -56,6 +62,7 @@ export const configureLegacyClient = async (
       callApiParams,
       openSearchClientPoolSetup.addClientToPool,
       config,
+      customApiSchemaRegistryPromise,
       rootClient,
       dataSourceId
     );
@@ -85,6 +92,7 @@ const getQueryClient = async (
   { endpoint, clientParams, options }: LegacyClientCallAPIParams,
   addClientToPool: (endpoint: string, authType: AuthType, client: Client | LegacyClient) => void,
   config: DataSourcePluginConfigType,
+  customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>,
   rootClient?: LegacyClient,
   dataSourceId?: string
 ) => {
@@ -92,7 +100,8 @@ const getQueryClient = async (
     auth: { type },
     endpoint: nodeUrl,
   } = dataSourceAttr;
-  const clientOptions = parseClientOptions(config, nodeUrl);
+  const registeredSchema = (await customApiSchemaRegistryPromise).getAll();
+  const clientOptions = parseClientOptions(config, nodeUrl, registeredSchema);
   const cacheKey = generateCacheKey(dataSourceAttr, dataSourceId);
 
   switch (type) {

--- a/src/plugins/data_source/server/legacy/configure_legacy_client.ts
+++ b/src/plugins/data_source/server/legacy/configure_legacy_client.ts
@@ -34,7 +34,6 @@ import {
   getDataSource,
   generateCacheKey,
 } from '../client/configure_client_utils';
-import { CustomApiSchemaRegistry } from '../schema_registry';
 
 export const configureLegacyClient = async (
   {
@@ -56,13 +55,15 @@ export const configureLegacyClient = async (
       dataSourceId
     ) as LegacyClient;
 
+    const registeredSchema = (await customApiSchemaRegistryPromise).getAll();
+
     return await getQueryClient(
       dataSourceAttr,
       cryptography,
       callApiParams,
       openSearchClientPoolSetup.addClientToPool,
       config,
-      customApiSchemaRegistryPromise,
+      registeredSchema,
       rootClient,
       dataSourceId
     );
@@ -82,6 +83,7 @@ export const configureLegacyClient = async (
  * @param dataSourceAttr data source saved object attributes
  * @param cryptography cryptography service for password encryption / decryption
  * @param config data source config
+ * @param registeredSchema registered API schema
  * @param addClientToPool function to add client to client pool
  * @param dataSourceId id of data source saved Object
  * @returns child client.
@@ -92,7 +94,7 @@ const getQueryClient = async (
   { endpoint, clientParams, options }: LegacyClientCallAPIParams,
   addClientToPool: (endpoint: string, authType: AuthType, client: Client | LegacyClient) => void,
   config: DataSourcePluginConfigType,
-  customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>,
+  registeredSchema: any[],
   rootClient?: LegacyClient,
   dataSourceId?: string
 ) => {
@@ -100,7 +102,6 @@ const getQueryClient = async (
     auth: { type },
     endpoint: nodeUrl,
   } = dataSourceAttr;
-  const registeredSchema = (await customApiSchemaRegistryPromise).getAll();
   const clientOptions = parseClientOptions(config, nodeUrl, registeredSchema);
   const cacheKey = generateCacheKey(dataSourceAttr, dataSourceId);
 

--- a/src/plugins/data_source/server/schema_registry/custom_api_schema_registry.test.ts
+++ b/src/plugins/data_source/server/schema_registry/custom_api_schema_registry.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CustomApiSchemaRegistry } from './custom_api_schema_registry';
+
+describe('CustomApiSchemaRegistry', () => {
+  let registry: CustomApiSchemaRegistry;
+
+  beforeEach(() => {
+    registry = new CustomApiSchemaRegistry();
+  });
+
+  it('allows to register and get api schema', () => {
+    const sqlPlugin = () => {};
+    registry.register(sqlPlugin);
+    expect(registry.getAll()).toEqual([sqlPlugin]);
+  });
+});

--- a/src/plugins/data_source/server/schema_registry/custom_api_schema_registry.ts
+++ b/src/plugins/data_source/server/schema_registry/custom_api_schema_registry.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export class CustomApiSchemaRegistry {
+  private readonly schemaRegistry: any[];
+
+  constructor() {
+    this.schemaRegistry = new Array();
+  }
+
+  public register(schema: any) {
+    this.schemaRegistry.push(schema);
+  }
+
+  public getAll(): any[] {
+    return this.schemaRegistry;
+  }
+}

--- a/src/plugins/data_source/server/schema_registry/index.ts
+++ b/src/plugins/data_source/server/schema_registry/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { CustomApiSchemaRegistry } from './custom_api_schema_registry';

--- a/src/plugins/data_source/server/types.ts
+++ b/src/plugins/data_source/server/types.ts
@@ -19,6 +19,7 @@ import {
 import { CryptographyServiceSetup } from './cryptography_service';
 import { DataSourceError } from './lib/error';
 import { IAuthenticationMethodRegistery } from './auth_registry';
+import { CustomApiSchemaRegistry } from './schema_registry';
 
 export interface LegacyClientCallAPIParams {
   endpoint: string;
@@ -34,6 +35,8 @@ export interface DataSourceClientParams {
   dataSourceId?: string;
   // required when creating test client
   testClientDataSourceAttr?: DataSourceAttributes;
+  // custom API schema registry promise, required for getting registered custom API schema
+  customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>;
 }
 
 export interface DataSourceCredentialsProviderOptions {
@@ -77,8 +80,10 @@ declare module 'src/core/server' {
 export interface DataSourcePluginSetup {
   createDataSourceError: (err: any) => DataSourceError;
   registerCredentialProvider: (method: AuthenticationMethod) => void;
+  registerCustomApiSchema: (schema: any) => void;
 }
 
 export interface DataSourcePluginStart {
   getAuthenticationMethodRegistery: () => IAuthenticationMethodRegistery;
+  getCustomApiSchemaRegistry: () => CustomApiSchemaRegistry;
 }


### PR DESCRIPTION
### Description

This change allows consumers of data source plugin to register the API schema to be used in OpenSearch client and legacy client. 

### Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5854

## Screenshot


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/2f10f57e-08e7-418c-bcc6-0da26e7c2b0d


## Testing the changes
Here are the steps which was performed in the screenshot
1. disable data source plugin
2. add sample data from local cluster, and checked dashboard displays as expected
3. enable data source plugin
4. check the dashboard added from remote data source, and verified dashboard displays as expected
5. go to query bench which was changed locally to register the schema and use the new client, and verified that it can connect with remote data source and perform query as expected

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
