### PR TITLE
[Workspace] Enable workspace params in saved objects management page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Export DataSourcePluginRequestContext at top level for plugins to use ([#6108](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6108))
 - [Workspace] Add delete saved objects by workspace functionality([#6013](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6013))
 - [Workspace] Add a workspace client in workspace plugin ([#6094](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6094))
+- [Workspace] Enable workspace params in saved objects management page ([#6026](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6026))
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/saved_objects_management/public/lib/fetch_export_by_type_and_search.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/fetch_export_by_type_and_search.test.ts
@@ -9,7 +9,7 @@ import { httpServiceMock } from '../../../../core/public/mocks';
 describe('fetchExportByTypeAndSearch', () => {
   it('make http call with body provided', async () => {
     const httpClient = httpServiceMock.createStartContract();
-    await fetchExportByTypeAndSearch(httpClient, [], undefined, true, {
+    await fetchExportByTypeAndSearch(httpClient, [], undefined, undefined, {
       workspaces: ['foo'],
     });
     expect(httpClient.post).toMatchInlineSnapshot(`
@@ -18,7 +18,7 @@ describe('fetchExportByTypeAndSearch', () => {
           Array [
             "/api/saved_objects/_export",
             Object {
-              "body": "{\\"workspaces\\":[\\"foo\\"],\\"type\\":[],\\"includeReferencesDeep\\":true}",
+              "body": "{\\"workspaces\\":[\\"foo\\"],\\"type\\":[],\\"includeReferencesDeep\\":false}",
             },
           ],
         ],

--- a/src/plugins/saved_objects_management/public/lib/fetch_export_by_type_and_search.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/fetch_export_by_type_and_search.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fetchExportByTypeAndSearch } from './fetch_export_by_type_and_search';
+import { httpServiceMock } from '../../../../core/public/mocks';
+
+describe('fetchExportByTypeAndSearch', () => {
+  it('make http call with body provided', async () => {
+    const httpClient = httpServiceMock.createStartContract();
+    await fetchExportByTypeAndSearch(httpClient, [], undefined, true, {
+      workspaces: ['foo'],
+    });
+    expect(httpClient.post).toMatchInlineSnapshot(`
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "/api/saved_objects/_export",
+            Object {
+              "body": "{\\"workspaces\\":[\\"foo\\"],\\"type\\":[],\\"includeReferencesDeep\\":true}",
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/src/plugins/saved_objects_management/public/lib/fetch_export_by_type_and_search.ts
+++ b/src/plugins/saved_objects_management/public/lib/fetch_export_by_type_and_search.ts
@@ -34,10 +34,12 @@ export async function fetchExportByTypeAndSearch(
   http: HttpStart,
   types: string[],
   search: string | undefined,
-  includeReferencesDeep: boolean = false
+  includeReferencesDeep: boolean = false,
+  body?: Record<string, unknown>
 ): Promise<Blob> {
   return http.post('/api/saved_objects/_export', {
     body: JSON.stringify({
+      ...body,
       type: types,
       search,
       includeReferencesDeep,

--- a/src/plugins/saved_objects_management/public/lib/fetch_export_objects.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/fetch_export_objects.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fetchExportObjects } from './fetch_export_objects';
+import { httpServiceMock } from '../../../../core/public/mocks';
+
+describe('fetchExportObjects', () => {
+  it('make http call with body provided', async () => {
+    const httpClient = httpServiceMock.createStartContract();
+    await fetchExportObjects(httpClient, [], false, {
+      workspaces: ['foo'],
+    });
+    expect(httpClient.post).toMatchInlineSnapshot(`
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "/api/saved_objects/_export",
+            Object {
+              "body": "{\\"workspaces\\":[\\"foo\\"],\\"objects\\":[],\\"includeReferencesDeep\\":false}",
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/src/plugins/saved_objects_management/public/lib/fetch_export_objects.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/fetch_export_objects.test.ts
@@ -32,9 +32,9 @@ describe('fetchExportObjects', () => {
     `);
   });
 
-  it('make http call with body provided and includeReferencesDeep is true', async () => {
+  it('make http call with body provided and includeReferencesDeep is undefined', async () => {
     const httpClient = httpServiceMock.createStartContract();
-    await fetchExportObjects(httpClient, [], true, {
+    await fetchExportObjects(httpClient, [], undefined, {
       workspaces: ['foo'],
     });
     expect(httpClient.post).toMatchInlineSnapshot(`
@@ -43,7 +43,7 @@ describe('fetchExportObjects', () => {
           Array [
             "/api/saved_objects/_export",
             Object {
-              "body": "{\\"workspaces\\":[\\"foo\\"],\\"objects\\":[],\\"includeReferencesDeep\\":true}",
+              "body": "{\\"workspaces\\":[\\"foo\\"],\\"objects\\":[],\\"includeReferencesDeep\\":false}",
             },
           ],
         ],

--- a/src/plugins/saved_objects_management/public/lib/fetch_export_objects.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/fetch_export_objects.test.ts
@@ -31,4 +31,29 @@ describe('fetchExportObjects', () => {
       }
     `);
   });
+
+  it('make http call with body provided and includeReferencesDeep is true', async () => {
+    const httpClient = httpServiceMock.createStartContract();
+    await fetchExportObjects(httpClient, [], true, {
+      workspaces: ['foo'],
+    });
+    expect(httpClient.post).toMatchInlineSnapshot(`
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "/api/saved_objects/_export",
+            Object {
+              "body": "{\\"workspaces\\":[\\"foo\\"],\\"objects\\":[],\\"includeReferencesDeep\\":true}",
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    `);
+  });
 });

--- a/src/plugins/saved_objects_management/public/lib/fetch_export_objects.ts
+++ b/src/plugins/saved_objects_management/public/lib/fetch_export_objects.ts
@@ -33,10 +33,12 @@ import { HttpStart } from 'src/core/public';
 export async function fetchExportObjects(
   http: HttpStart,
   objects: any[],
-  includeReferencesDeep: boolean = false
+  includeReferencesDeep: boolean = false,
+  body?: Record<string, unknown>
 ): Promise<Blob> {
   return http.post('/api/saved_objects/_export', {
     body: JSON.stringify({
+      ...body,
       objects,
       includeReferencesDeep,
     }),

--- a/src/plugins/saved_objects_management/public/lib/get_saved_object_counts.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/get_saved_object_counts.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getSavedObjectCounts } from './get_saved_object_counts';
+import { httpServiceMock } from '../../../../core/public/mocks';
+
+describe('getSavedObjectCounts', () => {
+  it('make http call with body provided', async () => {
+    const httpClient = httpServiceMock.createStartContract();
+    await getSavedObjectCounts(httpClient, {
+      typesToInclude: [],
+      workspaces: ['foo'],
+    });
+    expect(httpClient.post).toMatchInlineSnapshot(`
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "/api/opensearch-dashboards/management/saved_objects/scroll/counts",
+            Object {
+              "body": "{\\"typesToInclude\\":[],\\"workspaces\\":[\\"foo\\"]}",
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/src/plugins/saved_objects_management/public/lib/get_saved_object_counts.ts
+++ b/src/plugins/saved_objects_management/public/lib/get_saved_object_counts.ts
@@ -34,6 +34,7 @@ export interface SavedObjectCountOptions {
   typesToInclude: string[];
   namespacesToInclude?: string[];
   searchString?: string;
+  workspaces?: string[];
 }
 
 export async function getSavedObjectCounts(

--- a/src/plugins/saved_objects_management/public/lib/import_file.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/import_file.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { importFile } from './import_file';
+import { httpServiceMock } from '../../../../core/public/mocks';
+
+describe('importFile', () => {
+  it('make http call with body provided', async () => {
+    const httpClient = httpServiceMock.createStartContract();
+    const blob = new Blob(['']);
+    await importFile(httpClient, new File([blob], 'foo.ndjson'), {
+      overwrite: true,
+      createNewCopies: false,
+      workspaces: ['foo'],
+    });
+    expect(httpClient.post).toMatchInlineSnapshot(`
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "/api/saved_objects/_import",
+            Object {
+              "body": FormData {},
+              "headers": Object {
+                "Content-Type": undefined,
+              },
+              "query": Object {
+                "overwrite": true,
+                "workspaces": Array [
+                  "foo",
+                ],
+              },
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/src/plugins/saved_objects_management/public/lib/import_file.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/import_file.test.ts
@@ -16,9 +16,9 @@ describe('importFile', () => {
       {
         overwrite: true,
         createNewCopies: false,
-        workspaces: ['foo'],
       },
-      'foo'
+      'foo',
+      ['foo']
     );
     expect(httpClient.post).toMatchInlineSnapshot(`
       [MockFunction] {

--- a/src/plugins/saved_objects_management/public/lib/import_file.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/import_file.test.ts
@@ -7,14 +7,19 @@ import { importFile } from './import_file';
 import { httpServiceMock } from '../../../../core/public/mocks';
 
 describe('importFile', () => {
-  it('make http call with body provided', async () => {
+  it('make http call with body provided and data source id provided', async () => {
     const httpClient = httpServiceMock.createStartContract();
     const blob = new Blob(['']);
-    await importFile(httpClient, new File([blob], 'foo.ndjson'), {
-      overwrite: true,
-      createNewCopies: false,
-      workspaces: ['foo'],
-    });
+    await importFile(
+      httpClient,
+      new File([blob], 'foo.ndjson'),
+      {
+        overwrite: true,
+        createNewCopies: false,
+        workspaces: ['foo'],
+      },
+      'foo'
+    );
     expect(httpClient.post).toMatchInlineSnapshot(`
       [MockFunction] {
         "calls": Array [
@@ -26,6 +31,7 @@ describe('importFile', () => {
                 "Content-Type": undefined,
               },
               "query": Object {
+                "dataSourceId": "foo",
                 "overwrite": true,
                 "workspaces": Array [
                   "foo",

--- a/src/plugins/saved_objects_management/public/lib/import_file.ts
+++ b/src/plugins/saved_objects_management/public/lib/import_file.ts
@@ -40,12 +40,12 @@ interface ImportResponse {
 export async function importFile(
   http: HttpStart,
   file: File,
-  { createNewCopies, overwrite }: ImportMode,
+  { createNewCopies, overwrite, workspaces }: ImportMode,
   selectedDataSourceId?: string
 ) {
   const formData = new FormData();
   formData.append('file', file);
-  const query = createNewCopies ? { createNewCopies } : { overwrite };
+  const query = createNewCopies ? { createNewCopies, workspaces } : { overwrite, workspaces };
   if (selectedDataSourceId) {
     query.dataSourceId = selectedDataSourceId;
   }

--- a/src/plugins/saved_objects_management/public/lib/import_file.ts
+++ b/src/plugins/saved_objects_management/public/lib/import_file.ts
@@ -40,8 +40,9 @@ interface ImportResponse {
 export async function importFile(
   http: HttpStart,
   file: File,
-  { createNewCopies, overwrite, workspaces }: ImportMode,
-  selectedDataSourceId?: string
+  { createNewCopies, overwrite }: ImportMode,
+  selectedDataSourceId?: string,
+  workspaces?: string[]
 ) {
   const formData = new FormData();
   formData.append('file', file);

--- a/src/plugins/saved_objects_management/public/lib/resolve_import_errors.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/resolve_import_errors.test.ts
@@ -303,4 +303,69 @@ describe('resolveImportErrors', () => {
       }
     `);
   });
+
+  test('make http calls with workspaces', async () => {
+    httpMock.post.mockResolvedValueOnce({
+      success: false,
+      successCount: 0,
+      errors: [{ type: 'a', id: '1', error: { type: 'conflict' } }],
+    });
+    httpMock.post.mockResolvedValueOnce({
+      success: true,
+      successCount: 1,
+      successResults: [{ type: 'a', id: '1' }],
+    });
+    getConflictResolutions.mockResolvedValueOnce({});
+    getConflictResolutions.mockResolvedValueOnce({
+      'a:1': { retry: true, options: { overwrite: true } },
+    });
+    await resolveImportErrors({
+      http: httpMock,
+      getConflictResolutions,
+      state: {
+        importCount: 0,
+        unmatchedReferences: [{ existingIndexPatternId: '2', newIndexPatternId: '3', list: [] }],
+        failedImports: [
+          {
+            obj: { type: 'a', id: '1', meta: {} },
+            error: { type: 'missing_references', references: [{ type: 'index-pattern', id: '2' }] },
+          },
+        ],
+        importMode: { createNewCopies: false, overwrite: false },
+      },
+      workspaces: ['foo'],
+    });
+    expect(httpMock.post.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "/api/saved_objects/_resolve_import_errors",
+          Object {
+            "body": FormData {},
+            "headers": Object {
+              "Content-Type": undefined,
+            },
+            "query": Object {
+              "workspaces": Array [
+                "foo",
+              ],
+            },
+          },
+        ],
+        Array [
+          "/api/saved_objects/_resolve_import_errors",
+          Object {
+            "body": FormData {},
+            "headers": Object {
+              "Content-Type": undefined,
+            },
+            "query": Object {
+              "workspaces": Array [
+                "foo",
+              ],
+            },
+          },
+        ],
+      ]
+    `);
+  });
 });

--- a/src/plugins/saved_objects_management/public/lib/resolve_import_errors.test.ts
+++ b/src/plugins/saved_objects_management/public/lib/resolve_import_errors.test.ts
@@ -62,6 +62,7 @@ describe('resolveImportErrors', () => {
       http: httpMock,
       getConflictResolutions,
       state: { importCount: 0, importMode: { createNewCopies: false, overwrite: false } },
+      selectedDataSourceId: '',
     });
     expect(result).toMatchInlineSnapshot(`
       Object {
@@ -91,6 +92,7 @@ describe('resolveImportErrors', () => {
         ],
         importMode: { createNewCopies: false, overwrite: false },
       },
+      selectedDataSourceId: '',
     });
     expect(httpMock.post).not.toHaveBeenCalled();
     expect(result).toMatchInlineSnapshot(`
@@ -143,6 +145,7 @@ describe('resolveImportErrors', () => {
         ],
         importMode: { createNewCopies: false, overwrite: false },
       },
+      selectedDataSourceId: '',
     });
     expect(result).toMatchInlineSnapshot(`
       Object {
@@ -209,6 +212,7 @@ describe('resolveImportErrors', () => {
         ],
         importMode: { createNewCopies: false, overwrite: false },
       },
+      selectedDataSourceId: '',
     });
     expect(result).toMatchInlineSnapshot(`
       Object {
@@ -249,6 +253,7 @@ describe('resolveImportErrors', () => {
         ],
         importMode: { createNewCopies: false, overwrite: false },
       },
+      selectedDataSourceId: '',
     });
     expect(result).toMatchInlineSnapshot(`
       Object {
@@ -334,6 +339,7 @@ describe('resolveImportErrors', () => {
         importMode: { createNewCopies: false, overwrite: false },
       },
       workspaces: ['foo'],
+      selectedDataSourceId: '',
     });
     expect(httpMock.post.mock.calls).toMatchInlineSnapshot(`
       Array [

--- a/src/plugins/saved_objects_management/public/lib/resolve_import_errors.ts
+++ b/src/plugins/saved_objects_management/public/lib/resolve_import_errors.ts
@@ -90,12 +90,13 @@ async function callResolveImportErrorsApi(
   file: File,
   retries: any,
   createNewCopies: boolean,
-  selectedDataSourceId?: string
+  selectedDataSourceId?: string,
+  workspaces?: string[]
 ): Promise<SavedObjectsImportResponse> {
   const formData = new FormData();
   formData.append('file', file);
   formData.append('retries', JSON.stringify(retries));
-  const query = createNewCopies ? { createNewCopies } : {};
+  const query = createNewCopies ? { createNewCopies, workspaces } : { workspaces };
   if (selectedDataSourceId) {
     query.dataSourceId = selectedDataSourceId;
   }
@@ -172,6 +173,7 @@ export async function resolveImportErrors({
   getConflictResolutions,
   state,
   selectedDataSourceId,
+  workspaces,
 }: {
   http: HttpStart;
   getConflictResolutions: (
@@ -186,6 +188,7 @@ export async function resolveImportErrors({
     importMode: { createNewCopies: boolean; overwrite: boolean };
   };
   selectedDataSourceId: string;
+  workspaces?: string[];
 }) {
   const retryDecisionCache = new Map<string, RetryDecision>();
   const replaceReferencesCache = new Map<string, Reference[]>();
@@ -275,7 +278,8 @@ export async function resolveImportErrors({
       file!,
       retries,
       createNewCopies,
-      selectedDataSourceId
+      selectedDataSourceId,
+      workspaces
     );
     importCount = response.successCount; // reset the success count since we retry all successful results each time
     failedImports = [];

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
@@ -231,6 +231,9 @@ exports[`SavedObjectsTable should render normally 1`] = `
             "edit": false,
             "read": true,
           },
+          "workspaces": Object {
+            "enabled": false,
+          },
         },
         "currentAppId$": Observable {
           "_isScalar": false,

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/flyout.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/flyout.test.tsx.snap
@@ -246,6 +246,7 @@ exports[`Flyout conflicts should allow conflict resolution 2`] = `
             },
           ],
         },
+        "workspaces": undefined,
       },
     ],
   ],

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
@@ -184,6 +184,29 @@ describe('Flyout', () => {
     );
   });
 
+  it('should call importFile / resolveImportErrors with workspaces', async () => {
+    const component = shallowRender({ ...defaultProps, workspaces: ['foo'] });
+
+    // Ensure all promises resolve
+    await new Promise((resolve) => process.nextTick(resolve));
+    // Ensure the state changes are reflected
+    component.update();
+
+    await component.instance().import();
+    expect(importFileMock.mock.calls[0][2]).toMatchInlineSnapshot(`
+      Object {
+        "createNewCopies": true,
+        "overwrite": true,
+        "workspaces": Array [
+          "foo",
+        ],
+      }
+    `);
+
+    await component.instance().resolveImportErrors();
+    expect(resolveImportErrorsMock.mock.calls[0][0].workspaces).toEqual(['foo']);
+  });
+
   describe('conflicts', () => {
     beforeEach(() => {
       importFileMock.mockImplementation(() => ({
@@ -206,6 +229,7 @@ describe('Flyout', () => {
           },
         ],
       }));
+      resolveImportErrorsMock.mockClear();
       resolveImportErrorsMock.mockImplementation(() => ({
         status: 'success',
         importCount: 1,

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
@@ -197,9 +197,6 @@ describe('Flyout', () => {
       Object {
         "createNewCopies": true,
         "overwrite": true,
-        "workspaces": Array [
-          "foo",
-        ],
       }
     `);
 
@@ -255,6 +252,7 @@ describe('Flyout', () => {
           createNewCopies: true,
           overwrite: true,
         },
+        undefined,
         undefined
       );
       expect(component.state()).toMatchObject({

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
@@ -196,15 +196,7 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
 
     // Import the file
     try {
-      const response = await importFile(
-        http,
-        file!,
-        {
-          ...importMode,
-          workspaces,
-        },
-        selectedDataSourceId
-      );
+      const response = await importFile(http, file!, importMode, selectedDataSourceId, workspaces);
       this.setState(processImportResponse(response), () => {
         // Resolve import errors right away if there's no index patterns to match
         // This will ask about overwriting each object, etc

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_mode_control.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_mode_control.tsx
@@ -52,6 +52,7 @@ export interface ImportModeControlProps {
 export interface ImportMode {
   createNewCopies: boolean;
   overwrite: boolean;
+  workspaces?: string[];
 }
 
 const createNewCopiesDisabled = {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_mode_control.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/import_mode_control.tsx
@@ -52,7 +52,6 @@ export interface ImportModeControlProps {
 export interface ImportMode {
   createNewCopies: boolean;
   overwrite: boolean;
-  workspaces?: string[];
 }
 
 const createNewCopiesDisabled = {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
@@ -59,6 +59,7 @@ import {
   SavedObjectsTable,
   SavedObjectsTableProps,
   SavedObjectsTableState,
+  formatWorkspaceIdParams,
 } from './saved_objects_table';
 import { Flyout, Relationships } from './components';
 import { SavedObjectWithMetadata } from '../../types';
@@ -644,5 +645,25 @@ describe('SavedObjectsTable', () => {
       );
       expect(component.state('selectedSavedObjects').length).toBe(0);
     });
+  });
+});
+
+describe('formatWorkspaceIdParams', () => {
+  it('omit workspaces params when it is undefined', () => {
+    expect(
+      formatWorkspaceIdParams({
+        workspaces: undefined,
+        foo: 'bar',
+      })
+    ).toEqual({ foo: 'bar' });
+  });
+
+  it('reserve workspaces params when it is valid', () => {
+    expect(
+      formatWorkspaceIdParams({
+        workspaces: ['foo'],
+        foo: 'bar',
+      })
+    ).toEqual({ workspaces: ['foo'], foo: 'bar' });
   });
 });

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -184,16 +184,9 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
   private get workspaceIdQuery() {
     const currentWorkspaceId = this.props.workspaces.currentWorkspaceId$.getValue();
     const workspaceEnabled = this.props.applications.capabilities.workspaces.enabled;
-    // workspace is turned off
-    if (!workspaceEnabled) {
-      return undefined;
-    } else {
-      if (!currentWorkspaceId) {
-        return undefined;
-      } else {
-        return [currentWorkspaceId];
-      }
-    }
+
+    // only return the result when workspace feature is enabled.
+    return workspaceEnabled && currentWorkspaceId ? [currentWorkspaceId] : undefined;
   }
 
   componentDidMount() {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -139,8 +139,6 @@ export interface SavedObjectsTableState {
   exportAllOptions: ExportAllOption[];
   exportAllSelectedOptions: Record<string, boolean>;
   isIncludeReferencesDeepChecked: boolean;
-  currentWorkspaceId: string | null;
-  workspaceEnabled: boolean;
 }
 
 export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedObjectsTableState> {
@@ -171,13 +169,12 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
       exportAllOptions: [],
       exportAllSelectedOptions: {},
       isIncludeReferencesDeepChecked: true,
-      currentWorkspaceId: this.props.workspaces.currentWorkspaceId$.getValue(),
-      workspaceEnabled: this.props.applications.capabilities.workspaces.enabled,
     };
   }
 
   private get workspaceIdQuery() {
-    const { currentWorkspaceId, workspaceEnabled } = this.state;
+    const currentWorkspaceId = this.props.workspaces.currentWorkspaceId$.getValue();
+    const workspaceEnabled = this.props.applications.capabilities.workspaces.enabled;
     // workspace is turned off
     if (!workspaceEnabled) {
       return undefined;
@@ -597,7 +594,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
         close={this.hideImportFlyout}
         done={this.finishImport}
         http={this.props.http}
-        workspaces={this.state.currentWorkspaceId ? [this.state.currentWorkspaceId] : undefined}
+        workspaces={this.workspaceIdQuery}
         serviceRegistry={this.props.serviceRegistry}
         indexPatterns={this.props.indexPatterns}
         newIndexPatternUrl={newIndexPatternUrl}

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -141,6 +141,15 @@ export interface SavedObjectsTableState {
   isIncludeReferencesDeepChecked: boolean;
 }
 
+export function formatWorkspaceIdParams<T extends { workspaces?: string[] }>(
+  obj: T
+): T | Omit<T, 'workspaces'> {
+  const { workspaces, ...others } = obj;
+  if (workspaces) {
+    return obj;
+  }
+  return others;
+}
 export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedObjectsTableState> {
   private _isMounted = false;
 
@@ -187,16 +196,6 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
     }
   }
 
-  private formatWorkspaceIdParams<T extends { workspaces?: string[] }>(
-    obj: T
-  ): T | Omit<T, 'workspaces'> {
-    const { workspaces, ...others } = obj;
-    if (workspaces) {
-      return obj;
-    }
-    return others;
-  }
-
   componentDidMount() {
     this._isMounted = true;
     this.fetchSavedObjects();
@@ -216,7 +215,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
 
     const availableNamespaces = namespaceRegistry.getAll()?.map((ns) => ns.id) || [];
 
-    const filteredCountOptions: SavedObjectCountOptions = this.formatWorkspaceIdParams({
+    const filteredCountOptions: SavedObjectCountOptions = formatWorkspaceIdParams({
       typesToInclude: filteredTypes,
       searchString: queryText,
       workspaces: this.workspaceIdQuery,
@@ -249,7 +248,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
       exportAllSelectedOptions[id] = true;
     });
 
-    const countOptions: SavedObjectCountOptions = this.formatWorkspaceIdParams({
+    const countOptions: SavedObjectCountOptions = formatWorkspaceIdParams({
       typesToInclude: allowedTypes,
       searchString: queryText,
       workspaces: this.workspaceIdQuery,
@@ -286,7 +285,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
     const filteredTypes = filterQuery(allowedTypes, visibleTypes);
     // "searchFields" is missing from the "findOptions" but gets injected via the API.
     // The API extracts the fields from each uiExports.savedObjectsManagement "defaultSearchField" attribute
-    const findOptions: SavedObjectsFindOptions = this.formatWorkspaceIdParams({
+    const findOptions: SavedObjectsFindOptions = formatWorkspaceIdParams({
       search: queryText ? `${queryText}*` : undefined,
       perPage,
       page: page + 1,
@@ -439,7 +438,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
         http,
         objectsToExport,
         includeReferencesDeep,
-        this.formatWorkspaceIdParams({
+        formatWorkspaceIdParams({
           workspaces: this.workspaceIdQuery,
         })
       );
@@ -477,7 +476,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
         exportTypes,
         queryText ? `${queryText}*` : undefined,
         isIncludeReferencesDeepChecked,
-        this.formatWorkspaceIdParams({
+        formatWorkspaceIdParams({
           workspaces: this.workspaceIdQuery,
         })
       );

--- a/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
@@ -89,6 +89,7 @@ const SavedObjectsTablePage = ({
       indexPatterns={dataStart.indexPatterns}
       search={dataStart.search}
       http={coreStart.http}
+      workspaces={coreStart.workspaces}
       overlays={coreStart.overlays}
       notifications={coreStart.notifications}
       applications={coreStart.application}

--- a/src/plugins/saved_objects_management/server/routes/find.ts
+++ b/src/plugins/saved_objects_management/server/routes/find.ts
@@ -64,6 +64,9 @@ export const registerFindRoute = (
           fields: schema.oneOf([schema.string(), schema.arrayOf(schema.string())], {
             defaultValue: [],
           }),
+          workspaces: schema.maybe(
+            schema.oneOf([schema.string(), schema.arrayOf(schema.string())])
+          ),
         }),
       },
     },
@@ -94,6 +97,7 @@ export const registerFindRoute = (
         ...req.query,
         fields: undefined,
         searchFields: [...searchFields],
+        workspaces: req.query.workspaces ? Array<string>().concat(req.query.workspaces) : undefined,
       });
 
       const savedObjects = await Promise.all(

--- a/src/plugins/saved_objects_management/server/routes/scroll_count.ts
+++ b/src/plugins/saved_objects_management/server/routes/scroll_count.ts
@@ -41,6 +41,7 @@ export const registerScrollForCountRoute = (router: IRouter) => {
           typesToInclude: schema.arrayOf(schema.string()),
           namespacesToInclude: schema.maybe(schema.arrayOf(schema.string())),
           searchString: schema.maybe(schema.string()),
+          workspaces: schema.maybe(schema.arrayOf(schema.string())),
         }),
       },
     },
@@ -55,12 +56,18 @@ export const registerScrollForCountRoute = (router: IRouter) => {
         perPage: 1000,
       };
 
+      const requestHasWorkspaces = Array.isArray(req.body.workspaces) && req.body.workspaces.length;
+
       const requestHasNamespaces =
         Array.isArray(req.body.namespacesToInclude) && req.body.namespacesToInclude.length;
 
       if (requestHasNamespaces) {
         counts.namespaces = {};
         findOptions.namespaces = req.body.namespacesToInclude;
+      }
+
+      if (requestHasWorkspaces) {
+        findOptions.workspaces = req.body.workspaces;
       }
 
       if (req.body.searchString) {

--- a/src/plugins/workspace/opensearch_dashboards.json
+++ b/src/plugins/workspace/opensearch_dashboards.json
@@ -2,7 +2,7 @@
   "id": "workspace",
   "version": "opensearchDashboards",
   "server": true,
-  "ui": false,
+  "ui": true,
   "requiredPlugins": [
     "savedObjects"
   ],

--- a/src/plugins/workspace/server/plugin.test.ts
+++ b/src/plugins/workspace/server/plugin.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { coreMock } from '../../../core/server/mocks';
+import { WorkspacePlugin } from './plugin';
+
+describe('Workspace server plugin', () => {
+  it('#setup', async () => {
+    let value;
+    const setupMock = coreMock.createSetup();
+    const initializerContextConfigMock = coreMock.createPluginInitializerContext({
+      workspace: {
+        enabled: true,
+      },
+    });
+    setupMock.capabilities.registerProvider.mockImplementationOnce((fn) => (value = fn()));
+    const workspacePlugin = new WorkspacePlugin(initializerContextConfigMock);
+    await workspacePlugin.setup(setupMock);
+    expect(value).toMatchInlineSnapshot(`
+      Object {
+        "workspaces": Object {
+          "enabled": true,
+        },
+      }
+    `);
+  });
+});

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -46,6 +46,8 @@ export class WorkspacePlugin implements Plugin<{}, {}> {
       client: this.client as IWorkspaceClientImpl,
     });
 
+    core.capabilities.registerProvider(() => ({ workspaces: { enabled: true } }));
+
     return {
       client: this.client,
     };


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

### Issues Resolved

closes #6028 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
When enter saved objects management page in workspace foo. The page shows nothing as no objects have been created in this workspace.
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/ebd41aca-2d84-4bea-806a-cc67ef090d2d)

After importing with the ndjson file, objects can be found only in workspace foo.
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/1cbfadbd-fcbc-44bb-a6d9-8af77b256cdd)

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/effba2ef-42c0-4032-9158-85008a733901)

By switching to another workspace bar, no objects can be found because the objects imported before was in workspace foo
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/15398008-51dc-481c-9529-73c009fd87c0)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Using the branch to bootstrap
- Download the patch file [test.patch](https://github.com/opensearch-project/OpenSearch-Dashboards/files/14535728/test.patch)
- `git apply ./test.patch`, it will
    - enable workspace feature flag
    - switch to workspace foo manually as there is not a UI component to switch workspace for now
- Start OSD by using `yarn start --no-base-path` to make sure no random base path will be appended
- Navigate to devTools
- Insert test workspaces by calling
```
PUT .kibana/_doc/workspace:foo
{
  "type": "workspace",
  "workspace": {
    "name": "foo"
  }
}

PUT .kibana/_doc/workspace:bar
{
  "type": "workspace",
  "workspace": {
    "name": "bar"
  }
}
```
- Visit the saved objects management page: `http://localhost:5601/app/management/opensearch-dashboards/objects`
- You will find nothing can be found in this workspace(After applying the patch file, you are in workspace foo)
- Import by using the [file](https://github.com/opensearch-project/OpenSearch-Dashboards/files/14535815/export.28.ndjson.zip), download the file and extract that to find the import file.
- You will find some dashboards and visualizations are imported in the workspace.
- Go to file `src/plugins/workspace/public/plugin.ts`, change the 'foo' workspace to 'bar'. Refresh the page. By doing so you are in workspace bar.
- You will find the objects can not be found again.



### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
