### PR TITLE
Add default icon for selectable component and make sure the default datasource shows automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Add multi data source support to sample vega visualizations ([#6218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6218))
 - [Multiple Datasource] Fetch data source title for DataSourceView when only id is provided ([#6315](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6315)
 - [Workspace] Add permission control logic ([#6052](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6052))
+- [Multiple Datasource] Add default icon for selectable component and make sure the default datasource shows automatically ([#6327](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6327))
 - [Multiple Datasource] Pass selected data sources to plugin consumers when the multi-select component initially loads ([#6333](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6333))
 
 ### 🐛 Bug Fixes

--- a/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.tsx
@@ -5,17 +5,18 @@
 
 import React from 'react';
 import { EuiHeaderLinks } from '@elastic/eui';
+import { IUiSettingsClient } from 'src/core/public';
 import { DataSourceMenu } from './data_source_menu';
 import { DataSourceMenuProps } from './types';
 import { MountPointPortal } from '../../../../opensearch_dashboards_react/public';
 
-export function createDataSourceMenu<T>() {
+export function createDataSourceMenu<T>(uiSettings: IUiSettingsClient) {
   return (props: DataSourceMenuProps<T>) => {
     if (props.setMenuMountPoint) {
       return (
         <MountPointPortal setMountPoint={props.setMenuMountPoint}>
           <EuiHeaderLinks data-test-subj="top-nav" gutterSize="xs">
-            <DataSourceMenu {...props} />
+            <DataSourceMenu {...props} uiSettings={uiSettings} />
           </EuiHeaderLinks>
         </MountPointPortal>
       );

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -19,7 +19,7 @@ import {
 import { DataSourceSelectable } from '../data_source_selectable';
 
 export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement | null {
-  const { componentType, componentConfig } = props;
+  const { componentType, componentConfig, uiSettings } = props;
 
   function renderDataSourceView(config: DataSourceViewConfig): ReactElement | null {
     const { activeOption, fullWidth, savedObjects, notifications } = config;
@@ -75,6 +75,7 @@ export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement |
         dataSourceFilter={dataSourceFilter}
         hideLocalCluster={hideLocalCluster || false}
         fullWidth={fullWidth}
+        uiSettings={uiSettings}
       />
     );
   }

--- a/src/plugins/data_source_management/public/components/data_source_menu/types.ts
+++ b/src/plugins/data_source_management/public/components/data_source_menu/types.ts
@@ -7,6 +7,7 @@ import {
   NotificationsStart,
   SavedObjectsClientContract,
   SavedObject,
+  IUiSettingsClient,
 } from '../../../../../core/public';
 import { DataSourceAttributes } from '../../types';
 
@@ -23,6 +24,7 @@ export interface DataSourceBaseConfig {
 export interface DataSourceMenuProps<T = any> {
   componentType: DataSourceComponentType;
   componentConfig: T;
+  uiSettings?: IUiSettingsClient;
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
 }
 

--- a/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
@@ -35,6 +35,11 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
     <EuiPanel
       color="transparent"
       paddingSize="s"
+      style={
+        Object {
+          "width": "300px",
+        }
+      }
     >
       <EuiSpacer
         size="s"
@@ -47,6 +52,7 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
         options={
           Array [
             Object {
+              "checked": "on",
               "id": "",
               "label": "Local cluster",
             },
@@ -60,6 +66,7 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
             },
           ]
         }
+        renderOption={[Function]}
         searchProps={
           Object {
             "placeholder": "Search",
@@ -110,6 +117,11 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
     <EuiPanel
       color="transparent"
       paddingSize="s"
+      style={
+        Object {
+          "width": "300px",
+        }
+      }
     >
       <EuiSpacer
         size="s"
@@ -120,6 +132,7 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
         isPreFiltered={false}
         onChange={[Function]}
         options={Array []}
+        renderOption={[Function]}
         searchProps={
           Object {
             "placeholder": "Search",
@@ -150,7 +163,7 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
         onClick={[Function]}
         size="s"
       >
-        Local cluster
+        
       </EuiButtonEmpty>
     </React.Fragment>
   }
@@ -170,6 +183,11 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
     <EuiPanel
       color="transparent"
       paddingSize="s"
+      style={
+        Object {
+          "width": "300px",
+        }
+      }
     >
       <EuiSpacer
         size="s"
@@ -180,6 +198,7 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
         isPreFiltered={false}
         onChange={[Function]}
         options={Array []}
+        renderOption={[Function]}
         searchProps={
           Object {
             "placeholder": "Search",
@@ -264,6 +283,7 @@ Object {
                 <div>
                   <div
                     class="euiPanel euiPanel--paddingSmall euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow"
+                    style="width: 300px;"
                   >
                     <div
                       class="euiSpacer euiSpacer--s"

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
@@ -11,6 +11,7 @@ import { DataSourceSelectable } from './data_source_selectable';
 import { AuthType } from '../../types';
 import { getDataSourcesWithFieldsResponse, mockResponseForSavedObjectsCalls } from '../../mocks';
 import { render } from '@testing-library/react';
+import * as utils from '../utils';
 
 describe('DataSourceSelectable', () => {
   let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
@@ -109,6 +110,7 @@ describe('DataSourceSelectable', () => {
 
   it('should callback if changed state', async () => {
     const onSelectedDataSource = jest.fn();
+    spyOn(utils, 'getDefaultDataSource').and.returnValue([{ id: 'test2', label: 'test2' }]);
     const container = mount(
       <DataSourceSelectable
         savedObjectsClient={client}
@@ -125,7 +127,7 @@ describe('DataSourceSelectable', () => {
     const containerInstance = container.instance();
 
     containerInstance.onChange([{ id: 'test2', label: 'test2' }]);
-    expect(onSelectedDataSource).toBeCalledTimes(0);
+    expect(onSelectedDataSource).toBeCalledTimes(1);
     expect(containerInstance.state).toEqual({
       dataSourceOptions: [
         {
@@ -133,11 +135,12 @@ describe('DataSourceSelectable', () => {
           label: 'test2',
         },
       ],
+      defaultDataSource: null,
       isPopoverOpen: false,
       selectedOption: [
         {
-          id: '',
-          label: 'Local cluster',
+          id: 'test2',
+          label: 'test2',
         },
       ],
     });
@@ -151,6 +154,7 @@ describe('DataSourceSelectable', () => {
           label: 'test2',
         },
       ],
+      defaultDataSource: null,
       isPopoverOpen: false,
       selectedOption: [
         {
@@ -160,7 +164,9 @@ describe('DataSourceSelectable', () => {
         },
       ],
     });
+
     expect(onSelectedDataSource).toBeCalledWith([{ id: 'test2', label: 'test2' }]);
-    expect(onSelectedDataSource).toBeCalledTimes(1);
+    expect(onSelectedDataSource).toHaveBeenCalled();
+    expect(utils.getDefaultDataSource).toHaveBeenCalled();
   });
 });

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -16,7 +16,7 @@ import {
   noAuthCredentialAuthMethod,
 } from '../types';
 import { AuthenticationMethodRegistry } from '../auth_registry';
-import { DataSourceOption } from './data_source_selector/data_source_selector';
+import { DataSourceOption } from './data_source_menu/types';
 
 export async function getDataSources(savedObjectsClient: SavedObjectsClientContract) {
   return savedObjectsClient

--- a/src/plugins/data_source_management/public/plugin.test.ts
+++ b/src/plugins/data_source_management/public/plugin.test.ts
@@ -21,5 +21,9 @@ describe('#dataSourceManagement', () => {
     const start = doStart();
     const registry = start.getAuthenticationMethodRegistry();
     expect(registry.getAuthenticationMethod('typeA')).toEqual(typeA);
+    expect(setup.ui).toEqual({
+      DataSourceSelector: expect.any(Function),
+      getDataSourceMenu: expect.any(Function),
+    });
   });
 });

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -104,7 +104,7 @@ export class DataSourceManagementPlugin
       registerAuthenticationMethod,
       ui: {
         DataSourceSelector: createDataSourceSelector(uiSettings),
-        getDataSourceMenu: <T>() => createDataSourceMenu<T>(),
+        getDataSourceMenu: <T>() => createDataSourceMenu<T>(uiSettings),
       },
     };
   }


### PR DESCRIPTION
### Description
Modify seletable picker in datasource management to show the default datasource
### Issues Resolved



## Screenshot


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/979a66de-a8be-4d16-903c-6a8ea962628b


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
