### PR TITLE
[Workspace] Validate if workspace exists when setup inside a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Discover] Options button to configure legacy mode and remove the top navigation option ([#6170](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6170))
 - [Multiple Datasource] Add default functionality for customer to choose default datasource ([#6058](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6058))
 - [Multiple Datasource] Add import support for Vega when specifying a datasource ([#6123](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6123))
+- [Workspace] Validate if workspace exists when setup inside a workspace ([#6154](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6154))
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export const WORKSPACE_OVERVIEW_APP_ID = 'workspace_overview';
+export const WORKSPACE_FATAL_ERROR_APP_ID = 'workspace_fatal_error';
 export const WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID = 'workspace';
 export const WORKSPACE_CONFLICT_CONTROL_SAVED_OBJECTS_CLIENT_WRAPPER_ID =
   'workspace_conflict_control';

--- a/src/plugins/workspace/opensearch_dashboards.json
+++ b/src/plugins/workspace/opensearch_dashboards.json
@@ -7,5 +7,5 @@
     "savedObjects"
   ],
   "optionalPlugins": [],
-  "requiredBundles": []
+  "requiredBundles": ["opensearchDashboardsReact"]
 }

--- a/src/plugins/workspace/public/application.tsx
+++ b/src/plugins/workspace/public/application.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { AppMountParameters, ScopedHistory } from '../../../core/public';
+import { OpenSearchDashboardsContextProvider } from '../../opensearch_dashboards_react/public';
+import { WorkspaceFatalError } from './components/workspace_fatal_error';
+import { Services } from './types';
+
+export const renderFatalErrorApp = (params: AppMountParameters, services: Services) => {
+  const { element } = params;
+  const history = params.history as ScopedHistory<{ error?: string }>;
+  ReactDOM.render(
+    <OpenSearchDashboardsContextProvider services={services}>
+      <WorkspaceFatalError error={history.location.state.error} />
+    </OpenSearchDashboardsContextProvider>,
+    element
+  );
+
+  return () => {
+    ReactDOM.unmountComponentAtNode(element);
+  };
+};

--- a/src/plugins/workspace/public/application.tsx
+++ b/src/plugins/workspace/public/application.tsx
@@ -15,7 +15,7 @@ export const renderFatalErrorApp = (params: AppMountParameters, services: Servic
   const history = params.history as ScopedHistory<{ error?: string }>;
   ReactDOM.render(
     <OpenSearchDashboardsContextProvider services={services}>
-      <WorkspaceFatalError error={history.location.state.error} />
+      <WorkspaceFatalError error={history.location.state?.error} />
     </OpenSearchDashboardsContextProvider>,
     element
   );

--- a/src/plugins/workspace/public/components/workspace_fatal_error/__snapshots__/workspace_fatal_error.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_fatal_error/__snapshots__/workspace_fatal_error.test.tsx.snap
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<WorkspaceFatalError /> render error with callout 1`] = `
+<div>
+  <div
+    class="euiPage euiPage--paddingMedium euiPage--grow"
+    style="min-height: 100vh;"
+  >
+    <main
+      class="euiPageBody euiPageBody--borderRadiusNone"
+    >
+      <div
+        class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter"
+        role="main"
+      >
+        <div
+          class="euiEmptyPrompt"
+        >
+          <span
+            color="danger"
+            data-euiicon-type="alert"
+          />
+          <div
+            class="euiSpacer euiSpacer--m"
+          />
+          <h2
+            class="euiTitle euiTitle--medium"
+          >
+            <span>
+              Something went wrong
+            </span>
+          </h2>
+          <span
+            class="euiTextColor euiTextColor--subdued"
+          >
+            <div
+              class="euiSpacer euiSpacer--m"
+            />
+            <div
+              class="euiText euiText--medium"
+            >
+              <p>
+                <span>
+                  The workspace you want to go can not be found, try go back to home.
+                </span>
+              </p>
+            </div>
+          </span>
+          <div
+            class="euiSpacer euiSpacer--l"
+          />
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentCenter euiFlexGroup--directionColumn euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <button
+                class="euiButton euiButton--primary euiButton--fill"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    <span>
+                      Go back to home
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiCallOut euiCallOut--danger"
+        >
+          <div
+            class="euiCallOutHeader"
+          >
+            <span
+              aria-hidden="true"
+              class="euiCallOutHeader__icon"
+              color="inherit"
+              data-euiicon-type="alert"
+            />
+            <span
+              class="euiCallOutHeader__title"
+            >
+              errorInCallout
+            </span>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
+exports[`<WorkspaceFatalError /> render normally 1`] = `
+<div>
+  <div
+    class="euiPage euiPage--paddingMedium euiPage--grow"
+    style="min-height: 100vh;"
+  >
+    <main
+      class="euiPageBody euiPageBody--borderRadiusNone"
+    >
+      <div
+        class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter"
+        role="main"
+      >
+        <div
+          class="euiEmptyPrompt"
+        >
+          <span
+            color="danger"
+            data-euiicon-type="alert"
+          />
+          <div
+            class="euiSpacer euiSpacer--m"
+          />
+          <h2
+            class="euiTitle euiTitle--medium"
+          >
+            <span>
+              Something went wrong
+            </span>
+          </h2>
+          <span
+            class="euiTextColor euiTextColor--subdued"
+          >
+            <div
+              class="euiSpacer euiSpacer--m"
+            />
+            <div
+              class="euiText euiText--medium"
+            >
+              <p>
+                <span>
+                  The workspace you want to go can not be found, try go back to home.
+                </span>
+              </p>
+            </div>
+          </span>
+          <div
+            class="euiSpacer euiSpacer--l"
+          />
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentCenter euiFlexGroup--directionColumn euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <button
+                class="euiButton euiButton--primary euiButton--fill"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    <span>
+                      Go back to home
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;

--- a/src/plugins/workspace/public/components/workspace_fatal_error/__snapshots__/workspace_fatal_error.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_fatal_error/__snapshots__/workspace_fatal_error.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`<WorkspaceFatalError /> render error with callout 1`] = `
             >
               <p>
                 <span>
-                  The workspace you want to go can not be found, try go back to home.
+                  The workspace you are trying to access cannot be found. Please return to the homepage and try again.
                 </span>
               </p>
             </div>
@@ -66,7 +66,7 @@ exports[`<WorkspaceFatalError /> render error with callout 1`] = `
                     class="euiButton__text"
                   >
                     <span>
-                      Go back to home
+                      Go back to homepage
                     </span>
                   </span>
                 </span>
@@ -140,7 +140,7 @@ exports[`<WorkspaceFatalError /> render normally 1`] = `
             >
               <p>
                 <span>
-                  The workspace you want to go can not be found, try go back to home.
+                  The workspace you are trying to access cannot be found. Please return to the homepage and try again.
                 </span>
               </p>
             </div>
@@ -165,7 +165,7 @@ exports[`<WorkspaceFatalError /> render normally 1`] = `
                     class="euiButton__text"
                   >
                     <span>
-                      Go back to home
+                      Go back to homepage
                     </span>
                   </span>
                 </span>

--- a/src/plugins/workspace/public/components/workspace_fatal_error/index.ts
+++ b/src/plugins/workspace/public/components/workspace_fatal_error/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { WorkspaceFatalError } from './workspace_fatal_error';

--- a/src/plugins/workspace/public/components/workspace_fatal_error/workspace_fatal_error.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_fatal_error/workspace_fatal_error.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { WorkspaceFatalError } from './workspace_fatal_error';
+import { context } from '../../../../opensearch_dashboards_react/public';
+import { coreMock } from '../../../../../core/public/mocks';
+
+describe('<WorkspaceFatalError />', () => {
+  it('render normally', async () => {
+    const { findByText, container } = render(
+      <IntlProvider locale="en">
+        <WorkspaceFatalError />
+      </IntlProvider>
+    );
+    await findByText('Something went wrong');
+    expect(container).toMatchSnapshot();
+  });
+
+  it('render error with callout', async () => {
+    const { findByText, container } = render(
+      <IntlProvider locale="en">
+        <WorkspaceFatalError error="errorInCallout" />
+      </IntlProvider>
+    );
+    await findByText('errorInCallout');
+    expect(container).toMatchSnapshot();
+  });
+
+  it('click go back to home', async () => {
+    const { location } = window;
+    const setHrefSpy = jest.fn((href) => href);
+    if (window.location) {
+      // @ts-ignore
+      delete window.location;
+    }
+    window.location = {} as Location;
+    Object.defineProperty(window.location, 'href', {
+      get: () => 'http://localhost/',
+      set: setHrefSpy,
+    });
+    const coreStartMock = coreMock.createStart();
+    const { getByText } = render(
+      <IntlProvider locale="en">
+        <context.Provider
+          value={
+            {
+              services: coreStartMock,
+            } as any
+          }
+        >
+          <WorkspaceFatalError error="errorInCallout" />
+        </context.Provider>
+      </IntlProvider>
+    );
+    fireEvent.click(getByText('Go back to home'));
+    await waitFor(
+      () => {
+        expect(setHrefSpy).toBeCalledTimes(1);
+      },
+      {
+        container: document.body,
+      }
+    );
+    window.location = location;
+  });
+});

--- a/src/plugins/workspace/public/components/workspace_fatal_error/workspace_fatal_error.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_fatal_error/workspace_fatal_error.test.tsx
@@ -31,7 +31,7 @@ describe('<WorkspaceFatalError />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('click go back to home', async () => {
+  it('click go back to homepage', async () => {
     const { location } = window;
     const setHrefSpy = jest.fn((href) => href);
     if (window.location) {
@@ -57,7 +57,7 @@ describe('<WorkspaceFatalError />', () => {
         </context.Provider>
       </IntlProvider>
     );
-    fireEvent.click(getByText('Go back to home'));
+    fireEvent.click(getByText('Go back to homepage'));
     await waitFor(
       () => {
         expect(setHrefSpy).toBeCalledTimes(1);

--- a/src/plugins/workspace/public/components/workspace_fatal_error/workspace_fatal_error.tsx
+++ b/src/plugins/workspace/public/components/workspace_fatal_error/workspace_fatal_error.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiButton,
+  EuiEmptyPrompt,
+  EuiPage,
+  EuiPageBody,
+  EuiPageContent,
+  EuiCallOut,
+} from '@elastic/eui';
+import React from 'react';
+import { FormattedMessage } from '@osd/i18n/react';
+import { IBasePath } from 'opensearch-dashboards/public';
+import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
+import { formatUrlWithWorkspaceId } from '../../../../../core/public/utils';
+
+export function WorkspaceFatalError(props: { error?: string }) {
+  const {
+    services: { application, http },
+  } = useOpenSearchDashboards();
+  const goBackToHome = () => {
+    window.location.href = formatUrlWithWorkspaceId(
+      application?.getUrlForApp('home') || '',
+      '',
+      http?.basePath as IBasePath
+    );
+  };
+  return (
+    <EuiPage style={{ minHeight: '100vh' }}>
+      <EuiPageBody component="main">
+        <EuiPageContent verticalPosition="center" horizontalPosition="center">
+          <EuiEmptyPrompt
+            iconType="alert"
+            iconColor="danger"
+            title={
+              <h2>
+                <FormattedMessage
+                  id="core.fatalErrors.somethingWentWrongTitle"
+                  defaultMessage="Something went wrong"
+                />
+              </h2>
+            }
+            body={
+              <p>
+                <FormattedMessage
+                  id="core.fatalErrors.tryGoBackToDefaultWorkspaceDescription"
+                  defaultMessage="The workspace you want to go can not be found, try go back to home."
+                />
+              </p>
+            }
+            actions={[
+              <EuiButton color="primary" fill onClick={goBackToHome}>
+                <FormattedMessage
+                  id="core.fatalErrors.goBackToHome"
+                  defaultMessage="Go back to home"
+                />
+              </EuiButton>,
+            ]}
+          />
+          {props.error ? <EuiCallOut title={props.error} color="danger" iconType="alert" /> : null}
+        </EuiPageContent>
+      </EuiPageBody>
+    </EuiPage>
+  );
+}

--- a/src/plugins/workspace/public/components/workspace_fatal_error/workspace_fatal_error.tsx
+++ b/src/plugins/workspace/public/components/workspace_fatal_error/workspace_fatal_error.tsx
@@ -13,20 +13,17 @@ import {
 } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
-import { IBasePath } from 'opensearch-dashboards/public';
+import { HttpSetup } from 'opensearch-dashboards/public';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
-import { formatUrlWithWorkspaceId } from '../../../../../core/public/utils';
 
 export function WorkspaceFatalError(props: { error?: string }) {
   const {
-    services: { application, http },
+    services: { http },
   } = useOpenSearchDashboards();
   const goBackToHome = () => {
-    window.location.href = formatUrlWithWorkspaceId(
-      application?.getUrlForApp('home') || '',
-      '',
-      http?.basePath as IBasePath
-    );
+    window.location.href = (http as HttpSetup).basePath.prepend('/', {
+      withoutClientBasePath: true,
+    });
   };
   return (
     <EuiPage style={{ minHeight: '100vh' }}>

--- a/src/plugins/workspace/public/components/workspace_fatal_error/workspace_fatal_error.tsx
+++ b/src/plugins/workspace/public/components/workspace_fatal_error/workspace_fatal_error.tsx
@@ -47,7 +47,7 @@ export function WorkspaceFatalError(props: { error?: string }) {
               <p>
                 <FormattedMessage
                   id="core.fatalErrors.tryGoBackToDefaultWorkspaceDescription"
-                  defaultMessage="The workspace you want to go can not be found, try go back to home."
+                  defaultMessage="The workspace you are trying to access cannot be found. Please return to the homepage and try again."
                 />
               </p>
             }
@@ -55,7 +55,7 @@ export function WorkspaceFatalError(props: { error?: string }) {
               <EuiButton color="primary" fill onClick={goBackToHome}>
                 <FormattedMessage
                   id="core.fatalErrors.goBackToHome"
-                  defaultMessage="Go back to home"
+                  defaultMessage="Go back to homepage"
                 />
               </EuiButton>,
             ]}

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -3,9 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { waitFor } from '@testing-library/dom';
 import { workspaceClientMock, WorkspaceClientMock } from './workspace_client.mock';
-import { chromeServiceMock, coreMock } from '../../../core/public/mocks';
+import { applicationServiceMock, chromeServiceMock, coreMock } from '../../../core/public/mocks';
 import { WorkspacePlugin } from './plugin';
+import { WORKSPACE_FATAL_ERROR_APP_ID, WORKSPACE_OVERVIEW_APP_ID } from '../common/constants';
+import { Observable, Subscriber } from 'rxjs';
 
 describe('Workspace plugin', () => {
   const getSetupMock = () => ({
@@ -25,10 +28,15 @@ describe('Workspace plugin', () => {
 
   it('#call savedObjectsClient.setCurrentWorkspace when current workspace id changed', () => {
     const workspacePlugin = new WorkspacePlugin();
+    const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
+    workspacePlugin.setup(setupMock);
     workspacePlugin.start(coreStart);
     coreStart.workspaces.currentWorkspaceId$.next('foo');
     expect(coreStart.savedObjects.client.setCurrentWorkspace).toHaveBeenCalledWith('foo');
+    expect(setupMock.application.register).toBeCalledTimes(1);
+    expect(WorkspaceClientMock).toBeCalledTimes(1);
+    expect(workspaceClientMock.enterWorkspace).toBeCalledTimes(0);
   });
 
   it('#setup when workspace id is in url and enterWorkspace return error', async () => {
@@ -41,11 +49,82 @@ describe('Workspace plugin', () => {
           },
         } as any)
     );
+    workspaceClientMock.enterWorkspace.mockResolvedValue({
+      success: false,
+      error: 'error',
+    });
     const setupMock = getSetupMock();
+    const applicationStartMock = applicationServiceMock.createStartContract();
+    const chromeStartMock = chromeServiceMock.createStartContract();
+    setupMock.getStartServices.mockImplementation(() => {
+      return Promise.resolve([
+        {
+          application: applicationStartMock,
+          chrome: chromeStartMock,
+        },
+        {},
+        {},
+      ]) as any;
+    });
 
     const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(setupMock);
-    expect(setupMock.workspaces.currentWorkspaceId$.getValue()).toEqual('workspaceId');
+    expect(setupMock.application.register).toBeCalledTimes(1);
+    expect(WorkspaceClientMock).toBeCalledTimes(1);
+    expect(workspaceClientMock.enterWorkspace).toBeCalledWith('workspaceId');
+    expect(setupMock.getStartServices).toBeCalledTimes(1);
+    await waitFor(
+      () => {
+        expect(applicationStartMock.navigateToApp).toBeCalledWith(WORKSPACE_FATAL_ERROR_APP_ID, {
+          replace: true,
+          state: {
+            error: 'error',
+          },
+        });
+      },
+      {
+        container: document.body,
+      }
+    );
+    windowSpy.mockRestore();
+  });
+
+  it('#setup when workspace id is in url and enterWorkspace return success', async () => {
+    const windowSpy = jest.spyOn(window, 'window', 'get');
+    windowSpy.mockImplementation(
+      () =>
+        ({
+          location: {
+            href: 'http://localhost/w/workspaceId/app',
+          },
+        } as any)
+    );
+    workspaceClientMock.enterWorkspace.mockResolvedValue({
+      success: true,
+      error: 'error',
+    });
+    const setupMock = getSetupMock();
+    const applicationStartMock = applicationServiceMock.createStartContract();
+    let currentAppIdSubscriber: Subscriber<string> | undefined;
+    setupMock.getStartServices.mockImplementation(() => {
+      return Promise.resolve([
+        {
+          application: {
+            ...applicationStartMock,
+            currentAppId$: new Observable((subscriber) => {
+              currentAppIdSubscriber = subscriber;
+            }),
+          },
+        },
+        {},
+        {},
+      ]) as any;
+    });
+
+    const workspacePlugin = new WorkspacePlugin();
+    await workspacePlugin.setup(setupMock);
+    currentAppIdSubscriber?.next(WORKSPACE_FATAL_ERROR_APP_ID);
+    expect(applicationStartMock.navigateToApp).toBeCalledWith(WORKSPACE_OVERVIEW_APP_ID);
     windowSpy.mockRestore();
   });
 });

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Observable, Subscriber } from 'rxjs';
 import { waitFor } from '@testing-library/dom';
 import { workspaceClientMock, WorkspaceClientMock } from './workspace_client.mock';
 import { applicationServiceMock, chromeServiceMock, coreMock } from '../../../core/public/mocks';
 import { WorkspacePlugin } from './plugin';
 import { WORKSPACE_FATAL_ERROR_APP_ID, WORKSPACE_OVERVIEW_APP_ID } from '../common/constants';
-import { Observable, Subscriber } from 'rxjs';
 
 describe('Workspace plugin', () => {
   const getSetupMock = () => ({

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -26,11 +26,11 @@ describe('Workspace plugin', () => {
     expect(WorkspaceClientMock).toBeCalledTimes(1);
   });
 
-  it('#call savedObjectsClient.setCurrentWorkspace when current workspace id changed', () => {
+  it('#call savedObjectsClient.setCurrentWorkspace when current workspace id changed', async () => {
     const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
-    workspacePlugin.setup(setupMock);
+    await workspacePlugin.setup(setupMock);
     workspacePlugin.start(coreStart);
     coreStart.workspaces.currentWorkspaceId$.next('foo');
     expect(coreStart.savedObjects.client.setCurrentWorkspace).toHaveBeenCalledWith('foo');

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -4,9 +4,19 @@
  */
 
 import type { Subscription } from 'rxjs';
-import { Plugin, CoreStart, CoreSetup } from '../../../core/public';
+import {
+  Plugin,
+  CoreStart,
+  CoreSetup,
+  AppMountParameters,
+  AppNavLinkStatus,
+} from '../../../core/public';
+import { WORKSPACE_FATAL_ERROR_APP_ID, WORKSPACE_OVERVIEW_APP_ID } from '../common/constants';
 import { getWorkspaceIdFromUrl } from '../../../core/public/utils';
+import { Services } from './types';
 import { WorkspaceClient } from './workspace_client';
+
+type WorkspaceAppType = (params: AppMountParameters, services: Services) => () => void;
 
 export class WorkspacePlugin implements Plugin<{}, {}, {}> {
   private coreStart?: CoreStart;
@@ -33,8 +43,59 @@ export class WorkspacePlugin implements Plugin<{}, {}, {}> {
     const workspaceId = this.getWorkspaceIdFromURL(core.http.basePath.getBasePath());
 
     if (workspaceId) {
-      core.workspaces.currentWorkspaceId$.next(workspaceId);
+      const result = await workspaceClient.enterWorkspace(workspaceId);
+      if (!result.success) {
+        /**
+         * Fatal error service does not support customized actions
+         * So we have to use a self-hosted page to show the errors and redirect.
+         */
+        (async () => {
+          const [{ application, chrome }] = await core.getStartServices();
+          chrome.setIsVisible(false);
+          application.navigateToApp(WORKSPACE_FATAL_ERROR_APP_ID, {
+            replace: true,
+            state: {
+              error: result.error,
+            },
+          });
+        })();
+      } else {
+        /**
+         * If the workspace id is valid and user is currently on workspace_fatal_error page,
+         * we should redirect user to overview page of workspace.
+         */
+        (async () => {
+          const [{ application }] = await core.getStartServices();
+          const currentAppIdSubscription = application.currentAppId$.subscribe((currentAppId) => {
+            if (currentAppId === WORKSPACE_FATAL_ERROR_APP_ID) {
+              application.navigateToApp(WORKSPACE_OVERVIEW_APP_ID);
+            }
+            currentAppIdSubscription.unsubscribe();
+          });
+        })();
+      }
     }
+
+    const mountWorkspaceApp = async (params: AppMountParameters, renderApp: WorkspaceAppType) => {
+      const [coreStart] = await core.getStartServices();
+      const services = {
+        ...coreStart,
+        workspaceClient,
+      };
+
+      return renderApp(params, services);
+    };
+
+    // workspace fatal error
+    core.application.register({
+      id: WORKSPACE_FATAL_ERROR_APP_ID,
+      title: '',
+      navLinkStatus: AppNavLinkStatus.hidden,
+      async mount(params: AppMountParameters) {
+        const { renderFatalErrorApp } = await import('./application');
+        return mountWorkspaceApp(params, renderFatalErrorApp);
+      },
+    });
 
     return {};
   }

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -55,7 +55,7 @@ export class WorkspacePlugin implements Plugin<{}, {}, {}> {
           application.navigateToApp(WORKSPACE_FATAL_ERROR_APP_ID, {
             replace: true,
             state: {
-              error: result.error,
+              error: result?.error,
             },
           });
         })();

--- a/src/plugins/workspace/public/types.ts
+++ b/src/plugins/workspace/public/types.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CoreStart } from '../../../core/public';
+import { WorkspaceClient } from './workspace_client';
+
+export type Services = CoreStart & { workspaceClient: WorkspaceClient };


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
When user enters a url with workspaceId pattern inside url, workspace plugin should validate if the id exists, or should show an friendly error page to ask user to go back to home page without a pattern in url.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
closes #6155 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
<img width="1727" alt="image" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/446d9a52-8791-4bf2-80ea-d2c8862ae448">

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
- Using the branch to bootstrap
- Enable workspace feature flag in yml file by set `workspace.enabled: true`
- Start OSD by using `yarn start --no-base-path` to make sure no random base path will be appended
- Navigate to devTools
- Insert test workspaces by calling
```
PUT .kibana/_doc/workspace:foo
{
  "type": "workspace",
  "workspace": {
    "name": "foo"
  }
}
```
- Visit devTools under the test workspace: `http://localhost:5601/w/foo/app/dev_tools`, the page should render successfully.
- Visit devTools under a unexisting workspace: `http://localhost:5601/w/not_existing/app/dev_tools`, should see a page with error just like the screenshot above.
- Visit the error page under a existing worksapce: `http://localhost:5601/w/foo/app/workspace_fatal_error`, user should be redirect to `http://localhost:5601/w/foo/app/workspace_overview` page, though the page has not been implement yet.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
