### PR TITLE
[Manually backport 2.x] Add @BionIT as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @kristenTian @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe @ruanyl
+*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @kristenTian @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,7 +22,8 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sirazh Gabdullin          | [curq](https://github.com/curq)                     | External contributor |
 | Bandini Bhopi             | [bandinib-amzn](https://github.com/bandinib-amzn)   | Amazon      |
 | Su Zhou                   | [SuZhou-Joe](https://github.com/SuZhou-Joe)         | Amazon      |
-| Yulong Ruan               | [ruanyl](https://github.com/ruanyl)         | Amazon      |
+| Yulong Ruan               | [ruanyl](https://github.com/ruanyl)                 | Amazon      |
+| Lu Yu                     | [BionIT](https://github.com/BionIT)                 | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description

Manually backport 2.x for Add @BionIT as a maintainer - PR #5988 

### Issues Resolved
#5988 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
