### PR TITLE
[Multiple Datasource] Add installedPlugins list to data source saved …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Workspace] Add permission control logic ([#6052](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6052))
 - [Multiple Datasource] Add default icon for selectable component and make sure the default datasource shows automatically ([#6327](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6327))
 - [Multiple Datasource] Pass selected data sources to plugin consumers when the multi-select component initially loads ([#6333](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6333))
+- [Multiple Datasource] Add installedPlugins list to data source saved object ([#6348](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6348))
 - [Workspace] Add APIs to support plugin state in request ([#6303](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6303))
 
 ### 🐛 Bug Fixes

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -30,7 +30,7 @@ import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../common';
 import { ensureRawRequest } from '../../../../src/core/server/http/router';
 import { createDataSourceError } from './lib/error';
 import { registerTestConnectionRoute } from './routes/test_connection';
-import { registerFetchDataSourceVersionRoute } from './routes/fetch_data_source_version';
+import { registerFetchDataSourceMetaDataRoute } from './routes/fetch_data_source_metadata';
 import { AuthenticationMethodRegistry, IAuthenticationMethodRegistry } from './auth_registry';
 import { CustomApiSchemaRegistry } from './schema_registry';
 
@@ -134,7 +134,7 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
       authRegistryPromise,
       customApiSchemaRegistryPromise
     );
-    registerFetchDataSourceVersionRoute(
+    registerFetchDataSourceMetaDataRoute(
       router,
       dataSourceService,
       cryptographyServiceSetup,

--- a/src/plugins/data_source/server/routes/data_source_connection_validator.test.ts
+++ b/src/plugins/data_source/server/routes/data_source_connection_validator.test.ts
@@ -41,6 +41,38 @@ describe('DataSourceManagement: data_source_connection_validator.ts', () => {
       expect(fetchDataSourcesVersionResponse).toBe('2.11.0');
     });
 
+    test('fetchInstalledPlugins - Success: opensearch client response code is 200 and response body have installed plugin list', async () => {
+      const opensearchClient = opensearchServiceMock.createOpenSearchClient();
+      opensearchClient.info.mockResolvedValue(
+        opensearchServiceMock.createApiResponse({
+          statusCode: 200,
+          body: [
+            {
+              name: 'b40f6833d895d3a95333e325e8bea79b',
+              component: ' analysis-icu',
+              version: '2.11.0',
+            },
+            {
+              name: 'b40f6833d895d3a95333e325e8bea79b',
+              component: 'analysis-ik',
+              version: '2.11.0',
+            },
+            {
+              name: 'b40f6833d895d3a95333e325e8bea79b',
+              component: 'analysis-seunjeon',
+              version: '2.11.0',
+            },
+          ],
+        })
+      );
+      const dataSourceValidator = new DataSourceConnectionValidator(opensearchClient, {});
+      const fetchInstalledPluginsReponse = Array.from(
+        await dataSourceValidator.fetchInstalledPlugins()
+      );
+      const installedPlugins = ['analysis-icu', 'analysis-ik', 'analysis-seunjeon'];
+      fetchInstalledPluginsReponse.map((plugin) => expect(installedPlugins).toContain(plugin));
+    });
+
     test('failure: opensearch client response code is 200 but response body not have cluster name', async () => {
       try {
         const opensearchClient = opensearchServiceMock.createOpenSearchClient();

--- a/src/plugins/data_source/server/routes/data_source_connection_validator.ts
+++ b/src/plugins/data_source/server/routes/data_source_connection_validator.ts
@@ -54,8 +54,37 @@ export class DataSourceConnectionValidator {
 
       return dataSourceVersion;
     } catch (e) {
-      // return empty dataSoyrce version instead of throwing exception in case info() api call fails
+      // return empty dataSource version instead of throwing exception in case info() api call fails
       return dataSourceVersion;
+    }
+  }
+
+  async fetchInstalledPlugins() {
+    const installedPlugins = new Set();
+    try {
+      // TODO : retrieve installed plugins from OpenSearch Serverless datasource
+      if (
+        this.dataSourceAttr.auth?.credentials?.service === SigV4ServiceName.OpenSearchServerless
+      ) {
+        return installedPlugins;
+      }
+
+      await this.callDataCluster.cat
+        .plugins({
+          format: 'JSON',
+          v: true,
+        })
+        .then((response) => response.body)
+        .then((body) => {
+          body.forEach((plugin) => {
+            installedPlugins.add(plugin.component);
+          });
+        });
+
+      return installedPlugins;
+    } catch (e) {
+      // return empty installedPlugins instead of throwing exception in case cat.plugins() api call fails
+      return installedPlugins;
     }
   }
 }

--- a/src/plugins/data_source/server/routes/fetch_data_source_metadata.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_metadata.ts
@@ -12,7 +12,7 @@ import { CryptographyServiceSetup } from '../cryptography_service';
 import { IAuthenticationMethodRegistry } from '../auth_registry';
 import { CustomApiSchemaRegistry } from '../schema_registry/custom_api_schema_registry';
 
-export const registerFetchDataSourceVersionRoute = async (
+export const registerFetchDataSourceMetaDataRoute = async (
   router: IRouter,
   dataSourceServiceSetup: DataSourceServiceSetup,
   cryptography: CryptographyServiceSetup,
@@ -22,7 +22,7 @@ export const registerFetchDataSourceVersionRoute = async (
   const authRegistry = await authRegistryPromise;
   router.post(
     {
-      path: '/internal/data-source-management/fetchDataSourceVersion',
+      path: '/internal/data-source-management/fetchDataSourceMetaData',
       validate: {
         body: schema.object({
           id: schema.maybe(schema.string()),
@@ -75,7 +75,6 @@ export const registerFetchDataSourceVersionRoute = async (
     },
     async (context, request, response) => {
       const { dataSourceAttr, id: dataSourceId } = request.body;
-      let dataSourceVersion = '';
 
       try {
         const dataSourceClient: OpenSearchClient = await dataSourceServiceSetup.getDataSourceClient(
@@ -95,11 +94,13 @@ export const registerFetchDataSourceVersionRoute = async (
           dataSourceAttr
         );
 
-        dataSourceVersion = await dataSourceValidator.fetchDataSourceVersion();
+        const dataSourceVersion = await dataSourceValidator.fetchDataSourceVersion();
+        const installedPlugins = Array.from(await dataSourceValidator.fetchInstalledPlugins());
 
         return response.ok({
           body: {
             dataSourceVersion,
+            installedPlugins,
           },
         });
       } catch (err) {

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.test.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.test.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {
-  fetchDataSourceVersion,
+  fetchDataSourceMetaData,
   getMappedDataSources,
   mockDataSourceAttributesWithAuth,
   mockManagementPlugin,
@@ -28,8 +28,8 @@ describe('Datasource Management: Create Datasource Wizard', () => {
   describe('case1: should load resources successfully', () => {
     beforeEach(async () => {
       spyOn(utils, 'getDataSources').and.returnValue(Promise.resolve(getMappedDataSources));
-      spyOn(utils, 'fetchDataSourceVersion').and.returnValue(
-        Promise.resolve(fetchDataSourceVersion)
+      spyOn(utils, 'fetchDataSourceMetaData').and.returnValue(
+        Promise.resolve(fetchDataSourceMetaData)
       );
       await act(async () => {
         component = mount(

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.tsx
@@ -20,7 +20,7 @@ import {
   createSingleDataSource,
   getDataSources,
   testConnection,
-  fetchDataMetaData,
+  fetchDataSourceMetaData,
   handleSetDefaultDatasource,
 } from '../utils';
 import { LoadingMask } from '../loading_mask';
@@ -76,7 +76,7 @@ export const CreateDataSourceWizard: React.FunctionComponent<CreateDataSourceWiz
     setIsLoading(true);
     try {
       // Fetch data source metadata from added OS/ES domain/cluster
-      const metadata = await fetchDataMetaData(http, attributes);
+      const metadata = await fetchDataSourceMetaData(http, attributes);
       attributes.dataSourceVersion = metadata.dataSourceVersion;
       attributes.installedPlugins = metadata.installedPlugins;
       await createSingleDataSource(savedObjects.client, attributes);

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.tsx
@@ -20,7 +20,7 @@ import {
   createSingleDataSource,
   getDataSources,
   testConnection,
-  fetchDataSourceVersion,
+  fetchDataMetaData,
   handleSetDefaultDatasource,
 } from '../utils';
 import { LoadingMask } from '../loading_mask';
@@ -75,8 +75,10 @@ export const CreateDataSourceWizard: React.FunctionComponent<CreateDataSourceWiz
   const handleSubmit = async (attributes: DataSourceAttributes) => {
     setIsLoading(true);
     try {
-      const version = await fetchDataSourceVersion(http, attributes);
-      attributes.dataSourceVersion = version.dataSourceVersion;
+      // Fetch data source metadata from added OS/ES domain/cluster
+      const metadata = await fetchDataMetaData(http, attributes);
+      attributes.dataSourceVersion = metadata.dataSourceVersion;
+      attributes.installedPlugins = metadata.installedPlugins;
       await createSingleDataSource(savedObjects.client, attributes);
       // Set the first create data source as default data source.
       await handleSetDefaultDatasource(savedObjects.client, uiSettings);

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -203,7 +203,7 @@ export async function testConnection(
   });
 }
 
-export async function fetchDataMetaData(
+export async function fetchDataSourceMetaData(
   http: HttpStart,
   { endpoint, auth: { type, credentials } }: DataSourceAttributes,
   dataSourceID?: string

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -203,7 +203,7 @@ export async function testConnection(
   });
 }
 
-export async function fetchDataSourceVersion(
+export async function fetchDataMetaData(
   http: HttpStart,
   { endpoint, auth: { type, credentials } }: DataSourceAttributes,
   dataSourceID?: string
@@ -219,7 +219,7 @@ export async function fetchDataSourceVersion(
     },
   };
 
-  return await http.post(`/internal/data-source-management/fetchDataSourceVersion`, {
+  return await http.post(`/internal/data-source-management/fetchDataSourceMetaData`, {
     body: JSON.stringify(query),
   });
 }

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -232,8 +232,9 @@ export const getMappedDataSources = [
   },
 ];
 
-export const fetchDataSourceVersion = {
+export const fetchDataSourceMetaData = {
   dataSourceVersion: '2.11.0',
+  installedPlugins: ['opensearch-ml', 'opensearch-sql'],
 };
 
 export const mockDataSourceAttributesWithAuth = {

--- a/src/plugins/data_source_management/public/types.ts
+++ b/src/plugins/data_source_management/public/types.ts
@@ -141,6 +141,7 @@ export interface DataSourceAttributes extends SavedObjectAttributes {
   description?: string;
   endpoint?: string;
   dataSourceVersion?: string;
+  installedPlugins?: string[];
   auth: {
     type: AuthType | string;
     credentials:


### PR DESCRIPTION
### Description

* This change is the second step per RFC https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5877 aiming at decouple the strict version constrains between OSD Core and Plugins

* This change adds new attribute `installedPlugins` into the `data-source` saved object, which then will be leveraged by each plugin/component to filter out supported data sources based on individual plugin dependency

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6349

## Screenshot

* New `data-source` saved object , with `installedPlugins` added
```
"attributes": {
      "dataSourceVersion": {
        "S": "2.11.0"
      },
      "description": {
        "S": ""
      },
      "endpoint": {
        "S": "https://search-goodboy-211-5zcmfildjglhyfjzyro2oevmze.us-east-1.es.amazonaws.com"
      },
      "installedPlugins": {
        "L": [
          {
            "S": "analysis-icu"
          },
          {
            "S": "opensearch-jetty"
          },
          {
            "S": "opensearch-job-scheduler"
          },
          {
            "S": "opensearch-knn"
          },
          {
            "S": "opensearch-ml"
          },
          {
            "S": "opensearch-neural-search"
          },
          {
            "S": "opensearch-notifications"
          },
          {
            "S": "opensearch-notifications-core"
          },
          {
            "S": "opensearch-observability"
          },
          {
            "S": "opensearch-reports-scheduler"
          },
          {
            "S": "opensearch-security"
          },
          {
            "S": "opensearch-security-analytics"
          },
          {
            "S": "opensearch-sql"
          },
          {
            "S": "performance-analyzer"
          },
          {
            "S": "repository-s3"
          },
          {
            "S": "telemetry-otel"
          }
        ]
      },
      "title": {
        "S": "test003"
      }
    }
  },
```

## Testing the changes

All related test cases passed as

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/99905560/d174af46-1173-48af-82b5-f74ee9818a58)


### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
