### PR TITLE
[Manual Backport 2.x]Fix missing customApiRegistryPromise param for test connection (#5944)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Discover] Fix missing index pattern field from breaking Discover [#5626](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5626)
 - [BUG] Remove duplicate sample data as id 90943e30-9a47-11e8-b64d-95841ca0b247 ([5668](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5668))
 - [BUG][Multiple Datasource] Fix datasource testing connection unexpectedly passed with wrong endpoint [#5663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5663)
-- [Table Visualization] Fix filter action buttons for split table aggregations ([#5619](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5619))
 - [BUG][Multiple Datasource] Fix missing customApiRegistryPromise param for test connection ([#5944](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5944))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Discover] Fix missing index pattern field from breaking Discover [#5626](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5626)
 - [BUG] Remove duplicate sample data as id 90943e30-9a47-11e8-b64d-95841ca0b247 ([5668](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5668))
 - [BUG][Multiple Datasource] Fix datasource testing connection unexpectedly passed with wrong endpoint [#5663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5663)
+- [Table Visualization] Fix filter action buttons for split table aggregations ([#5619](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5619))
+- [BUG][Multiple Datasource] Fix missing customApiRegistryPromise param for test connection ([#5944](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5944))
+
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -129,7 +129,8 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
       router,
       dataSourceService,
       cryptographyServiceSetup,
-      authRegistryPromise
+      authRegistryPromise,
+      customApiSchemaRegistryPromise
     );
 
     const registerCredentialProvider = (method: AuthenticationMethod) => {

--- a/src/plugins/data_source/server/routes/test_connection.test.ts
+++ b/src/plugins/data_source/server/routes/test_connection.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import supertest from 'supertest';
+import { UnwrapPromise } from '@osd/utility-types';
+import { setupServer } from '../../../../../src/core/server/test_utils';
+
+import {
+  IAuthenticationMethodRegistery,
+  authenticationMethodRegisteryMock,
+} from '../auth_registry';
+import { CustomApiSchemaRegistry } from '../schema_registry';
+import { DataSourceServiceSetup } from '../../server/data_source_service';
+import { CryptographyServiceSetup } from '../cryptography_service';
+import { registerTestConnectionRoute } from './test_connection';
+import { AuthType } from '../../common/data_sources';
+// eslint-disable-next-line @osd/eslint/no-restricted-paths
+import { opensearchClientMock } from '../../../../../src/core/server/opensearch/client/mocks';
+
+type SetupServerReturn = UnwrapPromise<ReturnType<typeof setupServer>>;
+
+const URL = '/internal/data-source-management/validate';
+
+describe(`Test connection ${URL}`, () => {
+  let server: SetupServerReturn['server'];
+  let httpSetup: SetupServerReturn['httpSetup'];
+  let handlerContext: SetupServerReturn['handlerContext'];
+  let cryptographyMock: jest.Mocked<CryptographyServiceSetup>;
+  const customApiSchemaRegistry = new CustomApiSchemaRegistry();
+  let customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>;
+  let dataSourceClient: ReturnType<typeof opensearchClientMock.createInternalClient>;
+  let dataSourceServiceSetupMock: DataSourceServiceSetup;
+  let authRegistryPromiseMock: Promise<IAuthenticationMethodRegistery>;
+  const dataSourceAttr = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: AuthType.UsernamePasswordType,
+      credentials: {
+        username: 'testUser',
+        password: 'testPassword',
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    ({ server, httpSetup, handlerContext } = await setupServer());
+    customApiSchemaRegistryPromise = Promise.resolve(customApiSchemaRegistry);
+    authRegistryPromiseMock = Promise.resolve(authenticationMethodRegisteryMock.create());
+    dataSourceClient = opensearchClientMock.createInternalClient();
+
+    dataSourceServiceSetupMock = {
+      getDataSourceClient: jest.fn(() => Promise.resolve(dataSourceClient)),
+      getDataSourceLegacyClient: jest.fn(),
+    };
+
+    const router = httpSetup.createRouter('');
+    dataSourceClient.info.mockImplementationOnce(() =>
+      opensearchClientMock.createSuccessTransportRequestPromise({ cluster_name: 'testCluster' })
+    );
+    registerTestConnectionRoute(
+      router,
+      dataSourceServiceSetupMock,
+      cryptographyMock,
+      authRegistryPromiseMock,
+      customApiSchemaRegistryPromise
+    );
+
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('shows successful response', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr,
+      })
+      .expect(200);
+    expect(result.body).toEqual({ success: true });
+    expect(dataSourceServiceSetupMock.getDataSourceClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        savedObjects: handlerContext.savedObjects.client,
+        cryptography: cryptographyMock,
+        dataSourceId: 'testId',
+        testClientDataSourceAttr: dataSourceAttr,
+        customApiSchemaRegistryPromise,
+      })
+    );
+  });
+});

--- a/src/plugins/data_source/server/routes/test_connection.ts
+++ b/src/plugins/data_source/server/routes/test_connection.ts
@@ -15,7 +15,8 @@ export const registerTestConnectionRoute = async (
   router: IRouter,
   dataSourceServiceSetup: DataSourceServiceSetup,
   cryptography: CryptographyServiceSetup,
-  authRegistryPromise: Promise<IAuthenticationMethodRegistery>
+  authRegistryPromise: Promise<IAuthenticationMethodRegistery>,
+  customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>
 ) => {
   const authRegistry = await authRegistryPromise;
   router.post(
@@ -68,6 +69,7 @@ export const registerTestConnectionRoute = async (
             testClientDataSourceAttr: dataSourceAttr as DataSourceAttributes,
             request,
             authRegistry,
+            customApiSchemaRegistryPromise,
           }
         );
 


### PR DESCRIPTION
### Description

This is cherry pick of 6d5560e00c31748ddfbcd031241d67abaaf58c91 from https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5944

### Issues Resolved


## Screenshot


## Testing the changes



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
