### PR TITLE
Expose picker using function in data source management plugin setup

### DIFF
--- a/src/plugins/data_source_management/public/components/cluster_selector/cluster_selector.tsx
+++ b/src/plugins/data_source_management/public/components/cluster_selector/cluster_selector.tsx
@@ -16,7 +16,7 @@ export const LocalCluster: ClusterOption = {
   id: '',
 };
 
-interface ClusterSelectorProps {
+export interface ClusterSelectorProps {
   savedObjectsClient: SavedObjectsClientContract;
   notifications: ToastsStart;
   onSelectedDataSource: (clusterOption: ClusterOption[]) => void;

--- a/src/plugins/data_source_management/public/components/cluster_selector/create_cluster_selector.tsx
+++ b/src/plugins/data_source_management/public/components/cluster_selector/create_cluster_selector.tsx
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { ClusterSelector, ClusterSelectorProps } from './cluster_selector';
+
+export function createClusterSelector() {
+  return (props: ClusterSelectorProps) => <ClusterSelector {...props} />;
+}

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -7,6 +7,7 @@ import { DataSourcePluginSetup } from 'src/plugins/data_source/public';
 import { CoreSetup, CoreStart, Plugin } from '../../../core/public';
 
 import { PLUGIN_NAME } from '../common';
+import { createClusterSelector } from './components/cluster_selector/create_cluster_selector';
 
 import { ManagementSetup } from '../../management/public';
 import { IndexPatternManagementSetup } from '../../index_pattern_management/public';
@@ -17,6 +18,7 @@ import {
   AuthenticationMethodRegistery,
 } from './auth_registry';
 import { noAuthCredentialAuthMethod, sigV4AuthMethod, usernamePasswordAuthMethod } from './types';
+import { ClusterSelectorProps } from './components/cluster_selector/cluster_selector';
 
 export interface DataSourceManagementSetupDependencies {
   management: ManagementSetup;
@@ -26,6 +28,7 @@ export interface DataSourceManagementSetupDependencies {
 
 export interface DataSourceManagementPluginSetup {
   registerAuthenticationMethod: (authMethodValues: AuthenticationMethod) => void;
+  getDataSourcePicker: React.ComponentType<ClusterSelectorProps>;
 }
 
 export interface DataSourceManagementPluginStart {
@@ -91,7 +94,10 @@ export class DataSourceManagementPlugin
       registerAuthenticationMethod(sigV4AuthMethod);
     }
 
-    return { registerAuthenticationMethod };
+    return {
+      registerAuthenticationMethod,
+      getDataSourcePicker: createClusterSelector(),
+    };
   }
 
   public start(core: CoreStart) {


### PR DESCRIPTION
### Description
This change exposes data source picker as a function in the data source management plugin. 

### Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6018

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/0083d43e-6429-41c1-8557-66efbb56739c


## Testing the changes
The following was performed in the recording above:
1. enable data source plugin
2. go to add sample data page and add data from a data source is successful, note that the picker here is the same picker as used in alerting, query workbench plugins
3. go to query workbench plugin page, and query the indices from selected data source is successful, note that query workbench has been changed to use the function exposed by the plugin to render the picker
4. go to alerting plugin page, and query monitors from selected data source is successful, note that alerting has been changed to use the function exposed by the plugin to render the picker
5. run `node scripts/build_opensearch_dashboards_platform_plugins.js ` is successful
6. run `yarn build` for alerting plugin is successful

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
