### PR TITLE
[Workspace] Add base path when parsing url in http service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][MD]Expose picker using function in data source management plugin setup([#6030](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6030))
 - [BUG][Multiple Datasource] Fix data source filter bug and add tests ([#6152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6152))
 - [BUG][Multiple Datasource] Fix obsolete snapshots for test within data source management plugin ([#6185](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6185))
+- [Workspace] Add base path when parse url in http service ([#6233](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6233))
 
 ### 🚞 Infrastructure
 

--- a/src/core/public/http/http_service.test.ts
+++ b/src/core/public/http/http_service.test.ts
@@ -83,21 +83,22 @@ describe('#setup()', () => {
     expect(setupResult.basePath.get()).toEqual('');
   });
 
-  it('setup basePath with workspaceId provided in window.location.href', () => {
+  it('setup basePath with workspaceId provided in window.location.href and basePath present in injectedMetadata', () => {
     const windowSpy = jest.spyOn(window, 'window', 'get');
     windowSpy.mockImplementation(
       () =>
         ({
           location: {
-            href: 'http://localhost/w/workspaceId/app',
+            href: 'http://localhost/base_path/w/workspaceId/app',
           },
         } as any)
     );
     const injectedMetadata = injectedMetadataServiceMock.createSetupContract();
+    injectedMetadata.getBasePath.mockReturnValue('/base_path');
     const fatalErrors = fatalErrorsServiceMock.createSetupContract();
     const httpService = new HttpService();
     const setupResult = httpService.setup({ fatalErrors, injectedMetadata });
-    expect(setupResult.basePath.get()).toEqual('/w/workspaceId');
+    expect(setupResult.basePath.get()).toEqual('/base_path/w/workspaceId');
     windowSpy.mockRestore();
   });
 });

--- a/src/core/public/http/http_service.ts
+++ b/src/core/public/http/http_service.ts
@@ -53,7 +53,7 @@ export class HttpService implements CoreService<HttpSetup, HttpStart> {
   public setup({ injectedMetadata, fatalErrors }: HttpDeps): HttpSetup {
     const opensearchDashboardsVersion = injectedMetadata.getOpenSearchDashboardsVersion();
     let clientBasePath = '';
-    const workspaceId = getWorkspaceIdFromUrl(window.location.href);
+    const workspaceId = getWorkspaceIdFromUrl(window.location.href, injectedMetadata.getBasePath());
     if (workspaceId) {
       clientBasePath = `${WORKSPACE_PATH_PREFIX}/${workspaceId}`;
     }

--- a/src/core/utils/workspace.test.ts
+++ b/src/core/utils/workspace.test.ts
@@ -8,11 +8,11 @@ import { httpServiceMock } from '../public/mocks';
 
 describe('#getWorkspaceIdFromUrl', () => {
   it('return workspace when there is a match', () => {
-    expect(getWorkspaceIdFromUrl('http://localhost/w/foo')).toEqual('foo');
+    expect(getWorkspaceIdFromUrl('http://localhost/w/foo', '')).toEqual('foo');
   });
 
   it('return empty when there is not a match', () => {
-    expect(getWorkspaceIdFromUrl('http://localhost/w2/foo')).toEqual('');
+    expect(getWorkspaceIdFromUrl('http://localhost/w2/foo', '')).toEqual('');
   });
 
   it('return workspace when there is a match with basePath provided', () => {

--- a/src/core/utils/workspace.ts
+++ b/src/core/utils/workspace.ts
@@ -6,7 +6,7 @@
 import { WORKSPACE_PATH_PREFIX } from './constants';
 import { IBasePath } from '../public';
 
-export const getWorkspaceIdFromUrl = (url: string, basePath?: string): string => {
+export const getWorkspaceIdFromUrl = (url: string, basePath: string): string => {
   const regexp = new RegExp(`^${basePath || ''}\/w\/([^\/]*)`);
   const urlObject = new URL(url);
   const matchedResult = urlObject.pathname.match(regexp);

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -32,6 +32,7 @@ export class WorkspacePlugin implements Plugin<{}, {}, {}> {
       });
     }
   }
+
   private getWorkspaceIdFromURL(basePath: string): string | null {
     return getWorkspaceIdFromUrl(window.location.href, basePath);
   }

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -33,10 +33,6 @@ export class WorkspacePlugin implements Plugin<{}, {}, {}> {
     }
   }
 
-  private getWorkspaceIdFromURL(basePath: string): string | null {
-    return getWorkspaceIdFromUrl(window.location.href, basePath);
-  }
-
   public async setup(core: CoreSetup) {
     const workspaceClient = new WorkspaceClient(core.http, core.workspaces);
     await workspaceClient.init();
@@ -44,7 +40,10 @@ export class WorkspacePlugin implements Plugin<{}, {}, {}> {
     /**
      * Retrieve workspace id from url
      */
-    const workspaceId = this.getWorkspaceIdFromURL(core.http.basePath.getBasePath());
+    const workspaceId = getWorkspaceIdFromUrl(
+      window.location.href,
+      core.http.basePath.getBasePath()
+    );
 
     if (workspaceId) {
       const result = await workspaceClient.enterWorkspace(workspaceId);

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -32,8 +32,7 @@ export class WorkspacePlugin implements Plugin<{}, {}, {}> {
       });
     }
   }
-
-  private getWorkspaceIdFromURL(basePath?: string): string | null {
+  private getWorkspaceIdFromURL(basePath: string): string | null {
     return getWorkspaceIdFromUrl(window.location.href, basePath);
   }
 

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -29,7 +29,7 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     setupDeps.http.registerOnPreRouting(async (request, response, toolkit) => {
       const workspaceId = getWorkspaceIdFromUrl(
         request.url.toString(),
-        '' // No need to pass basePath here because BasePathService will rewrite the url.
+        '' // No need to pass basePath here because the request.url will be rewrite by registerOnPreRouting method in `src/core/server/http/http_server.ts`
       );
 
       if (workspaceId) {

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -27,7 +27,10 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
      * Proxy all {basePath}/w/{workspaceId}{osdPath*} paths to {basePath}{osdPath*}
      */
     setupDeps.http.registerOnPreRouting(async (request, response, toolkit) => {
-      const workspaceId = getWorkspaceIdFromUrl(request.url.toString());
+      const workspaceId = getWorkspaceIdFromUrl(
+        request.url.toString(),
+        '' // No need to pass basePath here because BasePathService will rewrite the url.
+      );
 
       if (workspaceId) {
         const requestUrl = new URL(request.url.toString());


### PR DESCRIPTION
### Description

Make basePath required in `getWorkspaceIdFromUrl` method.

### Issues Resolved

fixes #6015

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

- Using the branch to bootstrap
- Enable workspace by adding `workspace.enabled` to opensearch_dashboards.yml file 
- Start OSD by using `yarn start` to enable `basePath` feature.
- Navigate to devTools
- Insert test workspaces by calling
```
PUT .kibana/_doc/workspace:foo
{
  "type": "workspace",
  "workspace": {
    "name": "foo"
  }
}
```
- Visit the OpenSearch Dashboards under `foo` workspace: `http://localhost:5603/{random_basePath}/w/foo/app/dev_tools`
- The page should be able to load.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
