### PR TITLE
[Manually backport 2.x] Move @kristenTian to emeritus maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @kristenTian @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT
+*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,7 +13,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Josh Romero               | [joshuarrrr](https://github.com/joshuarrrr)         | Amazon      |
 | Abby Hu                   | [abbyhu2000](https://github.com/abbyhu2000)         | Amazon      |
 | Yan Zeng                  | [zengyan-amazon](https://github.com/zengyan-amazon) | Amazon      |
-| Kristen Tian              | [kristenTian](https://github.com/kristenTian)       | Amazon      |
 | Zhongnan Su               | [zhongnansu](https://github.com/zhongnansu)         | Amazon      |
 | Manasvini B Suryanarayana | [manasvinibs](https://github.com/manasvinibs)       | Amazon      |
 | Tao Liu                   | [Flyingliuhub](https://github.com/Flyingliuhub)     | Amazon      |
@@ -33,3 +32,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Mihir Soni    | [mihirsoni](https://github.com/mihirsoni)     | Amazon      |
 | Bishoy Boktor | [boktorbb](https://github.com/boktorbb)       | Amazon      |
 | Sean Neumann  | [seanneumann](https://github.com/seanneumann) | Contributor |
+| Kristen Tian  | [kristenTian](https://github.com/kristenTian) | Amazon      |


### PR DESCRIPTION
### Description

Move @kristenTian to emeritus maintainer, this is a manually backport 2.x PR from #6136 


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
