### PR TITLE
[MD] Create data source menu component able to be mount to nav bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Workspace] Optional workspaces params in repository ([#5949](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5949))
 - [Multiple Datasource] Refactoring create and edit form to use authentication registry ([#6002](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6002))
 - [Multiple Datasource] Expose a few properties for customize the appearance of the data source selector component ([#6057](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6057))
-
+- [Multiple Datasource] Create data source menu component able to be mount to nav bar ([#6082](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6082))
 
 
 ### 🐛 Bug Fixes

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
@@ -1,0 +1,146 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`create data source menu should render normally 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <nav
+        aria-label="App menu"
+        class="euiHeaderLinks osdTopNavMenu myclass"
+        data-test-subj="top-nav"
+      >
+        <div
+          class="euiHeaderLinks__list euiHeaderLinks__list--gutterXS"
+        >
+          <div
+            class="euiPopover euiPopover--anchorDownLeft"
+            id="dataSourceSelectableContextMenuPopover"
+          >
+            <div
+              class="euiPopover__anchor"
+            >
+              <span
+                data-euiicon-type="database"
+              />
+              <button
+                aria-label="dataSourceMenuButton"
+                class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
+                data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                >
+                  <span
+                    class="euiButtonContent__icon"
+                    color="inherit"
+                    data-euiicon-type="arrowDown"
+                  />
+                  <span
+                    class="euiButtonEmpty__text"
+                  />
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </body>,
+  "container": <div>
+    <nav
+      aria-label="App menu"
+      class="euiHeaderLinks osdTopNavMenu myclass"
+      data-test-subj="top-nav"
+    >
+      <div
+        class="euiHeaderLinks__list euiHeaderLinks__list--gutterXS"
+      >
+        <div
+          class="euiPopover euiPopover--anchorDownLeft"
+          id="dataSourceSelectableContextMenuPopover"
+        >
+          <div
+            class="euiPopover__anchor"
+          >
+            <span
+              data-euiicon-type="database"
+            />
+            <button
+              aria-label="dataSourceMenuButton"
+              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
+              data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+              type="button"
+            >
+              <span
+                class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+              >
+                <span
+                  class="euiButtonContent__icon"
+                  color="inherit"
+                  data-euiicon-type="arrowDown"
+                />
+                <span
+                  class="euiButtonEmpty__text"
+                />
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataSourceMenu should render normally with local cluster is hidden 1`] = `
+<Fragment>
+  <EuiHeaderLinks
+    className="osdTopNavMenu myclass"
+    data-test-subj="top-nav"
+    gutterSize="xs"
+  >
+    <DataSourceSelectable
+      disabled={false}
+      fullWidth={true}
+      hideLocalCluster={true}
+      notifications={
+        Object {
+          "add": [MockFunction],
+          "addDanger": [MockFunction],
+          "addError": [MockFunction],
+          "addInfo": [MockFunction],
+          "addSuccess": [MockFunction],
+          "addWarning": [MockFunction],
+          "get$": [MockFunction],
+          "remove": [MockFunction],
+        }
+      }
+      savedObjectsClient={
+        Object {
+          "find": [MockFunction],
+        }
+      }
+    />
+  </EuiHeaderLinks>
+</Fragment>
+`;
+
+exports[`DataSourceMenu should render normally with local cluster not hidden 1`] = `
+<Fragment>
+  <EuiHeaderLinks
+    className="osdTopNavMenu myclass"
+    data-test-subj="top-nav"
+    gutterSize="xs"
+  >
+    <DataSourceSelectable
+      disabled={false}
+      fullWidth={true}
+      hideLocalCluster={false}
+      notifications={
+        Object {
+          "add": [MockFunction],
+          "addDanger": [MockFunction],
+          "addError": [MockFunction],
+          "addInfo": [MockFunction],
+          "addSuccess": [MockFunction],
+          "addWarning": [MockFunction],
+          "get$": [MockFunction],
+          "remove": [MockFunction],
+        }
+      }
+      savedObjectsClient={
+        Object {
+          "find": [MockFunction],
+        }
+      }
+    />
+  </EuiHeaderLinks>
+</Fragment>
+`;

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_selectable.test.tsx.snap
@@ -1,0 +1,123 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataSourceSelectable should render normally with local cluster is hidden 1`] = `
+<EuiPopover
+  anchorPosition="downLeft"
+  button={
+    <React.Fragment>
+      <EuiIcon
+        type="database"
+      />
+      <EuiButtonEmpty
+        aria-label="dataSourceMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+        disabled={false}
+        iconSide="right"
+        iconType="arrowDown"
+        onClick={[Function]}
+        size="s"
+      >
+        
+      </EuiButtonEmpty>
+    </React.Fragment>
+  }
+  closePopover={[Function]}
+  display="inlineBlock"
+  hasArrow={true}
+  id="dataSourceSelectableContextMenuPopover"
+  isOpen={false}
+  ownFocus={true}
+  panelPaddingSize="none"
+>
+  <EuiContextMenuPanel
+    hasFocus={true}
+    items={Array []}
+  >
+    <EuiPanel
+      color="transparent"
+      paddingSize="s"
+    >
+      <EuiSpacer
+        size="s"
+      />
+      <EuiSelectable
+        aria-label="Search"
+        isPreFiltered={false}
+        onChange={[Function]}
+        options={Array []}
+        searchProps={
+          Object {
+            "placeholder": "Search",
+          }
+        }
+        searchable={true}
+        singleSelection={true}
+      >
+        <Component />
+      </EuiSelectable>
+    </EuiPanel>
+  </EuiContextMenuPanel>
+</EuiPopover>
+`;
+
+exports[`DataSourceSelectable should render normally with local cluster not hidden 1`] = `
+<EuiPopover
+  anchorPosition="downLeft"
+  button={
+    <React.Fragment>
+      <EuiIcon
+        type="database"
+      />
+      <EuiButtonEmpty
+        aria-label="dataSourceMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+        disabled={false}
+        iconSide="right"
+        iconType="arrowDown"
+        onClick={[Function]}
+        size="s"
+      >
+        Local cluster
+      </EuiButtonEmpty>
+    </React.Fragment>
+  }
+  closePopover={[Function]}
+  display="inlineBlock"
+  hasArrow={true}
+  id="dataSourceSelectableContextMenuPopover"
+  isOpen={false}
+  ownFocus={true}
+  panelPaddingSize="none"
+>
+  <EuiContextMenuPanel
+    hasFocus={true}
+    items={Array []}
+  >
+    <EuiPanel
+      color="transparent"
+      paddingSize="s"
+    >
+      <EuiSpacer
+        size="s"
+      />
+      <EuiSelectable
+        aria-label="Search"
+        isPreFiltered={false}
+        onChange={[Function]}
+        options={Array []}
+        searchProps={
+          Object {
+            "placeholder": "Search",
+          }
+        }
+        searchable={true}
+        singleSelection={true}
+      >
+        <Component />
+      </EuiSelectable>
+    </EuiPanel>
+  </EuiContextMenuPanel>
+</EuiPopover>
+`;

--- a/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createDataSourceMenu } from './create_data_source_menu';
+import { SavedObjectsClientContract } from '../../../../../core/public';
+import { notificationServiceMock } from '../../../../../core/public/mocks';
+import React from 'react';
+import { render } from '@testing-library/react';
+
+describe('create data source menu', () => {
+  let client: SavedObjectsClientContract;
+  const notifications = notificationServiceMock.createStartContract();
+
+  beforeEach(() => {
+    client = {
+      find: jest.fn().mockResolvedValue([]),
+    } as any;
+  });
+
+  it('should render normally', () => {
+    const props = {
+      showDataSourceSelectable: true,
+      appName: 'myapp',
+      savedObjects: client,
+      notifications,
+      fullWidth: true,
+      hideLocalCluster: true,
+      disableDataSourceSelectable: false,
+      className: 'myclass',
+    };
+    const TestComponent = createDataSourceMenu();
+    const component = render(<TestComponent {...props} />);
+    expect(component).toMatchSnapshot();
+    expect(client.find).toBeCalledWith({
+      fields: ['id', 'description', 'title'],
+      perPage: 10000,
+      type: 'data-source',
+    });
+    expect(notifications.toasts.addWarning).toBeCalledTimes(0);
+  });
+});

--- a/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.tsx
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { DataSourceMenu, DataSourceMenuProps } from './data_source_menu';
+
+export function createDataSourceMenu() {
+  return (props: DataSourceMenuProps) => {
+    return <DataSourceMenu {...props} />;
+  };
+}

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ShallowWrapper, shallow } from 'enzyme';
+import { SavedObjectsClientContract } from '../../../../../core/public';
+import { notificationServiceMock } from '../../../../../core/public/mocks';
+import React from 'react';
+import { DataSourceMenu } from './data_source_menu';
+
+describe('DataSourceMenu', () => {
+  let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
+
+  let client: SavedObjectsClientContract;
+  const notifications = notificationServiceMock.createStartContract();
+
+  beforeEach(() => {
+    client = {
+      find: jest.fn().mockResolvedValue([]),
+    } as any;
+  });
+
+  it('should render normally with local cluster not hidden', () => {
+    component = shallow(
+      <DataSourceMenu
+        showDataSourceSelectable={true}
+        appName={'myapp'}
+        savedObjects={client}
+        notifications={notifications}
+        fullWidth={true}
+        hideLocalCluster={false}
+        disableDataSourceSelectable={false}
+        className={'myclass'}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render normally with local cluster is hidden', () => {
+    component = shallow(
+      <DataSourceMenu
+        showDataSourceSelectable={true}
+        appName={'myapp'}
+        savedObjects={client}
+        notifications={notifications}
+        fullWidth={true}
+        hideLocalCluster={true}
+        disableDataSourceSelectable={false}
+        className={'myclass'}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { ReactElement } from 'react';
+import { EuiHeaderLinks } from '@elastic/eui';
+import classNames from 'classnames';
+
+import {
+  MountPoint,
+  NotificationsStart,
+  SavedObjectsClientContract,
+} from '../../../../../core/public';
+import { MountPointPortal } from '../../../../opensearch_dashboards_react/public';
+import { DataSourceSelectable } from './data_source_selectable';
+import { DataSourceOption } from '../data_source_selector/data_source_selector';
+
+export interface DataSourceMenuProps {
+  showDataSourceSelectable: boolean;
+  appName: string;
+  savedObjects: SavedObjectsClientContract;
+  notifications: NotificationsStart;
+  fullWidth: boolean;
+  hideLocalCluster: boolean;
+  dataSourceCallBackFunc: (dataSource: DataSourceOption) => void;
+  disableDataSourceSelectable?: boolean;
+  className?: string;
+  selectedOption?: DataSourceOption[];
+  setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
+}
+
+export function DataSourceMenu(props: DataSourceMenuProps): ReactElement | null {
+  const {
+    savedObjects,
+    notifications,
+    dataSourceCallBackFunc,
+    showDataSourceSelectable,
+    disableDataSourceSelectable,
+    fullWidth,
+    hideLocalCluster,
+    selectedOption,
+  } = props;
+
+  if (!showDataSourceSelectable) {
+    return null;
+  }
+
+  function renderMenu(className: string): ReactElement | null {
+    if (!showDataSourceSelectable) return null;
+    return (
+      <EuiHeaderLinks data-test-subj="top-nav" gutterSize="xs" className={className}>
+        {renderDataSourceSelectable()}
+      </EuiHeaderLinks>
+    );
+  }
+
+  function renderDataSourceSelectable(): ReactElement | null {
+    if (!showDataSourceSelectable) return null;
+    return (
+      <DataSourceSelectable
+        fullWidth={fullWidth}
+        hideLocalCluster={hideLocalCluster}
+        savedObjectsClient={savedObjects}
+        notifications={notifications.toasts}
+        onSelectedDataSource={dataSourceCallBackFunc}
+        disabled={disableDataSourceSelectable || false}
+        selectedOption={selectedOption && selectedOption.length > 0 ? selectedOption : undefined}
+      />
+    );
+  }
+
+  function renderLayout() {
+    const { setMenuMountPoint } = props;
+    const menuClassName = classNames('osdTopNavMenu', props.className);
+    if (setMenuMountPoint) {
+      return (
+        <>
+          <MountPointPortal setMountPoint={setMenuMountPoint}>
+            {renderMenu(menuClassName)}
+          </MountPointPortal>
+        </>
+      );
+    } else {
+      return <>{renderMenu(menuClassName)}</>;
+    }
+  }
+
+  return renderLayout();
+}
+
+DataSourceMenu.defaultProps = {
+  disableDataSourceSelectable: false,
+};

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_selectable.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ShallowWrapper, shallow } from 'enzyme';
+import { SavedObjectsClientContract } from '../../../../../core/public';
+import { notificationServiceMock } from '../../../../../core/public/mocks';
+import React from 'react';
+import { DataSourceSelectable } from './data_source_selectable';
+
+describe('DataSourceSelectable', () => {
+  let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
+
+  let client: SavedObjectsClientContract;
+  const { toasts } = notificationServiceMock.createStartContract();
+
+  beforeEach(() => {
+    client = {
+      find: jest.fn().mockResolvedValue([]),
+    } as any;
+  });
+
+  it('should render normally with local cluster not hidden', () => {
+    component = shallow(
+      <DataSourceSelectable
+        savedObjectsClient={client}
+        notifications={toasts}
+        onSelectedDataSource={jest.fn()}
+        disabled={false}
+        hideLocalCluster={false}
+        fullWidth={false}
+      />
+    );
+    expect(component).toMatchSnapshot();
+    expect(client.find).toBeCalledWith({
+      fields: ['id', 'description', 'title'],
+      perPage: 10000,
+      type: 'data-source',
+    });
+    expect(toasts.addWarning).toBeCalledTimes(0);
+  });
+
+  it('should render normally with local cluster is hidden', () => {
+    component = shallow(
+      <DataSourceSelectable
+        savedObjectsClient={client}
+        notifications={toasts}
+        onSelectedDataSource={jest.fn()}
+        disabled={false}
+        hideLocalCluster={true}
+        fullWidth={false}
+      />
+    );
+    expect(component).toMatchSnapshot();
+    expect(client.find).toBeCalledWith({
+      fields: ['id', 'description', 'title'],
+      perPage: 10000,
+      type: 'data-source',
+    });
+    expect(toasts.addWarning).toBeCalledTimes(0);
+  });
+});

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_selectable.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import {
+  EuiIcon,
+  EuiPopover,
+  EuiContextMenuPanel,
+  EuiPanel,
+  EuiButtonEmpty,
+  EuiSelectable,
+  EuiSpacer,
+} from '@elastic/eui';
+import { SavedObjectsClientContract, ToastsStart } from 'opensearch-dashboards/public';
+import { getDataSources } from '../utils';
+import { DataSourceOption, LocalCluster } from '../data_source_selector/data_source_selector';
+
+interface DataSourceSelectableProps {
+  savedObjectsClient: SavedObjectsClientContract;
+  notifications: ToastsStart;
+  onSelectedDataSource: (dataSource: DataSourceOption) => void;
+  disabled: boolean;
+  hideLocalCluster: boolean;
+  fullWidth: boolean;
+  selectedOption?: DataSourceOption[];
+}
+
+interface DataSourceSelectableState {
+  dataSourceOptions: DataSourceOption[];
+  selectedOption: DataSourceOption[];
+  isPopoverOpen: boolean;
+}
+
+export class DataSourceSelectable extends React.Component<
+  DataSourceSelectableProps,
+  DataSourceSelectableState
+> {
+  private _isMounted: boolean = false;
+
+  constructor(props: DataSourceSelectableProps) {
+    super(props);
+
+    this.state = {
+      isPopoverOpen: false,
+      selectedOption: this.props.selectedOption
+        ? this.props.selectedOption
+        : this.props.hideLocalCluster
+        ? []
+        : [LocalCluster],
+    };
+
+    this.onChange.bind(this);
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  onClick() {
+    this.setState({ ...this.state, isPopoverOpen: !this.state.isPopoverOpen });
+  }
+
+  closePopover() {
+    this.setState({ ...this.state, isPopoverOpen: false });
+  }
+
+  async componentDidMount() {
+    this._isMounted = true;
+    getDataSources(this.props.savedObjectsClient)
+      .then((fetchedDataSources) => {
+        if (fetchedDataSources?.length) {
+          let dataSourceOptions = fetchedDataSources.map((dataSource) => ({
+            id: dataSource.id,
+            label: dataSource.title,
+          }));
+
+          dataSourceOptions = dataSourceOptions.sort((a, b) =>
+            a.label.toLowerCase().localeCompare(b.label.toLowerCase())
+          );
+
+          if (!this.props.hideLocalCluster) {
+            dataSourceOptions.unshift(LocalCluster);
+          }
+
+          if (!this._isMounted) return;
+          this.setState({
+            ...this.state,
+            dataSourceOptions,
+          });
+        }
+      })
+      .catch(() => {
+        this.props.notifications.addWarning(
+          i18n.translate('dataSource.fetchDataSourceError', {
+            defaultMessage: 'Unable to fetch existing data sources',
+          })
+        );
+      });
+  }
+
+  onChange(options) {
+    if (!this._isMounted) return;
+    const selectedDataSource = options.find(({ checked }) => checked);
+
+    this.setState({
+      selectedOption: [selectedDataSource],
+    });
+    this.props.onSelectedDataSource({ ...selectedDataSource });
+  }
+
+  render() {
+    const button = (
+      <>
+        <EuiIcon type="database" />
+        <EuiButtonEmpty
+          className="euiHeaderLink"
+          onClick={this.onClick.bind(this)}
+          data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+          aria-label={i18n.translate('dataSourceSelectable.dataSourceOptionsButtonAriaLabel', {
+            defaultMessage: 'dataSourceMenuButton',
+          })}
+          iconType="arrowDown"
+          iconSide="right"
+          size="s"
+          disabled={this.props.disabled || false}
+        >
+          {(this.state.selectedOption &&
+            this.state.selectedOption.length > 0 &&
+            this.state.selectedOption[0].label) ||
+            ''}
+        </EuiButtonEmpty>
+      </>
+    );
+
+    return (
+      <EuiPopover
+        id={'dataSourceSelectableContextMenuPopover'}
+        button={button}
+        isOpen={this.state.isPopoverOpen}
+        closePopover={this.closePopover.bind(this)}
+        panelPaddingSize="none"
+        anchorPosition="downLeft"
+      >
+        <EuiContextMenuPanel>
+          <EuiPanel color="transparent" paddingSize="s">
+            <EuiSpacer size="s" />
+            <EuiSelectable
+              aria-label="Search"
+              searchable
+              searchProps={{
+                placeholder: 'Search',
+              }}
+              options={this.state.dataSourceOptions}
+              onChange={(newOptions) => this.onChange(newOptions)}
+              singleSelection={true}
+            >
+              {(list, search) => (
+                <>
+                  {search}
+                  {list}
+                </>
+              )}
+            </EuiSelectable>
+          </EuiPanel>
+        </EuiContextMenuPanel>
+      </EuiPopover>
+    );
+  }
+}

--- a/src/plugins/data_source_management/public/components/data_source_menu/index.ts
+++ b/src/plugins/data_source_management/public/components/data_source_menu/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { DataSourceMenu } from './data_source_menu';

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
@@ -38,6 +38,7 @@ interface DataSourceSelectorState {
 export interface DataSourceOption {
   label: string;
   id: string;
+  checked?: string;
 }
 
 export class DataSourceSelector extends React.Component<

--- a/src/plugins/data_source_management/public/index.ts
+++ b/src/plugins/data_source_management/public/index.ts
@@ -12,4 +12,5 @@ export function plugin() {
 }
 export { DataSourceManagementPluginStart } from './types';
 export { DataSourceSelector } from './components/data_source_selector';
+export { DataSourceMenu } from './components/data_source_menu';
 export { DataSourceManagementPlugin, DataSourceManagementPluginSetup } from './plugin';

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -19,6 +19,8 @@ import {
 } from './auth_registry';
 import { noAuthCredentialAuthMethod, sigV4AuthMethod, usernamePasswordAuthMethod } from './types';
 import { DataSourceSelectorProps } from './components/data_source_selector/data_source_selector';
+import { createDataSourceMenu } from './components/data_source_menu/create_data_source_menu';
+import { DataSourceMenuProps } from './components/data_source_menu/data_source_menu';
 
 export interface DataSourceManagementSetupDependencies {
   management: ManagementSetup;
@@ -28,7 +30,10 @@ export interface DataSourceManagementSetupDependencies {
 
 export interface DataSourceManagementPluginSetup {
   registerAuthenticationMethod: (authMethodValues: AuthenticationMethod) => void;
-  getDataSourceSelector: React.ComponentType<DataSourceSelectorProps>;
+  ui: {
+    DataSourceSelector: React.ComponentType<DataSourceSelectorProps>;
+    DataSourceMenu: React.ComponentType<DataSourceMenuProps>;
+  };
 }
 
 export interface DataSourceManagementPluginStart {
@@ -96,7 +101,10 @@ export class DataSourceManagementPlugin
 
     return {
       registerAuthenticationMethod,
-      getDataSourceSelector: createDataSourceSelector(),
+      ui: {
+        DataSourceSelector: createDataSourceSelector(),
+        DataSourceMenu: createDataSourceMenu(),
+      },
     };
   }
 


### PR DESCRIPTION
### Description
This change add a new data source menu component which exposes function to allow plugins to consume and mount to the navigation bar.

### Issues Resolved
This PR is to expose component without backporting to release branch yet.

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/8f154592-3b63-4feb-b520-cbed68ce3574


## Testing the changes
The following steps were performed in the recording above
1. enable data source plugin
2. go to search relevance and see the mounted data source menu, selected option to be `data sources` which is passed in via selectedOption
3. set to disable the menu will make the menu unclickable
4. go to query workbench and see the mounted data source menu, selected a data source and make query, will see the results from data source

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
