### PR TITLE
[CVE-2024-27088] Bump es5-ext from `0.10.59` to `0.10.64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 🛡 Security
 
+- [CVE-2024-27088] Bump es5-ext from `0.10.59` to `0.10.64` ([#6021](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6021))
+
 ### 📈 Features/Enhancements
 
 ### 🐛 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "**/set-value": "^4.1.0",
     "**/xml2js": "^0.5.0",
     "**/yaml": "^2.2.2",
-    "**/@babel/traverse": "^7.23.2"
+    "**/@babel/traverse": "^7.23.2",
+    "**/es5-ext": "^0.10.63"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8225,13 +8225,14 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
-  version "0.10.59"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.59.tgz#71038939730eb6f4f165f1421308fb60be363bc6"
-  integrity sha512-cOgyhW0tIJyQY1Kfw6Kr0viu9ZlUctVchRMZ7R0HiH3dxTSp5zJDLecwxUqPUrGKMsgBI1wd1FL+d9Jxfi4cLw==
+es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@^0.10.62, es5-ext@^0.10.63, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
+  version "0.10.64"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.64.tgz#12e4ffb48f1ba2ea777f1fcdd1918ef73ea21714"
+  integrity sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==
   dependencies:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.3"
+    esniff "^2.0.1"
     next-tick "^1.1.0"
 
 es6-error@^4.0.1:
@@ -8637,6 +8638,16 @@ eslint@^6.8.0:
     table "^5.2.3"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
+
+esniff@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/esniff/-/esniff-2.0.1.tgz#a4d4b43a5c71c7ec51c51098c1d8a29081f9b308"
+  integrity sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==
+  dependencies:
+    d "^1.0.1"
+    es5-ext "^0.10.62"
+    event-emitter "^0.3.5"
+    type "^2.7.2"
 
 espree@^6.1.2:
   version "6.2.1"
@@ -17991,6 +18002,11 @@ type@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/type/-/type-2.6.0.tgz#3ca6099af5981d36ca86b78442973694278a219f"
   integrity sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==
+
+type@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.7.2.tgz#2376a15a3a28b1efa0f5350dcf72d24df6ef98d0"
+  integrity sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==
 
 typechecker@^6.2.0:
   version "6.4.0"


### PR DESCRIPTION
### Description
From https://www.mend.io/vulnerability-database/CVE-2024-27088:
```
es5-ext contains ECMAScript 5 extensions. Passing functions with very long names or complex default argument names into `function#copy` or `function#toStringTokens` may cause the script to stall. The vulnerability is patched in v0.10.63.
```

This PR bumps `es5-ext` from 
```
=> Found "es5-ext@0.10.59"
info Reasons this module exists
   - "_project_#gulp-sourcemaps#debug-fabulous#memoizee" depends on it
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#es6-weak-map#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#d#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#event-emitter#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#lru-queue#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#timers-ext#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#es5-ext#es6-iterator#es5-ext"
info Disk size without dependencies: "2.21MB"
info Disk size with unique dependencies: "2.48MB"
info Disk size with transitive dependencies: "6.16MB"
info Number of shared dependencies: 5
Done in 1.58s.
```
to 
```
=> Found "es5-ext@0.10.64"
info Reasons this module exists
   - "_project_#gulp-sourcemaps#debug-fabulous#memoizee" depends on it
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#es6-weak-map#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#d#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#event-emitter#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#lru-queue#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#timers-ext#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#es5-ext#es6-iterator#es5-ext"
   - Hoisted from "_project_#gulp-sourcemaps#debug-fabulous#memoizee#es5-ext#esniff#es5-ext"
info Disk size without dependencies: "2.21MB"
info Disk size with unique dependencies: "3.41MB"
info Disk size with transitive dependencies: "7.18MB"
info Number of shared dependencies: 6
Done in 1.57s.
```
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6004


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
