### PR TITLE
[Multi Data Source] Render credential form registered from AuthMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Improved error handling for the search API when a null value is passed for the dataSourceId ([#5882](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5882))
 - [Multiple Datasource] Hide/Show authentication method in multi data source plugin based on configuration ([#5916](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5916))
 - [[Dynamic Configurations] Add support for dynamic application configurations ([#5855](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5855))
+- [Multiple Datasource] Refactoring create and edit form to use authentication registry ([#6002](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6002))
 
 ### 🐛 Bug Fixes
 

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -273,18 +273,16 @@ data_source.enabled: true
 # Set enabled false to hide authentication method in OpenSearch Dashboards.
 # If this setting is commented then all 3 options will be available in OpenSearch Dashboards.
 # Default value will be considered to True.
-data_source.authTypes:
-  NoAuthentication:
-    enabled: true
-  UsernamePassword:
-    enabled: true
-  AWSSigV4:
-    enabled: true
+#data_source.authTypes:
+#   NoAuthentication:
+#     enabled: true
+#   UsernamePassword:
+#     enabled: true
+#   AWSSigV4:
+#     enabled: true
 
 # Set the value of this setting to false to hide the help menu link to the OpenSearch Dashboards user survey
 # opensearchDashboards.survey.url: "https://survey.opensearch.org"
 
 # Set the value of this setting to true to enable plugin augmentation on Dashboard
 # vis_augmenter.pluginAugmentationEnabled: true
-
-dynamoDBStorage.enabled: true

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -243,7 +243,7 @@
 # vis_builder.enabled: false
 
 # Set the value of this setting to true to enable multiple data source feature.
-data_source.enabled: true
+#data_source.enabled: false
 # Set the value of this setting to true to hide local cluster in data source feature.
 #data_source.hideLocalCluster: false
 # Set the value of these settings to customize crypto materials to encryption saved credentials

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -236,7 +236,7 @@
 # vis_builder.enabled: false
 
 # Set the value of this setting to true to enable multiple data source feature.
-#data_source.enabled: false
+data_source.enabled: true
 # Set the value of this setting to true to hide local cluster in data source feature.
 #data_source.hideLocalCluster: false
 # Set the value of these settings to customize crypto materials to encryption saved credentials
@@ -273,16 +273,18 @@
 # Set enabled false to hide authentication method in OpenSearch Dashboards.
 # If this setting is commented then all 3 options will be available in OpenSearch Dashboards.
 # Default value will be considered to True.
-#data_source.authTypes:
-#   NoAuthentication:
-#     enabled: true
-#   UsernamePassword:
-#     enabled: true
-#   AWSSigV4:
-#     enabled: true
+data_source.authTypes:
+  NoAuthentication:
+    enabled: true
+  UsernamePassword:
+    enabled: true
+  AWSSigV4:
+    enabled: true
 
 # Set the value of this setting to false to hide the help menu link to the OpenSearch Dashboards user survey
 # opensearchDashboards.survey.url: "https://survey.opensearch.org"
 
 # Set the value of this setting to true to enable plugin augmentation on Dashboard
 # vis_augmenter.pluginAugmentationEnabled: true
+
+dynamoDBStorage.enabled: true

--- a/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.ts
+++ b/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.ts
@@ -9,7 +9,7 @@ import { EuiSuperSelectOption } from '@elastic/eui';
 export interface AuthenticationMethod {
   name: string;
   credentialSourceOption: EuiSuperSelectOption<string>;
-  credentialForm?: React.JSX.Element;
+  credentialForm?: (state?: any, setState?: any) => React.JSX.Element;
   crendentialFormField?: { [key: string]: string };
 }
 

--- a/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.ts
+++ b/src/plugins/data_source_management/public/auth_registry/authentication_methods_registry.ts
@@ -9,7 +9,10 @@ import { EuiSuperSelectOption } from '@elastic/eui';
 export interface AuthenticationMethod {
   name: string;
   credentialSourceOption: EuiSuperSelectOption<string>;
-  credentialForm?: (state?: any, setState?: any) => React.JSX.Element;
+  credentialForm?: (
+    state: { [key: string]: any },
+    setState: React.Dispatch<React.SetStateAction<any>>
+  ) => React.JSX.Element;
   crendentialFormField?: { [key: string]: string };
 }
 

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.test.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.test.tsx
@@ -17,7 +17,10 @@ import {
   sigV4AuthMethod,
   usernamePasswordAuthMethod,
 } from '../../../../types';
-import { AuthenticationMethodRegistery } from 'src/plugins/data_source_management/public/auth_registry';
+import {
+  AuthenticationMethod,
+  AuthenticationMethodRegistery,
+} from 'src/plugins/data_source_management/public/auth_registry';
 
 const titleIdentifier = '[data-test-subj="createDataSourceFormTitleField"]';
 const descriptionIdentifier = `[data-test-subj="createDataSourceFormDescriptionField"]`;
@@ -361,5 +364,49 @@ describe('Datasource Management: Create Datasource form with different authType 
       const authOptionSelector = component.find(authTypeIdentifier).last();
       expect(authOptionSelector.prop('disabled')).toBe(false);
     });
+  });
+});
+
+describe('Datasource Management: Create Datasource form with registered Auth Type', () => {
+  let component: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
+  const mockSubmitHandler = jest.fn();
+  const mockTestConnectionHandler = jest.fn();
+  const mockCancelHandler = jest.fn();
+  const mockCredentialForm = jest.fn();
+
+  /* Scenario 1: should render the page normally when only one registered Auth Type supported */
+  test('should render the page normally when only one registered Auth Type supported', () => {
+    const authTypeToBeTested = 'Some Auth Type';
+    const authMethodToBeTest = {
+      name: authTypeToBeTested,
+      credentialSourceOption: {
+        value: authTypeToBeTested,
+        inputDisplay: 'some input',
+      },
+      credentialForm: mockCredentialForm,
+    } as AuthenticationMethod;
+
+    const mockedContext = mockManagementPlugin.createDataSourceManagementContext();
+    mockedContext.authenticationMethodRegistery = new AuthenticationMethodRegistery();
+    mockedContext.authenticationMethodRegistery.registerAuthenticationMethod(authMethodToBeTest);
+
+    component = mount(
+      wrapWithIntl(
+        <CreateDataSourceForm
+          handleTestConnection={mockTestConnectionHandler}
+          handleSubmit={mockSubmitHandler}
+          handleCancel={mockCancelHandler}
+          existingDatasourceNamesList={['dup20']}
+        />
+      ),
+      {
+        wrappingComponent: OpenSearchDashboardsContextProvider,
+        wrappingComponentProps: {
+          services: mockedContext,
+        },
+      }
+    );
+
+    expect(mockCredentialForm).toHaveBeenCalled();
   });
 });

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.test.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.test.tsx
@@ -374,7 +374,6 @@ describe('Datasource Management: Create Datasource form with registered Auth Typ
   const mockCancelHandler = jest.fn();
   const mockCredentialForm = jest.fn();
 
-  /* Scenario 1: should call registered crendential form */
   test('should call registered crendential form', () => {
     const authTypeToBeTested = 'Some Auth Type';
     const authMethodToBeTest = {

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.test.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.test.tsx
@@ -17,10 +17,7 @@ import {
   sigV4AuthMethod,
   usernamePasswordAuthMethod,
 } from '../../../../types';
-import {
-  AuthenticationMethod,
-  AuthenticationMethodRegistery,
-} from 'src/plugins/data_source_management/public/auth_registry';
+import { AuthenticationMethod, AuthenticationMethodRegistery } from '../../../../auth_registry';
 
 const titleIdentifier = '[data-test-subj="createDataSourceFormTitleField"]';
 const descriptionIdentifier = `[data-test-subj="createDataSourceFormDescriptionField"]`;
@@ -372,11 +369,11 @@ describe('Datasource Management: Create Datasource form with registered Auth Typ
   const mockSubmitHandler = jest.fn();
   const mockTestConnectionHandler = jest.fn();
   const mockCancelHandler = jest.fn();
-  const mockCredentialForm = jest.fn();
 
-  test('should call registered crendential form', () => {
+  test('should call registered crendential form at the first round when registered method is at the first place and username & password disabled', () => {
+    const mockCredentialForm = jest.fn();
     const authTypeToBeTested = 'Some Auth Type';
-    const authMethodToBeTest = {
+    const authMethodToBeTested = {
       name: authTypeToBeTested,
       credentialSourceOption: {
         value: authTypeToBeTested,
@@ -385,27 +382,139 @@ describe('Datasource Management: Create Datasource form with registered Auth Typ
       credentialForm: mockCredentialForm,
     } as AuthenticationMethod;
 
-    const mockedContext = mockManagementPlugin.createDataSourceManagementContext();
-    mockedContext.authenticationMethodRegistery = new AuthenticationMethodRegistery();
-    mockedContext.authenticationMethodRegistery.registerAuthenticationMethod(authMethodToBeTest);
+    const authMethodCombinationsToBeTested = [
+      [authMethodToBeTested],
+      [authMethodToBeTested, sigV4AuthMethod],
+      [authMethodToBeTested, noAuthCredentialAuthMethod],
+      [authMethodToBeTested, noAuthCredentialAuthMethod, sigV4AuthMethod],
+    ];
 
-    component = mount(
-      wrapWithIntl(
-        <CreateDataSourceForm
-          handleTestConnection={mockTestConnectionHandler}
-          handleSubmit={mockSubmitHandler}
-          handleCancel={mockCancelHandler}
-          existingDatasourceNamesList={['dup20']}
-        />
-      ),
-      {
-        wrappingComponent: OpenSearchDashboardsContextProvider,
-        wrappingComponentProps: {
-          services: mockedContext,
-        },
-      }
-    );
+    authMethodCombinationsToBeTested.forEach((authMethodCombination) => {
+      const mockedContext = mockManagementPlugin.createDataSourceManagementContext();
+      mockedContext.authenticationMethodRegistery = new AuthenticationMethodRegistery();
 
-    expect(mockCredentialForm).toHaveBeenCalled();
+      authMethodCombination.forEach((authMethod) => {
+        mockedContext.authenticationMethodRegistery.registerAuthenticationMethod(authMethod);
+      });
+
+      component = mount(
+        wrapWithIntl(
+          <CreateDataSourceForm
+            handleTestConnection={mockTestConnectionHandler}
+            handleSubmit={mockSubmitHandler}
+            handleCancel={mockCancelHandler}
+            existingDatasourceNamesList={['dup20']}
+          />
+        ),
+        {
+          wrappingComponent: OpenSearchDashboardsContextProvider,
+          wrappingComponentProps: {
+            services: mockedContext,
+          },
+        }
+      );
+
+      expect(mockCredentialForm).toHaveBeenCalled();
+    });
+  });
+
+  test('should not call registered crendential form at the first round when registered method is at the first place and username & password enabled', () => {
+    const mockCredentialForm = jest.fn();
+    const authTypeToBeTested = 'Some Auth Type';
+    const authMethodToBeTested = {
+      name: authTypeToBeTested,
+      credentialSourceOption: {
+        value: authTypeToBeTested,
+        inputDisplay: 'some input',
+      },
+      credentialForm: mockCredentialForm,
+    } as AuthenticationMethod;
+
+    const authMethodCombinationsToBeTested = [
+      [authMethodToBeTested, usernamePasswordAuthMethod],
+      [authMethodToBeTested, usernamePasswordAuthMethod, sigV4AuthMethod],
+      [authMethodToBeTested, usernamePasswordAuthMethod, noAuthCredentialAuthMethod],
+      [
+        authMethodToBeTested,
+        usernamePasswordAuthMethod,
+        noAuthCredentialAuthMethod,
+        sigV4AuthMethod,
+      ],
+    ];
+
+    authMethodCombinationsToBeTested.forEach((authMethodCombination) => {
+      const mockedContext = mockManagementPlugin.createDataSourceManagementContext();
+      mockedContext.authenticationMethodRegistery = new AuthenticationMethodRegistery();
+
+      authMethodCombination.forEach((authMethod) => {
+        mockedContext.authenticationMethodRegistery.registerAuthenticationMethod(authMethod);
+      });
+
+      component = mount(
+        wrapWithIntl(
+          <CreateDataSourceForm
+            handleTestConnection={mockTestConnectionHandler}
+            handleSubmit={mockSubmitHandler}
+            handleCancel={mockCancelHandler}
+            existingDatasourceNamesList={['dup20']}
+          />
+        ),
+        {
+          wrappingComponent: OpenSearchDashboardsContextProvider,
+          wrappingComponentProps: {
+            services: mockedContext,
+          },
+        }
+      );
+
+      expect(mockCredentialForm).not.toHaveBeenCalled();
+    });
+  });
+
+  test('should not call registered crendential form at the first round when registered method is not at the first place', () => {
+    const mockCredentialForm = jest.fn();
+    const authTypeToBeTested = 'Some Auth Type';
+    const authMethodToBeTested = {
+      name: authTypeToBeTested,
+      credentialSourceOption: {
+        value: authTypeToBeTested,
+        inputDisplay: 'some input',
+      },
+      credentialForm: mockCredentialForm,
+    } as AuthenticationMethod;
+
+    const authMethodCombinationsToBeTested = [
+      [sigV4AuthMethod, authMethodToBeTested],
+      [noAuthCredentialAuthMethod, authMethodToBeTested],
+      [noAuthCredentialAuthMethod, authMethodToBeTested, sigV4AuthMethod],
+    ];
+
+    authMethodCombinationsToBeTested.forEach((authMethodCombination) => {
+      const mockedContext = mockManagementPlugin.createDataSourceManagementContext();
+      mockedContext.authenticationMethodRegistery = new AuthenticationMethodRegistery();
+
+      authMethodCombination.forEach((authMethod) => {
+        mockedContext.authenticationMethodRegistery.registerAuthenticationMethod(authMethod);
+      });
+
+      component = mount(
+        wrapWithIntl(
+          <CreateDataSourceForm
+            handleTestConnection={mockTestConnectionHandler}
+            handleSubmit={mockSubmitHandler}
+            handleCancel={mockCancelHandler}
+            existingDatasourceNamesList={['dup20']}
+          />
+        ),
+        {
+          wrappingComponent: OpenSearchDashboardsContextProvider,
+          wrappingComponentProps: {
+            services: mockedContext,
+          },
+        }
+      );
+
+      expect(mockCredentialForm).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.test.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.test.tsx
@@ -374,8 +374,8 @@ describe('Datasource Management: Create Datasource form with registered Auth Typ
   const mockCancelHandler = jest.fn();
   const mockCredentialForm = jest.fn();
 
-  /* Scenario 1: should render the page normally when only one registered Auth Type supported */
-  test('should render the page normally when only one registered Auth Type supported', () => {
+  /* Scenario 1: should call registered crendential form */
+  test('should call registered crendential form', () => {
     const authTypeToBeTested = 'Some Auth Type';
     const authMethodToBeTest = {
       name: authTypeToBeTested,

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
@@ -379,6 +379,8 @@ export class CreateDataSourceForm extends React.Component<
   /* Render create new credentials*/
   renderCreateNewCredentialsForm = (type: AuthType) => {
     switch (type) {
+      case AuthType.NoAuth:
+        return null;
       case AuthType.UsernamePasswordType:
         return (
           <>
@@ -515,7 +517,7 @@ export class CreateDataSourceForm extends React.Component<
         );
 
       default:
-        return this.getCredentialFormFromRegistry(this.state.auth.type);
+        return this.getCredentialFormFromRegistry(type);
     }
   };
 

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
@@ -22,7 +22,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
-import { AuthenticationMethodRegistery } from 'src/plugins/data_source_management/public/auth_registry';
+import { AuthenticationMethodRegistery } from '../../../../auth_registry';
 import { SigV4Content, SigV4ServiceName } from '../../../../../../data_source/common/data_sources';
 import {
   AuthType,

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
@@ -337,6 +337,8 @@ export class CreateDataSourceForm extends React.Component<
     if (authCredentialForm !== undefined) {
       return authCredentialForm(this.state, this.handleStateChange);
     }
+
+    return null;
   };
 
   /* Render methods */

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.test.tsx
@@ -21,10 +21,7 @@ import {
   sigV4AuthMethod,
   usernamePasswordAuthMethod,
 } from '../../../../types';
-import {
-  AuthenticationMethod,
-  AuthenticationMethodRegistery,
-} from 'src/plugins/data_source_management/public/auth_registry';
+import { AuthenticationMethod, AuthenticationMethodRegistery } from '../../../../auth_registry';
 
 const titleFieldIdentifier = 'dataSourceTitle';
 const titleFormRowIdentifier = '[data-test-subj="editDataSourceTitleFormRow"]';

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.test.tsx
@@ -21,6 +21,10 @@ import {
   sigV4AuthMethod,
   usernamePasswordAuthMethod,
 } from '../../../../types';
+import {
+  AuthenticationMethod,
+  AuthenticationMethodRegistery,
+} from 'src/plugins/data_source_management/public/auth_registry';
 
 const titleFieldIdentifier = 'dataSourceTitle';
 const titleFormRowIdentifier = '[data-test-subj="editDataSourceTitleFormRow"]';
@@ -338,5 +342,47 @@ describe('Datasource Management: Edit Datasource Form', () => {
       component.update();
       expect(mockFn).toHaveBeenCalled();
     });
+  });
+});
+
+describe('With Registered Authentication', () => {
+  let component: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
+  const mockCredentialForm = jest.fn();
+
+  test('should call registered crendential form', () => {
+    const authTypeToBeTested = 'Some Auth Type';
+    const authMethodToBeTest = {
+      name: authTypeToBeTested,
+      credentialSourceOption: {
+        value: authTypeToBeTested,
+        inputDisplay: 'some input',
+      },
+      credentialForm: mockCredentialForm,
+    } as AuthenticationMethod;
+
+    const mockedContext = mockManagementPlugin.createDataSourceManagementContext();
+    mockedContext.authenticationMethodRegistery = new AuthenticationMethodRegistery();
+    mockedContext.authenticationMethodRegistery.registerAuthenticationMethod(authMethodToBeTest);
+
+    component = mount(
+      wrapWithIntl(
+        <EditDataSourceForm
+          existingDataSource={mockDataSourceAttributesWithNoAuth}
+          existingDatasourceNamesList={existingDatasourceNamesList}
+          onDeleteDataSource={jest.fn()}
+          handleSubmit={jest.fn()}
+          handleTestConnection={jest.fn()}
+          displayToastMessage={jest.fn()}
+        />
+      ),
+      {
+        wrappingComponent: OpenSearchDashboardsContextProvider,
+        wrappingComponentProps: {
+          services: mockedContext,
+        },
+      }
+    );
+
+    expect(mockCredentialForm).toHaveBeenCalled();
   });
 });

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -537,6 +537,8 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
     if (authCredentialForm !== undefined) {
       return authCredentialForm(this.state, this.handleStateChange);
     }
+
+    return null;
   };
 
   /* Render methods */

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -24,6 +24,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
+import { AuthenticationMethodRegistery } from 'src/plugins/data_source_management/public/auth_registry';
 import { SigV4Content, SigV4ServiceName } from '../../../../../../data_source/common/data_sources';
 import { Header } from '../header';
 import {
@@ -43,6 +44,7 @@ import {
 } from '../../../validation';
 import { UpdatePasswordModal } from '../update_password_modal';
 import { UpdateAwsCredentialModal } from '../update_aws_credential_modal';
+import { getDefaultAuthMethod } from '../../../utils';
 
 export interface EditDataSourceProps {
   existingDataSource: DataSourceAttributes;
@@ -72,15 +74,19 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
   public readonly context!: DataSourceManagementContextValue;
   maskedPassword: string = '********';
   authOptions: Array<EuiSuperSelectOption<string>> = [];
+  authenticationMethodRegistery: AuthenticationMethodRegistery;
 
   constructor(props: EditDataSourceProps, context: DataSourceManagementContextValue) {
     super(props, context);
 
-    this.authOptions = context.services.authenticationMethodRegistery
+    this.authenticationMethodRegistery = context.services.authenticationMethodRegistery;
+    this.authOptions = this.authenticationMethodRegistery
       .getAllAuthenticationMethods()
       .map((authMethod) => {
         return authMethod.credentialSourceOption;
       });
+
+    const initialSelectedAuthMethod = getDefaultAuthMethod(this.authenticationMethodRegistery);
 
     this.state = {
       formErrorsByField: { ...defaultValidation },
@@ -88,7 +94,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
       description: '',
       endpoint: '',
       auth: {
-        type: AuthType.NoAuth,
+        type: initialSelectedAuthMethod?.name,
         credentials: {
           username: '',
           password: '',
@@ -518,6 +524,21 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
     }
   };
 
+  handleStateChange = (state: any) => {
+    this.setState(state);
+  };
+
+  getCredentialFormFromRegistry = (authType: string) => {
+    const registeredAuthMethod = this.authenticationMethodRegistery.getAuthenticationMethod(
+      authType
+    );
+    const authCredentialForm = registeredAuthMethod?.credentialForm;
+
+    if (authCredentialForm !== undefined) {
+      return authCredentialForm(this.state, this.handleStateChange);
+    }
+  };
+
   /* Render methods */
 
   /* Render modal for new credential */
@@ -796,12 +817,14 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
 
   renderSelectedAuthType = (type: AuthType) => {
     switch (type) {
+      case AuthType.NoAuth:
+        return null;
       case AuthType.UsernamePasswordType:
         return this.renderUsernamePasswordFields();
       case AuthType.SigV4:
         return this.renderSigV4ContentFields();
       default:
-        return null;
+        return this.getCredentialFormFromRegistry(type);
     }
   };
 

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -24,7 +24,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
-import { AuthenticationMethodRegistery } from 'src/plugins/data_source_management/public/auth_registry';
+import { AuthenticationMethodRegistery } from '../../../../auth_registry';
 import { SigV4Content, SigV4ServiceName } from '../../../../../../data_source/common/data_sources';
 import { Header } from '../header';
 import {


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Partial of Refactoring [create](https://github.com/opensearch-project/OpenSearch-Dashboards/tree/main/src/plugins/data_source_management/public/components/create_data_source_wizard) and [edit](https://github.com/opensearch-project/OpenSearch-Dashboards/tree/main/src/plugins/data_source_management/public/components/edit_data_source) form to use authentication registry user story.

- Render credential form registered from AuthMethod

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
Partially fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5692, https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5838

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/139305463/93ea7cc9-c77d-40ee-b756-10fc487ec428


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
Test cases added
### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
