### PR TITLE
[Backport 2.x] Fix sslConfig for multiple datasource to handle when certificateAuthorities is unset (#6282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 🐛 Bug Fixes
 
+- [Multiple Datasource] Fix sslConfig for multiple datasource to handle when certificateAuthorities is unset ([#6282](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6282))
+
 ### 🚞 Infrastructure
 
 ### 📝 Documentation

--- a/src/plugins/data_source/server/client/client_config.test.ts
+++ b/src/plugins/data_source/server/client/client_config.test.ts
@@ -46,7 +46,7 @@ describe('parseClientOptions', () => {
         ssl: {
           requestCert: true,
           rejectUnauthorized: false,
-          ca: [],
+          ca: undefined,
         },
       })
     );
@@ -105,6 +105,33 @@ describe('parseClientOptions', () => {
           requestCert: true,
           rejectUnauthorized: true,
           ca: ['content-of-some-path'],
+        },
+      })
+    );
+  });
+
+  test('test ssl config with verification mode set to full with no ca list', () => {
+    const config = {
+      enabled: true,
+      ssl: {
+        verificationMode: 'full',
+      },
+      clientPool: {
+        size: 5,
+      },
+    } as DataSourcePluginConfigType;
+    mockReadFileSync.mockReset();
+    mockReadFileSync.mockImplementation((path: string) => `content-of-${path}`);
+    const parsedConfig = parseClientOptions(config, TEST_DATA_SOURCE_ENDPOINT);
+    expect(mockReadFileSync).toHaveBeenCalledTimes(0);
+    mockReadFileSync.mockClear();
+    expect(parsedConfig).toEqual(
+      expect.objectContaining({
+        node: TEST_DATA_SOURCE_ENDPOINT,
+        ssl: {
+          requestCert: true,
+          rejectUnauthorized: true,
+          ca: undefined,
         },
       })
     );

--- a/src/plugins/data_source/server/client/client_config.ts
+++ b/src/plugins/data_source/server/client/client_config.ts
@@ -56,7 +56,7 @@ export function parseClientOptions(
       config.ssl?.certificateAuthorities
     );
 
-    sslConfig.ca = certificateAuthorities || [];
+    sslConfig.ca = certificateAuthorities;
   }
 
   const clientOptions: ClientOptions = {

--- a/src/plugins/data_source/server/legacy/client_config.test.ts
+++ b/src/plugins/data_source/server/legacy/client_config.test.ts
@@ -44,7 +44,7 @@ describe('parseClientOptions', () => {
         host: TEST_DATA_SOURCE_ENDPOINT,
         ssl: {
           rejectUnauthorized: false,
-          ca: [],
+          ca: undefined,
         },
       })
     );
@@ -101,6 +101,32 @@ describe('parseClientOptions', () => {
         ssl: {
           rejectUnauthorized: true,
           ca: ['content-of-some-path'],
+        },
+      })
+    );
+  });
+
+  test('test ssl config with verification mode set to full with no ca list', () => {
+    const config = {
+      enabled: true,
+      ssl: {
+        verificationMode: 'full',
+      },
+      clientPool: {
+        size: 5,
+      },
+    } as DataSourcePluginConfigType;
+    mockReadFileSync.mockReset();
+    mockReadFileSync.mockImplementation((path: string) => `content-of-${path}`);
+    const parsedConfig = parseClientOptions(config, TEST_DATA_SOURCE_ENDPOINT);
+    expect(mockReadFileSync).toHaveBeenCalledTimes(0);
+    mockReadFileSync.mockClear();
+    expect(parsedConfig).toEqual(
+      expect.objectContaining({
+        host: TEST_DATA_SOURCE_ENDPOINT,
+        ssl: {
+          rejectUnauthorized: true,
+          ca: undefined,
         },
       })
     );

--- a/src/plugins/data_source/server/legacy/client_config.ts
+++ b/src/plugins/data_source/server/legacy/client_config.ts
@@ -55,7 +55,7 @@ export function parseClientOptions(
       config.ssl?.certificateAuthorities
     );
 
-    sslConfig.ca = certificateAuthorities || [];
+    sslConfig.ca = certificateAuthorities;
   }
 
   const configOptions: ConfigOptions = {

--- a/src/plugins/data_source/server/util/tls_settings_provider.test.ts
+++ b/src/plugins/data_source/server/util/tls_settings_provider.test.ts
@@ -40,7 +40,7 @@ describe('readCertificateAuthorities', () => {
     expect(mockReadFileSync).toHaveBeenCalledTimes(0);
     mockReadFileSync.mockClear();
     expect(certificateAuthorities).toEqual({
-      certificateAuthorities: [],
+      certificateAuthorities: undefined,
     });
   });
 
@@ -52,7 +52,7 @@ describe('readCertificateAuthorities', () => {
     expect(mockReadFileSync).toHaveBeenCalledTimes(0);
     mockReadFileSync.mockClear();
     expect(certificateAuthorities).toEqual({
-      certificateAuthorities: [],
+      certificateAuthorities: undefined,
     });
   });
 });

--- a/src/plugins/data_source/server/util/tls_settings_provider.ts
+++ b/src/plugins/data_source/server/util/tls_settings_provider.ts
@@ -8,7 +8,7 @@ import { readFileSync } from 'fs';
 export const readCertificateAuthorities = (
   listOfCertificateAuthorities: string | string[] | undefined
 ) => {
-  let certificateAuthorities: string[] | undefined = [];
+  let certificateAuthorities: string[] | undefined;
 
   const addCertificateAuthorities = (ca: string[]) => {
     if (ca && ca.length) {


### PR DESCRIPTION
Manual backport of #6282 to 2.x