### PR TITLE
[Multiple Datasource] Add component to show single selected data source in read only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Expose filterfn in datasource menu component to allow filter data sources before rendering in navigation bar ([#6113](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6113))
 - [Workspace] Add delete saved objects by workspace functionality([#6013](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6013))
 - [Workspace] Add a workspace client in workspace plugin ([#6094](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6094))
+- [Multiple Datasource] Add component to show single selected data source in read only mode ([#6125](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6125))
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DataSourceMenu should render normally with local cluster is hidden 1`] = `
+exports[`DataSourceMenu should render data source selectable only with local cluster is hidden 1`] = `
 <Fragment>
   <EuiHeaderLinks
     className="osdTopNavMenu myclass"
@@ -23,6 +23,7 @@ exports[`DataSourceMenu should render normally with local cluster is hidden 1`] 
           "remove": [MockFunction],
         }
       }
+      onSelectedDataSource={[MockFunction]}
       savedObjectsClient={
         Object {
           "find": [MockFunction],
@@ -33,7 +34,7 @@ exports[`DataSourceMenu should render normally with local cluster is hidden 1`] 
 </Fragment>
 `;
 
-exports[`DataSourceMenu should render normally with local cluster not hidden 1`] = `
+exports[`DataSourceMenu should render data source selectable only with local cluster not hidden 1`] = `
 <Fragment>
   <EuiHeaderLinks
     className="osdTopNavMenu myclass"
@@ -56,11 +57,26 @@ exports[`DataSourceMenu should render normally with local cluster not hidden 1`]
           "remove": [MockFunction],
         }
       }
+      onSelectedDataSource={[MockFunction]}
       savedObjectsClient={
         Object {
           "find": [MockFunction],
         }
       }
+    />
+  </EuiHeaderLinks>
+</Fragment>
+`;
+
+exports[`DataSourceMenu should render data source view only 1`] = `
+<Fragment>
+  <EuiHeaderLinks
+    className="osdTopNavMenu myclass"
+    data-test-subj="top-nav"
+    gutterSize="xs"
+  >
+    <DataSourceView
+      fullWidth={true}
     />
   </EuiHeaderLinks>
 </Fragment>

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.test.tsx
@@ -21,7 +21,7 @@ describe('DataSourceMenu', () => {
     } as any;
   });
 
-  it('should render normally with local cluster not hidden', () => {
+  it('should render data source selectable only with local cluster not hidden', () => {
     component = shallow(
       <DataSourceMenu
         showDataSourceSelectable={true}
@@ -32,12 +32,13 @@ describe('DataSourceMenu', () => {
         hideLocalCluster={false}
         disableDataSourceSelectable={false}
         className={'myclass'}
+        dataSourceCallBackFunc={jest.fn()}
       />
     );
     expect(component).toMatchSnapshot();
   });
 
-  it('should render normally with local cluster is hidden', () => {
+  it('should render data source selectable only with local cluster is hidden', () => {
     component = shallow(
       <DataSourceMenu
         showDataSourceSelectable={true}
@@ -47,6 +48,19 @@ describe('DataSourceMenu', () => {
         fullWidth={true}
         hideLocalCluster={true}
         disableDataSourceSelectable={false}
+        className={'myclass'}
+        dataSourceCallBackFunc={jest.fn()}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render data source view only', () => {
+    component = shallow(
+      <DataSourceMenu
+        showDataSourceView={true}
+        appName={'myapp'}
+        fullWidth={true}
         className={'myclass'}
       />
     );

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -15,15 +15,17 @@ import {
 import { MountPointPortal } from '../../../../opensearch_dashboards_react/public';
 import { DataSourceSelectable } from './data_source_selectable';
 import { DataSourceOption } from '../data_source_selector/data_source_selector';
+import { DataSourceView } from '../data_source_view';
 
 export interface DataSourceMenuProps {
-  showDataSourceSelectable: boolean;
+  showDataSourceSelectable?: boolean;
+  showDataSourceView?: boolean;
   appName: string;
-  savedObjects: SavedObjectsClientContract;
-  notifications: NotificationsStart;
+  savedObjects?: SavedObjectsClientContract;
+  notifications?: NotificationsStart;
   fullWidth: boolean;
-  hideLocalCluster: boolean;
-  dataSourceCallBackFunc: (dataSource: DataSourceOption) => void;
+  hideLocalCluster?: boolean;
+  dataSourceCallBackFunc?: (dataSource: DataSourceOption) => void;
   disableDataSourceSelectable?: boolean;
   className?: string;
   selectedOption?: DataSourceOption[];
@@ -41,35 +43,41 @@ export function DataSourceMenu(props: DataSourceMenuProps): ReactElement | null 
     fullWidth,
     hideLocalCluster,
     selectedOption,
+    showDataSourceView,
     filterFn,
   } = props;
 
-  if (!showDataSourceSelectable) {
+  if (!showDataSourceSelectable && !showDataSourceView) {
     return null;
   }
 
-  function renderMenu(className: string): ReactElement | null {
-    if (!showDataSourceSelectable) return null;
+  function renderDataSourceView(className: string): ReactElement | null {
+    if (!showDataSourceView) return null;
     return (
       <EuiHeaderLinks data-test-subj="top-nav" gutterSize="xs" className={className}>
-        {renderDataSourceSelectable()}
+        <DataSourceView
+          fullWidth={fullWidth}
+          selectedOption={selectedOption && selectedOption.length > 0 ? selectedOption : undefined}
+        />
       </EuiHeaderLinks>
     );
   }
 
-  function renderDataSourceSelectable(): ReactElement | null {
+  function renderDataSourceSelectable(className: string): ReactElement | null {
     if (!showDataSourceSelectable) return null;
     return (
-      <DataSourceSelectable
-        fullWidth={fullWidth}
-        hideLocalCluster={hideLocalCluster}
-        savedObjectsClient={savedObjects}
-        notifications={notifications.toasts}
-        onSelectedDataSource={dataSourceCallBackFunc}
-        disabled={disableDataSourceSelectable || false}
-        selectedOption={selectedOption && selectedOption.length > 0 ? selectedOption : undefined}
-        filterFn={filterFn}
-      />
+      <EuiHeaderLinks data-test-subj="top-nav" gutterSize="xs" className={className}>
+        <DataSourceSelectable
+          fullWidth={fullWidth}
+          hideLocalCluster={hideLocalCluster || false}
+          savedObjectsClient={savedObjects!}
+          notifications={notifications!.toasts}
+          onSelectedDataSource={dataSourceCallBackFunc!}
+          disabled={disableDataSourceSelectable || false}
+          selectedOption={selectedOption && selectedOption.length > 0 ? selectedOption : undefined}
+          filterFn={filterFn}
+        />
+      </EuiHeaderLinks>
     );
   }
 
@@ -80,12 +88,18 @@ export function DataSourceMenu(props: DataSourceMenuProps): ReactElement | null 
       return (
         <>
           <MountPointPortal setMountPoint={setMenuMountPoint}>
-            {renderMenu(menuClassName)}
+            {renderDataSourceSelectable(menuClassName)}
+            {renderDataSourceView(menuClassName)}
           </MountPointPortal>
         </>
       );
     } else {
-      return <>{renderMenu(menuClassName)}</>;
+      return (
+        <>
+          {renderDataSourceSelectable(menuClassName)}
+          {renderDataSourceView(menuClassName)}
+        </>
+      );
     }
   }
 
@@ -94,4 +108,6 @@ export function DataSourceMenu(props: DataSourceMenuProps): ReactElement | null 
 
 DataSourceMenu.defaultProps = {
   disableDataSourceSelectable: false,
+  showDataSourceView: false,
+  showDataSourceSelectable: false,
 };

--- a/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataSourceView should render normally with local cluster not hidden 1`] = `
+<Fragment>
+  <EuiButtonEmpty
+    aria-label="dataSourceViewMenuButton"
+    className="euiHeaderLink"
+    data-test-subj="dataSourceViewContextMenuHeaderLink"
+    disabled={true}
+    iconSide="left"
+    iconType="database"
+    size="s"
+  >
+    test1
+  </EuiButtonEmpty>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonIcon
+        aria-label="Next"
+        display="empty"
+        iconType="iInCircle"
+        onClick={[Function]}
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenu
+      initialPanelId={0}
+      panels={
+        Array [
+          Object {
+            "id": 0,
+            "items": Array [
+              Object {
+                "disabled": true,
+                "name": "test1",
+              },
+            ],
+            "title": "Selected data source",
+          },
+        ]
+      }
+      size="m"
+    />
+  </EuiPopover>
+</Fragment>
+`;

--- a/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`DataSourceView should render normally with local cluster not hidden 1`]
     closePopover={[Function]}
     display="inlineBlock"
     hasArrow={true}
-    id="dataSourceSViewContextMenuPopover"
+    id="dataSourceViewContextMenuPopover"
     isOpen={false}
     ownFocus={true}
     panelPaddingSize="none"

--- a/src/plugins/data_source_management/public/components/data_source_view/data_source_view.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_view/data_source_view.test.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ShallowWrapper, shallow } from 'enzyme';
+import React from 'react';
+import { DataSourceView } from './data_source_view';
+
+describe('DataSourceView', () => {
+  let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
+
+  it('should render normally with local cluster not hidden', () => {
+    component = shallow(
+      <DataSourceView fullWidth={false} selectedOption={[{ id: 'test1', label: 'test1' }]} />
+    );
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import { EuiPopover, EuiButtonEmpty, EuiButtonIcon, EuiContextMenu } from '@elastic/eui';
+import { DataSourceOption } from '../data_source_selector/data_source_selector';
+
+interface DataSourceViewProps {
+  fullWidth: boolean;
+  selectedOption?: DataSourceOption[];
+}
+
+interface DataSourceViewState {
+  dataSourceOptions: DataSourceOption[];
+  selectedOption: DataSourceOption[];
+  isPopoverOpen: boolean;
+}
+
+export class DataSourceView extends React.Component<DataSourceViewProps, DataSourceViewState> {
+  private _isMounted: boolean = false;
+
+  constructor(props: DataSourceViewProps) {
+    super(props);
+
+    this.state = {
+      isPopoverOpen: false,
+      selectedOption: this.props.selectedOption ? this.props.selectedOption : [],
+    };
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  onClick() {
+    this.setState({ ...this.state, isPopoverOpen: !this.state.isPopoverOpen });
+  }
+
+  closePopover() {
+    this.setState({ ...this.state, isPopoverOpen: false });
+  }
+
+  async componentDidMount() {
+    this._isMounted = true;
+  }
+
+  render() {
+    const button = (
+      <EuiButtonIcon
+        iconType="iInCircle"
+        display="empty"
+        aria-label="Next"
+        onClick={this.onClick.bind(this)}
+      />
+    );
+
+    let items = [];
+
+    if (this.props.selectedOption) {
+      items = this.props.selectedOption.map((option) => {
+        return {
+          name: option.label,
+          disabled: true,
+        };
+      });
+    }
+
+    const panels = [
+      {
+        id: 0,
+        title: 'Selected data source',
+        items,
+      },
+    ];
+
+    return (
+      <>
+        <EuiButtonEmpty
+          className="euiHeaderLink"
+          data-test-subj="dataSourceViewContextMenuHeaderLink"
+          aria-label={i18n.translate('dataSourceView.dataSourceOptionsButtonAriaLabel', {
+            defaultMessage: 'dataSourceViewMenuButton',
+          })}
+          iconType="database"
+          iconSide="left"
+          size="s"
+          disabled={true}
+        >
+          {this.props.selectedOption && this.props.selectedOption.length > 0
+            ? this.props.selectedOption[0].label
+            : ''}
+        </EuiButtonEmpty>
+        <EuiPopover
+          id={'dataSourceSViewContextMenuPopover'}
+          button={button}
+          isOpen={this.state.isPopoverOpen}
+          closePopover={this.closePopover.bind(this)}
+          panelPaddingSize="none"
+          anchorPosition="downLeft"
+        >
+          <EuiContextMenu initialPanelId={0} panels={panels} />
+        </EuiPopover>
+      </>
+    );
+  }
+}

--- a/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
@@ -14,14 +14,11 @@ interface DataSourceViewProps {
 }
 
 interface DataSourceViewState {
-  dataSourceOptions: DataSourceOption[];
   selectedOption: DataSourceOption[];
   isPopoverOpen: boolean;
 }
 
 export class DataSourceView extends React.Component<DataSourceViewProps, DataSourceViewState> {
-  private _isMounted: boolean = false;
-
   constructor(props: DataSourceViewProps) {
     super(props);
 
@@ -31,20 +28,12 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
     };
   }
 
-  componentWillUnmount() {
-    this._isMounted = false;
-  }
-
   onClick() {
     this.setState({ ...this.state, isPopoverOpen: !this.state.isPopoverOpen });
   }
 
   closePopover() {
     this.setState({ ...this.state, isPopoverOpen: false });
-  }
-
-  async componentDidMount() {
-    this._isMounted = true;
   }
 
   render() {
@@ -94,7 +83,7 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
             : ''}
         </EuiButtonEmpty>
         <EuiPopover
-          id={'dataSourceSViewContextMenuPopover'}
+          id={'dataSourceViewContextMenuPopover'}
           button={button}
           isOpen={this.state.isPopoverOpen}
           closePopover={this.closePopover.bind(this)}

--- a/src/plugins/data_source_management/public/components/data_source_view/index.ts
+++ b/src/plugins/data_source_management/public/components/data_source_view/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { DataSourceView } from './data_source_view';


### PR DESCRIPTION
### Description

This change adds component to show single selected data source in read only mode

### Issues Resolved


## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/e88fb8e3-076c-49aa-b9fc-7b476d14cd99



## Testing the changes
The following were performed in the recording:
1. enable data source plugin, and see the mounted single selected data source component
2. when clicking on the info icon, a drop down shows which displays the currently used data source
3. disable data source plugin, and we should not see the mounted single selected data source component

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
