### PR TITLE
[MD]Add default icon in multi-selectable picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Add default icon for selectable component and make sure the default datasource shows automatically ([#6327](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6327))
 - [Multiple Datasource] Pass selected data sources to plugin consumers when the multi-select component initially loads ([#6333](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6333))
 - [Multiple Datasource] Add installedPlugins list to data source saved object ([#6348](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6348))
+- [Multiple Datasource] Add default icon in multi-selectable picker ([#6357](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6357))
 - [Workspace] Add APIs to support plugin state in request ([#6303](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6303))
 
 ### 🐛 Bug Fixes

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -44,6 +44,7 @@ export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement |
         savedObjectsClient={savedObjects!}
         notifications={notifications!.toasts}
         onSelectedDataSources={onSelectedDataSources!}
+        uiSettings={uiSettings}
       />
     );
   }

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/__snapshots__/data_source_filter_group.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/__snapshots__/data_source_filter_group.test.tsx.snap
@@ -62,7 +62,17 @@ exports[`DataSourceFilterGroup should render normally 1`] = `
         }
       }
     >
-      name1
+      <DataSourceOptionItem
+        defaultDataSource="1"
+        item={
+          Object {
+            "checked": "on",
+            "id": "1",
+            "label": "name1",
+            "visible": true,
+          }
+        }
+      />
     </EuiFilterSelectItem>
   </div>
   <EuiPopoverFooter>
@@ -204,7 +214,33 @@ Object {
                   <span
                     class="euiFlexItem euiFilterSelectItem__content"
                   >
-                    name1
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrow1"
+                      >
+                        name1
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <span
+                          class="euiBadge euiBadge--iconLeft"
+                          style="background-color: rgb(211, 218, 230); color: rgb(0, 0, 0);"
+                        >
+                          <span
+                            class="euiBadge__content"
+                          >
+                            <span
+                              class="euiBadge__text"
+                            >
+                              Default
+                            </span>
+                          </span>
+                        </span>
+                      </div>
+                    </div>
                   </span>
                 </span>
               </button>
@@ -497,7 +533,15 @@ Object {
                   <span
                     class="euiFlexItem euiFilterSelectItem__content"
                   >
-                    name1
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrow1"
+                      >
+                        name1
+                      </div>
+                    </div>
                   </span>
                 </span>
               </button>

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/__snapshots__/data_source_multi_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/__snapshots__/data_source_multi_selectable.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`DataSourceMultiSelectable should render normally with local cluster hidden 1`] = `
 <DataSourceFilterGroup
+  defaultDataSource={null}
   selectedOptions={Array []}
   setSelectedOptions={[Function]}
 />
@@ -9,6 +10,7 @@ exports[`DataSourceMultiSelectable should render normally with local cluster hid
 
 exports[`DataSourceMultiSelectable should render normally with local cluster not hidden 1`] = `
 <DataSourceFilterGroup
+  defaultDataSource={null}
   selectedOptions={Array []}
   setSelectedOptions={[Function]}
 />

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_filter_group.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_filter_group.test.tsx
@@ -17,6 +17,7 @@ describe('DataSourceFilterGroup', () => {
       <DataSourceFilterGroup
         selectedOptions={[{ id: '1', label: 'name1', checked: 'on', visible: true }]}
         setSelectedOptions={(items) => mockCallBack(items)}
+        defaultDataSource="1"
       />
     );
     expect(component).toMatchSnapshot();
@@ -28,6 +29,7 @@ describe('DataSourceFilterGroup', () => {
       <DataSourceFilterGroup
         selectedOptions={[{ id: '1', label: 'name1', checked: 'on', visible: true }]}
         setSelectedOptions={(items) => mockCallBack(items)}
+        defaultDataSource="1"
       />
     );
     const button = await container.findByTestId('dataSourceFilterGroupButton');

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_filter_group.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_filter_group.tsx
@@ -16,6 +16,7 @@ import {
   EuiButtonEmpty,
 } from '@elastic/eui';
 import { DataSourceOption } from '../data_source_selector/data_source_selector';
+import { DataSourceOptionItem } from '../data_source_option';
 
 export interface SelectedDataSourceOption extends DataSourceOption {
   label: string;
@@ -27,6 +28,7 @@ export interface SelectedDataSourceOption extends DataSourceOption {
 export interface DataSourceFilterGroupProps {
   selectedOptions: SelectedDataSourceOption[];
   setSelectedOptions: (options: SelectedDataSourceOption[]) => void;
+  defaultDataSource: string | null;
 }
 
 type SelectionToggleOptionIds = 'select_all' | 'deselect_all';
@@ -45,6 +47,7 @@ const selectionToggleButtons = [
 export const DataSourceFilterGroup: React.FC<DataSourceFilterGroupProps> = ({
   selectedOptions,
   setSelectedOptions,
+  defaultDataSource,
 }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [selectionToggleSelectedId, setSelectionToggleSelectedId] = useState<
@@ -148,7 +151,7 @@ export const DataSourceFilterGroup: React.FC<DataSourceFilterGroupProps> = ({
               showIcons={true}
               style={itemStyle}
             >
-              {item.label}
+              <DataSourceOptionItem item={item} defaultDataSource={defaultDataSource} />
             </EuiFilterSelectItem>
           );
         })}

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { SavedObjectsClientContract, ToastsStart } from 'opensearch-dashboards/public';
 import { i18n } from '@osd/i18n';
+import { IUiSettingsClient } from 'src/core/public';
 import { DataSourceFilterGroup, SelectedDataSourceOption } from './data_source_filter_group';
 import { getDataSourcesWithFields } from '../utils';
 
@@ -15,11 +16,13 @@ export interface DataSourceMultiSeletableProps {
   onSelectedDataSources: (dataSources: SelectedDataSourceOption[]) => void;
   hideLocalCluster: boolean;
   fullWidth: boolean;
+  uiSettings?: IUiSettingsClient;
 }
 
 interface DataSourceMultiSeletableState {
   dataSourceOptions: SelectedDataSourceOption[];
   selectedOptions: SelectedDataSourceOption[];
+  defaultDataSource: string | null;
 }
 
 export class DataSourceMultiSelectable extends React.Component<
@@ -34,6 +37,7 @@ export class DataSourceMultiSelectable extends React.Component<
     this.state = {
       dataSourceOptions: [],
       selectedOptions: [],
+      defaultDataSource: null,
     };
   }
 
@@ -43,46 +47,49 @@ export class DataSourceMultiSelectable extends React.Component<
 
   async componentDidMount() {
     this._isMounted = true;
-    getDataSourcesWithFields(this.props.savedObjectsClient, ['id', 'title', 'auth.type'])
-      .then((fetchedDataSources) => {
-        if (fetchedDataSources?.length) {
-          // all data sources are selected by default on initial page load
-          const selectedOptions: SelectedDataSourceOption[] = fetchedDataSources.map(
-            (dataSource) => ({
-              id: dataSource.id,
-              label: dataSource.attributes?.title || '',
-              checked: 'on',
-              visible: true,
-            })
-          );
+    try {
+      const defaultDataSource = this.props.uiSettings?.get('defaultDataSource', null) ?? null;
+      let selectedOptions: SelectedDataSourceOption[] = [];
+      const fetchedDataSources = await getDataSourcesWithFields(this.props.savedObjectsClient, [
+        'id',
+        'title',
+        'auth.type',
+      ]);
 
-          if (!this.props.hideLocalCluster) {
-            selectedOptions.unshift({
-              id: '',
-              label: 'Local cluster',
-              checked: 'on',
-              visible: true,
-            });
-          }
+      if (fetchedDataSources?.length) {
+        selectedOptions = fetchedDataSources.map((dataSource) => ({
+          id: dataSource.id,
+          label: dataSource.attributes?.title || '',
+          checked: 'on',
+          visible: true,
+        }));
+      }
 
-          if (!this._isMounted) return;
-          this.setState({
-            ...this.state,
-            selectedOptions,
-          });
+      if (!this.props.hideLocalCluster) {
+        selectedOptions.unshift({
+          id: '',
+          label: 'Local cluster',
+          checked: 'on',
+          visible: true,
+        });
+      }
 
-          this.props.onSelectedDataSources(
-            selectedOptions.filter((option) => option.checked === 'on')
-          );
-        }
-      })
-      .catch(() => {
-        this.props.notifications.addWarning(
-          i18n.translate('dataSource.fetchDataSourceError', {
-            defaultMessage: 'Unable to fetch existing data sources',
-          })
-        );
+      if (!this._isMounted) return;
+
+      this.setState({
+        ...this.state,
+        selectedOptions,
+        defaultDataSource,
       });
+
+      this.props.onSelectedDataSources(selectedOptions);
+    } catch (error) {
+      this.props.notifications.addWarning(
+        i18n.translate('dataSource.fetchDataSourceError', {
+          defaultMessage: 'Unable to fetch existing data sources',
+        })
+      );
+    }
   }
 
   onChange(selectedOptions: SelectedDataSourceOption[]) {
@@ -98,6 +105,7 @@ export class DataSourceMultiSelectable extends React.Component<
       <DataSourceFilterGroup
         selectedOptions={this.state.selectedOptions}
         setSelectedOptions={this.onChange.bind(this)}
+        defaultDataSource={this.state.defaultDataSource}
       />
     );
   }

--- a/src/plugins/data_source_management/public/components/data_source_option.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_option.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { DataSourceOptionItem } from './data_source_option';
+import { SelectedDataSourceOption } from './data_source_multi_selectable/data_source_filter_group';
+
+describe('Test on ShowDataSourceOption', () => {
+  it('should render the component with label', () => {
+    const item: SelectedDataSourceOption = {
+      id: '1',
+      label: 'DataSource 1',
+      visible: true,
+    };
+    const defaultDataSource = null;
+
+    const component = shallow(
+      <DataSourceOptionItem item={item} defaultDataSource={defaultDataSource} />
+    );
+
+    expect(component.find(EuiFlexGroup)).toHaveLength(1);
+    expect(component.find(EuiFlexItem)).toHaveLength(1);
+    expect(component.find(EuiBadge)).toHaveLength(0);
+  });
+
+  it('should render the component with label and default badge', () => {
+    const item = {
+      id: '1',
+      label: 'DataSource 1',
+      visible: true,
+    };
+    const defaultDataSource = '1';
+
+    const component = shallow(
+      <DataSourceOptionItem item={item} defaultDataSource={defaultDataSource} />
+    );
+
+    expect(component.find(EuiFlexGroup)).toHaveLength(1);
+    expect(component.find(EuiFlexItem)).toHaveLength(2);
+    expect(component.find(EuiBadge)).toHaveLength(1);
+  });
+});

--- a/src/plugins/data_source_management/public/components/data_source_option.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_option.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiBadge } from '@elastic/eui';
+import { SelectedDataSourceOption } from './data_source_multi_selectable/data_source_filter_group';
+
+export interface DataSourceOptionItemProps {
+  item: SelectedDataSourceOption;
+  defaultDataSource: string | null;
+}
+
+export const DataSourceOptionItem: React.FC<DataSourceOptionItemProps> = ({
+  item,
+  defaultDataSource,
+}) => {
+  return (
+    <EuiFlexGroup alignItems="center">
+      <EuiFlexItem grow={1}>{item.label}</EuiFlexItem>
+      {item.id === defaultDataSource && (
+        <EuiFlexItem grow={false}>
+          <EuiBadge iconSide="left">Default</EuiBadge>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+};


### PR DESCRIPTION
### Description

Add default icon in multi-selectable picker and fix a bug in when datasource length is 0, localcluster would not be added. 

## Screenshot


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/161a22a2-e4ac-4f51-b7c8-93c83950a197


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
