### PR TITLE
[Multiple Datasource] Remove arrow down icon from data source selectable component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Dynamic Configurations] Pass request headers when making application config calls ([#6164](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6164))
 - [Discover] Options button to configure legacy mode and remove the top navigation option ([#6170](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6170))
 - [Multiple Datasource] Add default functionality for customer to choose default datasource ([#6058](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6058))
+- [Multiple Datasource] Remove arrow down icon from data source selectable component ([#6257](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6257))
 
 
 ### 🐛 Bug Fixes

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
@@ -20,9 +20,6 @@ Object {
             <div
               class="euiPopover__anchor"
             >
-              <span
-                data-euiicon-type="database"
-              />
               <button
                 aria-label="dataSourceMenuButton"
                 class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
@@ -30,12 +27,12 @@ Object {
                 type="button"
               >
                 <span
-                  class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                  class="euiButtonContent euiButtonEmpty__content"
                 >
                   <span
                     class="euiButtonContent__icon"
                     color="inherit"
-                    data-euiicon-type="arrowDown"
+                    data-euiicon-type="database"
                   />
                   <span
                     class="euiButtonEmpty__text"
@@ -64,9 +61,6 @@ Object {
           <div
             class="euiPopover__anchor"
           >
-            <span
-              data-euiicon-type="database"
-            />
             <button
               aria-label="dataSourceMenuButton"
               class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
@@ -74,12 +68,12 @@ Object {
               type="button"
             >
               <span
-                class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                class="euiButtonContent euiButtonEmpty__content"
               >
                 <span
                   class="euiButtonContent__icon"
                   color="inherit"
-                  data-euiicon-type="arrowDown"
+                  data-euiicon-type="database"
                 />
                 <span
                   class="euiButtonEmpty__text"

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
@@ -12,9 +12,6 @@ Object {
         <div
           class="euiPopover__anchor"
         >
-          <span
-            data-euiicon-type="database"
-          />
           <button
             aria-label="dataSourceMenuButton"
             class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
@@ -22,12 +19,12 @@ Object {
             type="button"
           >
             <span
-              class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+              class="euiButtonContent euiButtonEmpty__content"
             >
               <span
                 class="euiButtonContent__icon"
                 color="inherit"
-                data-euiicon-type="arrowDown"
+                data-euiicon-type="database"
               />
               <span
                 class="euiButtonEmpty__text"
@@ -46,9 +43,6 @@ Object {
       <div
         class="euiPopover__anchor"
       >
-        <span
-          data-euiicon-type="database"
-        />
         <button
           aria-label="dataSourceMenuButton"
           class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
@@ -56,12 +50,12 @@ Object {
           type="button"
         >
           <span
-            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+            class="euiButtonContent euiButtonEmpty__content"
           >
             <span
               class="euiButtonContent__icon"
               color="inherit"
-              data-euiicon-type="arrowDown"
+              data-euiicon-type="database"
             />
             <span
               class="euiButtonEmpty__text"
@@ -171,46 +165,7 @@ Object {
     </div>
     <div />
   </body>,
-  "container": <div>
-    <nav
-      aria-label="App menu"
-      class="euiHeaderLinks osdTopNavMenu myclass"
-      data-test-subj="top-nav"
-    >
-      <div
-        class="euiHeaderLinks__list euiHeaderLinks__list--gutterXS"
-      >
-        <div
-          class="euiPopover euiPopover--anchorDownLeft"
-          id="dataSourceSelectableContextMenuPopover"
-        >
-          <div
-            class="euiPopover__anchor"
-          >
-            <button
-              aria-label="dataSourceMenuButton"
-              class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
-              data-test-subj="dataSourceSelectableContextMenuHeaderLink"
-              type="button"
-            >
-              <span
-                class="euiButtonContent euiButtonEmpty__content"
-              >
-                <span
-                  class="euiButtonContent__icon"
-                  color="inherit"
-                  data-euiicon-type="database"
-                />
-                <span
-                  class="euiButtonEmpty__text"
-                />
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-    </nav>
-  </div>,
+  "container": <div />,
   "debug": [Function],
   "findAllByAltText": [Function],
   "findAllByDisplayValue": [Function],

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_selectable.test.tsx.snap
@@ -5,16 +5,13 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
   anchorPosition="downLeft"
   button={
     <React.Fragment>
-      <EuiIcon
-        type="database"
-      />
       <EuiButtonEmpty
         aria-label="dataSourceMenuButton"
         className="euiHeaderLink"
         data-test-subj="dataSourceSelectableContextMenuHeaderLink"
         disabled={false}
-        iconSide="right"
-        iconType="arrowDown"
+        iconSide="left"
+        iconType="database"
         onClick={[Function]}
         size="s"
       >
@@ -81,16 +78,13 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
   anchorPosition="downLeft"
   button={
     <React.Fragment>
-      <EuiIcon
-        type="database"
-      />
       <EuiButtonEmpty
         aria-label="dataSourceMenuButton"
         className="euiHeaderLink"
         data-test-subj="dataSourceSelectableContextMenuHeaderLink"
         disabled={false}
-        iconSide="right"
-        iconType="arrowDown"
+        iconSide="left"
+        iconType="database"
         onClick={[Function]}
         size="s"
       >
@@ -142,16 +136,13 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
   anchorPosition="downLeft"
   button={
     <React.Fragment>
-      <EuiIcon
-        type="database"
-      />
       <EuiButtonEmpty
         aria-label="dataSourceMenuButton"
         className="euiHeaderLink"
         data-test-subj="dataSourceSelectableContextMenuHeaderLink"
         disabled={false}
-        iconSide="right"
-        iconType="arrowDown"
+        iconSide="left"
+        iconType="database"
         onClick={[Function]}
         size="s"
       >

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_selectable.tsx
@@ -125,7 +125,6 @@ export class DataSourceSelectable extends React.Component<
   render() {
     const button = (
       <>
-        <EuiIcon type="database" />
         <EuiButtonEmpty
           className="euiHeaderLink"
           onClick={this.onClick.bind(this)}
@@ -133,8 +132,8 @@ export class DataSourceSelectable extends React.Component<
           aria-label={i18n.translate('dataSourceSelectable.dataSourceOptionsButtonAriaLabel', {
             defaultMessage: 'dataSourceMenuButton',
           })}
-          iconType="arrowDown"
-          iconSide="right"
+          iconType="database"
+          iconSide="left"
           size="s"
           disabled={this.props.disabled || false}
         >


### PR DESCRIPTION
### Description
This change is part of https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6216 to remove arrowdown icon from data source selectable component

### Issues Resolved


## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/57cb6e86-de4e-4dc5-811d-e7ece60379b2



## Testing the changes
After removing the arrow down icon, the data source selectable component renders correctly

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
