### PR TITLE
[Multiple Datasource] Move data source selectable to its own folder, fix test and a few type errors for data source selectable component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][MD]Expose picker using function in data source management plugin setup([#6030](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6030))
 - [BUG][Multiple Datasource] Fix data source filter bug and add tests ([#6152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6152))
 - [BUG][Multiple Datasource] Fix obsolete snapshots for test within data source management plugin ([#6185](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6185))
-- [Multiple Datasource] Move data source selectable to its own folder, fix test and a few type errors for data source selectable component ([#6287](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6287))
 - [Workspace] Add base path when parse url in http service ([#6233](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6233))
 - [Multiple Datasource] Fix sslConfig for multiple datasource to handle when certificateAuthorities is unset ([#6282](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6282))
 
@@ -125,6 +124,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### 🪛 Refactoring
 
 - Remove unused Sass in `tile_map` plugin ([#4110](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4110))
+- [Multiple Datasource] Move data source selectable to its own folder, fix test and a few type errors for data source selectable component ([#6287](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6287))
 
 ### 🔩 Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][MD]Expose picker using function in data source management plugin setup([#6030](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6030))
 - [BUG][Multiple Datasource] Fix data source filter bug and add tests ([#6152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6152))
 - [BUG][Multiple Datasource] Fix obsolete snapshots for test within data source management plugin ([#6185](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6185))
+- [Multiple Datasource] Move data source selectable to its own folder, fix test and a few type errors for data source selectable component ([#6287](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6287))
 - [Workspace] Add base path when parse url in http service ([#6233](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6233))
 - [Multiple Datasource] Fix sslConfig for multiple datasource to handle when certificateAuthorities is unset ([#6282](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6282))
 

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
@@ -7,6 +7,7 @@ Object {
     <div>
       <div
         class="euiPopover euiPopover--anchorDownLeft"
+        data-test-subj="dataSourceSelectableContextMenuPopover"
         id="dataSourceSelectableContextMenuPopover"
       >
         <div
@@ -38,6 +39,7 @@ Object {
   "container": <div>
     <div
       class="euiPopover euiPopover--anchorDownLeft"
+      data-test-subj="dataSourceSelectableContextMenuPopover"
       id="dataSourceSelectableContextMenuPopover"
     >
       <div
@@ -134,6 +136,7 @@ Object {
         >
           <div
             class="euiPopover euiPopover--anchorDownLeft"
+            data-test-subj="dataSourceSelectableContextMenuPopover"
             id="dataSourceSelectableContextMenuPopover"
           >
             <div

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -5,10 +5,9 @@
 
 import React, { ReactElement } from 'react';
 
-import { DataSourceSelectable } from './data_source_selectable';
 import { DataSourceAggregatedView } from '../data_source_aggregated_view';
 import { DataSourceView } from '../data_source_view';
-import { DataSourceMultiSelectable } from '../data_source_multi_selectable/data_source_multi_selectable';
+import { DataSourceMultiSelectable } from '../data_source_multi_selectable';
 import {
   DataSourceAggregatedViewConfig,
   DataSourceComponentType,
@@ -17,6 +16,7 @@ import {
   DataSourceSelectableConfig,
   DataSourceViewConfig,
 } from './types';
+import { DataSourceSelectable } from '../data_source_selectable';
 
 export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement | null {
   const { componentType, componentConfig } = props;

--- a/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
             },
             Object {
               "id": "test2",
-              "label": "test3",
+              "label": "test2",
             },
             Object {
               "id": "test3",

--- a/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
     </React.Fragment>
   }
   closePopover={[Function]}
+  data-test-subj="dataSourceSelectableContextMenuPopover"
   display="inlineBlock"
   hasArrow={true}
   id="dataSourceSelectableContextMenuPopover"
@@ -94,6 +95,7 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
     </React.Fragment>
   }
   closePopover={[Function]}
+  data-test-subj="dataSourceSelectableContextMenuPopover"
   display="inlineBlock"
   hasArrow={true}
   id="dataSourceSelectableContextMenuPopover"
@@ -153,6 +155,7 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
     </React.Fragment>
   }
   closePopover={[Function]}
+  data-test-subj="dataSourceSelectableContextMenuPopover"
   display="inlineBlock"
   hasArrow={true}
   id="dataSourceSelectableContextMenuPopover"
@@ -199,6 +202,7 @@ Object {
     <div>
       <div
         class="euiPopover euiPopover--anchorDownLeft"
+        data-test-subj="dataSourceSelectableContextMenuPopover"
         id="dataSourceSelectableContextMenuPopover"
       >
         <div
@@ -338,6 +342,7 @@ Object {
   "container": <div>
     <div
       class="euiPopover euiPopover--anchorDownLeft"
+      data-test-subj="dataSourceSelectableContextMenuPopover"
       id="dataSourceSelectableContextMenuPopover"
     >
       <div

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
@@ -90,7 +90,7 @@ describe('DataSourceSelectable', () => {
       <DataSourceSelectable
         savedObjectsClient={client}
         notifications={toasts}
-        onSelectedDataSource={onSelectedDataSource}
+        onSelectedDataSources={onSelectedDataSource}
         disabled={false}
         hideLocalCluster={false}
         fullWidth={false}

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -165,6 +165,7 @@ export class DataSourceSelectable extends React.Component<
         closePopover={this.closePopover.bind(this)}
         panelPaddingSize="none"
         anchorPosition="downLeft"
+        data-test-subj={'dataSourceSelectableContextMenuPopover'}
       >
         <EuiContextMenuPanel>
           <EuiPanel color="transparent" paddingSize="s">

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import { i18n } from '@osd/i18n';
 import {
-  EuiIcon,
   EuiPopover,
   EuiContextMenuPanel,
   EuiPanel,
@@ -19,7 +18,7 @@ import { getDataSourcesWithFields } from '../utils';
 import { LocalCluster } from '../data_source_selector/data_source_selector';
 import { SavedObject } from '../../../../../core/public';
 import { DataSourceAttributes } from '../../types';
-import { DataSourceOption } from './types';
+import { DataSourceOption } from '../data_source_menu/types';
 
 interface DataSourceSelectableProps {
   savedObjectsClient: SavedObjectsClientContract;
@@ -33,9 +32,13 @@ interface DataSourceSelectableProps {
 }
 
 interface DataSourceSelectableState {
-  dataSourceOptions: DataSourceOption[];
-  selectedOption: DataSourceOption[];
+  dataSourceOptions: SelectedDataSourceOption[];
   isPopoverOpen: boolean;
+  selectedOption?: SelectedDataSourceOption[];
+}
+
+interface SelectedDataSourceOption extends DataSourceOption {
+  checked?: boolean;
 }
 
 export class DataSourceSelectable extends React.Component<
@@ -48,6 +51,7 @@ export class DataSourceSelectable extends React.Component<
     super(props);
 
     this.state = {
+      dataSourceOptions: [],
       isPopoverOpen: false,
       selectedOption: this.props.selectedOption
         ? this.props.selectedOption
@@ -76,7 +80,7 @@ export class DataSourceSelectable extends React.Component<
     getDataSourcesWithFields(this.props.savedObjectsClient, ['id', 'title', 'auth.type'])
       .then((fetchedDataSources) => {
         if (fetchedDataSources?.length) {
-          let filteredDataSources = [];
+          let filteredDataSources: Array<SavedObject<DataSourceAttributes>> = [];
           if (this.props.dataSourceFilter) {
             filteredDataSources = fetchedDataSources.filter((ds) =>
               this.props.dataSourceFilter!(ds)
@@ -113,15 +117,21 @@ export class DataSourceSelectable extends React.Component<
       });
   }
 
-  onChange(options) {
+  onChange(options: SelectedDataSourceOption[]) {
     if (!this._isMounted) return;
     const selectedDataSource = options.find(({ checked }) => checked);
 
-    this.setState({
-      selectedOption: [selectedDataSource],
-    });
+    this.setState({ dataSourceOptions: options });
 
-    this.props.onSelectedDataSources([selectedDataSource]);
+    if (selectedDataSource) {
+      this.setState({
+        selectedOption: [selectedDataSource],
+      });
+
+      this.props.onSelectedDataSources([
+        { id: selectedDataSource.id!, label: selectedDataSource.label },
+      ]);
+    }
   }
 
   render() {

--- a/src/plugins/data_source_management/public/components/data_source_selectable/index.ts
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/index.ts
@@ -1,0 +1,5 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export { DataSourceSelectable } from './data_source_selectable';

--- a/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/data_source_selector.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/data_source_selector.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`DataSourceSelector: check dataSource options should always place local 
       },
       Object {
         "id": "test2",
-        "label": "test3",
+        "label": "test2",
       },
       Object {
         "id": "test3",
@@ -127,7 +127,7 @@ exports[`DataSourceSelector: check dataSource options should filter options if c
       },
       Object {
         "id": "test2",
-        "label": "test3",
+        "label": "test2",
       },
       Object {
         "id": "test3",
@@ -176,7 +176,7 @@ exports[`DataSourceSelector: check dataSource options should hide prepend if rem
       },
       Object {
         "id": "test2",
-        "label": "test3",
+        "label": "test2",
       },
       Object {
         "id": "test3",
@@ -247,7 +247,7 @@ exports[`DataSourceSelector: check dataSource options should show custom placeho
       },
       Object {
         "id": "test2",
-        "label": "test3",
+        "label": "test2",
       },
       Object {
         "id": "test3",

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -141,7 +141,7 @@ export const getDataSourcesWithFieldsResponse = {
       type: 'data-source',
       description: 'test datasource2',
       attributes: {
-        title: 'test3',
+        title: 'test2',
         auth: {
           type: AuthType.UsernamePasswordType,
         },


### PR DESCRIPTION
### Description
This change moves data source selectable to its own folder, fix test and a few type errors for data source selectable component

### Issues Resolved


## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/402d3969-07d0-439d-a606-09b5fcf01c36


## Testing the changes
The following were performed in the video:
1. enable data source 
2. go to search relevance which mounted data source selectable component, select a data source from the menu, and it should show the option as selected and also reflect in the button text

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
