### PR TITLE
Fixes authentication_methods_registry.mock module

### DIFF
--- a/src/plugins/data_source/server/auth_registry/index.ts
+++ b/src/plugins/data_source/server/auth_registry/index.ts
@@ -7,5 +7,3 @@ export {
   IAuthenticationMethodRegistery,
   AuthenticationMethodRegistery,
 } from './authentication_methods_registry';
-
-export { authenticationMethodRegisteryMock } from './authentication_methods_registry.mock';

--- a/src/plugins/data_source/server/client/configure_client.test.ts
+++ b/src/plugins/data_source/server/client/configure_client.test.ts
@@ -27,10 +27,8 @@ import { cryptographyServiceSetupMock } from '../cryptography_service.mocks';
 import { CryptographyServiceSetup } from '../cryptography_service';
 import { DataSourceClientParams, AuthenticationMethod } from '../types';
 import { CustomApiSchemaRegistry } from '../schema_registry';
-import {
-  IAuthenticationMethodRegistery,
-  authenticationMethodRegisteryMock,
-} from '../auth_registry';
+import { IAuthenticationMethodRegistery } from '../auth_registry';
+import { authenticationMethodRegisteryMock } from '../auth_registry/authentication_methods_registry.mock';
 
 const DATA_SOURCE_ID = 'a54b76ec86771ee865a0f74a305dfff8';
 

--- a/src/plugins/data_source/server/legacy/configure_legacy_client.test.ts
+++ b/src/plugins/data_source/server/legacy/configure_legacy_client.test.ts
@@ -20,10 +20,8 @@ import {
 } from './configure_legacy_client.test.mocks';
 import { configureLegacyClient } from './configure_legacy_client';
 import { CustomApiSchemaRegistry } from '../schema_registry';
-import {
-  IAuthenticationMethodRegistery,
-  authenticationMethodRegisteryMock,
-} from '../auth_registry';
+import { IAuthenticationMethodRegistery } from '../auth_registry';
+import { authenticationMethodRegisteryMock } from '../auth_registry/authentication_methods_registry.mock';
 
 const DATA_SOURCE_ID = 'a54b76ec86771ee865a0f74a305dfff8';
 

--- a/src/plugins/data_source/server/routes/test_connection.test.ts
+++ b/src/plugins/data_source/server/routes/test_connection.test.ts
@@ -7,10 +7,8 @@ import supertest from 'supertest';
 import { UnwrapPromise } from '@osd/utility-types';
 import { setupServer } from '../../../../../src/core/server/test_utils';
 
-import {
-  IAuthenticationMethodRegistery,
-  authenticationMethodRegisteryMock,
-} from '../auth_registry';
+import { IAuthenticationMethodRegistery } from '../auth_registry';
+import { authenticationMethodRegisteryMock } from '../auth_registry/authentication_methods_registry.mock';
 import { CustomApiSchemaRegistry } from '../schema_registry';
 import { DataSourceServiceSetup } from '../../server/data_source_service';
 import { CryptographyServiceSetup } from '../cryptography_service';


### PR DESCRIPTION
### Description

The issue was OSD doesn't come up healthy when running the built artifact due to `Error: Cannot find module './authentication_methods_registry.mock`

### Issues Resolved

#5952

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

```
yarn build

./bin/opensearch-dashboards
.
.
.
  log   [18:57:48.280] [info][listening] Server running at http://localhost:5601
  log   [18:57:48.323] [info][server][OpenSearchDashboards][http] http server running at http://localhost:5601
```

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
