### PR TITLE
Employ a patched version of hoek that addresses CVE-2020-36604

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecations
 
 ### 🛡 Security
-- Support dynamic CSP rules to mitigate Clickjacking https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5641
 
+- Support dynamic CSP rules to mitigate Clickjacking https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5641
+- [CVE-2020-36604] Employ a patched version of hoek `6.1.3` ([#6148](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6148))
 - [CVE-2024-27088] Bump es5-ext from `0.10.59` to `0.10.64` ([#6021](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6021))
 
 ### 📈 Features/Enhancements
+
 - [MD]Change cluster selector component name to data source selector ([#6042](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6042))
 - [Multiple Datasource] Add interfaces to register add-on authentication method from plug-in module ([#5851](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5851))
 - [Multiple Datasource] Able to Hide "Local Cluster" option from datasource DropDown ([#5827](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5827))

--- a/package.json
+++ b/package.json
@@ -89,30 +89,32 @@
     "url": "https://github.com/opensearch-project/opensearch-dashboards.git"
   },
   "resolutions": {
+    "**/@babel/traverse": "^7.23.2",
     "**/@types/node": "~18.7.0",
     "**/ansi-regex": "^5.0.1",
     "**/async": "^3.2.3",
     "**/d3-color": "^3.1.0",
     "**/elasticsearch/agentkeepalive": "^4.5.0",
+    "**/es5-ext": "^0.10.63",
     "**/follow-redirects": "^1.15.4",
     "**/glob-parent": "^6.0.0",
     "**/hoist-non-react-statics": "^3.3.2",
+    "**/jest-config": "npm:@amoo-miki/jest-config@27.5.1",
+    "**/jest-jasmine2": "npm:@amoo-miki/jest-jasmine2@27.5.1",
+    "**/joi/hoek": "npm:@amoo-miki/hoek@6.1.3",
     "**/json-schema": "^0.4.0",
     "**/kind-of": ">=6.0.3",
     "**/loader-utils": "^2.0.4",
     "**/node-jose": "^2.2.0",
     "**/nth-check": "^2.0.1",
+    "**/semver": "^7.5.3",
+    "**/set-value": "^4.1.0",
+    "**/topo/hoek": "npm:@amoo-miki/hoek@6.1.3",
     "**/trim": "^0.0.3",
     "**/typescript": "4.6.4",
     "**/unset-value": "^2.0.1",
-    "**/jest-config": "npm:@amoo-miki/jest-config@27.5.1",
-    "**/jest-jasmine2": "npm:@amoo-miki/jest-jasmine2@27.5.1",
-    "**/semver": "^7.5.3",
-    "**/set-value": "^4.1.0",
     "**/xml2js": "^0.5.0",
-    "**/yaml": "^2.2.2",
-    "**/@babel/traverse": "^7.23.2",
-    "**/es5-ext": "^0.10.63"
+    "**/yaml": "^2.2.2"
   },
   "workspaces": {
     "packages": [
@@ -234,7 +236,7 @@
     "whatwg-fetch": "^3.0.0",
     "yauzl": "^2.10.0",
     "@opensearch-dashboards-test/opensearch-dashboards-test-library": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.6.tar.gz"
-    
+
   },
   "devDependencies": {
     "@babel/core": "^7.22.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10335,10 +10335,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoek@6.x.x:
+hoek@6.x.x, "hoek@npm:@amoo-miki/hoek@6.1.3":
   version "6.1.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.3.tgz#73b7d33952e01fe27a38b0457294b79dd8da242c"
-  integrity sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==
+  resolved "https://registry.yarnpkg.com/@amoo-miki/hoek/-/hoek-6.1.3.tgz#621a8323985a52ae088bb38a29a06d74b73eec7e"
+  integrity sha512-NQRZo6rjCqAmh1Jyav6OUnHikHbluO3kIwhvnT5tPTic7OpxzgeLsWa5050+otYSL6Zy4ONuMC7WcIEXTQX49Q==
 
 hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
### Description

Employ a patched version of hoek that addresses CVE-2020-36604.

Note: the patched library has tests added for prototype poisoning.

```
% npm run test

> @amoo-miki/hoek@6.1.3 test
> lab -a code -t 100 -L

  ..................................................
  ..................................................
  ..................................................
  ................................

182 tests complete
Test duration: 159 ms
Assertions count: 522 (verbosity: 2.87)
The following leaks were detected:globalThis, FinalizationRegistry, WeakRef
Coverage: 100.00%
Linting results: No issues
```

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
