### PR TITLE
[Bug][Discover] Allow saved sort from search embeddable to load in Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG] Remove duplicate sample data as id 90943e30-9a47-11e8-b64d-95841ca0b247 ([5668](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5668))
 - [BUG][Multiple Datasource] Fix datasource testing connection unexpectedly passed with wrong endpoint [#5663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5663)
 - [Table Visualization] Fix filter action buttons for split table aggregations ([#5619](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5619))
+- [BUG][Discover] Allow saved sort from search embeddable to load in Dashboard ([#5934](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5934))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/discover/public/embeddable/search_embeddable.tsx
+++ b/src/plugins/discover/public/embeddable/search_embeddable.tsx
@@ -47,7 +47,6 @@ import {
 } from '../../../data/public';
 import { Container, Embeddable } from '../../../embeddable/public';
 import { ISearchEmbeddable, SearchInput, SearchOutput } from './types';
-import { getDefaultSort } from '../application/view_components/utils/get_default_sort';
 import { getSortForSearchSource } from '../application/view_components/utils/get_sort_for_search_source';
 import {
   getRequestInspectorStats,
@@ -215,12 +214,6 @@ export class SearchEmbeddable
     if (!indexPattern) {
       return;
     }
-
-    const sort = getDefaultSort(
-      indexPattern,
-      this.services.uiSettings.get(SORT_DEFAULT_ORDER_SETTING, 'desc')
-    );
-    this.savedSearch.sort = sort;
 
     const searchProps: SearchProps = {
       columns: this.savedSearch.columns,


### PR DESCRIPTION
### Description
Remove default sort to use saved search sort.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5933

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/b616acfa-2585-4d61-bd26-0361dbbd57d7




### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
