### PR TITLE
[Discover] Allow save query to load correctly in Discover

### DIFF
--- a/src/plugins/discover/public/application/utils/state_management/discover_slice.test.tsx
+++ b/src/plugins/discover/public/application/utils/state_management/discover_slice.test.tsx
@@ -4,6 +4,7 @@
  */
 
 import { discoverSlice, DiscoverState } from './discover_slice';
+import { SortOrder } from '../../../saved_searches/types';
 
 describe('discoverSlice', () => {
   let initialState: DiscoverState;
@@ -133,5 +134,41 @@ describe('discoverSlice', () => {
     };
     const result = discoverSlice.reducer(initialState, action);
     expect(result.columns).toEqual(['column1', 'column2', 'column3']);
+  });
+
+  it('should set the savedQuery when a valid string is provided', () => {
+    const savedQueryId = 'some-query-id';
+    const action = { type: 'discover/setSavedQuery', payload: savedQueryId };
+    const result = discoverSlice.reducer(initialState, action);
+    expect(result.savedQuery).toEqual(savedQueryId);
+  });
+
+  it('should remove the savedQuery from state when payload is undefined', () => {
+    // pre-set the savedQuery in the initialState
+    const initialStateWithSavedQuery = {
+      ...initialState,
+      savedQuery: 'existing-query-id',
+    };
+
+    const action = { type: 'discover/setSavedQuery', payload: undefined };
+    const result = discoverSlice.reducer(initialStateWithSavedQuery, action);
+
+    // Check that savedQuery is not in the resulting state
+    expect(result.savedQuery).toBeUndefined();
+  });
+
+  it('should not affect other state properties when setting savedQuery', () => {
+    const initialStateWithOtherProperties = {
+      ...initialState,
+      columns: ['column1', 'column2'],
+      sort: [['field1', 'asc']] as SortOrder[],
+    };
+    const savedQueryId = 'new-query-id';
+    const action = { type: 'discover/setSavedQuery', payload: savedQueryId };
+    const result = discoverSlice.reducer(initialStateWithOtherProperties, action);
+    // check that other properties remain unchanged
+    expect(result.columns).toEqual(['column1', 'column2']);
+    expect(result.sort).toEqual([['field1', 'asc']] as SortOrder[]);
+    expect(result.savedQuery).toEqual(savedQueryId);
   });
 });

--- a/src/plugins/discover/public/application/utils/state_management/discover_slice.test.tsx
+++ b/src/plugins/discover/public/application/utils/state_management/discover_slice.test.tsx
@@ -136,7 +136,7 @@ describe('discoverSlice', () => {
     expect(result.columns).toEqual(['column1', 'column2', 'column3']);
   });
 
