### PR TITLE
[osd/std] Add additional recovery from false-positives in handling of long numerals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Multiple Datasource] Fix datasource testing connection unexpectedly passed with wrong endpoint [#5663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5663)
 - [Table Visualization] Fix filter action buttons for split table aggregations ([#5619](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5619))
 - [BUG][Discover] Allow saved sort from search embeddable to load in Dashboard ([#5934](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5934))
+- [osd/std] Add additional recovery from false-positives in handling of long numerals ([#5956](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5956))
 
 ### 🚞 Infrastructure
 

--- a/packages/osd-std/src/json.ts
+++ b/packages/osd-std/src/json.ts
@@ -150,16 +150,38 @@ const parseStringWithLongNumerals = (
     } catch (e) {
       hadException = true;
       /* There are two types of exception objects that can be raised:
-       *  1) a proper object with lineNumber and columnNumber which we can use
-       *  2) a textual message with the position that we need to parse
+       *  1) a textual message with the position that we need to parse
+       *     i. Unexpected [token|string ...] at position ...
+       *    ii. expected ',' or '}' after property value in object at line ... column ...
+       *  2) a proper object with lineNumber and columnNumber which we can use
+       *    Note: this might refer to the part of the code that threw the exception but
+       *          we will try it anyway; the regex is specific enough to not produce
+       *          false-positives.
        */
       let { lineNumber, columnNumber } = e;
-      if (!lineNumber || !columnNumber) {
-        const match = e?.message?.match?.(/^Unexpected token.*at position (\d+)$/);
+
+      if (typeof e?.message === 'string') {
+        /* Check for 1-i (seen in Node)
+         * Finding "..."෴1111"..." inside a string value, the extra quotes throw a syntax error
+         * and the position points to " that is assumed to be the begining of a value.
+         */
+        let match = e.message.match(/^Unexpected .*at position (\d+)(\s|$)/);
         if (match) {
           lineNumber = 1;
-          // The position is zero-indexed; adding 1 to normalize it for the -2 that comes later
+          // Add 1 to reach the marker
           columnNumber = parseInt(match[1], 10) + 1;
+        } else {
+          /* Check for 1-ii (seen in browsers)
+           * Finding "...,"෴1111"..." inside a string value, the extra quotes throw a syntax error
+           * and the column number points to the marker after the " that is assumed to be terminating the
+           * value.
+           */
+          // ToDo: Add functional tests for this path
+          match = e.message.match(/expected .*at line (\d+) column (\d+)(\s|$)/);
+          if (match) {
+            lineNumber = parseInt(match[1], 10);
+            columnNumber = parseInt(match[2], 10);
+          }
         }
       }
 


### PR DESCRIPTION
### Description

The parsing of JSON strings with long numerals in @osd/std handled two false-positive scenarios. A new one was discovered where mixed escaped quotes inside a string value resulted in a different exception in browsers that the one already handled for Node.

### Issues Resolved

Fixes #5923

### Check List

- [X] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
