### PR TITLE
[Multiple Datasource] Expose filterfn in datasource menu component

### DIFF
--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_selectable.test.tsx.snap
@@ -1,5 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DataSourceSelectable should filter options if configured 1`] = `
+<EuiPopover
+  anchorPosition="downLeft"
+  button={
+    <React.Fragment>
+      <EuiIcon
+        type="database"
+      />
+      <EuiButtonEmpty
+        aria-label="dataSourceMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+        disabled={false}
+        iconSide="right"
+        iconType="arrowDown"
+        onClick={[Function]}
+        size="s"
+      >
+        Local cluster
+      </EuiButtonEmpty>
+    </React.Fragment>
+  }
+  closePopover={[Function]}
+  display="inlineBlock"
+  hasArrow={true}
+  id="dataSourceSelectableContextMenuPopover"
+  isOpen={false}
+  ownFocus={true}
+  panelPaddingSize="none"
+>
+  <EuiContextMenuPanel
+    hasFocus={true}
+    items={Array []}
+  >
+    <EuiPanel
+      color="transparent"
+      paddingSize="s"
+    >
+      <EuiSpacer
+        size="s"
+      />
+      <EuiSelectable
+        aria-label="Search"
+        isPreFiltered={false}
+        onChange={[Function]}
+        options={
+          Array [
+            Object {
+              "id": "",
+              "label": "Local cluster",
+            },
+            Object {
+              "id": "test2",
+              "label": "test3",
+            },
+            Object {
+              "id": "test3",
+              "label": "test3",
+            },
+          ]
+        }
+        searchProps={
+          Object {
+            "placeholder": "Search",
+          }
+        }
+        searchable={true}
+        singleSelection={true}
+      >
+        <Component />
+      </EuiSelectable>
+    </EuiPanel>
+  </EuiContextMenuPanel>
+</EuiPopover>
+`;
+
 exports[`DataSourceSelectable should render normally with local cluster is hidden 1`] = `
 <EuiPopover
   anchorPosition="downLeft"

--- a/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.test.tsx
@@ -34,7 +34,7 @@ describe('create data source menu', () => {
     const component = render(<TestComponent {...props} />);
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'description', 'title'],
+      fields: ['id', 'title', 'auth.type'],
       perPage: 10000,
       type: 'data-source',
     });

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -28,6 +28,7 @@ export interface DataSourceMenuProps {
   className?: string;
   selectedOption?: DataSourceOption[];
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
+  filterFn?: (dataSource: any) => boolean;
 }
 
 export function DataSourceMenu(props: DataSourceMenuProps): ReactElement | null {
@@ -40,6 +41,7 @@ export function DataSourceMenu(props: DataSourceMenuProps): ReactElement | null 
     fullWidth,
     hideLocalCluster,
     selectedOption,
+    filterFn,
   } = props;
 
   if (!showDataSourceSelectable) {
@@ -66,6 +68,7 @@ export function DataSourceMenu(props: DataSourceMenuProps): ReactElement | null 
         onSelectedDataSource={dataSourceCallBackFunc}
         disabled={disableDataSourceSelectable || false}
         selectedOption={selectedOption && selectedOption.length > 0 ? selectedOption : undefined}
+        filterFn={filterFn}
       />
     );
   }

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_selectable.test.tsx
@@ -8,17 +8,21 @@ import { SavedObjectsClientContract } from '../../../../../core/public';
 import { notificationServiceMock } from '../../../../../core/public/mocks';
 import React from 'react';
 import { DataSourceSelectable } from './data_source_selectable';
+import { AuthType } from '../../types';
+import { getDataSourcesWithFieldsResponse, mockResponseForSavedObjectsCalls } from '../../mocks';
 
 describe('DataSourceSelectable', () => {
   let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
 
   let client: SavedObjectsClientContract;
   const { toasts } = notificationServiceMock.createStartContract();
+  const nextTick = () => new Promise((res) => process.nextTick(res));
 
   beforeEach(() => {
     client = {
       find: jest.fn().mockResolvedValue([]),
     } as any;
+    mockResponseForSavedObjectsCalls(client, 'find', getDataSourcesWithFieldsResponse);
   });
 
   it('should render normally with local cluster not hidden', () => {
@@ -34,7 +38,7 @@ describe('DataSourceSelectable', () => {
     );
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'description', 'title'],
+      fields: ['id', 'title', 'auth.type'],
       perPage: 10000,
       type: 'data-source',
     });
@@ -54,10 +58,28 @@ describe('DataSourceSelectable', () => {
     );
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'description', 'title'],
+      fields: ['id', 'title', 'auth.type'],
       perPage: 10000,
       type: 'data-source',
     });
+    expect(toasts.addWarning).toBeCalledTimes(0);
+  });
+
+  it('should filter options if configured', async () => {
+    component = shallow(
+      <DataSourceSelectable
+        savedObjectsClient={client}
+        notifications={toasts}
+        onSelectedDataSource={jest.fn()}
+        disabled={false}
+        hideLocalCluster={false}
+        fullWidth={false}
+        filterFn={(ds) => ds.attributes.auth.type !== AuthType.NoAuth}
+      />
+    );
+    component.instance().componentDidMount!();
+    await nextTick();
+    expect(component).toMatchSnapshot();
     expect(toasts.addWarning).toBeCalledTimes(0);
   });
 });


### PR DESCRIPTION
### Description

In https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6057, we exposed a few properties in data source selector component for plugins to consume, and in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6082, we created a new data source menu component to be mounted into navigation bar. Based on requirements, we should also expose this filter function to allow plugins to exclude data sources that don't make sense to render in options

### Issues Resolved


## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/9a60ceb0-dc3d-4bfe-9b8a-ba8cfd98ae2f



## Testing the changes
The following steps were performed in the recording:
1. create a data source with no authentication
2. go to add sample data page, and see that the data source picker shows all available data sources including the one configured with no authentication
3. go to query workbench plugin, and see that the data source menu doesn't show the data source with no auth
4. go to the query workbench implementation, and see the filterfn passed in will exclude the data sources with no auth

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
