### PR TITLE
Fix Test connection for data source

### DIFF
--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -129,7 +129,8 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
       router,
       dataSourceService,
       cryptographyServiceSetup,
-      authRegistryPromise
+      authRegistryPromise,
+      customApiSchemaRegistryPromise
     );
 
     const registerCredentialProvider = (method: AuthenticationMethod) => {

--- a/src/plugins/data_source/server/routes/test_connection.ts
+++ b/src/plugins/data_source/server/routes/test_connection.ts
@@ -10,12 +10,14 @@ import { DataSourceConnectionValidator } from './data_source_connection_validato
 import { DataSourceServiceSetup } from '../data_source_service';
 import { CryptographyServiceSetup } from '../cryptography_service';
 import { IAuthenticationMethodRegistery } from '../auth_registry';
+import { CustomApiSchemaRegistry } from '../schema_registry';
 
 export const registerTestConnectionRoute = async (
   router: IRouter,
   dataSourceServiceSetup: DataSourceServiceSetup,
   cryptography: CryptographyServiceSetup,
-  authRegistryPromise: Promise<IAuthenticationMethodRegistery>
+  authRegistryPromise: Promise<IAuthenticationMethodRegistery>,
+  customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>
 ) => {
   const authRegistry = await authRegistryPromise;
   router.post(
@@ -66,6 +68,7 @@ export const registerTestConnectionRoute = async (
             cryptography,
             dataSourceId,
             testClientDataSourceAttr: dataSourceAttr as DataSourceAttributes,
+            customApiSchemaRegistryPromise,
             request,
             authRegistry,
           }


### PR DESCRIPTION
### Description

Due to missing `customApiRegistry` parameter, Test connection was broken in data source. This PR fixes that issue.

### Issues Resolved

#5924

## Screenshot


<img width="1912" alt="Screenshot 2024-02-26 at 2 25 34 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/63824432/304506f9-f6af-4997-9de0-f00432f0a9ab">

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
