### PR TITLE
[Multiple Datasource] Fix data source filter bug and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Multiple Datasource] Fix missing customApiRegistryPromise param for test connection ([#5944](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5944))
 - [BUG][Multiple Datasource] Add a migration function for datasource to add migrationVersion field ([#6025](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6025))
 - [BUG][MD]Expose picker using function in data source management plugin setup([#6030](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6030))
+- [BUG][Multiple Datasource] Fix data source filter bug and add tests ([#6152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6152))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/data_source_selector.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/data_source_selector.test.tsx.snap
@@ -202,6 +202,29 @@ exports[`DataSourceSelector: check dataSource options should hide prepend if rem
 />
 `;
 
+exports[`DataSourceSelector: check dataSource options should return empty options if filter out all options and hide local cluster 1`] = `
+<EuiComboBox
+  aria-label="Select a data source"
+  async={false}
+  compressed={false}
+  data-test-subj="dataSourceSelectorComboBox"
+  fullWidth={false}
+  isClearable={true}
+  isDisabled={false}
+  onChange={[Function]}
+  options={Array []}
+  placeholder="Select a data source"
+  prepend="Data source"
+  selectedOptions={Array []}
+  singleSelection={
+    Object {
+      "asPlainText": true,
+    }
+  }
+  sortMatchesBy="none"
+/>
+`;
+
 exports[`DataSourceSelector: check dataSource options should show custom placeholder text if configured 1`] = `
 <EuiComboBox
   aria-label="Make a selection"

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.test.tsx
@@ -143,10 +143,28 @@ describe('DataSourceSelector: check dataSource options', () => {
         disabled={false}
         hideLocalCluster={false}
         fullWidth={false}
-        filterFn={(ds) => ds.attributes.auth.type !== AuthType.NoAuth}
+        dataSourceFilter={(ds) => ds.attributes.auth.type !== AuthType.NoAuth}
       />
     );
 
+    component.instance().componentDidMount!();
+    await nextTick();
+    expect(component).toMatchSnapshot();
+    expect(toasts.addWarning).toBeCalledTimes(0);
+  });
+
+  it('should return empty options if filter out all options and hide local cluster', async () => {
+    component = shallow(
+      <DataSourceSelector
+        savedObjectsClient={client}
+        notifications={toasts}
+        onSelectedDataSource={jest.fn()}
+        disabled={false}
+        hideLocalCluster={true}
+        fullWidth={false}
+        dataSourceFilter={(ds) => ds.attributes.auth.type === 'random'}
+      />
+    );
     component.instance().componentDidMount!();
     await nextTick();
     expect(component).toMatchSnapshot();

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
@@ -6,8 +6,9 @@
 import React from 'react';
 import { i18n } from '@osd/i18n';
 import { EuiComboBox } from '@elastic/eui';
-import { SavedObjectsClientContract, ToastsStart } from 'opensearch-dashboards/public';
+import { SavedObjectsClientContract, ToastsStart, SavedObject } from 'opensearch-dashboards/public';
 import { getDataSourcesWithFields } from '../utils';
+import { DataSourceAttributes } from '../../types';
 
 export const LocalCluster: DataSourceOption = {
   label: i18n.translate('dataSource.localCluster', {
@@ -26,7 +27,7 @@ export interface DataSourceSelectorProps {
   defaultOption?: DataSourceOption[];
   placeholderText?: string;
   removePrepend?: boolean;
-  filterFn?: (dataSource: any) => boolean;
+  dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
   compressed?: boolean;
 }
 
@@ -73,14 +74,13 @@ export class DataSourceSelector extends React.Component<
     getDataSourcesWithFields(this.props.savedObjectsClient, ['id', 'title', 'auth.type'])
       .then((fetchedDataSources) => {
         if (fetchedDataSources?.length) {
-          let filteredDataSources = [];
-          if (this.props.filterFn) {
-            filteredDataSources = fetchedDataSources.filter((ds) => this.props.filterFn!(ds));
+          let filteredDataSources = fetchedDataSources;
+          if (this.props.dataSourceFilter) {
+            filteredDataSources = fetchedDataSources.filter((ds) =>
+              this.props.dataSourceFilter!(ds)
+            );
           }
 
-          if (filteredDataSources.length === 0) {
-            filteredDataSources = fetchedDataSources;
-          }
           const dataSourceOptions = filteredDataSources.map((dataSource) => ({
             id: dataSource.id,
             label: dataSource.attributes?.title || '',

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { HttpStart, SavedObjectsClientContract } from 'src/core/public';
+import { HttpStart, SavedObjectsClientContract, SavedObject } from 'src/core/public';
 import {
   DataSourceAttributes,
   DataSourceTableItem,
@@ -39,8 +39,8 @@ export async function getDataSources(savedObjectsClient: SavedObjectsClientContr
 export async function getDataSourcesWithFields(
   savedObjectsClient: SavedObjectsClientContract,
   fields: string[]
-) {
-  const response = await savedObjectsClient.find({
+): Promise<Array<SavedObject<DataSourceAttributes>>> {
+  const response = await savedObjectsClient.find<DataSourceAttributes>({
     type: 'data-source',
     fields,
     perPage: 10000,


### PR DESCRIPTION
### Description
This change fixes the bug for data source filter, rename the filter function, and added type for the datasource object 

### Issues Resolved
Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6151

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/e98b9ac5-dc3a-414d-ba4a-9a78673b5cba



## Testing the changes
The following steps were performed in the recording:
1. enable data source plugin
2. go to add sample data page, and data source selector renders correctly with all available options
3. go to dev tools, and data source selector renders correctly with all available options
4. go to search relevance, and data source selector renders correctly with all available options
5. add filter function in search relevance remove all data sources, and should show local cluster option only

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
