### PR TITLE
[Multiple Datasource] Use data source filter function before rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Workspace] Add workspace id in basePath ([#6060](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6060))
 - Implement new home page ([#6065](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6065))
 - Add sidecar service ([#5920](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5920))
+- [Multiple Datasource] Use data source filter function before rendering ([#6175](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6175))
 
 
 ### 🐛 Bug Fixes

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/__snapshots__/data_source_aggregated_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/__snapshots__/data_source_aggregated_view.test.tsx.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DataSourceAggregatedView should render normally with data source filter 1`] = `
+<Fragment>
+  <EuiButtonEmpty
+    aria-label="dataSourceAggregatedViewMenuButton"
+    className="euiHeaderLink"
+    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+    disabled={true}
+    iconSide="left"
+    iconType="database"
+    size="s"
+  >
+    Data sources
+  </EuiButtonEmpty>
+  <EuiNotificationBadge
+    color="subdued"
+  >
+    All
+  </EuiNotificationBadge>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonIcon
+        aria-label="show data sources"
+        data-test-subj="dataSourceAggregatedViewInfoButton"
+        display="empty"
+        iconType="iInCircle"
+        onClick={[Function]}
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenu
+      initialPanelId={0}
+      panels={
+        Array [
+          Object {
+            "id": 0,
+            "items": Array [],
+            "title": "Selected data sources",
+          },
+        ]
+      }
+      size="m"
+    />
+  </EuiPopover>
+</Fragment>
+`;
+
 exports[`DataSourceAggregatedView should render normally with local cluster and actice selections 1`] = `
 <Fragment>
   <EuiButtonEmpty
@@ -59,7 +113,7 @@ exports[`DataSourceAggregatedView should render normally with local cluster and 
 </Fragment>
 `;
 
-exports[`DataSourceAggregatedView should render normally with local cluster and actice selections 2`] = `
+exports[`DataSourceAggregatedView should render normally with local cluster hidden and all options 1`] = `
 <Fragment>
   <EuiButtonEmpty
     aria-label="dataSourceAggregatedViewMenuButton"
@@ -103,7 +157,7 @@ exports[`DataSourceAggregatedView should render normally with local cluster and 
           Object {
             "id": 0,
             "items": Array [],
-            "title": "Selected data sources",
+            "title": "Data sources (0)",
           },
         ]
       }
@@ -113,7 +167,61 @@ exports[`DataSourceAggregatedView should render normally with local cluster and 
 </Fragment>
 `;
 
-exports[`DataSourceAggregatedView should render normally with local cluster and actice selections 3`] = `
+exports[`DataSourceAggregatedView should render normally with local cluster not hidden and all options 1`] = `
+<Fragment>
+  <EuiButtonEmpty
+    aria-label="dataSourceAggregatedViewMenuButton"
+    className="euiHeaderLink"
+    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+    disabled={true}
+    iconSide="left"
+    iconType="database"
+    size="s"
+  >
+    Data sources
+  </EuiButtonEmpty>
+  <EuiNotificationBadge
+    color="subdued"
+  >
+    All
+  </EuiNotificationBadge>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonIcon
+        aria-label="show data sources"
+        data-test-subj="dataSourceAggregatedViewInfoButton"
+        display="empty"
+        iconType="iInCircle"
+        onClick={[Function]}
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenu
+      initialPanelId={0}
+      panels={
+        Array [
+          Object {
+            "id": 0,
+            "items": Array [],
+            "title": "Data sources (0)",
+          },
+        ]
+      }
+      size="m"
+    />
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView should render popup when clicking on info icon 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -338,112 +446,4 @@ Object {
   "rerender": [Function],
   "unmount": [Function],
 }
-`;
-
-exports[`DataSourceAggregatedView should render normally with local cluster hidden and all options 1`] = `
-<Fragment>
-  <EuiButtonEmpty
-    aria-label="dataSourceAggregatedViewMenuButton"
-    className="euiHeaderLink"
-    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-    disabled={true}
-    iconSide="left"
-    iconType="database"
-    size="s"
-  >
-    Data sources
-  </EuiButtonEmpty>
-  <EuiNotificationBadge
-    color="subdued"
-  >
-    All
-  </EuiNotificationBadge>
-  <EuiPopover
-    anchorPosition="downLeft"
-    button={
-      <EuiButtonIcon
-        aria-label="show data sources"
-        data-test-subj="dataSourceAggregatedViewInfoButton"
-        display="empty"
-        iconType="iInCircle"
-        onClick={[Function]}
-      />
-    }
-    closePopover={[Function]}
-    display="inlineBlock"
-    hasArrow={true}
-    id="dataSourceSViewContextMenuPopover"
-    isOpen={false}
-    ownFocus={true}
-    panelPaddingSize="none"
-  >
-    <EuiContextMenu
-      initialPanelId={0}
-      panels={
-        Array [
-          Object {
-            "id": 0,
-            "items": Array [],
-            "title": "Data sources (0)",
-          },
-        ]
-      }
-      size="m"
-    />
-  </EuiPopover>
-</Fragment>
-`;
-
-exports[`DataSourceAggregatedView should render normally with local cluster not hidden and all options 1`] = `
-<Fragment>
-  <EuiButtonEmpty
-    aria-label="dataSourceAggregatedViewMenuButton"
-    className="euiHeaderLink"
-    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-    disabled={true}
-    iconSide="left"
-    iconType="database"
-    size="s"
-  >
-    Data sources
-  </EuiButtonEmpty>
-  <EuiNotificationBadge
-    color="subdued"
-  >
-    All
-  </EuiNotificationBadge>
-  <EuiPopover
-    anchorPosition="downLeft"
-    button={
-      <EuiButtonIcon
-        aria-label="show data sources"
-        data-test-subj="dataSourceAggregatedViewInfoButton"
-        display="empty"
-        iconType="iInCircle"
-        onClick={[Function]}
-      />
-    }
-    closePopover={[Function]}
-    display="inlineBlock"
-    hasArrow={true}
-    id="dataSourceSViewContextMenuPopover"
-    isOpen={false}
-    ownFocus={true}
-    panelPaddingSize="none"
-  >
-    <EuiContextMenu
-      initialPanelId={0}
-      panels={
-        Array [
-          Object {
-            "id": 0,
-            "items": Array [],
-            "title": "Data sources (0)",
-          },
-        ]
-      }
-      size="m"
-    />
-  </EuiPopover>
-</Fragment>
 `;


### PR DESCRIPTION
### Description
This change will store all data sources fetched during initial load, then apply the datasource filter function before rendering so that it can filter based on changes in the filter function.

### Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6174

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/27b5e077-3a90-4094-a311-19c402de1dd3



## Testing the changes
The following steps were performed in the recording:
1. go to add sample data, and data source selector should render correctly with currently available data sources
2. add sample data from a data source is successful, and dashboard renders successfully
3. go to dev tool, and data source selector should render correctly with currently available data sources
4. make a query and is successfully returning response
5. go to search relevance and the data source selector should render correctly, with local cluster as default option and no other options available to choose
6. select a data source from the data source menu in the nav bar which acts as filter, then check the data source selector, which should have the selected data source as another option in addition to local cluster

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
