### PR TITLE
[manual][backport-2.x] Add @xinruiba as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT
+*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT @xinruiba

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,6 +23,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Su Zhou                   | [SuZhou-Joe](https://github.com/SuZhou-Joe)         | Amazon      |
 | Yulong Ruan               | [ruanyl](https://github.com/ruanyl)                 | Amazon      |
 | Lu Yu                     | [BionIT](https://github.com/BionIT)                 | Amazon      |
+| Xinrui Bai                | [xinruiba](https://github.com/xinruiba)             | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
Add @xinruiba as a maintainer, this PR is backport 2.x from #6217

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
