### PR TITLE
Pass request headers when making application config calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Implement new home page ([#6065](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6065))
 - Add sidecar service ([#5920](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5920))
 - [Chrome] Introduce registerCollapsibleNavHeader to allow plugins to customize the rendering of nav menu header ([#5244](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5244))
+- [Dynamic Configurations] Pass request headers when making application config calls ([#6164](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6164))
 
 
 ### 🐛 Bug Fixes

--- a/src/plugins/application_config/README.md
+++ b/src/plugins/application_config/README.md
@@ -61,13 +61,13 @@ Let's call this plugin `MyConfigurationClientPlugin`.
 First, this plugin will need to implement a class `MyConfigurationClient` based on interface `ConfigurationClient` defined in the `types.ts` under directory `src/plugins/application_config/server/types.ts`. Below are the functions inside the interface.
 
 ```
-  getConfig(): Promise<Map<string, string>>;
+  getConfig(options?: ConfigurationClientOptions): Promise<Map<string, string>>;
 
-  getEntityConfig(entity: string): Promise<string>;
+  getEntityConfig(entity: string, options?: ConfigurationClientOptions): Promise<string>;
 
-  updateEntityConfig(entity: string, newValue: string): Promise<string>;
+  updateEntityConfig(entity: string, newValue: string, options?: ConfigurationClientOptions): Promise<string>;
 
-  deleteEntityConfig(entity: string): Promise<string>;
+  deleteEntityConfig(entity: string, options?: ConfigurationClientOptions): Promise<string>;
 ```
 
 Second, this plugin needs to declare `applicationConfig` as its dependency by adding it to `requiredPlugins` in its own `opensearch_dashboards.json`.

--- a/src/plugins/application_config/README.md
+++ b/src/plugins/application_config/README.md
@@ -70,6 +70,8 @@ First, this plugin will need to implement a class `MyConfigurationClient` based 
   deleteEntityConfig(entity: string, options?: ConfigurationClientOptions): Promise<string>;
 ```
 
+`ConfigurationClientOptions` wraps some additional parameters including request headers.
+
 Second, this plugin needs to declare `applicationConfig` as its dependency by adding it to `requiredPlugins` in its own `opensearch_dashboards.json`.
 
 Third, the plugin will define a new type called `AppPluginSetupDependencies` as follows in its own `types.ts`.

--- a/src/plugins/application_config/server/routes/index.test.ts
+++ b/src/plugins/application_config/server/routes/index.test.ts
@@ -79,6 +79,8 @@ describe('application config routes', () => {
         getConfig: jest.fn().mockReturnValue(configurations),
       };
 
+      const request = {};
+
       const okResponse = {
         statusCode: 200,
       };
@@ -89,7 +91,7 @@ describe('application config routes', () => {
 
       const logger = loggerMock.create();
 
-      const returnedResponse = await handleGetConfig(client, response, logger);
+      const returnedResponse = await handleGetConfig(client, request, response, logger);
 
       expect(returnedResponse).toBe(okResponse);
 
@@ -109,13 +111,15 @@ describe('application config routes', () => {
         }),
       };
 
+      const request = {};
+
       const response = {
         customError: jest.fn().mockReturnValue(ERROR_RESPONSE),
       };
 
       const logger = loggerMock.create();
 
-      const returnedResponse = await handleGetConfig(client, response, logger);
+      const returnedResponse = await handleGetConfig(client, request, response, logger);
 
       expect(returnedResponse).toBe(ERROR_RESPONSE);
 

--- a/src/plugins/application_config/server/routes/index.ts
+++ b/src/plugins/application_config/server/routes/index.ts
@@ -85,6 +85,8 @@ export async function handleGetEntityConfig(
   response: OpenSearchDashboardsResponseFactory,
   logger: Logger
 ) {
+  logger.info(`Received a request to get entity config for ${request.params.entity}.`);
+
   try {
     const result = await client.getEntityConfig(request.params.entity, {
       headers: request.headers,
@@ -106,6 +108,10 @@ export async function handleUpdateEntityConfig(
   response: OpenSearchDashboardsResponseFactory,
   logger: Logger
 ) {
+  logger.info(
+    `Received a request to update entity ${request.params.entity} with new value ${request.body.newValue}.`
+  );
+
   try {
     const result = await client.updateEntityConfig(request.params.entity, request.body.newValue, {
       headers: request.headers,
@@ -127,6 +133,8 @@ export async function handleDeleteEntityConfig(
   response: OpenSearchDashboardsResponseFactory,
   logger: Logger
 ) {
+  logger.info(`Received a request to delete entity ${request.params.entity}.`);
+
   try {
     const result = await client.deleteEntityConfig(request.params.entity, {
       headers: request.headers,
@@ -148,6 +156,8 @@ export async function handleGetConfig(
   response: OpenSearchDashboardsResponseFactory,
   logger: Logger
 ) {
+  logger.info('Received a request to get all configurations.');
+
   try {
     const result = await client.getConfig({ headers: request.headers });
     return response.ok({

--- a/src/plugins/application_config/server/routes/index.ts
+++ b/src/plugins/application_config/server/routes/index.ts
@@ -86,7 +86,9 @@ export async function handleGetEntityConfig(
   logger: Logger
 ) {
   try {
-    const result = await client.getEntityConfig(request.params.entity, { request });
+    const result = await client.getEntityConfig(request.params.entity, {
+      headers: request.headers,
+    });
     return response.ok({
       body: {
         value: result,
@@ -106,7 +108,7 @@ export async function handleUpdateEntityConfig(
 ) {
   try {
     const result = await client.updateEntityConfig(request.params.entity, request.body.newValue, {
-      request,
+      headers: request.headers,
     });
     return response.ok({
       body: {
@@ -126,7 +128,9 @@ export async function handleDeleteEntityConfig(
   logger: Logger
 ) {
   try {
-    const result = await client.deleteEntityConfig(request.params.entity, { request });
+    const result = await client.deleteEntityConfig(request.params.entity, {
+      headers: request.headers,
+    });
     return response.ok({
       body: {
         deletedEntity: result,
@@ -145,7 +149,7 @@ export async function handleGetConfig(
   logger: Logger
 ) {
   try {
-    const result = await client.getConfig({ request });
+    const result = await client.getConfig({ headers: request.headers });
     return response.ok({
       body: {
         value: result,

--- a/src/plugins/application_config/server/routes/index.ts
+++ b/src/plugins/application_config/server/routes/index.ts
@@ -26,7 +26,7 @@ export function defineRoutes(
     async (context, request, response) => {
       const client = getConfigurationClient(context.core.opensearch.client);
 
-      return await handleGetConfig(client, response, logger);
+      return await handleGetConfig(client, request, response, logger);
     }
   );
   router.get(
@@ -86,7 +86,7 @@ export async function handleGetEntityConfig(
   logger: Logger
 ) {
   try {
-    const result = await client.getEntityConfig(request.params.entity);
+    const result = await client.getEntityConfig(request.params.entity, { request });
     return response.ok({
       body: {
         value: result,
@@ -105,7 +105,9 @@ export async function handleUpdateEntityConfig(
   logger: Logger
 ) {
   try {
-    const result = await client.updateEntityConfig(request.params.entity, request.body.newValue);
+    const result = await client.updateEntityConfig(request.params.entity, request.body.newValue, {
+      request,
+    });
     return response.ok({
       body: {
         newValue: result,
@@ -124,7 +126,7 @@ export async function handleDeleteEntityConfig(
   logger: Logger
 ) {
   try {
-    const result = await client.deleteEntityConfig(request.params.entity);
+    const result = await client.deleteEntityConfig(request.params.entity, { request });
     return response.ok({
       body: {
         deletedEntity: result,
@@ -138,11 +140,12 @@ export async function handleDeleteEntityConfig(
 
 export async function handleGetConfig(
   client: ConfigurationClient,
+  request: OpenSearchDashboardsRequest,
   response: OpenSearchDashboardsResponseFactory,
   logger: Logger
 ) {
   try {
-    const result = await client.getConfig();
+    const result = await client.getConfig({ request });
     return response.ok({
       body: {
         value: result,

--- a/src/plugins/application_config/server/types.ts
+++ b/src/plugins/application_config/server/types.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IScopedClusterClient } from 'src/core/server';
+import { IScopedClusterClient, OpenSearchDashboardsRequest } from 'src/core/server';
 
 export interface ApplicationConfigPluginSetup {
   getConfigurationClient: (inputOpenSearchClient: IScopedClusterClient) => ConfigurationClient;
@@ -11,6 +11,10 @@ export interface ApplicationConfigPluginSetup {
 }
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ApplicationConfigPluginStart {}
+
+export interface ConfigurationClientOptions {
+  request: OpenSearchDashboardsRequest;
+}
 
 /**
  * The interface defines the operations against the application configurations at both entity level and whole level.
@@ -23,7 +27,7 @@ export interface ConfigurationClient {
    * @param {array} array of connections
    * @returns {ConnectionPool}
    */
-  getConfig(): Promise<Map<string, string>>;
+  getConfig(options?: ConfigurationClientOptions): Promise<Map<string, string>>;
 
   /**
    * Get the value for the input entity.
@@ -31,7 +35,7 @@ export interface ConfigurationClient {
    * @param {entity} name of the entity
    * @returns {string} value of the entity
    */
-  getEntityConfig(entity: string): Promise<string>;
+  getEntityConfig(entity: string, options?: ConfigurationClientOptions): Promise<string>;
 
   /**
    * Update the input entity with a new value.
@@ -40,7 +44,11 @@ export interface ConfigurationClient {
    * @param {newValue} new configuration value of the entity
    * @returns {string} updated configuration value of the entity
    */
-  updateEntityConfig(entity: string, newValue: string): Promise<string>;
+  updateEntityConfig(
+    entity: string,
+    newValue: string,
+    options?: ConfigurationClientOptions
+  ): Promise<string>;
 
   /**
    * Delete the input entity from configurations.
@@ -48,5 +56,5 @@ export interface ConfigurationClient {
    * @param {entity} name of the entity
    * @returns {string} name of the deleted entity
    */
-  deleteEntityConfig(entity: string): Promise<string>;
+  deleteEntityConfig(entity: string, options?: ConfigurationClientOptions): Promise<string>;
 }

--- a/src/plugins/application_config/server/types.ts
+++ b/src/plugins/application_config/server/types.ts
@@ -24,8 +24,8 @@ export interface ConfigurationClient {
   /**
    * Get all the configurations.
    *
-   * @param {array} array of connections
-   * @returns {ConnectionPool}
+   * @param {options} options, an optional parameter
+   * @returns {Map<string, string>} all the configurations
    */
   getConfig(options?: ConfigurationClientOptions): Promise<Map<string, string>>;
 
@@ -33,6 +33,7 @@ export interface ConfigurationClient {
    * Get the value for the input entity.
    *
    * @param {entity} name of the entity
+   * @param {options} options, an optional parameter
    * @returns {string} value of the entity
    */
   getEntityConfig(entity: string, options?: ConfigurationClientOptions): Promise<string>;
@@ -42,6 +43,7 @@ export interface ConfigurationClient {
    *
    * @param {entity} name of the entity
    * @param {newValue} new configuration value of the entity
+   * @param {options} options, an optional parameter
    * @returns {string} updated configuration value of the entity
    */
   updateEntityConfig(
@@ -54,6 +56,7 @@ export interface ConfigurationClient {
    * Delete the input entity from configurations.
    *
    * @param {entity} name of the entity
+   * @param {options} options, an optional parameter
    * @returns {string} name of the deleted entity
    */
   deleteEntityConfig(entity: string, options?: ConfigurationClientOptions): Promise<string>;

--- a/src/plugins/application_config/server/types.ts
+++ b/src/plugins/application_config/server/types.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IScopedClusterClient, OpenSearchDashboardsRequest } from 'src/core/server';
+import { IScopedClusterClient, Headers } from 'src/core/server';
 
 export interface ApplicationConfigPluginSetup {
   getConfigurationClient: (inputOpenSearchClient: IScopedClusterClient) => ConfigurationClient;
@@ -13,7 +13,7 @@ export interface ApplicationConfigPluginSetup {
 export interface ApplicationConfigPluginStart {}
 
 export interface ConfigurationClientOptions {
-  request: OpenSearchDashboardsRequest;
+  headers: Headers;
 }
 
 /**

--- a/src/plugins/csp_handler/server/csp_handlers.ts
+++ b/src/plugins/csp_handler/server/csp_handlers.ts
@@ -51,7 +51,9 @@ export function createCspRulesPreResponseHandler(
 
       const client = getConfigurationClient(coreStart.opensearch.client.asScoped(request));
 
-      const cspRules = await client.getEntityConfig(CSP_RULES_CONFIG_KEY, { request });
+      const cspRules = await client.getEntityConfig(CSP_RULES_CONFIG_KEY, {
+        headers: request.headers,
+      });
 
       if (!cspRules) {
         return appendFrameAncestorsWhenMissing(cspHeader, toolkit);

--- a/src/plugins/csp_handler/server/csp_handlers.ts
+++ b/src/plugins/csp_handler/server/csp_handlers.ts
@@ -51,7 +51,7 @@ export function createCspRulesPreResponseHandler(
 
       const client = getConfigurationClient(coreStart.opensearch.client.asScoped(request));
 
-      const cspRules = await client.getEntityConfig(CSP_RULES_CONFIG_KEY);
+      const cspRules = await client.getEntityConfig(CSP_RULES_CONFIG_KEY, { request });
 
       if (!cspRules) {
         return appendFrameAncestorsWhenMissing(cspHeader, toolkit);


### PR DESCRIPTION
### Description

Application config plugin allows external plugin to register a different storage other than the default OpenSearch. The external plugin may need some additional information about the request headers when handling the requests.

### Issues Resolved

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

Update the csp rules.

call
```
curl 'http://localhost:5601/api/appconfig/csp.rules' -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty' --data-raw '{"newValue":"frame-ancestors https://example-site.org"}'
```
response

```
{"newValue":"frame-ancestors https://example-site.org"}%
```

Confirm on UI that the new value is used.

<img width="1901" alt="Screenshot 2024-03-15 at 2 51 39 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/60111637/3cc4d16f-7aed-49e5-a511-0a6d255bbd51">

Check API calls to all configs

`curl 'http://localhost:5601/api/appconfig'`

response

```
{"value":{"csp.rules":"frame-ancestors https://example-site.org"}}%
```

Check API to get only csp rules.

```
curl 'http://localhost:5601/api/appconfig/csp.rules'
```

response

```
{"value":"frame-ancestors https://example-site.org"}%
```

Delete
```
curl 'http://localhost:5601/api/appconfig/csp.rules' -X DELETE -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty'
```

Response

```
{"deletedEntity":"csp.rules"}%
```

Get all again

```
curl 'http://localhost:5601/api/appconfig'
```

response
```
{"value":{}}%
```

verify that default csp with frame ancestors is used.

<img width="1900" alt="Screenshot 2024-03-15 at 2 52 04 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/60111637/2cf10669-464d-4536-83c5-49ca063a077d">


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