-  it('should set the savedQuery when a valid string is provided', () => {
+  it('should set the savedQuery when a valid id is provided', () => {
     const savedQueryId = 'some-query-id';
     const action = { type: 'discover/setSavedQuery', payload: savedQueryId };
     const result = discoverSlice.reducer(initialState, action);

--- a/src/plugins/discover/public/application/utils/state_management/discover_slice.tsx
+++ b/src/plugins/discover/public/application/utils/state_management/discover_slice.tsx
@@ -46,6 +46,7 @@ export interface DiscoverState {
   /**
    * Metadata for the view
    */
+  savedQuery?: string;
   metadata?: {
     /**
      * Number of lines to display per row
@@ -109,6 +110,9 @@ export const discoverSlice = createSlice({
   reducers: {
     setState(state, action: PayloadAction<DiscoverState>) {
       return action.payload;
+    },
+    getState(state, action: PayloadAction<DiscoverState>) {
+      return state;
     },
     addColumn(state, action: PayloadAction<{ column: string; index?: number }>) {
       const columns = utils.addColumn(state.columns || [], action.payload);
@@ -188,6 +192,18 @@ export const discoverSlice = createSlice({
         },
       };
     },
+    setSavedQuery(state, action: PayloadAction<string | undefined>) {
+      if (action.payload === undefined) {
+        // if the payload is undefined, remove the savedQuery property
+        const { savedQuery, ...restState } = state;
+        return restState;
+      } else {
+        return {
+          ...state,
+          savedQuery: action.payload,
+        };
+      }
+    },
   },
 });
 
@@ -201,8 +217,10 @@ export const {
   setSort,
   setInterval,
   setState,
+  getState,
   updateState,
   setSavedSearchId,
   setMetadata,
+  setSavedQuery,
 } = discoverSlice.actions;
 export const { reducer } = discoverSlice;

--- a/src/plugins/discover/public/application/utils/state_management/discover_slice.tsx
+++ b/src/plugins/discover/public/application/utils/state_management/discover_slice.tsx
@@ -111,9 +111,6 @@ export const discoverSlice = createSlice({
     setState(state, action: PayloadAction<DiscoverState>) {
       return action.payload;
     },
-    getState(state, action: PayloadAction<DiscoverState>) {
-      return state;
-    },
     addColumn(state, action: PayloadAction<{ column: string; index?: number }>) {
       const columns = utils.addColumn(state.columns || [], action.payload);
       return { ...state, columns: buildColumns(columns) };
@@ -217,7 +214,6 @@ export const {
   setSort,
   setInterval,
   setState,
-  getState,
   updateState,
   setSavedSearchId,
   setMetadata,

--- a/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_table.tsx
@@ -22,6 +22,7 @@ import { DocViewFilterFn } from '../../doc_views/doc_views_types';
 import { SortOrder } from '../../../saved_searches/types';
 import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { popularizeField } from '../../helpers/popularize_field';
+import { buildColumns } from '../../utils/columns';
 
 interface Props {
   rows?: OpenSearchSearchHit[];
@@ -39,7 +40,20 @@ export const DiscoverTable = ({ rows, scrollToTop }: Props) => {
   } = services;
 
   const { refetch$, indexPattern, savedSearch } = useDiscoverContext();
-  const { columns, sort } = useSelector((state) => state.discover);
+  const { columns } = useSelector((state) => {
+    const stateColumns = state.discover.columns;
+    // check if state columns is not undefined, otherwise use buildColumns
+    return {
+      columns: stateColumns !== undefined ? stateColumns : buildColumns([]),
+    };
+  });
+  const { sort } = useSelector((state) => {
+    const stateSort = state.discover.sort;
+    // check if state sort is not undefined, otherwise assign an empty array
+    return {
+      sort: stateSort !== undefined ? stateSort : [],
+    };
+  });
   const dispatch = useDispatch();
   const onAddColumn = (col: string) => {
     if (indexPattern && capabilities.discover?.save) {

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -21,6 +21,7 @@ import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_re
 import { filterColumns } from '../utils/filter_columns';
 import { DEFAULT_COLUMNS_SETTING, MODIFY_COLUMNS_ON_SWITCH } from '../../../../common';
 import { OpenSearchSearchHit } from '../../../application/doc_views/doc_views_types';
+import { buildColumns } from '../../utils/columns';
 import './discover_canvas.scss';
 import { getNewDiscoverSetting, setNewDiscoverSetting } from '../../components/utils/local_storage';
 
@@ -29,9 +30,16 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
   const panelRef = useRef<HTMLDivElement>(null);
   const { data$, refetch$, indexPattern } = useDiscoverContext();
   const {
-    services: { uiSettings, storage },
+    services: { uiSettings, storage, capabilities },
   } = useOpenSearchDashboards<DiscoverViewServices>();
-  const { columns } = useSelector((state) => state.discover);
+  const { columns } = useSelector((state) => {
+    const stateColumns = state.discover.columns;
+
+    // check if stateColumns is not undefined, otherwise use buildColumns
+    return {
+      columns: stateColumns !== undefined ? stateColumns : buildColumns([]),
+    };
+  });
   const filteredColumns = filterColumns(
     columns,
     indexPattern,
@@ -97,6 +105,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
       panelRef.current.scrollTop = 0;
     }
   };
+  const showSaveQuery = !!capabilities.discover?.saveQuery;
 
   const [isOptionsOpen, setOptionsOpen] = useState(false);
   const [useLegacy, setUseLegacy] = useState(!getNewDiscoverSetting(storage));
@@ -159,6 +168,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history }: ViewPro
           setHeaderActionMenu,
           onQuerySubmit,
         }}
+        showSaveQuery={showSaveQuery}
       />
       {fetchState.status === ResultStatus.NO_RESULTS && (
         <DiscoverNoResults timeFieldName={timeField} queryLanguage={''} />

--- a/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
@@ -14,18 +14,22 @@ import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { getTopNavLinks } from '../../components/top_nav/get_top_nav_links';
 import { getRootBreadcrumbs } from '../../helpers/breadcrumbs';
 import { useDiscoverContext } from '../context';
+import { useDispatch, setSavedQuery, useSelector } from '../../utils/state_management';
 
 export interface TopNavProps {
   opts: {
     setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
     onQuerySubmit: (payload: { dateRange: TimeRange; query?: Query }, isUpdate?: boolean) => void;
   };
+  showSaveQuery: boolean;
 }
 
-export const TopNav = ({ opts }: TopNavProps) => {
+export const TopNav = ({ opts, showSaveQuery }: TopNavProps) => {
   const { services } = useOpenSearchDashboards<DiscoverViewServices>();
   const { inspectorAdapters, savedSearch, indexPattern } = useDiscoverContext();
   const [indexPatterns, setIndexPatterns] = useState<IndexPattern[] | undefined>(undefined);
+  const state = useSelector((s) => s.discover);
+  const dispatch = useDispatch();
 
   const {
     navigation: {
@@ -79,13 +83,17 @@ export const TopNav = ({ opts }: TopNavProps) => {
     indexPattern,
   ]);
 
+  const updateSavedQueryId = (newSavedQueryId: string | undefined) => {
+    dispatch(setSavedQuery(newSavedQueryId));
+  };
+
   return (
     <TopNavMenu
       appName={PLUGIN_ID}
       config={topNavLinks}
       showSearchBar
       showDatePicker={showDatePicker}
-      showSaveQuery
+      showSaveQuery={showSaveQuery}
       useDefaultBehaviors
       setMenuMountPoint={opts.setHeaderActionMenu}
       indexPatterns={indexPattern ? [indexPattern] : indexPatterns}
@@ -94,6 +102,8 @@ export const TopNav = ({ opts }: TopNavProps) => {
       // is ported to main, pass dataSource to TopNavMenu by picking
       // commit 328e08e688c again.
       onQuerySubmit={opts.onQuerySubmit}
+      savedQueryId={state.savedQuery}
+      onSavedQueryIdChange={updateSavedQueryId}
     />
   );
 };

--- a/src/plugins/discover/public/application/view_components/context/index.tsx
+++ b/src/plugins/discover/public/application/view_components/context/index.tsx
@@ -10,7 +10,7 @@ import {
   useOpenSearchDashboards,
 } from '../../../../../opensearch_dashboards_react/public';
 import { getServices } from '../../../opensearch_dashboards_services';
-import { useSearch, SearchContextValue } from '../utils/use_search';
+import { useSearch, SearchContextValue, ResultStatus } from '../utils/use_search';
 
 const SearchContext = React.createContext<SearchContextValue>({} as SearchContextValue);
 
@@ -21,6 +21,9 @@ export default function DiscoverContext({ children }: React.PropsWithChildren<Vi
   const searchParams = useSearch({
     ...deServices,
     ...services,
+  });
+  searchParams.data$.next({
+    status: ResultStatus.LOADING,
   });
 
   return (

--- a/src/plugins/discover/public/application/view_components/panel/index.tsx
+++ b/src/plugins/discover/public/application/view_components/panel/index.tsx
@@ -37,9 +37,13 @@ export default function DiscoverPanel(props: ViewProps) {
   const { data$, indexPattern } = useDiscoverContext();
   const [fetchState, setFetchState] = useState<SearchData>(data$.getValue());
 
-  const { columns } = useSelector((state) => ({
-    columns: state.discover.columns,
-  }));
+  const { columns } = useSelector((state) => {
+    const stateColumns = state.discover.columns;
+    // check if state columns is not undefined, otherwise use buildColumns
+    return {
+      columns: stateColumns !== undefined ? stateColumns : buildColumns([]),
+    };
+  });
 
   const prevColumns = useRef(columns);
   const dispatch = useDispatch();
@@ -49,6 +53,7 @@ export default function DiscoverPanel(props: ViewProps) {
     if (columns !== prevColumns.current) {
       let updatedColumns = buildColumns(columns);
       if (
+        columns &&
         timeFieldname &&
         !prevColumns.current.includes(timeFieldname) &&
         columns.includes(timeFieldname)

--- a/src/plugins/discover/public/url_generator.ts
+++ b/src/plugins/discover/public/url_generator.ts
@@ -78,6 +78,10 @@ export interface DiscoverUrlGeneratorState {
    * whether to hash the data in the url to avoid url length issues.
    */
   useHash?: boolean;
+  /**
+   * Saved query Id
+   */
+  savedQuery?: string;
 }
 
 interface Params {
@@ -99,12 +103,14 @@ export class DiscoverUrlGenerator
     savedSearchId,
     timeRange,
     useHash = this.params.useHash,
+    savedQuery,
   }: DiscoverUrlGeneratorState): Promise<string> => {
     const savedSearchPath = savedSearchId ? encodeURIComponent(savedSearchId) : '';
     const appState: {
       query?: Query;
       filters?: Filter[];
       index?: string;
+      savedQuery?: string;
     } = {};
     const queryState: QueryState = {};
 
@@ -117,6 +123,7 @@ export class DiscoverUrlGenerator
     if (filters && filters.length)
       queryState.filters = filters?.filter((f) => opensearchFilters.isFilterPinned(f));
     if (refreshInterval) queryState.refreshInterval = refreshInterval;
+    if (savedQuery) appState.savedQuery = savedQuery;
 
     let url = `${this.params.appBasePath}#/${savedSearchPath}`;
     url = setStateToOsdUrl<QueryState>('_g', queryState, { useHash }, url);

--- a/src/plugins/vis_builder/public/application/components/top_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/top_nav.tsx
@@ -14,11 +14,13 @@ import { VisBuilderServices } from '../../types';
 import './top_nav.scss';
 import { useIndexPatterns, useSavedVisBuilderVis } from '../utils/use';
 import { useTypedSelector, useTypedDispatch } from '../utils/state_management';
+import { setSavedQuery } from '../utils/state_management/visualization_slice';
 import { setEditorState } from '../utils/state_management/metadata_slice';
 import { useCanSave } from '../utils/use/use_can_save';
 import { saveStateToSavedObject } from '../../saved_visualizations/transforms';
 import { TopNavMenuData } from '../../../../navigation/public';
 import { opensearchFilters, connectStorageToQueryState } from '../../../../data/public';
+import { RootState } from '../../../../data_explorer/public';
 
 function useDeepEffect(callback, dependencies) {
   const currentDepsRef = useRef(dependencies);
@@ -40,8 +42,9 @@ export const TopNav = () => {
       ui: { TopNavMenu },
     },
     appName,
+    capabilities,
   } = services;
-  const rootState = useTypedSelector((state) => state);
+  const rootState = useTypedSelector((state: RootState) => state);
   const dispatch = useTypedDispatch();
 
   useDeepEffect(() => {
@@ -93,6 +96,11 @@ export const TopNav = () => {
     dispatch(setEditorState({ state: 'loading' }));
   });
 
+  const updateSavedQueryId = (newSavedQueryId: string | undefined) => {
+    dispatch(setSavedQuery(newSavedQueryId));
+  };
+  const showSaveQuery = !!capabilities['visualization-visbuilder']?.saveQuery;
+
   return (
     <div className="vbTopNav">
       <TopNavMenu
@@ -102,8 +110,10 @@ export const TopNav = () => {
         indexPatterns={indexPattern ? [indexPattern] : []}
         showDatePicker={!!indexPattern?.timeFieldName ?? true}
         showSearchBar
-        showSaveQuery
+        showSaveQuery={showSaveQuery}
         useDefaultBehaviors
+        savedQueryId={rootState.visualization.savedQuery}
+        onSavedQueryIdChange={updateSavedQueryId}
       />
     </div>
   );

--- a/src/plugins/vis_builder/public/application/utils/state_management/visualization_slice.test.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/visualization_slice.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  slice as visualizationSlice,
+  VisualizationState,
+  setIndexPattern,
+  setSearchField,
+  editDraftAgg,
+  saveDraftAgg,
+  updateAggConfigParams,
+  setAggParamValue,
+  reorderAgg,
+  setSavedQuery,
+  setState,
+} from './visualization_slice';
+import { CreateAggConfigParams } from '../../../../../data/common';
+
+describe('visualizationSlice', () => {
+  let initialState: VisualizationState;
+
+  beforeEach(() => {
+    initialState = {
+      searchField: '',
+      activeVisualization: {
+        name: 'some-vis',
+        aggConfigParams: [],
+      },
+      savedQuery: undefined,
+    } as VisualizationState;
+  });
+
+  it('should handle setIndexPattern', () => {
+    const indexPattern = 'new-index-pattern';
+    const action = setIndexPattern(indexPattern);
+    const result = visualizationSlice.reducer(initialState, action);
+    expect(result.indexPattern).toEqual(indexPattern);
+  });
+
+  it('should handle setSearchField', () => {
+    const searchField = 'new-search-field';
+    const action = setSearchField(searchField);
+    const result = visualizationSlice.reducer(initialState, action);
+    expect(result.searchField).toEqual(searchField);
+  });
+
+  it('should handle editDraftAgg', () => {
+    const draftAgg: CreateAggConfigParams = { id: '1', enabled: true, type: 'count', params: {} };
+    const action = editDraftAgg(draftAgg);
+    const result = visualizationSlice.reducer(initialState, action);
+    expect(result.activeVisualization?.draftAgg).toEqual(draftAgg);
+  });
+
+  it('should handle saveDraftAgg', () => {
+    const draftAgg: CreateAggConfigParams = { id: '1', enabled: true, type: 'count', params: {} };
+    const stateWithDraft = {
+      ...initialState,
+      activeVisualization: {
+        name: 'some-name',
+        draftAgg,
+        aggConfigParams: [],
+      },
+    };
+    const action = saveDraftAgg(undefined);
+    const result = visualizationSlice.reducer(stateWithDraft, action);
+    expect(result.activeVisualization?.aggConfigParams).toContain(draftAgg);
+  });
+
+  it('should handle updateAggConfigParams', () => {
+    const newAggConfigParams: CreateAggConfigParams[] = [
+      { id: '2', enabled: true, type: 'avg', params: {} },
+    ];
+    const action = updateAggConfigParams(newAggConfigParams);
+    const result = visualizationSlice.reducer(initialState, action);
+    expect(result.activeVisualization?.aggConfigParams).toEqual(newAggConfigParams);
+  });
+
+  it('should handle setAggParamValue', () => {
+    const aggParamValue = { aggId: '1', paramName: 'field', value: 'newField' };
+    const action = setAggParamValue(aggParamValue);
+
+    const initialStateWithAgg = {
+      ...initialState,
+      activeVisualization: {
+        ...initialState.activeVisualization,
+        name: 'defaultName',
+        aggConfigParams: [{ id: '1', enabled: true, type: 'count', params: {} }],
+      },
+    };
+
+    const result = visualizationSlice.reducer(initialStateWithAgg, action);
+    expect(
+      result.activeVisualization?.aggConfigParams?.[0]?.params?.[aggParamValue.paramName]
+    ).toEqual(aggParamValue.value);
+  });
+
+  it('should handle reorderAgg', () => {
+    const reorderAction = { sourceId: '1', destinationId: '2' };
+    const action = reorderAgg(reorderAction);
+
+    // Initial state with multiple aggregations
+    const initialStateWithMultipleAggs = {
+      ...initialState,
+      activeVisualization: {
+        ...initialState.activeVisualization,
+        name: 'defaultName',
+        aggConfigParams: [
+          { id: '1', enabled: true, type: 'count', params: {} },
+          { id: '2', enabled: true, type: 'avg', params: {} },
+        ],
+      },
+    };
+
+    const result = visualizationSlice.reducer(initialStateWithMultipleAggs, action);
+    // verify the order of aggConfigParams
+    expect(result.activeVisualization?.aggConfigParams[0].id).toEqual('2');
+    expect(result.activeVisualization?.aggConfigParams[1].id).toEqual('1');
+  });
+
+  it('should handle savedQueryId by setSavedQuery', () => {
+    const savedQueryId = 'some-query-id';
+    const action = setSavedQuery(savedQueryId);
+    const result = visualizationSlice.reducer(initialState, action) as VisualizationState;
+    expect(result.savedQuery).toEqual(savedQueryId);
+  });
+
+  it('should handle undefined savedQueryId by setSavedQuery', () => {
+    const savedQueryId = undefined;
+    const action = setSavedQuery(savedQueryId);
+    const result = visualizationSlice.reducer(initialState, action) as VisualizationState;
+    expect(result.savedQuery).toBeUndefined();
+  });
+
+  it('should handle setState', () => {
+    const newState = {
+      searchField: 'new-search-field',
+      activeVisualization: {
+        name: 'new-vis',
+        aggConfigParams: [],
+      },
+    };
+    const action = setState(newState);
+    const result = visualizationSlice.reducer(initialState, action);
+    expect(result).toEqual(newState);
+  });
+});

--- a/src/plugins/vis_builder/public/application/utils/state_management/visualization_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/visualization_slice.ts
@@ -16,6 +16,7 @@ export interface VisualizationState {
     aggConfigParams: CreateAggConfigParams[];
     draftAgg?: CreateAggConfigParams;
   };
+  savedQuery?: string;
 }
 
 const initialState: VisualizationState = {
@@ -115,6 +116,18 @@ export const slice = createSlice({
         [action.payload.paramName]: action.payload.value,
       };
     },
+    setSavedQuery(state, action: PayloadAction<string | undefined>) {
+      if (action.payload === undefined) {
+        // if the payload is undefined, remove the savedQuery property
+        const { savedQuery, ...restState } = state;
+        return restState;
+      } else {
+        return {
+          ...state,
+          savedQuery: action.payload,
+        };
+      }
+    },
     setState: (_state, action: PayloadAction<VisualizationState>) => {
       return action.payload;
     },
@@ -138,5 +151,6 @@ export const {
   updateAggConfigParams,
   setAggParamValue,
   reorderAgg,
+  setSavedQuery,
   setState,
 } = slice.actions;

--- a/src/plugins/vis_builder/public/plugin.ts
+++ b/src/plugins/vis_builder/public/plugin.ts
@@ -163,6 +163,7 @@ export class VisBuilderPlugin
           embeddable: pluginsStart.embeddable,
           dashboard: pluginsStart.dashboard,
           uiActions: pluginsStart.uiActions,
+          capabilities: coreStart.application.capabilities,
         };
 
         // Instantiate the store

--- a/src/plugins/vis_builder/public/types.ts
+++ b/src/plugins/vis_builder/public/types.ts
@@ -17,6 +17,7 @@ import { AppMountParameters, CoreStart, ToastsStart, ScopedHistory } from '../..
 import { IOsdUrlStateStorage } from '../../opensearch_dashboards_utils/public';
 import { DataPublicPluginSetup } from '../../data/public';
 import { UiActionsStart } from '../../ui_actions/public';
+import { Capabilities } from '../../../core/public';
 
 export type VisBuilderSetup = TypeServiceSetup;
 export interface VisBuilderStart extends TypeServiceStart {
@@ -54,6 +55,7 @@ export interface VisBuilderServices extends CoreStart {
   osdUrlStateStorage: IOsdUrlStateStorage;
   dashboard: DashboardStart;
   uiActions: UiActionsStart;
+  capabilities: Capabilities;
 }
 
 export interface ISavedVis {

--- a/src/plugins/vis_builder/server/capabilities_provider.ts
+++ b/src/plugins/vis_builder/server/capabilities_provider.ts
@@ -12,6 +12,6 @@ export const capabilitiesProvider = () => ({
     show: true,
     // showWriteControls: true,
     // save: true,
-    // saveQuery: true,
+    saveQuery: true,
   },
 });


### PR DESCRIPTION
## Description
* add save query logic in Discover
* add save query logic in VisBuilder

## Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5942

## Changelog
- fix: Load saved queries into Discover correctly

## Screenshot
* discover save query

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/939cce87-a711-45c9-b38f-207c8a4e350d


* visbuilder save query

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/ca88a01d-0214-4b51-a0e2-951bf848ceae




### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

