### PR TITLE
add version number to newly created datasource object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Workspace] Add workspace id in basePath ([#6060](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6060))
 - Implement new home page ([#6065](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6065))
 - Add sidecar service ([#5920](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5920))
+- [Multiple Datasource] Add datasource version number to newly created data source object([#6178](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6178))
 
 
 ### 🐛 Bug Fixes

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -30,6 +30,7 @@ import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../common';
 import { ensureRawRequest } from '../../../../src/core/server/http/router';
 import { createDataSourceError } from './lib/error';
 import { registerTestConnectionRoute } from './routes/test_connection';
+import { registerFetchDataSourceVersionRoute } from './routes/fetch_data_source_version';
 import { AuthenticationMethodRegistery, IAuthenticationMethodRegistery } from './auth_registry';
 import { CustomApiSchemaRegistry } from './schema_registry';
 
@@ -127,6 +128,13 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
 
     const router = core.http.createRouter();
     registerTestConnectionRoute(
+      router,
+      dataSourceService,
+      cryptographyServiceSetup,
+      authRegistryPromise,
+      customApiSchemaRegistryPromise
+    );
+    registerFetchDataSourceVersionRoute(
       router,
       dataSourceService,
       cryptographyServiceSetup,

--- a/src/plugins/data_source/server/routes/data_source_connection_validator.ts
+++ b/src/plugins/data_source/server/routes/data_source_connection_validator.ts
@@ -35,4 +35,27 @@ export class DataSourceConnectionValidator {
       throw createDataSourceError(e);
     }
   }
+
+  async fetchDataSourceVersion() {
+    let dataSourceVersion = '';
+    try {
+      // OpenSearch Serverless does not have version concept
+      if (
+        this.dataSourceAttr.auth?.credentials?.service === SigV4ServiceName.OpenSearchServerless
+      ) {
+        return dataSourceVersion;
+      }
+      await this.callDataCluster
+        .info()
+        .then((response) => response.body)
+        .then((body) => {
+          dataSourceVersion = body.version.number;
+        });
+
+      return dataSourceVersion;
+    } catch (e) {
+      // return empty dataSoyrce version instead of throwing exception in case info() api call fails
+      return dataSourceVersion;
+    }
+  }
 }

--- a/src/plugins/data_source/server/routes/fetch_data_source_version.test.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_version.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import supertest from 'supertest';
+import { UnwrapPromise } from '@osd/utility-types';
+import { setupServer } from '../../../../../src/core/server/test_utils';
+
+import { IAuthenticationMethodRegistery } from '../auth_registry';
+import { authenticationMethodRegisteryMock } from '../auth_registry/authentication_methods_registry.mock';
+import { CustomApiSchemaRegistry } from '../schema_registry';
+import { DataSourceServiceSetup } from '../../server/data_source_service';
+import { CryptographyServiceSetup } from '../cryptography_service';
+import { registerFetchDataSourceVersionRoute } from './fetch_data_source_version';
+import { AuthType } from '../../common/data_sources';
+// eslint-disable-next-line @osd/eslint/no-restricted-paths
+import { opensearchClientMock } from '../../../../../src/core/server/opensearch/client/mocks';
+
+type SetupServerReturn = UnwrapPromise<ReturnType<typeof setupServer>>;
+
+const URL = '/internal/data-source-management/fetchDataSourceVersion';
+
+describe(`Fetch DataSource Version ${URL}`, () => {
+  let server: SetupServerReturn['server'];
+  let httpSetup: SetupServerReturn['httpSetup'];
+  let handlerContext: SetupServerReturn['handlerContext'];
+  let cryptographyMock: jest.Mocked<CryptographyServiceSetup>;
+  const customApiSchemaRegistry = new CustomApiSchemaRegistry();
+  let customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>;
+  let dataSourceClient: ReturnType<typeof opensearchClientMock.createInternalClient>;
+  let dataSourceServiceSetupMock: DataSourceServiceSetup;
+  let authRegistryPromiseMock: Promise<IAuthenticationMethodRegistery>;
+  const dataSourceAttr = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: AuthType.UsernamePasswordType,
+      credentials: {
+        username: 'testUser',
+        password: 'testPassword',
+      },
+    },
+  };
+
+  const dataSourceAttrMissingCredentialForNoAuth = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: AuthType.NoAuth,
+      credentials: {},
+    },
+  };
+
+  const dataSourceAttrMissingCredentialForBasicAuth = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: AuthType.UsernamePasswordType,
+      credentials: {},
+    },
+  };
+
+  const dataSourceAttrMissingCredentialForSigV4Auth = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: AuthType.SigV4,
+      credentials: {},
+    },
+  };
+
+  const dataSourceAttrPartialCredentialForSigV4Auth = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: AuthType.SigV4,
+      credentials: {
+        accessKey: 'testKey',
+        service: 'service',
+      },
+    },
+  };
+
+  const dataSourceAttrPartialCredentialForBasicAuth = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: AuthType.UsernamePasswordType,
+      credentials: {
+        username: 'testName',
+      },
+    },
+  };
+
+  const dataSourceAttrForSigV4Auth = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: AuthType.SigV4,
+      credentials: {
+        accessKey: 'testKey',
+        service: 'es',
+        secretKey: 'testSecret',
+        region: 'testRegion',
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    ({ server, httpSetup, handlerContext } = await setupServer());
+    customApiSchemaRegistryPromise = Promise.resolve(customApiSchemaRegistry);
+    authRegistryPromiseMock = Promise.resolve(authenticationMethodRegisteryMock.create());
+    dataSourceClient = opensearchClientMock.createInternalClient();
+
+    dataSourceServiceSetupMock = {
+      getDataSourceClient: jest.fn(() => Promise.resolve(dataSourceClient)),
+      getDataSourceLegacyClient: jest.fn(),
+    };
+
+    const router = httpSetup.createRouter('');
+    dataSourceClient.info.mockImplementationOnce(() =>
+      opensearchClientMock.createSuccessTransportRequestPromise({ version: { number: '2.11.0' } })
+    );
+    registerFetchDataSourceVersionRoute(
+      router,
+      dataSourceServiceSetupMock,
+      cryptographyMock,
+      authRegistryPromiseMock,
+      customApiSchemaRegistryPromise
+    );
+
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('shows successful response', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr,
+      })
+      .expect(200);
+    expect(result.body).toEqual({ dataSourceVersion: '2.11.0' });
+    expect(dataSourceServiceSetupMock.getDataSourceClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        savedObjects: handlerContext.savedObjects.client,
+        cryptography: cryptographyMock,
+        dataSourceId: 'testId',
+        testClientDataSourceAttr: dataSourceAttr,
+        customApiSchemaRegistryPromise,
+      })
+    );
+  });
+
+  it('no credential with no auth should succeed', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrMissingCredentialForNoAuth,
+      })
+      .expect(200);
+    expect(result.body).toEqual({ dataSourceVersion: '2.11.0' });
+  });
+
+  it('no credential with basic auth should fail', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrMissingCredentialForBasicAuth,
+      })
+      .expect(400);
+    expect(result.body.error).toEqual('Bad Request');
+  });
+
+  it('no credential with sigv4 auth should fail', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrMissingCredentialForSigV4Auth,
+      })
+      .expect(400);
+    expect(result.body.error).toEqual('Bad Request');
+  });
+
+  it('partial credential with sigv4 auth should fail', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrPartialCredentialForSigV4Auth,
+      })
+      .expect(400);
+    expect(result.body.error).toEqual('Bad Request');
+  });
+
+  it('partial credential with basic auth should fail', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrPartialCredentialForBasicAuth,
+      })
+      .expect(400);
+    expect(result.body.error).toEqual('Bad Request');
+  });
+
+  it('full credential with sigV4 auth should success', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrForSigV4Auth,
+      })
+      .expect(200);
+    expect(result.body).toEqual({ dataSourceVersion: '2.11.0' });
+  });
+});

