### PR TITLE
[MD] Expose a few properties for customize the appearance of the data source selector component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 📈 Features/Enhancements
 - [MD]Change cluster selector component name to data source selector ([#6042](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6042)) 
+- [MD]Expose a few properties for customize the appearance of the data source selector component ([#6057](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6057))
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/create_data_source_selector.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/create_data_source_selector.test.tsx.snap
@@ -9,12 +9,12 @@ Object {
         aria-expanded="false"
         aria-haspopup="listbox"
         aria-label="Select a data source"
-        class="euiComboBox euiComboBox--compressed"
+        class="euiComboBox"
         data-test-subj="dataSourceSelectorComboBox"
         role="combobox"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group"
+          class="euiFormControlLayout euiFormControlLayout--group"
         >
           <label
             class="euiFormLabel euiFormControlLayout__prepend"
@@ -25,7 +25,7 @@ Object {
             class="euiFormControlLayout__childrenWrapper"
           >
             <div
-              class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable euiComboBox__inputWrap--inGroup"
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable euiComboBox__inputWrap--inGroup"
               data-test-subj="comboBoxInput"
               tabindex="-1"
             >
@@ -56,7 +56,7 @@ Object {
             >
               <button
                 aria-label="Clear input"
-                class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
+                class="euiFormControlLayoutClearButton"
                 data-test-subj="comboBoxClearButton"
                 type="button"
               >
@@ -88,12 +88,12 @@ Object {
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-label="Select a data source"
-      class="euiComboBox euiComboBox--compressed"
+      class="euiComboBox"
       data-test-subj="dataSourceSelectorComboBox"
       role="combobox"
     >
       <div
-        class="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group"
+        class="euiFormControlLayout euiFormControlLayout--group"
       >
         <label
           class="euiFormLabel euiFormControlLayout__prepend"
@@ -104,7 +104,7 @@ Object {
           class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable euiComboBox__inputWrap--inGroup"
+            class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable euiComboBox__inputWrap--inGroup"
             data-test-subj="comboBoxInput"
             tabindex="-1"
           >
@@ -135,7 +135,7 @@ Object {
           >
             <button
               aria-label="Clear input"
-              class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
+              class="euiFormControlLayoutClearButton"
               data-test-subj="comboBoxClearButton"
               type="button"
             >

--- a/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/data_source_selector.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/data_source_selector.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`DataSourceSelector should render normally with local cluster is hidden 
 <EuiComboBox
   aria-label="Select a data source"
   async={false}
-  compressed={true}
+  compressed={false}
   data-test-subj="dataSourceSelectorComboBox"
   fullWidth={false}
   isClearable={true}
@@ -27,7 +27,7 @@ exports[`DataSourceSelector should render normally with local cluster not hidden
 <EuiComboBox
   aria-label="Select a data source"
   async={false}
-  compressed={true}
+  compressed={false}
   data-test-subj="dataSourceSelectorComboBox"
   fullWidth={false}
   isClearable={true}
@@ -64,7 +64,7 @@ exports[`DataSourceSelector: check dataSource options should always place local 
 <EuiComboBox
   aria-label="Select a data source"
   async={false}
-  compressed={true}
+  compressed={false}
   data-test-subj="dataSourceSelectorComboBox"
   fullWidth={false}
   isClearable={true}
@@ -77,24 +77,162 @@ exports[`DataSourceSelector: check dataSource options should always place local 
         "label": "Local cluster",
       },
       Object {
-        "id": "test",
-        "label": "test",
+        "id": "test1",
+        "label": "test1",
       },
       Object {
         "id": "test2",
-        "label": "test",
+        "label": "test3",
       },
       Object {
-        "id": "alpha-test",
-        "label": "alpha-test",
-      },
-      Object {
-        "id": "beta-test",
-        "label": "beta-test",
+        "id": "test3",
+        "label": "test3",
       },
     ]
   }
   placeholder="Select a data source"
+  prepend="Data source"
+  selectedOptions={
+    Array [
+      Object {
+        "id": "",
+        "label": "Local cluster",
+      },
+    ]
+  }
+  singleSelection={
+    Object {
+      "asPlainText": true,
+    }
+  }
+  sortMatchesBy="none"
+/>
+`;
+
+exports[`DataSourceSelector: check dataSource options should filter options if configured 1`] = `
+<EuiComboBox
+  aria-label="Select a data source"
+  async={false}
+  compressed={false}
+  data-test-subj="dataSourceSelectorComboBox"
+  fullWidth={false}
+  isClearable={true}
+  isDisabled={false}
+  onChange={[Function]}
+  options={
+    Array [
+      Object {
+        "id": "",
+        "label": "Local cluster",
+      },
+      Object {
+        "id": "test2",
+        "label": "test3",
+      },
+      Object {
+        "id": "test3",
+        "label": "test3",
+      },
+    ]
+  }
+  placeholder="Select a data source"
+  prepend="Data source"
+  selectedOptions={
+    Array [
+      Object {
+        "id": "",
+        "label": "Local cluster",
+      },
+    ]
+  }
+  singleSelection={
+    Object {
+      "asPlainText": true,
+    }
+  }
+  sortMatchesBy="none"
+/>
+`;
+
+exports[`DataSourceSelector: check dataSource options should hide prepend if removePrepend is true 1`] = `
+<EuiComboBox
+  aria-label="Select a data source"
+  async={false}
+  compressed={false}
+  data-test-subj="dataSourceSelectorComboBox"
+  fullWidth={false}
+  isClearable={true}
+  isDisabled={false}
+  onChange={[Function]}
+  options={
+    Array [
+      Object {
+        "id": "",
+        "label": "Local cluster",
+      },
+      Object {
+        "id": "test1",
+        "label": "test1",
+      },
+      Object {
+        "id": "test2",
+        "label": "test3",
+      },
+      Object {
+        "id": "test3",
+        "label": "test3",
+      },
+    ]
+  }
+  placeholder="Select a data source"
+  selectedOptions={
+    Array [
+      Object {
+        "id": "",
+        "label": "Local cluster",
+      },
+    ]
+  }
+  singleSelection={
+    Object {
+      "asPlainText": true,
+    }
+  }
+  sortMatchesBy="none"
+/>
+`;
+
+exports[`DataSourceSelector: check dataSource options should show custom placeholder text if configured 1`] = `
+<EuiComboBox
+  aria-label="Make a selection"
+  async={false}
+  compressed={false}
+  data-test-subj="dataSourceSelectorComboBox"
+  fullWidth={false}
+  isClearable={true}
+  isDisabled={false}
+  onChange={[Function]}
+  options={
+    Array [
+      Object {
+        "id": "",
+        "label": "Local cluster",
+      },
+      Object {
+        "id": "test1",
+        "label": "test1",
+      },
+      Object {
+        "id": "test2",
+        "label": "test3",
+      },
+      Object {
+        "id": "test3",
+        "label": "test3",
+      },
+    ]
+  }
+  placeholder="Make a selection"
   prepend="Data source"
   selectedOptions={
     Array [

--- a/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.test.tsx
@@ -31,7 +31,7 @@ describe('create data source selector', () => {
     const component = render(<TestComponent {...props} />);
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'description', 'title'],
+      fields: ['id', 'title', 'auth.type'],
       perPage: 10000,
       type: 'data-source',
     });

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.test.tsx
@@ -8,7 +8,8 @@ import { DataSourceSelector } from './data_source_selector';
 import { SavedObjectsClientContract } from '../../../../../core/public';
 import { notificationServiceMock } from '../../../../../core/public/mocks';
 import React from 'react';
-import { getDataSourcesResponse, mockResponseForSavedObjectsCalls } from '../../mocks';
+import { getDataSourcesWithFieldsResponse, mockResponseForSavedObjectsCalls } from '../../mocks';
+import { AuthType } from 'src/plugins/data_source/common/data_sources';
 
 describe('DataSourceSelector', () => {
   let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
@@ -35,7 +36,7 @@ describe('DataSourceSelector', () => {
     );
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'description', 'title'],
+      fields: ['id', 'title', 'auth.type'],
       perPage: 10000,
       type: 'data-source',
     });
@@ -55,7 +56,7 @@ describe('DataSourceSelector', () => {
     );
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'description', 'title'],
+      fields: ['id', 'title', 'auth.type'],
       perPage: 10000,
       type: 'data-source',
     });
@@ -74,7 +75,7 @@ describe('DataSourceSelector: check dataSource options', () => {
       find: jest.fn().mockResolvedValue([]),
     } as any;
 
-    mockResponseForSavedObjectsCalls(client, 'find', getDataSourcesResponse);
+    mockResponseForSavedObjectsCalls(client, 'find', getDataSourcesWithFieldsResponse);
   });
 
   it('should always place local cluster option as the first option when local cluster not hidden', async () => {
@@ -86,6 +87,63 @@ describe('DataSourceSelector: check dataSource options', () => {
         disabled={false}
         hideLocalCluster={false}
         fullWidth={false}
+      />
+    );
+
+    component.instance().componentDidMount!();
+    await nextTick();
+    expect(component).toMatchSnapshot();
+    expect(toasts.addWarning).toBeCalledTimes(0);
+  });
+
+  it('should hide prepend if removePrepend is true', async () => {
+    component = shallow(
+      <DataSourceSelector
+        savedObjectsClient={client}
+        notifications={toasts}
+        onSelectedDataSource={jest.fn()}
+        disabled={false}
+        hideLocalCluster={false}
+        fullWidth={false}
+        removePrepend={true}
+      />
+    );
+
+    component.instance().componentDidMount!();
+    await nextTick();
+    expect(component).toMatchSnapshot();
+    expect(toasts.addWarning).toBeCalledTimes(0);
+  });
+
+  it('should show custom placeholder text if configured', async () => {
+    component = shallow(
+      <DataSourceSelector
+        savedObjectsClient={client}
+        notifications={toasts}
+        onSelectedDataSource={jest.fn()}
+        disabled={false}
+        hideLocalCluster={false}
+        fullWidth={false}
+        placeholderText={'Make a selection'}
+      />
+    );
+
+    component.instance().componentDidMount!();
+    await nextTick();
+    expect(component).toMatchSnapshot();
+    expect(toasts.addWarning).toBeCalledTimes(0);
+  });
+
+  it('should filter options if configured', async () => {
+    component = shallow(
+      <DataSourceSelector
+        savedObjectsClient={client}
+        notifications={toasts}
+        onSelectedDataSource={jest.fn()}
+        disabled={false}
+        hideLocalCluster={false}
+        fullWidth={false}
+        filterFn={(ds) => ds.attributes.auth.type !== AuthType.NoAuth}
       />
     );
 

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
@@ -114,15 +114,26 @@ export class DataSourceSelector extends React.Component<
   }
 
   render() {
-    const placeholderText = this.props.placeholderText || 'Select a data source';
+    const placeholderText =
+      this.props.placeholderText === undefined
+        ? 'Select a data source'
+        : this.props.placeholderText;
     return (
       <EuiComboBox
-        aria-label={i18n.translate('dataSourceSelectorComboBoxAriaLabel', {
-          defaultMessage: placeholderText,
-        })}
-        placeholder={i18n.translate('dataSourceSelectorComboBoxPlaceholder', {
-          defaultMessage: placeholderText,
-        })}
+        aria-label={
+          placeholderText
+            ? i18n.translate('dataSourceSelectorComboBoxAriaLabel', {
+                defaultMessage: placeholderText,
+              })
+            : 'dataSourceSelectorCombobox'
+        }
+        placeholder={
+          placeholderText
+            ? i18n.translate('dataSourceSelectorComboBoxPlaceholder', {
+                defaultMessage: placeholderText,
+              })
+            : ''
+        }
         singleSelection={{ asPlainText: true }}
         options={this.state.dataSourceOptions}
         selectedOptions={this.state.selectedOption}

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { i18n } from '@osd/i18n';
 import { EuiComboBox } from '@elastic/eui';
 import { SavedObjectsClientContract, ToastsStart } from 'opensearch-dashboards/public';
-import { getDataSources } from '../utils';
+import { getDataSourcesWithFields } from '../utils';
 
 export const LocalCluster: DataSourceOption = {
   label: i18n.translate('dataSource.localCluster', {
@@ -23,6 +23,11 @@ export interface DataSourceSelectorProps {
   disabled: boolean;
   hideLocalCluster: boolean;
   fullWidth: boolean;
+  defaultOption?: DataSourceOption[];
+  placeholderText?: string;
+  removePrepend?: boolean;
+  filterFn?: (dataSource: any) => boolean;
+  compressed?: boolean;
 }
 
 interface DataSourceSelectorState {
@@ -45,8 +50,16 @@ export class DataSourceSelector extends React.Component<
     super(props);
 
     this.state = {
-      dataSourceOptions: this.props.hideLocalCluster ? [] : [LocalCluster],
-      selectedOption: this.props.hideLocalCluster ? [] : [LocalCluster],
+      dataSourceOptions: this.props.defaultOption
+        ? this.props.defaultOption
+        : this.props.hideLocalCluster
+        ? []
+        : [LocalCluster],
+      selectedOption: this.props.defaultOption
+        ? this.props.defaultOption
+        : this.props.hideLocalCluster
+        ? []
+        : [LocalCluster],
     };
   }
 
@@ -56,12 +69,20 @@ export class DataSourceSelector extends React.Component<
 
   async componentDidMount() {
     this._isMounted = true;
-    getDataSources(this.props.savedObjectsClient)
+    getDataSourcesWithFields(this.props.savedObjectsClient, ['id', 'title', 'auth.type'])
       .then((fetchedDataSources) => {
         if (fetchedDataSources?.length) {
-          const dataSourceOptions = fetchedDataSources.map((dataSource) => ({
+          let filteredDataSources = [];
+          if (this.props.filterFn) {
+            filteredDataSources = fetchedDataSources.filter((ds) => this.props.filterFn!(ds));
+          }
+
+          if (filteredDataSources.length === 0) {
+            filteredDataSources = fetchedDataSources;
+          }
+          const dataSourceOptions = filteredDataSources.map((dataSource) => ({
             id: dataSource.id,
-            label: dataSource.title,
+            label: dataSource.attributes?.title || '',
           }));
 
           if (!this.props.hideLocalCluster) {
@@ -93,22 +114,27 @@ export class DataSourceSelector extends React.Component<
   }
 
   render() {
+    const placeholderText = this.props.placeholderText || 'Select a data source';
     return (
       <EuiComboBox
         aria-label={i18n.translate('dataSourceSelectorComboBoxAriaLabel', {
-          defaultMessage: 'Select a data source',
+          defaultMessage: placeholderText,
         })}
         placeholder={i18n.translate('dataSourceSelectorComboBoxPlaceholder', {
-          defaultMessage: 'Select a data source',
+          defaultMessage: placeholderText,
         })}
         singleSelection={{ asPlainText: true }}
         options={this.state.dataSourceOptions}
         selectedOptions={this.state.selectedOption}
         onChange={(e) => this.onChange(e)}
-        prepend={i18n.translate('dataSourceSelectorComboBoxPrepend', {
-          defaultMessage: 'Data source',
-        })}
-        compressed
+        prepend={
+          this.props.removePrepend
+            ? undefined
+            : i18n.translate('dataSourceSelectorComboBoxPrepend', {
+                defaultMessage: 'Data source',
+              })
+        }
+        compressed={this.props.compressed || false}
         isDisabled={this.props.disabled}
         fullWidth={this.props.fullWidth || false}
         data-test-subj={'dataSourceSelectorComboBox'}

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -36,6 +36,19 @@ export async function getDataSources(savedObjectsClient: SavedObjectsClientContr
     );
 }
 
+export async function getDataSourcesWithFields(
+  savedObjectsClient: SavedObjectsClientContract,
+  fields: string[]
+) {
+  const response = await savedObjectsClient.find({
+    type: 'data-source',
+    fields,
+    perPage: 10000,
+  });
+
+  return response?.savedObjects;
+}
+
 export async function getDataSourceById(
   id: string,
   savedObjectsClient: SavedObjectsClientContract

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -108,6 +108,43 @@ export const getDataSourcesResponse = {
   ],
 };
 
+export const getDataSourcesWithFieldsResponse = {
+  savedObjects: [
+    {
+      id: 'test1',
+      type: 'data-source',
+      attributes: {
+        title: 'test1',
+        auth: {
+          type: AuthType.NoAuth,
+        },
+      },
+    },
+    {
+      id: 'test2',
+      type: 'data-source',
+      description: 'test datasource2',
+      attributes: {
+        title: 'test3',
+        auth: {
+          type: AuthType.UsernamePasswordType,
+        },
+      },
+    },
+    {
+      id: 'test3',
+      type: 'data-source',
+      description: 'test datasource3',
+      attributes: {
+        title: 'test3',
+        auth: {
+          type: AuthType.SigV4,
+        },
+      },
+    },
+  ],
+};
+
 export const existingDatasourceNamesList = [
   'test123',
   'testTest20',


### PR DESCRIPTION
### Description
This change exposes a few properties like 
- defaultOption: the defaulted selected option when the component renders
- placeholderText: the place holder text when the selected option is cleared, default is `Select a data source`
- removePrepend: whether there will be a prepend
- filterFn: the function that will be used to filter the data source options
- compressed

### Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5992

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/beaa10c3-4905-4805-8ff6-0c307d5ff7d1



## Testing the changes
The following steps are performed in the recording above:
1. enable data source plugin
2. go to add sample data and data source picker should render correctly and import sample data from a data source should be successful, going to the dashboard, it should render correctly
3. go to dev tools and data source picker should render correctly and query against a data source should return results
4. go to add sample data to check the options without filtering, it should show the data source named noauth2
5. go to query workbench plugin to check the options with filter to remove noauth2, and it should not show data source named noauth2, query using the selected data source is successful
6. go to search relevance plugin to check the removePrepend which is true and means no prepend should show, and defaultOption which is empty thus placeholder text should show

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
