### PR TITLE
[MDS] Support Vega Visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-- [Multiple Datasource] Add Vega support to MDS by specifying a data source name in the Vega spec ([#5975](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5975))
 
 ### 💥 Breaking Changes
 
@@ -12,7 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### 🛡 Security
 
 ### 📈 Features/Enhancements
-- [MD]Change cluster selector component name to data source selector ([#6042](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6042)) 
+- [MD]Change cluster selector component name to data source selector ([#6042](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6042))
 - [Multiple Datasource] Add interfaces to register add-on authentication method from plug-in module ([#5851](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5851))
 - [Multiple Datasource] Able to Hide "Local Cluster" option from datasource DropDown ([#5827](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5827))
 - [Multiple Datasource] Add api registry and allow it to be added into client config in data source plugin ([#5895](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5895))
@@ -23,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Dynamic Configurations] Add support for dynamic application configurations ([#5855](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5855))
 - [Workspace] Optional workspaces params in repository ([#5949](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5949))
 - [Multiple Datasource] Refactoring create and edit form to use authentication registry ([#6002](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6002))
+- [Multiple Datasource] Add Vega support to MDS by specifying a data source name in the Vega spec ([#5975](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5975))
 
 ### 🐛 Bug Fixes
 
@@ -36,7 +36,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [osd/std] Add additional recovery from false-positives in handling of long numerals ([#5956](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5956))
 - [BUG][Multiple Datasource] Fix missing customApiRegistryPromise param for test connection ([#5944](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5944))
 - [BUG][Multiple Datasource] Add a migration function for datasource to add migrationVersion field ([#6025](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6025))
-- [BUG][MD]Expose picker using function in data source management plugin setup([#6030](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6030)) 
+- [BUG][MD]Expose picker using function in data source management plugin setup([#6030](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6030))
 
 ### 🚞 Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Concatenate data source name with index pattern name and change delimiter to double colon ([#5907](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5907))
 - [Multiple Datasource] Refactor client and legacy client to use authentication registry ([#5881](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5881))
 - [Multiple Datasource] Improved error handling for the search API when a null value is passed for the dataSourceId ([#5882](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5882))
+- [Multiple Datasource] Add Vega support to MDS by specifying a data source id in the Vega spec ([#5975](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5975))
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+- [Multiple Datasource] Add Vega support to MDS by specifying a data source name in the Vega spec ([#5975](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5975))
 
 ### 💥 Breaking Changes
 
@@ -70,7 +71,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Concatenate data source name with index pattern name and change delimiter to double colon ([#5907](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5907))
 - [Multiple Datasource] Refactor client and legacy client to use authentication registry ([#5881](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5881))
 - [Multiple Datasource] Improved error handling for the search API when a null value is passed for the dataSourceId ([#5882](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5882))
-- [Multiple Datasource] Add Vega support to MDS by specifying a data source id in the Vega spec ([#5975](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5975))
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/vis_type_vega/opensearch_dashboards.json
+++ b/src/plugins/vis_type_vega/opensearch_dashboards.json
@@ -11,7 +11,7 @@
     "inspector",
     "uiActions"
   ],
-  "optionalPlugins": ["home", "usageCollection"],
+  "optionalPlugins": ["home", "usageCollection", "dataSource"],
   "requiredBundles": [
     "opensearchDashboardsUtils",
     "opensearchDashboardsReact",

--- a/src/plugins/vis_type_vega/public/data_model/opensearch_query_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/opensearch_query_parser.ts
@@ -229,7 +229,7 @@ export class OpenSearchQueryParser {
       name: getRequestName(r, index),
     }));
 
-    const data$ = this._searchAPI.search(opensearchSearches);
+    const data$ = await this._searchAPI.search(opensearchSearches);
 
     const results = await data$.toPromise();
 

--- a/src/plugins/vis_type_vega/public/data_model/search_api.test.ts
+++ b/src/plugins/vis_type_vega/public/data_model/search_api.test.ts
@@ -12,12 +12,23 @@ describe('SearchAPI.findDataSourceId', () => {
     if (query.search === `"uniqueDataSource"`) {
       return Promise.resolve({
         total: 1,
-        savedObjects: [{ id: 'some-datasource-id' }],
+        savedObjects: [{ id: 'some-datasource-id', attributes: { title: 'uniqueDataSource' } }],
       });
     } else if (query.search === `"duplicateDataSource"`) {
       return Promise.resolve({
         total: 2,
-        savedObjects: [{ id: 'some-datasource-id' }, { id: 'some-other-datasource-id' }],
+        savedObjects: [
+          { id: 'some-datasource-id', attributes: { title: 'duplicateDataSource' } },
+          { id: 'some-other-datasource-id', attributes: { title: 'duplicateDataSource' } },
+        ],
+      });
+    } else if (query.search === `"DataSource"`) {
+      return Promise.resolve({
+        total: 2,
+        savedObjects: [
+          { id: 'some-datasource-id', attributes: { title: 'DataSource' } },
+          { id: 'some-other-datasource-id', attributes: { title: 'DataSource Copy' } },
+        ],
       });
     } else {
       return Promise.resolve({
@@ -42,19 +53,24 @@ describe('SearchAPI.findDataSourceId', () => {
   test('If dataSource is enabled but no matching dataSourceName, then throw error', () => {
     const searchAPI = getSearchAPI(true);
     expect(searchAPI.findDataSourceIdbyName('nonexistentDataSource')).rejects.toThrowError(
-      'Expected exactly 1 result for data_source_name nonexistentDataSource but got 0 results'
+      'Expected exactly 1 result for data_source_name "nonexistentDataSource" but got 0 results'
     );
   });
 
   test('If dataSource is enabled but multiple dataSourceNames, then throw error', () => {
     const searchAPI = getSearchAPI(true);
     expect(searchAPI.findDataSourceIdbyName('duplicateDataSource')).rejects.toThrowError(
-      'Expected exactly 1 result for data_source_name duplicateDataSource but got 2 results'
+      'Expected exactly 1 result for data_source_name "duplicateDataSource" but got 2 results'
     );
   });
 
   test('If dataSource is enabled but only one dataSourceName, then return id', async () => {
     const searchAPI = getSearchAPI(true);
     expect(await searchAPI.findDataSourceIdbyName('uniqueDataSource')).toBe('some-datasource-id');
+  });
+
+  test('If dataSource is enabled and the dataSourceName is a prefix of another, ensure the prefix is only returned', async () => {
+    const searchAPI = getSearchAPI(true);
+    expect(await searchAPI.findDataSourceIdbyName('DataSource')).toBe('some-datasource-id');
   });
 });

--- a/src/plugins/vis_type_vega/public/data_model/search_api.test.ts
+++ b/src/plugins/vis_type_vega/public/data_model/search_api.test.ts
@@ -5,8 +5,91 @@
 
 import { SavedObjectsClientContract, SavedObjectsFindOptions } from 'opensearch-dashboards/public';
 import { SearchAPI, SearchAPIDependencies } from './search_api';
+import { ISearchStart } from 'src/plugins/data/public';
+import { IUiSettingsClient } from 'opensearch-dashboards/public';
 
-describe('SearchAPI.findDataSourceId', () => {
+jest.mock('rxjs', () => ({
+  combineLatest: jest.fn().mockImplementation((obj) => obj),
+}));
+
+jest.mock('../../../data/public', () => ({
+  getSearchParamsFromRequest: jest.fn().mockImplementation((obj, _) => obj),
+}));
+
+interface MockSearch {
+  params?: Record<string, unknown>;
+  dataSourceId?: string;
+  pipe: () => {};
+}
+
+describe('SearchAPI.search', () => {
+  // This will only test that searchApiParams were correctly set. As such, every other function can be mocked
+  const getSearchAPI = (dataSourceEnabled: boolean) => {
+    const savedObjectsClient = {} as SavedObjectsClientContract;
+
+    const searchStartMock = {} as ISearchStart;
+    searchStartMock.search = jest.fn().mockImplementation((obj, _) => {
+      const mockedSearchResults = {} as MockSearch;
+      mockedSearchResults.params = obj;
+      mockedSearchResults.pipe = jest.fn().mockReturnValue(mockedSearchResults.params);
+      return mockedSearchResults;
+    });
+
+    const uiSettings = {} as IUiSettingsClient;
+    uiSettings.get = jest.fn().mockReturnValue(0);
+    uiSettings.get.bind = jest.fn().mockReturnValue(0);
+
+    const dependencies = {
+      savedObjectsClient,
+      dataSourceEnabled,
+      search: searchStartMock,
+      uiSettings,
+    } as SearchAPIDependencies;
+    const searchAPI = new SearchAPI(dependencies);
+    searchAPI.findDataSourceIdbyName = jest.fn().mockImplementation((name) => {
+      if (!dataSourceEnabled) {
+        throw new Error();
+      }
+      if (name === 'exampleName') {
+        return Promise.resolve('some-id');
+      }
+    });
+
+    return searchAPI;
+  };
+
+  test('If MDS is disabled and there is no datasource, return params without datasource id', async () => {
+    const searchAPI = getSearchAPI(false);
+    const requests = [{ name: 'example-id' }];
+    const fetchParams = ((await searchAPI.search(requests)) as unknown) as MockSearch[];
+    expect(fetchParams[0].params).toBe(requests[0]);
+    expect(fetchParams[0].hasOwnProperty('dataSourceId')).toBe(false);
+  });
+
+  test('If MDS is disabled and there is a datasource, it should throw an errorr', () => {
+    const searchAPI = getSearchAPI(false);
+    const requests = [{ name: 'example-id', data_source_name: 'non-existent-datasource' }];
+    expect(searchAPI.search(requests)).rejects.toThrowError();
+  });
+
+  test('If MDS is enabled and there is no datasource, return params without datasource id', async () => {
+    const searchAPI = getSearchAPI(true);
+    const requests = [{ name: 'example-id' }];
+    const fetchParams = ((await searchAPI.search(requests)) as unknown) as MockSearch[];
+    expect(fetchParams[0].params).toBe(requests[0]);
+    expect(fetchParams[0].hasOwnProperty('dataSourceId')).toBe(false);
+  });
+
+  test('If MDS is enabled and there is a datasource, return params with datasource id', async () => {
+    const searchAPI = getSearchAPI(true);
+    const requests = [{ name: 'example-id', data_source_name: 'exampleName' }];
+    const fetchParams = ((await searchAPI.search(requests)) as unknown) as MockSearch[];
+    expect(fetchParams[0].hasOwnProperty('params')).toBe(true);
+    expect(fetchParams[0].dataSourceId).toBe('some-id');
+  });
+});
+
+describe('SearchAPI.findDataSourceIdbyName', () => {
   const savedObjectsClient = {} as SavedObjectsClientContract;
   savedObjectsClient.find = jest.fn().mockImplementation((query: SavedObjectsFindOptions) => {
     if (query.search === `"uniqueDataSource"`) {

--- a/src/plugins/vis_type_vega/public/data_model/search_api.test.ts
+++ b/src/plugins/vis_type_vega/public/data_model/search_api.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsClientContract, SavedObjectsFindOptions } from 'opensearch-dashboards/public';
+import { SearchAPI, SearchAPIDependencies } from './search_api';
+
+describe('SearchAPI.findDataSourceId', () => {
+  const savedObjectsClient = {} as SavedObjectsClientContract;
+  savedObjectsClient.find = jest.fn().mockImplementation((query: SavedObjectsFindOptions) => {
+    if (query.search === `"uniqueDataSource"`) {
+      return Promise.resolve({
+        total: 1,
+        savedObjects: [{ id: 'some-datasource-id' }],
+      });
+    } else if (query.search === `"duplicateDataSource"`) {
+      return Promise.resolve({
+        total: 2,
+        savedObjects: [{ id: 'some-datasource-id' }, { id: 'some-other-datasource-id' }],
+      });
+    } else {
+      return Promise.resolve({
+        total: 0,
+        savedObjects: [],
+      });
+    }
+  });
+
+  const getSearchAPI = (dataSourceEnabled: boolean) => {
+    const dependencies = { savedObjectsClient, dataSourceEnabled } as SearchAPIDependencies;
+    return new SearchAPI(dependencies);
+  };
+
+  test('If dataSource is disabled, throw error', () => {
+    const searchAPI = getSearchAPI(false);
+    expect(searchAPI.findDataSourceIdbyName('nonexistentDataSource')).rejects.toThrowError(
+      'data_source_name cannot be used because data_source.enabled is false'
+    );
+  });
+
+  test('If dataSource is enabled but no matching dataSourceName, then throw error', () => {
+    const searchAPI = getSearchAPI(true);
+    expect(searchAPI.findDataSourceIdbyName('nonexistentDataSource')).rejects.toThrowError(
+      'Expected exactly 1 result for data_source_name nonexistentDataSource but got 0 results'
+    );
+  });
+
+  test('If dataSource is enabled but multiple dataSourceNames, then throw error', () => {
+    const searchAPI = getSearchAPI(true);
+    expect(searchAPI.findDataSourceIdbyName('duplicateDataSource')).rejects.toThrowError(
+      'Expected exactly 1 result for data_source_name duplicateDataSource but got 2 results'
+    );
+  });
+
+  test('If dataSource is enabled but only one dataSourceName, then return id', async () => {
+    const searchAPI = getSearchAPI(true);
+    expect(await searchAPI.findDataSourceIdbyName('uniqueDataSource')).toBe('some-datasource-id');
+  });
+});

--- a/src/plugins/vis_type_vega/public/data_model/search_api.ts
+++ b/src/plugins/vis_type_vega/public/data_model/search_api.ts
@@ -61,7 +61,7 @@ export class SearchAPI {
     return combineLatest(
       searchRequests.map((request) => {
         const requestId = request.name;
-        const dataSourceId = request.dataSourceId;
+        const dataSourceId = request.data_source_id;
         const params = getSearchParamsFromRequest(request, {
           getConfig: this.dependencies.uiSettings.get.bind(this.dependencies.uiSettings),
         });

--- a/src/plugins/vis_type_vega/public/data_model/search_api.ts
+++ b/src/plugins/vis_type_vega/public/data_model/search_api.ts
@@ -105,13 +105,18 @@ export class SearchAPI {
     }
     const dataSources = await this.dataSourceFindQuery(dataSourceName);
 
-    if (dataSources.total !== 1) {
+    // In the case that data_source_name is a prefix of another name, match exact data_source_name
+    const possibleDataSourceIds = dataSources.savedObjects.filter(
+      (obj) => obj.attributes.title === dataSourceName
+    );
+
+    if (possibleDataSourceIds.length !== 1) {
       throw new Error(
-        `Expected exactly 1 result for data_source_name ${dataSourceName} but got ${dataSources.total} results`
+        `Expected exactly 1 result for data_source_name "${dataSourceName}" but got ${possibleDataSourceIds.length} results`
       );
     }
 
-    return dataSources.savedObjects.pop()?.id;
+    return possibleDataSourceIds.pop()?.id;
   }
 
   async dataSourceFindQuery(dataSourceName: string) {
@@ -120,7 +125,7 @@ export class SearchAPI {
       perPage: 10,
       search: `"${dataSourceName}"`,
       searchFields: ['title'],
-      fields: ['id'],
+      fields: ['id', 'title'],
     });
   }
 

--- a/src/plugins/vis_type_vega/public/data_model/search_api.ts
+++ b/src/plugins/vis_type_vega/public/data_model/search_api.ts
@@ -61,6 +61,7 @@ export class SearchAPI {
     return combineLatest(
       searchRequests.map((request) => {
         const requestId = request.name;
+        const dataSourceId = request.dataSourceId;
         const params = getSearchParamsFromRequest(request, {
           getConfig: this.dependencies.uiSettings.get.bind(this.dependencies.uiSettings),
         });
@@ -70,7 +71,9 @@ export class SearchAPI {
           requestResponders[requestId].json(params.body);
         }
 
-        return search({ params }, { abortSignal: this.abortSignal }).pipe(
+        const searchApiParams = dataSourceId ? { params, dataSourceId } : { params };
+
+        return search(searchApiParams, { abortSignal: this.abortSignal }).pipe(
           tap((data) => this.inspectSearchResult(data, requestResponders[requestId])),
           map((data) => ({
             name: requestId,

--- a/src/plugins/vis_type_vega/public/data_model/types.ts
+++ b/src/plugins/vis_type_vega/public/data_model/types.ts
@@ -186,7 +186,7 @@ export interface UrlObject {
   [CONSTANTS.TYPE]?: string;
   name?: string;
   index?: string;
-  dataSourceId?: string;
+  data_source_id?: string;
   body?: Body;
   size?: number;
   timeout?: string;

--- a/src/plugins/vis_type_vega/public/data_model/types.ts
+++ b/src/plugins/vis_type_vega/public/data_model/types.ts
@@ -186,6 +186,7 @@ export interface UrlObject {
   [CONSTANTS.TYPE]?: string;
   name?: string;
   index?: string;
+  dataSourceId?: string;
   body?: Body;
   size?: number;
   timeout?: string;

--- a/src/plugins/vis_type_vega/public/data_model/types.ts
+++ b/src/plugins/vis_type_vega/public/data_model/types.ts
@@ -186,7 +186,7 @@ export interface UrlObject {
   [CONSTANTS.TYPE]?: string;
   name?: string;
   index?: string;
-  data_source_id?: string;
+  data_source_name?: string;
   body?: Body;
   size?: number;
   timeout?: string;

--- a/src/plugins/vis_type_vega/public/default.spec.hjson
+++ b/src/plugins/vis_type_vega/public/default.spec.hjson
@@ -29,6 +29,10 @@
 
       // Which index to search
       index: _all
+
+      // If "data_source.enabled: true", optionally set the data source name to query from (omit field if querying from local cluster)
+      // data_source_name: Example US Cluster
+
       // Aggregate data by the time field into time buckets, counting the number of documents in each bucket.
       body: {
         aggs: {

--- a/src/plugins/vis_type_vega/public/plugin.ts
+++ b/src/plugins/vis_type_vega/public/plugin.ts
@@ -28,6 +28,7 @@
  * under the License.
  */
 
+import { DataSourcePluginSetup } from 'src/plugins/data_source/public';
 import { PluginInitializerContext, CoreSetup, CoreStart, Plugin } from '../../../core/public';
 import { Plugin as ExpressionsPublicPlugin } from '../../expressions/public';
 import { DataPublicPluginSetup, DataPublicPluginStart } from '../../data/public';
@@ -41,6 +42,8 @@ import {
   setUISettings,
   setMapsLegacyConfig,
   setInjectedMetadata,
+  setDataSourceEnabled,
+  setSavedObjectsClient,
 } from './services';
 
 import { createVegaFn } from './expressions/vega_fn';
@@ -69,6 +72,7 @@ export interface VegaPluginSetupDependencies {
   visualizations: VisualizationsSetup;
   inspector: InspectorSetup;
   data: DataPublicPluginSetup;
+  dataSource?: DataSourcePluginSetup;
   mapsLegacy: any;
 }
 
@@ -88,7 +92,14 @@ export class VegaPlugin implements Plugin<Promise<void>, void> {
 
   public async setup(
     core: CoreSetup,
-    { inspector, data, expressions, visualizations, mapsLegacy }: VegaPluginSetupDependencies
+    {
+      inspector,
+      data,
+      expressions,
+      visualizations,
+      mapsLegacy,
+      dataSource,
+    }: VegaPluginSetupDependencies
   ) {
     setInjectedVars({
       enableExternalUrls: this.initializerContext.config.get().enableExternalUrls,
@@ -96,6 +107,7 @@ export class VegaPlugin implements Plugin<Promise<void>, void> {
     });
     setUISettings(core.uiSettings);
     setMapsLegacyConfig(mapsLegacy.config);
+    setDataSourceEnabled({ enabled: !!dataSource });
 
     const visualizationDependencies: Readonly<VegaVisualizationDependencies> = {
       core,
@@ -116,6 +128,7 @@ export class VegaPlugin implements Plugin<Promise<void>, void> {
   public start(core: CoreStart, { data, uiActions }: VegaPluginStartDependencies) {
     setNotifications(core.notifications);
     setData(data);
+    setSavedObjectsClient(core.savedObjects);
     setUiActions(uiActions);
     setInjectedMetadata(core.injectedMetadata);
   }

--- a/src/plugins/vis_type_vega/public/services.ts
+++ b/src/plugins/vis_type_vega/public/services.ts
@@ -28,7 +28,12 @@
  * under the License.
  */
 
-import { CoreStart, NotificationsStart, IUiSettingsClient } from 'src/core/public';
+import {
+  CoreStart,
+  NotificationsStart,
+  IUiSettingsClient,
+  SavedObjectsStart,
+} from 'src/core/public';
 
 import { DataPublicPluginStart } from '../../data/public';
 import { createGetterSetter } from '../../opensearch_dashboards_utils/public';
@@ -36,6 +41,12 @@ import { MapsLegacyConfig } from '../../maps_legacy/config';
 import { UiActionsStart } from '../../ui_actions/public';
 
 export const [getData, setData] = createGetterSetter<DataPublicPluginStart>('Data');
+export const [getDataSourceEnabled, setDataSourceEnabled] = createGetterSetter<{
+  enabled: boolean;
+}>('DataSource');
+export const [getSavedObjectsClient, setSavedObjectsClient] = createGetterSetter<SavedObjectsStart>(
+  'SavedObjects'
+);
 
 export const [getNotifications, setNotifications] = createGetterSetter<NotificationsStart>(
   'Notifications'

--- a/src/plugins/vis_type_vega/public/vega_request_handler.ts
+++ b/src/plugins/vis_type_vega/public/vega_request_handler.ts
@@ -35,7 +35,12 @@ import { TimeCache } from './data_model/time_cache';
 
 import { VegaVisualizationDependencies } from './plugin';
 import { VisParams } from './expressions/vega_fn';
-import { getData, getInjectedMetadata } from './services';
+import {
+  getData,
+  getDataSourceEnabled,
+  getInjectedMetadata,
+  getSavedObjectsClient,
+} from './services';
 import { VegaInspectorAdapters } from './vega_inspector';
 
 interface VegaRequestHandlerParams {
@@ -70,6 +75,8 @@ export function createVegaRequestHandler(
           uiSettings,
           search: getData().search,
           injectedMetadata: getInjectedMetadata(),
+          dataSourceEnabled: getDataSourceEnabled().enabled,
+          savedObjectsClient: getSavedObjectsClient().client,
         },
         context.abortSignal,
         context.inspectorAdapters


### PR DESCRIPTION
### Description

This PR adds Vega support for MDS. If `data_source.enabled: true` and a `data_source_id` field is provided in the Vega spec, then the Vega visualization will render with data from the data source (assuming the data source has the specified index).

### Issues Resolved
closes #5927 

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/2f36633b-075a-4e0b-accd-a141e4ae28a7



## Testing the changes
### Pre-requisites
1. Enable MDS (set`data_source.enabled: true` in `opensearch_dashboards.yml`)
2. Add data source (in this example, it is `vegaDataSource`)
3. Add the newly created data source name to the `data_source_name` field under the `url` body

### Testing
1. Go to Visualize -> Create visualization -> Vega
2. Copy-paste existing Vega visualization from the data source (or create a new one)
3. Add a field `data_source_id` to the vega spec under `url` and set the value to the data source id.
5. Vega should render, update when timefield is updated, and save.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
