### PR TITLE
[BUG] Support duplicate index pattern name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Multiple Datasource] Fix datasource testing connection unexpectedly passed with wrong endpoint [#5663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5663)
 - [Table Visualization] Fix filter action buttons for split table aggregations ([#5619](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5619))
 - [BUG][Discover] Allow saved sort from search embeddable to load in Dashboard ([#5934](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5934))
+- [BUG][Discover] Add key to index pattern options for support deplicate index pattern names([#5946](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5946))
+
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/data/public/data_sources/datasource_selector/datasource_selectable.test.tsx
+++ b/src/plugins/data/public/data_sources/datasource_selector/datasource_selectable.test.tsx
@@ -181,4 +181,47 @@ describe('DataSourceSelectable', () => {
     ];
     expect(optionTexts).toEqual(expectedIndexPatternSortedOrder);
   });
+
+  it('should allow display and selection of duplicated index patterns based on unique key', async () => {
+    const mockDataSourceOptionListWithDuplicates = [
+      {
+        label: 'Index patterns',
+        options: [
+          { label: 'duplicate-index-pattern', key: 'unique-key-1' },
+          { label: 'unique-index-pattern-1', key: 'unique-key-2' },
+          { label: 'duplicate-index-pattern', key: 'unique-key-3' },
+          { label: 'unique-index-pattern-2', key: 'unique-key-4' },
+        ],
+      },
+    ] as any;
+
+    const handleSelect = jest.fn();
+
+    render(
+      <DataSourceSelectable
+        dataSources={[
+          ({
+            getDataSet: jest.fn().mockResolvedValue([]),
+            getType: jest.fn().mockReturnValue('DEFAULT_INDEX_PATTERNS'),
+            getName: jest.fn().mockReturnValue('Index patterns'),
+          } as unknown) as DataSourceType,
+        ]}
+        dataSourceOptionList={mockDataSourceOptionListWithDuplicates}
+        selectedSources={selectedSourcesMock}
+        onDataSourceSelect={handleSelect}
+        setDataSourceOptionList={setDataSourceOptionListMock}
+        onGetDataSetError={onFetchDataSetErrorMock}
+      />
+    );
+
+    const button = screen.getByLabelText('Open list of options');
+    fireEvent.click(button);
+
+    const optionsToSelect = screen.getAllByText('duplicate-index-pattern');
+    fireEvent.click(optionsToSelect[1]);
+
+    expect(handleSelect).toHaveBeenCalledWith(
+      expect.objectContaining([{ key: 'unique-key-3', label: 'duplicate-index-pattern' }])
+    );
+  });
 });

--- a/src/plugins/data/public/data_sources/datasource_selector/datasource_selectable.tsx
+++ b/src/plugins/data/public/data_sources/datasource_selector/datasource_selectable.tsx
@@ -52,6 +52,7 @@ export const getSourceOptions = (dataSource: DataSourceType, dataSet: DataSetTyp
       ...optionContent,
       label: dataSet.title,
       value: dataSet.id,
+      key: dataSet.id,
     };
   }
   return {


### PR DESCRIPTION
### Description

Before
![Screenshot 2024-02-23 at 11 02 21 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/80358241/562880d5-2783-4c44-aedc-ee8f2aef5465)

After
![Screenshot 2024-02-23 at 11 03 01 PM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/80358241/b0875686-012e-4a77-b023-148c621e6224)

After adding the id key, the duplicate index pattern is able to be selected, and seeing the index pattern id is reflected in search url.


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
