### PR TITLE
[Multiple Datasource] Enhanced data source selector with default datasource shows as first choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Make sure customer always have a default datasource ([#6237](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6237))
 - [Workspace] Add workspace list page ([#6182](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6182))
 - [Workspace] Add workspaces column to saved objects page ([#6225](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6225))
+- [Multiple Datasource] Enhanced data source selector with default datasource shows as first choice ([#6293](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6293))
 - [Multiple Datasource] Add multi data source support to sample vega visualizations ([#6218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6218))
 - [Workspace] Add permission control logic ([#6052](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6052))
 

--- a/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/data_source_selector.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/data_source_selector.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`DataSourceSelector should render normally with local cluster is hidden 
   options={Array []}
   placeholder="Select a data source"
   prepend="Data source"
+  renderOption={[Function]}
   selectedOptions={Array []}
   singleSelection={
     Object {
@@ -43,6 +44,7 @@ exports[`DataSourceSelector should render normally with local cluster not hidden
   }
   placeholder="Select a data source"
   prepend="Data source"
+  renderOption={[Function]}
   selectedOptions={
     Array [
       Object {
@@ -92,6 +94,7 @@ exports[`DataSourceSelector: check dataSource options should always place local 
   }
   placeholder="Select a data source"
   prepend="Data source"
+  renderOption={[Function]}
   selectedOptions={
     Array [
       Object {
@@ -137,6 +140,45 @@ exports[`DataSourceSelector: check dataSource options should filter options if c
   }
   placeholder="Select a data source"
   prepend="Data source"
+  renderOption={[Function]}
+  selectedOptions={
+    Array [
+      Object {
+        "id": "",
+        "label": "Local cluster",
+      },
+    ]
+  }
+  singleSelection={
+    Object {
+      "asPlainText": true,
+    }
+  }
+  sortMatchesBy="none"
+/>
+`;
+
+exports[`DataSourceSelector: check dataSource options should get default datasource if uiSettings exists 1`] = `
+<EuiComboBox
+  aria-label="Select a data source"
+  async={false}
+  compressed={false}
+  data-test-subj="dataSourceSelectorComboBox"
+  fullWidth={false}
+  isClearable={true}
+  isDisabled={false}
+  onChange={[Function]}
+  options={
+    Array [
+      Object {
+        "id": "",
+        "label": "Local cluster",
+      },
+    ]
+  }
+  placeholder="Select a data source"
+  prepend="Data source"
+  renderOption={[Function]}
   selectedOptions={
     Array [
       Object {
@@ -185,6 +227,45 @@ exports[`DataSourceSelector: check dataSource options should hide prepend if rem
     ]
   }
   placeholder="Select a data source"
+  renderOption={[Function]}
+  selectedOptions={
+    Array [
+      Object {
+        "id": "",
+        "label": "Local cluster",
+      },
+    ]
+  }
+  singleSelection={
+    Object {
+      "asPlainText": true,
+    }
+  }
+  sortMatchesBy="none"
+/>
+`;
+
+exports[`DataSourceSelector: check dataSource options should not render options with default badge when id does not matches defaultDataSource 1`] = `
+<EuiComboBox
+  aria-label="Select a data source"
+  async={false}
+  compressed={false}
+  data-test-subj="dataSourceSelectorComboBox"
+  fullWidth={false}
+  isClearable={true}
+  isDisabled={false}
+  onChange={[Function]}
+  options={
+    Array [
+      Object {
+        "id": "",
+        "label": "Local cluster",
+      },
+    ]
+  }
+  placeholder="Select a data source"
+  prepend="Data source"
+  renderOption={[Function]}
   selectedOptions={
     Array [
       Object {
@@ -215,6 +296,7 @@ exports[`DataSourceSelector: check dataSource options should return empty option
   options={Array []}
   placeholder="Select a data source"
   prepend="Data source"
+  renderOption={[Function]}
   selectedOptions={Array []}
   singleSelection={
     Object {
@@ -257,6 +339,7 @@ exports[`DataSourceSelector: check dataSource options should show custom placeho
   }
   placeholder="Make a selection"
   prepend="Data source"
+  renderOption={[Function]}
   selectedOptions={
     Array [
       Object {

--- a/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.test.tsx
@@ -7,9 +7,11 @@ import { SavedObjectsClientContract } from '../../../../../core/public';
 import { notificationServiceMock } from '../../../../../core/public/mocks';
 import React from 'react';
 import { render } from '@testing-library/react';
+import { coreMock } from '../../../../../core/public/mocks';
 
 describe('create data source selector', () => {
   let client: SavedObjectsClientContract;
+  const { uiSettings } = coreMock.createSetup();
   const { toasts } = notificationServiceMock.createStartContract();
 
   beforeEach(() => {
@@ -27,7 +29,7 @@ describe('create data source selector', () => {
       hideLocalCluster: false,
       fullWidth: false,
     };
-    const TestComponent = createDataSourceSelector();
+    const TestComponent = createDataSourceSelector(uiSettings);
     const component = render(<TestComponent {...props} />);
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({

--- a/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.tsx
@@ -4,8 +4,11 @@
  */
 
 import React from 'react';
+import { IUiSettingsClient } from 'src/core/public';
 import { DataSourceSelector, DataSourceSelectorProps } from './data_source_selector';
 
-export function createDataSourceSelector() {
-  return (props: DataSourceSelectorProps) => <DataSourceSelector {...props} />;
+export function createDataSourceSelector(uiSettings: IUiSettingsClient) {
+  return (props: DataSourceSelectorProps) => (
+    <DataSourceSelector {...props} uiSettings={uiSettings} />
+  );
 }

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
@@ -130,7 +130,7 @@ export class DataSourceSelector extends React.Component<
         ? 'Select a data source'
         : this.props.placeholderText;
 
-    // We render again here to make sure each time we will get the latest filtered data sources
+    // The filter condition can be changed, thus we filter again here to make sure each time we will get the filtered data sources before rendering
     const dataSources = getFilteredDataSources(
       this.state.allDataSources,
       this.props.dataSourceFilter

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
@@ -5,9 +5,10 @@
 
 import React from 'react';
 import { i18n } from '@osd/i18n';
-import { EuiComboBox } from '@elastic/eui';
+import { EuiComboBox, EuiBadge, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 import { SavedObjectsClientContract, ToastsStart, SavedObject } from 'opensearch-dashboards/public';
-import { getDataSourcesWithFields } from '../utils';
+import { IUiSettingsClient } from 'src/core/public';
+import { getDataSourcesWithFields, getDefaultDataSource, getFilteredDataSources } from '../utils';
 import { DataSourceAttributes } from '../../types';
 
 export const LocalCluster: DataSourceOption = {
@@ -29,11 +30,13 @@ export interface DataSourceSelectorProps {
   removePrepend?: boolean;
   dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
   compressed?: boolean;
+  uiSettings?: IUiSettingsClient;
 }
 
 interface DataSourceSelectorState {
   selectedOption: DataSourceOption[];
   allDataSources: Array<SavedObject<DataSourceAttributes>>;
+  defaultDataSource: string | null;
 }
 
 export interface DataSourceOption {
@@ -53,6 +56,7 @@ export class DataSourceSelector extends React.Component<
 
     this.state = {
       allDataSources: [],
+      defaultDataSource: '',
       selectedOption: this.props.defaultOption
         ? this.props.defaultOption
         : this.props.hideLocalCluster
@@ -67,6 +71,13 @@ export class DataSourceSelector extends React.Component<
 
   async componentDidMount() {
     this._isMounted = true;
+
+    const currentDefaultDataSource = this.props.uiSettings?.get('defaultDataSource', null) ?? null;
+    this.setState({
+      ...this.state,
+      defaultDataSource: currentDefaultDataSource,
+    });
+
     getDataSourcesWithFields(this.props.savedObjectsClient, ['id', 'title', 'auth.type'])
       .then((fetchedDataSources) => {
         if (fetchedDataSources?.length) {
@@ -74,6 +85,25 @@ export class DataSourceSelector extends React.Component<
           this.setState({
             ...this.state,
             allDataSources: fetchedDataSources,
+          });
+        }
+        const dataSources = getFilteredDataSources(
+          this.state.allDataSources,
+          this.props.dataSourceFilter
+        );
+        const selectedDataSource = getDefaultDataSource(
+          dataSources,
+          LocalCluster,
+          this.props.uiSettings,
+          this.props.hideLocalCluster,
+          this.props.defaultOption
+        );
+        if (selectedDataSource.length === 0) {
+          this.props.notifications.addWarning('No connected data source available.');
+        } else {
+          this.props.onSelectedDataSource(selectedDataSource);
+          this.setState({
+            selectedOption: selectedDataSource,
           });
         }
       })
@@ -100,9 +130,11 @@ export class DataSourceSelector extends React.Component<
         ? 'Select a data source'
         : this.props.placeholderText;
 
-    const dataSources = this.props.dataSourceFilter
-      ? this.state.allDataSources.filter((ds) => this.props.dataSourceFilter!(ds))
-      : this.state.allDataSources;
+    // We render again here to make sure each time we will get the latest filtered data sources
+    const dataSources = getFilteredDataSources(
+      this.state.allDataSources,
+      this.props.dataSourceFilter
+    );
 
     const options = dataSources.map((ds) => ({ id: ds.id, label: ds.attributes?.title || '' }));
     if (!this.props.hideLocalCluster) {
@@ -140,6 +172,16 @@ export class DataSourceSelector extends React.Component<
         isDisabled={this.props.disabled}
         fullWidth={this.props.fullWidth || false}
         data-test-subj={'dataSourceSelectorComboBox'}
+        renderOption={(option) => (
+          <EuiFlexGroup alignItems="center">
+            <EuiFlexItem grow={1}>{option.label}</EuiFlexItem>
+            {option.id === this.state.defaultDataSource && (
+              <EuiFlexItem grow={false}>
+                <EuiBadge iconSide="left">Default</EuiBadge>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        )}
       />
     );
   }

--- a/src/plugins/data_source_management/public/components/utils.test.ts
+++ b/src/plugins/data_source_management/public/components/utils.test.ts
@@ -16,6 +16,8 @@ import {
   updateDataSourceById,
   handleSetDefaultDatasource,
   setFirstDataSourceAsDefault,
+  getFilteredDataSources,
+  getDefaultDataSource,
 } from './utils';
 import { coreMock } from '../../../../core/public/mocks';
 import {
@@ -28,6 +30,7 @@ import {
   mockResponseForSavedObjectsCalls,
   mockUiSettingsCalls,
   getSingleDataSourceResponse,
+  getDataSource,
 } from '../mocks';
 import {
   AuthType,
@@ -35,9 +38,10 @@ import {
   sigV4AuthMethod,
   usernamePasswordAuthMethod,
 } from '../types';
-import { HttpStart } from 'opensearch-dashboards/public';
+import { HttpStart, SavedObject } from 'opensearch-dashboards/public';
 import { AuthenticationMethod, AuthenticationMethodRegistry } from '../auth_registry';
 import { deepEqual } from 'assert';
+import { DataSourceAttributes } from 'src/plugins/data_source/common/data_sources';
 
 const { savedObjects } = coreMock.createStart();
 const { uiSettings } = coreMock.createStart();
@@ -493,6 +497,86 @@ describe('DataSourceManagement: Utils.ts', () => {
       );
 
       expect(deepEqual(registedAuthTypeCredentials, expectExtractedAuthCredentials));
+    });
+  });
+
+  describe('Check on get filter datasource', () => {
+    test('should return all data sources when no filter is provided', () => {
+      const dataSources: Array<SavedObject<DataSourceAttributes>> = [
+        {
+          id: '1',
+          type: '',
+          references: [],
+          attributes: {
+            title: 'DataSource 1',
+            endpoint: '',
+            auth: { type: AuthType.NoAuth, credentials: undefined },
+            name: AuthType.NoAuth,
+          },
+        },
+      ];
+
+      const result = getFilteredDataSources(dataSources);
+
+      expect(result).toEqual(dataSources);
+    });
+
+    test('should return filtered data sources when a filter is provided', () => {
+      const filter = (dataSource: SavedObject<DataSourceAttributes>) => dataSource.id === '2';
+      const result = getFilteredDataSources(getDataSource, filter);
+
+      expect(result).toEqual([
+        {
+          id: '2',
+          type: '',
+          references: [],
+          attributes: {
+            title: 'DataSource 1',
+            endpoint: '',
+            auth: { type: AuthType.NoAuth, credentials: undefined },
+            name: AuthType.NoAuth,
+          },
+        },
+      ]);
+    });
+  });
+  describe('getDefaultDataSource', () => {
+    const LocalCluster = { id: 'local', label: 'Local Cluster' };
+    const hideLocalCluster = false;
+    const defaultOption = [{ id: '2', label: 'Default Option' }];
+
+    it('should return the default option if it exists in the data sources', () => {
+      const result = getDefaultDataSource(
+        getDataSource,
+        LocalCluster,
+        uiSettings,
+        hideLocalCluster,
+        defaultOption
+      );
+      expect(result).toEqual([defaultOption[0]]);
+    });
+
+    it('should return local cluster if it exists and no default options in the data sources', () => {
+      mockUiSettingsCalls(uiSettings, 'get', null);
+      const result = getDefaultDataSource(
+        getDataSource,
+        LocalCluster,
+        uiSettings,
+        hideLocalCluster
+      );
+      expect(result).toEqual([LocalCluster]);
+    });
+
+    it('should return the default datasource if hideLocalCluster is false', () => {
+      mockUiSettingsCalls(uiSettings, 'get', '1');
+      const result = getDefaultDataSource(getDataSource, LocalCluster, uiSettings, true);
+      expect(result).toEqual([{ id: '1', label: 'DataSource 1' }]);
+    });
+
+    it('should return an empty default data source if no default option, hideLocalCluster is ture and no default datasource', () => {
+      mockUiSettingsCalls(uiSettings, 'get', null);
+      const result = getDefaultDataSource(getDataSource, LocalCluster, uiSettings, true);
+      expect(result).toEqual([]);
     });
   });
 });

--- a/src/plugins/data_source_management/public/components/utils.test.ts
+++ b/src/plugins/data_source_management/public/components/utils.test.ts
@@ -531,7 +531,7 @@ describe('DataSourceManagement: Utils.ts', () => {
           type: '',
           references: [],
           attributes: {
-            title: 'DataSource 1',
+            title: 'DataSource 2',
             endpoint: '',
             auth: { type: AuthType.NoAuth, credentials: undefined },
             name: AuthType.NoAuth,
@@ -568,15 +568,15 @@ describe('DataSourceManagement: Utils.ts', () => {
     });
 
     it('should return the default datasource if hideLocalCluster is false', () => {
-      mockUiSettingsCalls(uiSettings, 'get', '1');
+      mockUiSettingsCalls(uiSettings, 'get', '2');
       const result = getDefaultDataSource(getDataSource, LocalCluster, uiSettings, true);
-      expect(result).toEqual([{ id: '1', label: 'DataSource 1' }]);
+      expect(result).toEqual([{ id: '2', label: 'DataSource 2' }]);
     });
 
-    it('should return an empty default data source if no default option, hideLocalCluster is ture and no default datasource', () => {
+    it('should return the first data source if no default option, hideLocalCluster is ture and no default datasource', () => {
       mockUiSettingsCalls(uiSettings, 'get', null);
       const result = getDefaultDataSource(getDataSource, LocalCluster, uiSettings, true);
-      expect(result).toEqual([]);
+      expect(result).toEqual([{ id: '1', label: 'DataSource 1' }]);
     });
   });
 });

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -110,18 +110,20 @@ export function getDefaultDataSource(
         label: defaultOption?.[0]?.label || defaultOptionDataSource.attributes?.title,
       },
     ];
-  } else if (defaultDataSourceAfterCheck) {
+}
+if (defaultDataSourceAfterCheck) {
     return [
       {
         id: defaultDataSourceAfterCheck.id,
         label: defaultDataSourceAfterCheck.attributes?.title || '',
       },
     ];
-  } else if (!hideLocalCluster) {
-    return [LocalCluster];
-  } else {
-    return [];
   }
+  if (!hideLocalCluster) {
+    return [LocalCluster];
+  } 
+    return [];
+  
 }
 
 export async function getDataSourceById(

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -110,8 +110,8 @@ export function getDefaultDataSource(
         label: defaultOption?.[0]?.label || defaultOptionDataSource.attributes?.title,
       },
     ];
-}
-if (defaultDataSourceAfterCheck) {
+  }
+  if (defaultDataSourceAfterCheck) {
     return [
       {
         id: defaultDataSourceAfterCheck.id,
@@ -121,9 +121,16 @@ if (defaultDataSourceAfterCheck) {
   }
   if (!hideLocalCluster) {
     return [LocalCluster];
-  } 
-    return [];
-  
+  }
+  if (dataSources.length > 0) {
+    return [
+      {
+        id: dataSources[0].id,
+        label: dataSources[0].attributes.title,
+      },
+    ];
+  }
+  return [];
 }
 
 export async function getDataSourceById(

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -78,6 +78,42 @@ export const getSingleDataSourceResponse = {
   ],
 };
 
+export const getDataSource = [
+  {
+    id: '1',
+    type: '',
+    references: [],
+    attributes: {
+      title: 'DataSource 1',
+      endpoint: '',
+      auth: { type: AuthType.NoAuth, credentials: undefined },
+      name: AuthType.NoAuth,
+    },
+  },
+  {
+    id: '2',
+    type: '',
+    references: [],
+    attributes: {
+      title: 'DataSource 1',
+      endpoint: '',
+      auth: { type: AuthType.NoAuth, credentials: undefined },
+      name: AuthType.NoAuth,
+    },
+  },
+  {
+    id: '3',
+    type: '',
+    references: [],
+    attributes: {
+      title: 'DataSource 1',
+      endpoint: '',
+      auth: { type: AuthType.NoAuth, credentials: undefined },
+      name: AuthType.NoAuth,
+    },
+  },
+];
+
 /* Mock data responses - JSON*/
 export const getDataSourcesResponse = {
   savedObjects: [

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -95,7 +95,7 @@ export const getDataSource = [
     type: '',
     references: [],
     attributes: {
-      title: 'DataSource 1',
+      title: 'DataSource 2',
       endpoint: '',
       auth: { type: AuthType.NoAuth, credentials: undefined },
       name: AuthType.NoAuth,

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -57,6 +57,7 @@ export class DataSourceManagementPlugin
     { management, indexPatternManagement, dataSource }: DataSourceManagementSetupDependencies
   ) {
     const opensearchDashboardsSection = management.sections.section.opensearchDashboards;
+    const uiSettings = core.uiSettings;
 
     if (!opensearchDashboardsSection) {
       throw new Error('`opensearchDashboards` management section not found.');
@@ -102,7 +103,7 @@ export class DataSourceManagementPlugin
     return {
       registerAuthenticationMethod,
       ui: {
-        DataSourceSelector: createDataSourceSelector(),
+        DataSourceSelector: createDataSourceSelector(uiSettings),
         getDataSourceMenu: <T>() => createDataSourceMenu<T>(),
       },
     };

--- a/src/plugins/dev_tools/public/application.tsx
+++ b/src/plugins/dev_tools/public/application.tsx
@@ -77,7 +77,7 @@ function DevToolsWrapper({
   uiSettings,
 }: DevToolsWrapperProps) {
   const mountedTool = useRef<MountedDevToolDescriptor | null>(null);
-  const [isLoading, setIsLoading] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState<boolean>(true);
 
   useEffect(
     () => () => {
@@ -114,7 +114,7 @@ function DevToolsWrapper({
       mountpoint: mountPoint,
       unmountHandler,
     };
-    setIsLoading(true);
+    setIsLoading(false);
   };
 
   return (
@@ -135,7 +135,7 @@ function DevToolsWrapper({
             </EuiTab>
           </EuiToolTip>
         ))}
-        {dataSourceEnabled && isLoading ? (
+        {dataSourceEnabled && !isLoading ? (
           <div className="devAppDataSourceSelector">
             <DataSourceSelector
               savedObjectsClient={savedObjects.client}

--- a/src/plugins/dev_tools/public/application.tsx
+++ b/src/plugins/dev_tools/public/application.tsx
@@ -39,6 +39,7 @@ import {
   ApplicationStart,
   ChromeStart,
   CoreStart,
+  IUiSettingsClient,
   NotificationsStart,
   SavedObjectsStart,
   ScopedHistory,
@@ -48,7 +49,6 @@ import { DataSourceSelector } from '../../data_source_management/public';
 import { DevToolApp } from './dev_tool';
 import { DevToolsSetupDependencies } from './plugin';
 import { addHelpMenuToAppChrome } from './utils/util';
-
 interface DevToolsWrapperProps {
   devTools: readonly DevToolApp[];
   activeDevTool: DevToolApp;
@@ -57,6 +57,7 @@ interface DevToolsWrapperProps {
   notifications: NotificationsStart;
   dataSourceEnabled: boolean;
   hideLocalCluster: boolean;
+  uiSettings: IUiSettingsClient;
 }
 
 interface MountedDevToolDescriptor {
@@ -73,8 +74,10 @@ function DevToolsWrapper({
   notifications: { toasts },
   dataSourceEnabled,
   hideLocalCluster,
+  uiSettings,
 }: DevToolsWrapperProps) {
   const mountedTool = useRef<MountedDevToolDescriptor | null>(null);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   useEffect(
     () => () => {
@@ -111,6 +114,7 @@ function DevToolsWrapper({
       mountpoint: mountPoint,
       unmountHandler,
     };
+    setIsLoading(true);
   };
 
   return (
@@ -131,7 +135,7 @@ function DevToolsWrapper({
             </EuiTab>
           </EuiToolTip>
         ))}
-        {dataSourceEnabled ? (
+        {dataSourceEnabled && isLoading ? (
           <div className="devAppDataSourceSelector">
             <DataSourceSelector
               savedObjectsClient={savedObjects.client}
@@ -140,6 +144,7 @@ function DevToolsWrapper({
               disabled={!dataSourceEnabled}
               hideLocalCluster={hideLocalCluster}
               fullWidth={false}
+              uiSettings={uiSettings}
             />
           </div>
         ) : null}
@@ -213,7 +218,7 @@ function setBreadcrumbs(chrome: ChromeStart) {
 }
 
 export function renderApp(
-  { application, chrome, docLinks, savedObjects, notifications }: CoreStart,
+  { application, chrome, docLinks, savedObjects, notifications, uiSettings }: CoreStart,
   element: HTMLElement,
   history: ScopedHistory,
   devTools: readonly DevToolApp[],
@@ -251,6 +256,7 @@ export function renderApp(
                     notifications={notifications}
                     dataSourceEnabled={dataSourceEnabled}
                     hideLocalCluster={hideLocalCluster}
+                    uiSettings={uiSettings}
                   />
                 )}
               />

--- a/src/plugins/home/public/application/components/tutorial_directory.js
+++ b/src/plugins/home/public/application/components/tutorial_directory.js
@@ -236,6 +236,7 @@ class TutorialDirectoryUi extends React.Component {
           onSelectedDataSource={this.onSelectedDataSourceChange}
           disabled={!isDataSourceEnabled}
           hideLocalCluster={isLocalClusterHidden}
+          uiSettings={getServices().uiSettings}
         />
       </div>
     ) : null;


### PR DESCRIPTION
### Description
*  add the default icon in the selector
* Add a showDefault function that plugins team can use and get the Default datasource

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/64cc706e-a468-466d-b3ad-a9516d8ae63c


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