--- a/src/plugins/data_source/server/routes/fetch_data_source_version.test.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_version.test.ts
@@ -100,6 +100,58 @@ describe(`Fetch DataSource Version ${URL}`, () => {
     },
   };
 
+  const dataSourceAttrForRegisteredAuthWithCredentials = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: 'Some Registered Type',
+      credentials: {
+        firstField: 'some value',
+        secondField: 'some value',
+      },
+    },
+  };
+
+  const dataSourceAttrForRegisteredAuthWithEmptyCredentials = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: 'Some Registered Type',
+      credentials: {},
+    },
+  };
+
+  const dataSourceAttrForRegisteredAuthWithoutCredentials = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: 'Some Registered Type',
+    },
+  };
+
+  const dataSourceAttrForRegisteredAuthWithNoAuthType = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: AuthType.NoAuth,
+      credentials: {
+        field: 'some value',
+      },
+    },
+  };
+
+  const dataSourceAttrForRegisteredAuthWithBasicAuthType = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: AuthType.UsernamePasswordType,
+      credentials: {},
+    },
+  };
+
+  const dataSourceAttrForRegisteredAuthWithSigV4AuthType = {
+    endpoint: 'https://test.com',
+    auth: {
+      type: AuthType.SigV4,
+      credentials: {},
+    },
+  };
+
   beforeEach(async () => {
     ({ server, httpSetup, handlerContext } = await setupServer());
     customApiSchemaRegistryPromise = Promise.resolve(customApiSchemaRegistry);
@@ -205,12 +257,87 @@ describe(`Fetch DataSource Version ${URL}`, () => {
     expect(result.body.error).toEqual('Bad Request');
   });
 
+  it('registered Auth with NoAuthType should fail', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrForRegisteredAuthWithNoAuthType,
+      })
+      .expect(400);
+    expect(result.body.error).toEqual('Bad Request');
+    expect(result.body.message).toContain(
+      `Must not be no_auth or username_password or sigv4 for registered auth types`
+    );
+  });
+
+  it('registered Auth with Basic AuthType should fail', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrForRegisteredAuthWithBasicAuthType,
+      })
+      .expect(400);
+    expect(result.body.error).toEqual('Bad Request');
+    expect(result.body.message).toContain(
+      `Must not be no_auth or username_password or sigv4 for registered auth types`
+    );
+  });
+
+  it('registered Auth with sigV4 AuthType should fail', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrForRegisteredAuthWithSigV4AuthType,
+      })
+      .expect(400);
+    expect(result.body.error).toEqual('Bad Request');
+    expect(result.body.message).toContain(
+      `Must not be no_auth or username_password or sigv4 for registered auth types`
+    );
+  });
+
   it('full credential with sigV4 auth should success', async () => {
     const result = await supertest(httpSetup.server.listener)
       .post(URL)
       .send({
         id: 'testId',
         dataSourceAttr: dataSourceAttrForSigV4Auth,
+      })
+      .expect(200);
+    expect(result.body).toEqual({ dataSourceVersion: '2.11.0' });
+  });
+
+  it('credential with registered auth type should success', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrForRegisteredAuthWithCredentials,
+      })
+      .expect(200);
+    expect(result.body).toEqual({ dataSourceVersion: '2.11.0' });
+  });
+
+  it('empty credential with registered auth type should success', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrForRegisteredAuthWithEmptyCredentials,
+      })
+      .expect(200);
+    expect(result.body).toEqual({ dataSourceVersion: '2.11.0' });
+  });
+
+  it('no credential with registered auth type should success', async () => {
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: dataSourceAttrForRegisteredAuthWithoutCredentials,
       })
       .expect(200);
     expect(result.body).toEqual({ dataSourceVersion: '2.11.0' });

