### PR TITLE
[BUG] Fix obsolete snapshots for test within data source management plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Multiple Datasource] Add a migration function for datasource to add migrationVersion field ([#6025](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6025))
 - [BUG][MD]Expose picker using function in data source management plugin setup([#6030](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6030))
 - [BUG][Multiple Datasource] Fix data source filter bug and add tests ([#6152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6152))
+- [BUG][Multiple Datasource] Fix obsolete snapshots for test within data source management plugin ([#6185](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6185))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/__snapshots__/data_source_aggregated_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/__snapshots__/data_source_aggregated_view.test.tsx.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DataSourceAggregatedView should render normally with data source filter 1`] = `
+<Fragment>
+  <EuiButtonEmpty
+    aria-label="dataSourceAggregatedViewMenuButton"
+    className="euiHeaderLink"
+    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+    disabled={true}
+    iconSide="left"
+    iconType="database"
+    size="s"
+  >
+    Data sources
+  </EuiButtonEmpty>
+  <EuiNotificationBadge
+    color="subdued"
+  >
+    All
+  </EuiNotificationBadge>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonIcon
+        aria-label="show data sources"
+        data-test-subj="dataSourceAggregatedViewInfoButton"
+        display="empty"
+        iconType="iInCircle"
+        onClick={[Function]}
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenu
+      initialPanelId={0}
+      panels={
+        Array [
+          Object {
+            "id": 0,
+            "items": Array [],
+            "title": "Selected data sources",
+          },
+        ]
+      }
+      size="m"
+    />
+  </EuiPopover>
+</Fragment>
+`;
+
 exports[`DataSourceAggregatedView should render normally with local cluster and actice selections 1`] = `
 <Fragment>
   <EuiButtonEmpty
@@ -59,7 +113,7 @@ exports[`DataSourceAggregatedView should render normally with local cluster and 
 </Fragment>
 `;
 
-exports[`DataSourceAggregatedView should render normally with local cluster and actice selections 2`] = `
+exports[`DataSourceAggregatedView should render normally with local cluster hidden and all options 1`] = `
 <Fragment>
   <EuiButtonEmpty
     aria-label="dataSourceAggregatedViewMenuButton"
@@ -103,7 +157,7 @@ exports[`DataSourceAggregatedView should render normally with local cluster and 
           Object {
             "id": 0,
             "items": Array [],
-            "title": "Selected data sources",
+            "title": "Data sources (0)",
           },
         ]
       }
@@ -113,7 +167,61 @@ exports[`DataSourceAggregatedView should render normally with local cluster and 
 </Fragment>
 `;
 
-exports[`DataSourceAggregatedView should render normally with local cluster and actice selections 3`] = `
+exports[`DataSourceAggregatedView should render normally with local cluster not hidden and all options 1`] = `
+<Fragment>
+  <EuiButtonEmpty
+    aria-label="dataSourceAggregatedViewMenuButton"
+    className="euiHeaderLink"
+    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+    disabled={true}
+    iconSide="left"
+    iconType="database"
+    size="s"
+  >
+    Data sources
+  </EuiButtonEmpty>
+  <EuiNotificationBadge
+    color="subdued"
+  >
+    All
+  </EuiNotificationBadge>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonIcon
+        aria-label="show data sources"
+        data-test-subj="dataSourceAggregatedViewInfoButton"
+        display="empty"
+        iconType="iInCircle"
+        onClick={[Function]}
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenu
+      initialPanelId={0}
+      panels={
+        Array [
+          Object {
+            "id": 0,
+            "items": Array [],
+            "title": "Data sources (0)",
+          },
+        ]
+      }
+      size="m"
+    />
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView should render popup when clicking on info icon 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -338,112 +446,4 @@ Object {
   "rerender": [Function],
   "unmount": [Function],
 }
-`;
-
-exports[`DataSourceAggregatedView should render normally with local cluster hidden and all options 1`] = `
-<Fragment>
-  <EuiButtonEmpty
-    aria-label="dataSourceAggregatedViewMenuButton"
-    className="euiHeaderLink"
-    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-    disabled={true}
-    iconSide="left"
-    iconType="database"
-    size="s"
-  >
-    Data sources
-  </EuiButtonEmpty>
-  <EuiNotificationBadge
-    color="subdued"
-  >
-    All
-  </EuiNotificationBadge>
-  <EuiPopover
-    anchorPosition="downLeft"
-    button={
-      <EuiButtonIcon
-        aria-label="show data sources"
-        data-test-subj="dataSourceAggregatedViewInfoButton"
-        display="empty"
-        iconType="iInCircle"
-        onClick={[Function]}
-      />
-    }
-    closePopover={[Function]}
-    display="inlineBlock"
-    hasArrow={true}
-    id="dataSourceSViewContextMenuPopover"
-    isOpen={false}
-    ownFocus={true}
-    panelPaddingSize="none"
-  >
-    <EuiContextMenu
-      initialPanelId={0}
-      panels={
-        Array [
-          Object {
-            "id": 0,
-            "items": Array [],
-            "title": "Data sources (0)",
-          },
-        ]
-      }
-      size="m"
-    />
-  </EuiPopover>
-</Fragment>
-`;
-
-exports[`DataSourceAggregatedView should render normally with local cluster not hidden and all options 1`] = `
-<Fragment>
-  <EuiButtonEmpty
-    aria-label="dataSourceAggregatedViewMenuButton"
-    className="euiHeaderLink"
-    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-    disabled={true}
-    iconSide="left"
-    iconType="database"
-    size="s"
-  >
-    Data sources
-  </EuiButtonEmpty>
-  <EuiNotificationBadge
-    color="subdued"
-  >
-    All
-  </EuiNotificationBadge>
-  <EuiPopover
-    anchorPosition="downLeft"
-    button={
-      <EuiButtonIcon
-        aria-label="show data sources"
-        data-test-subj="dataSourceAggregatedViewInfoButton"
-        display="empty"
-        iconType="iInCircle"
-        onClick={[Function]}
-      />
-    }
-    closePopover={[Function]}
-    display="inlineBlock"
-    hasArrow={true}
-    id="dataSourceSViewContextMenuPopover"
-    isOpen={false}
-    ownFocus={true}
-    panelPaddingSize="none"
-  >
-    <EuiContextMenu
-      initialPanelId={0}
-      panels={
-        Array [
-          Object {
-            "id": 0,
-            "items": Array [],
-            "title": "Data sources (0)",
-          },
-        ]
-      }
-      size="m"
-    />
-  </EuiPopover>
-</Fragment>
 `;


### PR DESCRIPTION
### Description
This change removes obsolete snapshots to fix the test under data source management plugin

### Issues Resolved

## Screenshot


## Testing the changes
The obsolete snapshots from the tests were removed by executing `yarn test:jest -u src/plugins/data_source_management/` and the following is the output
```
Snapshot Summary
 › 2 snapshots removed from 1 test suite.
   ↳ src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.test.tsx
       • DataSourceAggregatedView should render normally with local cluster and actice selections 2
       • DataSourceAggregatedView should render normally with local cluster and actice selections 3

Test Suites: 22 passed, 22 total
Tests:       133 passed, 133 total
Snapshots:   2 removed, 38 passed, 38 total
Time:        15.354 s
Ran all test suites matching /src\/plugins\/data_source_management\//i.
```

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
