### PR TITLE
Fix sslConfig for multiple datasource to handle when certificateAuthorities is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Multiple Datasource] Fix data source filter bug and add tests ([#6152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6152))
 - [BUG][Multiple Datasource] Fix obsolete snapshots for test within data source management plugin ([#6185](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6185))
 - [Workspace] Add base path when parse url in http service ([#6233](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6233))
+- [Multiple Datasource] Fix sslConfig for multiple datasource to handle when certificateAuthorities is unset ([#6282](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6282))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/data_source/server/client/client_config.test.ts
+++ b/src/plugins/data_source/server/client/client_config.test.ts
@@ -46,7 +46,7 @@ describe('parseClientOptions', () => {
         ssl: {
           requestCert: true,
           rejectUnauthorized: false,
-          ca: [],
+          ca: undefined,
         },
       })
     );
@@ -105,6 +105,33 @@ describe('parseClientOptions', () => {
           requestCert: true,
           rejectUnauthorized: true,
           ca: ['content-of-some-path'],
+        },
+      })
+    );
+  });
+
+  test('test ssl config with verification mode set to full with no ca list', () => {
+    const config = {
+      enabled: true,
+      ssl: {
+        verificationMode: 'full',
+      },
+      clientPool: {
+        size: 5,
+      },
+    } as DataSourcePluginConfigType;
+    mockReadFileSync.mockReset();
+    mockReadFileSync.mockImplementation((path: string) => `content-of-${path}`);
+    const parsedConfig = parseClientOptions(config, TEST_DATA_SOURCE_ENDPOINT);
+    expect(mockReadFileSync).toHaveBeenCalledTimes(0);
+    mockReadFileSync.mockClear();
+    expect(parsedConfig).toEqual(
+      expect.objectContaining({
+        node: TEST_DATA_SOURCE_ENDPOINT,
+        ssl: {
+          requestCert: true,
+          rejectUnauthorized: true,
+          ca: undefined,
         },
       })
     );

--- a/src/plugins/data_source/server/client/client_config.ts
+++ b/src/plugins/data_source/server/client/client_config.ts
@@ -56,7 +56,7 @@ export function parseClientOptions(
       config.ssl?.certificateAuthorities
     );
 
-    sslConfig.ca = certificateAuthorities || [];
+    sslConfig.ca = certificateAuthorities;
   }
 
   const clientOptions: ClientOptions = {

--- a/src/plugins/data_source/server/legacy/client_config.test.ts
+++ b/src/plugins/data_source/server/legacy/client_config.test.ts
@@ -44,7 +44,7 @@ describe('parseClientOptions', () => {
         host: TEST_DATA_SOURCE_ENDPOINT,
         ssl: {
           rejectUnauthorized: false,
-          ca: [],
+          ca: undefined,
         },
       })
     );
@@ -101,6 +101,32 @@ describe('parseClientOptions', () => {
         ssl: {
           rejectUnauthorized: true,
           ca: ['content-of-some-path'],
+        },
+      })
+    );
+  });
+
+  test('test ssl config with verification mode set to full with no ca list', () => {
+    const config = {
+      enabled: true,
+      ssl: {
+        verificationMode: 'full',
+      },
+      clientPool: {
+        size: 5,
+      },
+    } as DataSourcePluginConfigType;
+    mockReadFileSync.mockReset();
+    mockReadFileSync.mockImplementation((path: string) => `content-of-${path}`);
+    const parsedConfig = parseClientOptions(config, TEST_DATA_SOURCE_ENDPOINT);
+    expect(mockReadFileSync).toHaveBeenCalledTimes(0);
+    mockReadFileSync.mockClear();
+    expect(parsedConfig).toEqual(
+      expect.objectContaining({
+        host: TEST_DATA_SOURCE_ENDPOINT,
+        ssl: {
+          rejectUnauthorized: true,
+          ca: undefined,
         },
       })
     );

--- a/src/plugins/data_source/server/legacy/client_config.ts
+++ b/src/plugins/data_source/server/legacy/client_config.ts
@@ -55,7 +55,7 @@ export function parseClientOptions(
       config.ssl?.certificateAuthorities
     );
 
-    sslConfig.ca = certificateAuthorities || [];
+    sslConfig.ca = certificateAuthorities;
   }
 
   const configOptions: ConfigOptions = {

--- a/src/plugins/data_source/server/util/tls_settings_provider.test.ts
+++ b/src/plugins/data_source/server/util/tls_settings_provider.test.ts
@@ -40,7 +40,7 @@ describe('readCertificateAuthorities', () => {
     expect(mockReadFileSync).toHaveBeenCalledTimes(0);
     mockReadFileSync.mockClear();
     expect(certificateAuthorities).toEqual({
-      certificateAuthorities: [],
+      certificateAuthorities: undefined,
     });
   });
 
@@ -52,7 +52,7 @@ describe('readCertificateAuthorities', () => {
     expect(mockReadFileSync).toHaveBeenCalledTimes(0);
     mockReadFileSync.mockClear();
     expect(certificateAuthorities).toEqual({
-      certificateAuthorities: [],
+      certificateAuthorities: undefined,
     });
   });
 });

--- a/src/plugins/data_source/server/util/tls_settings_provider.ts
+++ b/src/plugins/data_source/server/util/tls_settings_provider.ts
@@ -8,7 +8,7 @@ import { readFileSync } from 'fs';
 export const readCertificateAuthorities = (
   listOfCertificateAuthorities: string | string[] | undefined
 ) => {
-  let certificateAuthorities: string[] | undefined = [];
+  let certificateAuthorities: string[] | undefined;
 
   const addCertificateAuthorities = (ca: string[]) => {
     if (ca && ca.length) {


### PR DESCRIPTION
### Description

Fixes the logic in TLS configuration for multiple datasources to match the behavior of [opensearch_client_config.ts](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/core/server/opensearch/legacy/opensearch_client_config.ts) which sets the `ca` portion of the ssl config to `undefined` (instead of empty list) when the `datasource.ssl.certificateAuthorities` setting is not set in `opensearch_dashboards.yml`.

### Issues Resolved

- https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6281

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