--- a/src/plugins/data_source/server/routes/fetch_data_source_version.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_version.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+import { IRouter, OpenSearchClient } from 'opensearch-dashboards/server';
+import { AuthType, DataSourceAttributes, SigV4ServiceName } from '../../common/data_sources';
+import { DataSourceConnectionValidator } from './data_source_connection_validator';
+import { DataSourceServiceSetup } from '../data_source_service';
+import { CryptographyServiceSetup } from '../cryptography_service';
+import { IAuthenticationMethodRegistery } from '../auth_registry';
+import { CustomApiSchemaRegistry } from '../schema_registry/custom_api_schema_registry';
+
+export const registerFetchDataSourceVersionRoute = async (
+  router: IRouter,
+  dataSourceServiceSetup: DataSourceServiceSetup,
+  cryptography: CryptographyServiceSetup,
+  authRegistryPromise: Promise<IAuthenticationMethodRegistery>,
+  customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>
+) => {
+  const authRegistry = await authRegistryPromise;
+  router.post(
+    {
+      path: '/internal/data-source-management/fetchDataSourceVersion',
+      validate: {
+        body: schema.object({
+          id: schema.maybe(schema.string()),
+          dataSourceAttr: schema.object({
+            endpoint: schema.string(),
+            auth: schema.maybe(
+              schema.oneOf([
+                schema.object({
+                  type: schema.literal(AuthType.NoAuth),
+                  credentials: schema.object({}),
+                }),
+                schema.object({
+                  type: schema.literal(AuthType.UsernamePasswordType),
+                  credentials: schema.object({
+                    username: schema.string(),
+                    password: schema.string(),
+                  }),
+                }),
+                schema.object({
+                  type: schema.literal(AuthType.SigV4),
+                  credentials: schema.object({
+                    region: schema.string(),
+                    accessKey: schema.string(),
+                    secretKey: schema.string(),
+                    service: schema.oneOf([
+                      schema.literal(SigV4ServiceName.OpenSearch),
+                      schema.literal(SigV4ServiceName.OpenSearchServerless),
+                    ]),
+                  }),
+                }),
+              ])
+            ),
+          }),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      const { dataSourceAttr, id: dataSourceId } = request.body;
+      let dataSourceVersion = '';
+
+      try {
+        const dataSourceClient: OpenSearchClient = await dataSourceServiceSetup.getDataSourceClient(
+          {
+            savedObjects: context.core.savedObjects.client,
+            cryptography,
+            dataSourceId,
+            testClientDataSourceAttr: dataSourceAttr as DataSourceAttributes,
+            request,
+            authRegistry,
+            customApiSchemaRegistryPromise,
+          }
+        );
+
+        const dataSourceValidator = new DataSourceConnectionValidator(
+          dataSourceClient,
+          dataSourceAttr
+        );
+
+        dataSourceVersion = await dataSourceValidator.fetchDataSourceVersion();
+
+        return response.ok({
+          body: {
+            dataSourceVersion,
+          },
+        });
+      } catch (err) {
+        return response.customError({
+          statusCode: err.statusCode || 500,
+          body: {
+            message: err.message,
+            attributes: {
+              error: err.body?.error || err.message,
+            },
+          },
+        });
+      }
+    }
+  );
+};

--- a/src/plugins/data_source/server/routes/fetch_data_source_version.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_version.ts
@@ -53,6 +53,20 @@ export const registerFetchDataSourceVersionRoute = async (
                     ]),
                   }),
                 }),
