### PR TITLE
[Admin] Add @ruanyl as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @kristenTian @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe
+*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @kristenTian @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe @ruanyl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Move @seanneumann to emeritus maintainer ([#5634](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5634))
 - Remove `ui-select` dev dependency ([#5660](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5660))
 - Bump `chromedriver` dependency to `121.0.1"` ([#5926](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5926))
+- Add @ruanyl as a maintainer ([#5982](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5982))
 
 ### 🪛 Refactoring
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,6 +22,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sirazh Gabdullin          | [curq](https://github.com/curq)                     | External contributor |
 | Bandini Bhopi             | [bandinib-amzn](https://github.com/bandinib-amzn)   | Amazon      |
 | Su Zhou                   | [SuZhou-Joe](https://github.com/SuZhou-Joe)         | Amazon      |
+| Yulong Ruan               | [ruanyl](https://github.com/ruanyl)         | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
Updates MAINTAINERS.md and .github/CODEOWNERS.

Here are their current merge contributions, total contributions, and issues:
- https://github.com/opensearch-project/OpenSearch-Dashboards/pulls?q=is%3Apr+is%3Amerged+author%3Aruanyl+
- https://github.com/opensearch-project/OpenSearch-Dashboards/pulls?q=is%3Apr+author%3Aruanyl+
- https://github.com/opensearch-project/OpenSearch-Dashboards/issues?q=is%3Aissue+ruanyl+is%3Aopen

Issue:
n/a

Signed-off-by: Su Zhou <suzhou@amazon.com>