### PR TITLE
fix a doc reference typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ OpenSearch is a community project that is built and maintained by people just li
 
 ### Join the Discussion
 
-See the [communication guide](COMMUNICATION.md)for information on how to join our slack workspace, forum, or developer office hours.
+See the [communication guide](COMMUNICATIONS.md)for information on how to join our slack workspace, forum, or developer office hours.
 
 ### Bug Reports
 


### PR DESCRIPTION
### Description

the doc reference in CONTRIBUTING.md link to COMMUNICATIONS.md is wrong.

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