+                schema.object({
+                  type: schema.string({
+                    validate: (value) => {
+                      if (
+                        value === AuthType.NoAuth ||
+                        value === AuthType.UsernamePasswordType ||
+                        value === AuthType.SigV4
+                      ) {
+                        return `Must not be no_auth or username_password or sigv4 for registered auth types`;
+                      }
+                    },
+                  }),
+                  credentials: schema.nullable(schema.any()),
+                }),
               ])
             ),
           }),

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.test.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.test.tsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import {
+  fetchDataSourceVersion,
   getMappedDataSources,
   mockDataSourceAttributesWithAuth,
   mockManagementPlugin,
@@ -27,6 +28,9 @@ describe('Datasource Management: Create Datasource Wizard', () => {
   describe('case1: should load resources successfully', () => {
     beforeEach(async () => {
       spyOn(utils, 'getDataSources').and.returnValue(Promise.resolve(getMappedDataSources));
+      spyOn(utils, 'fetchDataSourceVersion').and.returnValue(
+        Promise.resolve(fetchDataSourceVersion)
+      );
       await act(async () => {
         component = mount(
           wrapWithIntl(

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.tsx
@@ -74,7 +74,7 @@ export const CreateDataSourceWizard: React.FunctionComponent<CreateDataSourceWiz
     setIsLoading(true);
     try {
       const version = await fetchDataSourceVersion(http, attributes);
-      attributes.version = version.dataSourceVersion;
+      attributes.dataSourceVersion = version.dataSourceVersion;
       await createSingleDataSource(savedObjects.client, attributes);
       props.history.push('');
     } catch (e) {

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.tsx
@@ -16,7 +16,12 @@ import {
 } from '../../types';
 import { getCreateBreadcrumbs } from '../breadcrumbs';
 import { CreateDataSourceForm } from './components/create_form';
-import { createSingleDataSource, getDataSources, testConnection } from '../utils';
+import {
+  createSingleDataSource,
+  getDataSources,
+  testConnection,
+  fetchDataSourceVersion,
+} from '../utils';
 import { LoadingMask } from '../loading_mask';
 
 type CreateDataSourceWizardProps = RouteComponentProps;
@@ -68,6 +73,8 @@ export const CreateDataSourceWizard: React.FunctionComponent<CreateDataSourceWiz
   const handleSubmit = async (attributes: DataSourceAttributes) => {
     setIsLoading(true);
     try {
+      const version = await fetchDataSourceVersion(http, attributes);
+      attributes.version = version.dataSourceVersion;
       await createSingleDataSource(savedObjects.client, attributes);
       props.history.push('');
     } catch (e) {

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -119,6 +119,27 @@ export async function testConnection(
   });
 }
 
+export async function fetchDataSourceVersion(
+  http: HttpStart,
+  { endpoint, auth: { type, credentials } }: DataSourceAttributes,
+  dataSourceID?: string
+) {
+  const query: any = {
+    id: dataSourceID,
+    dataSourceAttr: {
+      endpoint,
+      auth: {
+        type,
+        credentials,
+      },
+    },
+  };
+
+  return await http.post(`/internal/data-source-management/fetchDataSourceVersion`, {
+    body: JSON.stringify(query),
+  });
+}
+
 export const isValidUrl = (endpoint: string) => {
   try {
     const url = new URL(endpoint);

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -180,6 +180,10 @@ export const getMappedDataSources = [
   },
 ];
 
+export const fetchDataSourceVersion = {
+  dataSourceVersion: '2.11.0',
+};
+
 export const mockDataSourceAttributesWithAuth = {
   id: 'test',
   title: 'create-test-ds',

--- a/src/plugins/data_source_management/public/types.ts
+++ b/src/plugins/data_source_management/public/types.ts
@@ -140,7 +140,7 @@ export interface DataSourceAttributes extends SavedObjectAttributes {
   title: string;
   description?: string;
   endpoint?: string;
-  version?: string;
+  dataSourceVersion?: string;
   auth: {
     type: AuthType | string;
     credentials:

--- a/src/plugins/data_source_management/public/types.ts
+++ b/src/plugins/data_source_management/public/types.ts
@@ -140,6 +140,7 @@ export interface DataSourceAttributes extends SavedObjectAttributes {
   title: string;
   description?: string;
   endpoint?: string;
+  version?: string;
   auth: {
     type: AuthType | string;
     credentials:


### PR DESCRIPTION
### Description

* This change is the first step per RFC https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5877 aiming at decouple the strict version constrains between OSD Core and Plugins

* To make it happen this first step change is to include the data source version number in the newly created `data-source` object which would be consumed by plugins as part of the proof for determining version support

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6177

## Screenshot

* Unit Test passed

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/99905560/58309a7a-429e-4d47-a39e-64b77924c52f)

* Demonstration Recording

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/99905560/c0b82a86-2eb9-4f2b-a34d-1a46433146a0


In the recording we demoed two scenarios:

1. When data source connection checks out, the data source version number is added to the data-source saved object
2. When data source connection doesn't work, the data source version number will be empty but will not block the creation of data-source saved object

## Testing the changes

R1 - https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6178/commits/028ae3cc9af7538fe3678c02a1bd6ef625339512 - `update attribute key from version to dataSourceVersion`

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/99905560/7fa078d9-5633-4781-a10c-635adfabd7f8)


R2 - https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6178/commits/9beabfb7734480b4558656cde1d81c475c0f5d5b - `add support and test coverage for custom auth type`

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/99905560/009d4d8f-ead2-4b98-9a85-722e37d6291d)


### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
