### PR TITLE
Create a migration function for datasource to add migrationVersion field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [osd/std] Add additional recovery from false-positives in handling of long numerals ([#5956](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5956))
 - [BUG][Discover] Allow saved sort from search embeddable to load in Dashboard ([#5934](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5934))
 - [BUG][Multiple Datasource] Fix missing customApiRegistryPromise param for test connection ([#5944](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5944))
+- [BUG][Multiple Datasource] Add a migration function for datasource to add migrationVersion field ([#6022](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6025)
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/data_source/server/saved_objects/data_source.test.ts
+++ b/src/plugins/data_source/server/saved_objects/data_source.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { migrateDataSource } from './data_source';
+import { savedObjectsServiceMock } from '../../../../core/server/mocks';
+
+const contextMock = savedObjectsServiceMock.createMigrationContext();
+
+describe('migrateDataSource Function', () => {
+  it('should return the input document unchanged', () => {
+    const mockDoc = {
+      id: 'test-id',
+      type: 'test-type',
+      attributes: {
+        name: 'Test Name',
+        description: 'Test Description',
+      },
+      references: [],
+    };
+
+    // Call the migrateDataSource function with the mock document
+    const result = migrateDataSource(mockDoc, contextMock);
+
+    // Expect the result to be deeply equal to the mock document
+    expect(result).toEqual(mockDoc);
+  });
+});

--- a/src/plugins/data_source/server/saved_objects/data_source.ts
+++ b/src/plugins/data_source/server/saved_objects/data_source.ts
@@ -3,7 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SavedObjectsType } from 'opensearch-dashboards/server';
+import { flow } from 'lodash';
+import { SavedObjectMigrationFn, SavedObjectsType } from 'opensearch-dashboards/server';
+
+// create a migration function which return the doc without any changes
+export const migrateDataSource: SavedObjectMigrationFn<any, any> = (doc) => ({
+  ...doc,
+});
 
 export const dataSource: SavedObjectsType = {
   name: 'data-source',
@@ -33,5 +39,8 @@ export const dataSource: SavedObjectsType = {
         type: 'text',
       },
     },
+  },
+  migrations: {
+    '2.4.0': flow(migrateDataSource), // 2.4.0 is the version that introduces the datasource
   },
 };


### PR DESCRIPTION
### Description
This PR is to add a migration function with version 2.4.0 for datasource to add a migrationVersion field. 
For more information, please refer to the RFC: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6022

### Issues Resolved

#6022 

## Testing the changes

For the testing, it is included in this RFC: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6022

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
