### PR TITLE
[Multiple Datasource] Pass selected data sources to plugin consumers when the multi-select component initially loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Add multi data source support to sample vega visualizations ([#6218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6218))
 - [Multiple Datasource] Fetch data source title for DataSourceView when only id is provided ([#6315](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6315)
 - [Workspace] Add permission control logic ([#6052](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6052))
+- [Multiple Datasource] Pass selected data sources to plugin consumers when the multi-select component initially loads ([#6333](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6333))
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
@@ -70,6 +70,10 @@ export class DataSourceMultiSelectable extends React.Component<
             ...this.state,
             selectedOptions,
           });
+
+          this.props.onSelectedDataSources(
+            selectedOptions.filter((option) => option.checked === 'on')
+          );
         }
       })
       .catch(() => {


### PR DESCRIPTION
### Description

The multi-selectable component does not call the callback function on initial load of the component. This means that plugins cannot initially fetch the dataSourceIds when first rendering the page. This PR makes a call to the callback function upon `componentDidMount()`

### Issues Resolved

Closes #6324 

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/2c258196-6cb9-499f-8143-5fc19c73eeeb

## Testing the changes

In the `multi-select` component, a `console.log()` statement was added to the callback function and this callback function was passed into the `multi-select` component. Because the log statement was called without any selection changes, it shows that the callback function was called when the `multi-select` component initially loaded.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
