### PR TITLE
[MD]Read hideLocalCluster setting from yml and set in data source selector and data source menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Workspace] Add base path when parse url in http service ([#6233](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6233))
 - [Multiple Datasource] Fix sslConfig for multiple datasource to handle when certificateAuthorities is unset ([#6282](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6282))
 - [BUG][Multiple Datasource]Fix bug in data source aggregated view to change it to depend on displayAllCompatibleDataSources property to show the badge value ([#6291](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6291))
+- [BUG][Multiple Datasource]Read hideLocalCluster setting from yml and set in data source selector and data source menu ([#6361](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6361))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
@@ -1,5 +1,130 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`create data source menu should ignore props.hideLocalCluster, and show local cluster when data_source.hideLocalCluster is set to false 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="euiPopover euiPopover--anchorDownLeft"
+        data-test-subj="dataSourceSelectableContextMenuPopover"
+        id="dataSourceSelectableContextMenuPopover"
+      >
+        <div
+          class="euiPopover__anchor"
+        >
+          <button
+            aria-label="dataSourceMenuButton"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
+            data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+            type="button"
+          >
+            <span
+              class="euiButtonContent euiButtonEmpty__content"
+            >
+              <span
+                class="euiButtonContent__icon"
+                color="inherit"
+                data-euiicon-type="database"
+              />
+              <span
+                class="euiButtonEmpty__text"
+              >
+                Local cluster
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="euiPopover euiPopover--anchorDownLeft"
+      data-test-subj="dataSourceSelectableContextMenuPopover"
+      id="dataSourceSelectableContextMenuPopover"
+    >
+      <div
+        class="euiPopover__anchor"
+      >
+        <button
+          aria-label="dataSourceMenuButton"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
+          data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButtonEmpty__content"
+          >
+            <span
+              class="euiButtonContent__icon"
+              color="inherit"
+              data-euiicon-type="database"
+            />
+            <span
+              class="euiButtonEmpty__text"
+            >
+              Local cluster
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`create data source menu should render data source selectable normally 1`] = `
 Object {
   "asFragment": [Function],

--- a/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.test.tsx
@@ -5,15 +5,17 @@
 
 import { createDataSourceMenu } from './create_data_source_menu';
 import { MountPoint, SavedObjectsClientContract } from '../../../../../core/public';
-import { notificationServiceMock } from '../../../../../core/public/mocks';
+import { coreMock, notificationServiceMock } from '../../../../../core/public/mocks';
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { act, getByText, render } from '@testing-library/react';
 import { DataSourceComponentType, DataSourceSelectableConfig } from './types';
 import { ReactWrapper } from 'enzyme';
+import { mockDataSourcePluginSetupWithShowLocalCluster } from '../../mocks';
 
 describe('create data source menu', () => {
   let client: SavedObjectsClientContract;
   const notifications = notificationServiceMock.createStartContract();
+  const { uiSettings } = coreMock.createSetup();
 
   beforeEach(() => {
     client = {
@@ -26,13 +28,16 @@ describe('create data source menu', () => {
       componentType: DataSourceComponentType.DataSourceSelectable,
       componentConfig: {
         fullWidth: true,
-        hideLocalCluster: true,
         onSelectedDataSources: jest.fn(),
         savedObjects: client,
         notifications,
       },
     };
-    const TestComponent = createDataSourceMenu<DataSourceSelectableConfig>();
+    const TestComponent = createDataSourceMenu<DataSourceSelectableConfig>(
+      uiSettings,
+      mockDataSourcePluginSetupWithShowLocalCluster
+    );
+
     const component = render(<TestComponent {...props} />);
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
@@ -41,6 +46,36 @@ describe('create data source menu', () => {
       type: 'data-source',
     });
     expect(notifications.toasts.addWarning).toBeCalledTimes(0);
+  });
+
+  it('should ignore props.hideLocalCluster, and show local cluster when data_source.hideLocalCluster is set to false', async () => {
+    let component;
+    const props = {
+      componentType: DataSourceComponentType.DataSourceSelectable,
+      hideLocalCluster: true,
+      componentConfig: {
+        fullWidth: true,
+        onSelectedDataSources: jest.fn(),
+        savedObjects: client,
+        notifications,
+      },
+    };
+    const TestComponent = createDataSourceMenu<DataSourceSelectableConfig>(
+      uiSettings,
+      mockDataSourcePluginSetupWithShowLocalCluster
+    );
+    await act(async () => {
+      component = render(<TestComponent {...props} />);
+    });
+
+    expect(component).toMatchSnapshot();
+    expect(client.find).toBeCalledWith({
+      fields: ['id', 'title', 'auth.type'],
+      perPage: 10000,
+      type: 'data-source',
+    });
+    expect(notifications.toasts.addWarning).toBeCalledTimes(0);
+    expect(getByText(component.container, 'Local cluster')).toBeInTheDocument();
   });
 });
 
@@ -52,6 +87,7 @@ describe('when setMenuMountPoint is provided', () => {
 
   let client: SavedObjectsClientContract;
   const notifications = notificationServiceMock.createStartContract();
+  const { uiSettings } = coreMock.createSetup();
 
   const refresh = () => {
     new Promise(async (resolve) => {
@@ -91,7 +127,10 @@ describe('when setMenuMountPoint is provided', () => {
         notifications,
       },
     };
-    const TestComponent = createDataSourceMenu<DataSourceSelectableConfig>();
+    const TestComponent = createDataSourceMenu<DataSourceSelectableConfig>(
+      uiSettings,
+      mockDataSourcePluginSetupWithShowLocalCluster
+    );
     const component = render(<TestComponent {...props} />);
     act(() => {
       mountPoint(portalTarget);

--- a/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.tsx
@@ -13,10 +13,10 @@ import { MountPointPortal } from '../../../../opensearch_dashboards_react/public
 
 export function createDataSourceMenu<T>(
   uiSettings: IUiSettingsClient,
-  dataSource: DataSourcePluginSetup
+  dataSourcePluginSetup: DataSourcePluginSetup
 ) {
   return (props: DataSourceMenuProps<T>) => {
-    const { hideLocalCluster } = dataSource;
+    const { hideLocalCluster } = dataSourcePluginSetup;
     if (props.setMenuMountPoint) {
       return (
         <MountPointPortal setMountPoint={props.setMenuMountPoint}>

--- a/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.tsx
@@ -6,21 +6,32 @@
 import React from 'react';
 import { EuiHeaderLinks } from '@elastic/eui';
 import { IUiSettingsClient } from 'src/core/public';
+import { DataSourcePluginSetup } from 'src/plugins/data_source/public';
 import { DataSourceMenu } from './data_source_menu';
 import { DataSourceMenuProps } from './types';
 import { MountPointPortal } from '../../../../opensearch_dashboards_react/public';
 
-export function createDataSourceMenu<T>(uiSettings: IUiSettingsClient) {
+export function createDataSourceMenu<T>(
+  uiSettings: IUiSettingsClient,
+  dataSource: DataSourcePluginSetup
+) {
   return (props: DataSourceMenuProps<T>) => {
+    const { hideLocalCluster } = dataSource;
     if (props.setMenuMountPoint) {
       return (
         <MountPointPortal setMountPoint={props.setMenuMountPoint}>
           <EuiHeaderLinks data-test-subj="top-nav" gutterSize="xs">
-            <DataSourceMenu {...props} uiSettings={uiSettings} />
+            <DataSourceMenu
+              {...props}
+              uiSettings={uiSettings}
+              hideLocalCluster={hideLocalCluster}
+            />
           </EuiHeaderLinks>
         </MountPointPortal>
       );
     }
-    return <DataSourceMenu {...props} />;
+    return (
+      <DataSourceMenu {...props} uiSettings={uiSettings} hideLocalCluster={hideLocalCluster} />
+    );
   };
 }

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.test.tsx
@@ -29,7 +29,6 @@ describe('DataSourceMenu', () => {
         componentType={DataSourceComponentType.DataSourceSelectable}
         componentConfig={{
           fullWidth: true,
-          hideLocalCluster: false,
           onSelectedDataSources: jest.fn(),
           savedObjects: client,
           notifications,
@@ -43,9 +42,9 @@ describe('DataSourceMenu', () => {
     component = shallow(
       <DataSourceMenu
         componentType={DataSourceComponentType.DataSourceSelectable}
+        hideLocalCluster={true}
         componentConfig={{
           fullWidth: true,
-          hideLocalCluster: true,
           onSelectedDataSources: jest.fn(),
           savedObjects: client,
           notifications,
@@ -61,7 +60,6 @@ describe('DataSourceMenu', () => {
         componentType={DataSourceComponentType.DataSourceView}
         componentConfig={{
           fullWidth: true,
-          hideLocalCluster: true,
           savedObjects: client,
           notifications,
         }}
@@ -76,7 +74,6 @@ describe('DataSourceMenu', () => {
         componentType={DataSourceComponentType.DataSourceView}
         componentConfig={{
           fullWidth: true,
-          hideLocalCluster: true,
           notifications,
         }}
       />
@@ -90,7 +87,6 @@ describe('DataSourceMenu', () => {
         componentType={DataSourceComponentType.DataSourceView}
         componentConfig={{
           fullWidth: true,
-          hideLocalCluster: true,
           savedObjects: client,
           notifications,
           activeOption: [{ id: 'test', label: 'test-label' }],
@@ -106,7 +102,6 @@ describe('DataSourceMenu', () => {
         componentType={DataSourceComponentType.DataSourceView}
         componentConfig={{
           fullWidth: true,
-          hideLocalCluster: true,
           savedObjects: client,
           notifications,
           activeOption: [{ id: 'test' }],
@@ -122,7 +117,6 @@ describe('DataSourceMenu', () => {
         componentType={DataSourceComponentType.DataSourceAggregatedView}
         componentConfig={{
           fullWidth: true,
-          hideLocalCluster: true,
           savedObjects: client,
           notifications,
           displayAllCompatibleDataSources: true,
@@ -138,7 +132,6 @@ describe('DataSourceMenu', () => {
         componentType={''}
         componentConfig={{
           fullWidth: true,
-          hideLocalCluster: true,
           savedObjects: client,
           notifications,
         }}

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -19,7 +19,7 @@ import {
 import { DataSourceSelectable } from '../data_source_selectable';
 
 export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement | null {
-  const { componentType, componentConfig, uiSettings } = props;
+  const { componentType, componentConfig, uiSettings, hideLocalCluster } = props;
 
   function renderDataSourceView(config: DataSourceViewConfig): ReactElement | null {
     const { activeOption, fullWidth, savedObjects, notifications } = config;
@@ -36,13 +36,7 @@ export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement |
   function renderDataSourceMultiSelectable(
     config: DataSourceMultiSelectableConfig
   ): ReactElement | null {
-    const {
-      fullWidth,
-      hideLocalCluster,
-      savedObjects,
-      notifications,
-      onSelectedDataSources,
-    } = config;
+    const { fullWidth, savedObjects, notifications, onSelectedDataSources } = config;
     return (
       <DataSourceMultiSelectable
         fullWidth={fullWidth}
@@ -59,7 +53,6 @@ export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement |
       onSelectedDataSources,
       disabled,
       activeOption,
-      hideLocalCluster,
       fullWidth,
       savedObjects,
       notifications,
@@ -85,7 +78,6 @@ export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement |
   ): ReactElement | null {
     const {
       fullWidth,
-      hideLocalCluster,
       activeDataSourceIds,
       displayAllCompatibleDataSources,
       savedObjects,

--- a/src/plugins/data_source_management/public/components/data_source_menu/types.ts
+++ b/src/plugins/data_source_management/public/components/data_source_menu/types.ts
@@ -24,6 +24,7 @@ export interface DataSourceBaseConfig {
 export interface DataSourceMenuProps<T = any> {
   componentType: DataSourceComponentType;
   componentConfig: T;
+  hideLocalCluster?: boolean;
   uiSettings?: IUiSettingsClient;
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
 }
@@ -47,7 +48,6 @@ export interface DataSourceAggregatedViewConfig extends DataSourceBaseConfig {
   savedObjects: SavedObjectsClientContract;
   notifications: NotificationsStart;
   activeDataSourceIds?: string[];
-  hideLocalCluster?: boolean;
   displayAllCompatibleDataSources?: boolean;
   dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
 }
@@ -57,7 +57,6 @@ export interface DataSourceSelectableConfig extends DataSourceBaseConfig {
   savedObjects: SavedObjectsClientContract;
   notifications: NotificationsStart;
   activeOption?: DataSourceOption[];
-  hideLocalCluster?: boolean;
   dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
 }
 
@@ -65,5 +64,4 @@ export interface DataSourceMultiSelectableConfig extends DataSourceBaseConfig {
   onSelectedDataSources: (dataSources: DataSourceOption[]) => void;
   savedObjects: SavedObjectsClientContract;
   notifications: NotificationsStart;
-  hideLocalCluster?: boolean;
 }

--- a/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/create_data_source_selector.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/create_data_source_selector.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`create data source selector should render normally 1`] = `
+exports[`create data source selector should ignore props.hideLocalCluster, and show local cluster when data_source.hideLocalCluster is set to false 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -144,6 +144,197 @@ Object {
                 data-euiicon-type="cross"
               />
             </button>
+            <button
+              aria-label="Open list of options"
+              class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+              data-test-subj="comboBoxToggleListButton"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`create data source selector should render normally 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-label="Select a data source"
+        class="euiComboBox"
+        data-test-subj="dataSourceSelectorComboBox"
+        role="combobox"
+      >
+        <div
+          class="euiFormControlLayout euiFormControlLayout--group"
+        >
+          <label
+            class="euiFormLabel euiFormControlLayout__prepend"
+          >
+            Data source
+          </label>
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable euiComboBox__inputWrap--inGroup"
+              data-test-subj="comboBoxInput"
+              tabindex="-1"
+            >
+              <p
+                class="euiComboBoxPlaceholder"
+              >
+                Select a data source
+              </p>
+              <div
+                class="euiComboBox__input"
+                style="font-size: 14px; display: inline-block;"
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  role="textbox"
+                  style="box-sizing: content-box; width: 2px;"
+                  value=""
+                />
+                <div
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                />
+              </div>
+            </div>
+            <div
+              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Open list of options"
+                class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                  class="euiFormControlLayoutCustomIcon__icon"
+                  data-euiicon-type="arrowDown"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-label="Select a data source"
+      class="euiComboBox"
+      data-test-subj="dataSourceSelectorComboBox"
+      role="combobox"
+    >
+      <div
+        class="euiFormControlLayout euiFormControlLayout--group"
+      >
+        <label
+          class="euiFormLabel euiFormControlLayout__prepend"
+        >
+          Data source
+        </label>
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <div
+            class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable euiComboBox__inputWrap--inGroup"
+            data-test-subj="comboBoxInput"
+            tabindex="-1"
+          >
+            <p
+              class="euiComboBoxPlaceholder"
+            >
+              Select a data source
+            </p>
+            <div
+              class="euiComboBox__input"
+              style="font-size: 14px; display: inline-block;"
+            >
+              <input
+                aria-controls=""
+                data-test-subj="comboBoxSearchInput"
+                role="textbox"
+                style="box-sizing: content-box; width: 2px;"
+                value=""
+              />
+              <div
+                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+              />
+            </div>
+          </div>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
             <button
               aria-label="Open list of options"
               class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"

--- a/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.test.tsx
@@ -6,8 +6,12 @@ import { createDataSourceSelector } from './create_data_source_selector';
 import { SavedObjectsClientContract } from '../../../../../core/public';
 import { notificationServiceMock } from '../../../../../core/public/mocks';
 import React from 'react';
-import { render } from '@testing-library/react';
+import { getByText, render } from '@testing-library/react';
 import { coreMock } from '../../../../../core/public/mocks';
+import {
+  mockDataSourcePluginSetupWithHideLocalCluster,
+  mockDataSourcePluginSetupWithShowLocalCluster,
+} from '../../mocks';
 
 describe('create data source selector', () => {
   let client: SavedObjectsClientContract;
@@ -29,7 +33,10 @@ describe('create data source selector', () => {
       hideLocalCluster: false,
       fullWidth: false,
     };
-    const TestComponent = createDataSourceSelector(uiSettings);
+    const TestComponent = createDataSourceSelector(
+      uiSettings,
+      mockDataSourcePluginSetupWithHideLocalCluster
+    );
     const component = render(<TestComponent {...props} />);
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
@@ -38,5 +45,23 @@ describe('create data source selector', () => {
       type: 'data-source',
     });
     expect(toasts.addWarning).toBeCalledTimes(0);
+  });
+
+  it('should ignore props.hideLocalCluster, and show local cluster when data_source.hideLocalCluster is set to false', () => {
+    const props = {
+      savedObjectsClient: client,
+      notifications: toasts,
+      onSelectedDataSource: jest.fn(),
+      disabled: false,
+      hideLocalCluster: true,
+      fullWidth: false,
+    };
+    const TestComponent = createDataSourceSelector(
+      uiSettings,
+      mockDataSourcePluginSetupWithShowLocalCluster
+    );
+    const component = render(<TestComponent {...props} />);
+    expect(component).toMatchSnapshot();
+    expect(getByText(component.container, 'Local cluster')).toBeInTheDocument();
   });
 });

--- a/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.tsx
@@ -5,10 +5,15 @@
 
 import React from 'react';
 import { IUiSettingsClient } from 'src/core/public';
+import { DataSourcePluginSetup } from 'src/plugins/data_source/public';
 import { DataSourceSelector, DataSourceSelectorProps } from './data_source_selector';
 
-export function createDataSourceSelector(uiSettings: IUiSettingsClient) {
+export function createDataSourceSelector(
+  uiSettings: IUiSettingsClient,
+  dataSource: DataSourcePluginSetup
+) {
+  const { hideLocalCluster } = dataSource;
   return (props: DataSourceSelectorProps) => (
-    <DataSourceSelector {...props} uiSettings={uiSettings} />
+    <DataSourceSelector {...props} uiSettings={uiSettings} hideLocalCluster={hideLocalCluster} />
   );
 }

--- a/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.tsx
@@ -10,9 +10,9 @@ import { DataSourceSelector, DataSourceSelectorProps } from './data_source_selec
 
 export function createDataSourceSelector(
   uiSettings: IUiSettingsClient,
-  dataSource: DataSourcePluginSetup
+  dataSourcePluginSetup: DataSourcePluginSetup
 ) {
-  const { hideLocalCluster } = dataSource;
+  const { hideLocalCluster } = dataSourcePluginSetup;
   return (props: DataSourceSelectorProps) => (
     <DataSourceSelector {...props} uiSettings={uiSettings} hideLocalCluster={hideLocalCluster} />
   );

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
@@ -23,8 +23,8 @@ export interface DataSourceSelectorProps {
   notifications: ToastsStart;
   onSelectedDataSource: (dataSourceOption: DataSourceOption[]) => void;
   disabled: boolean;
-  hideLocalCluster: boolean;
   fullWidth: boolean;
+  hideLocalCluster?: boolean;
   defaultOption?: DataSourceOption[];
   placeholderText?: string;
   removePrepend?: boolean;

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -7,6 +7,7 @@ import React from 'react';
 import { throwError } from 'rxjs';
 import { SavedObjectsClientContract } from 'opensearch-dashboards/public';
 import { IUiSettingsClient } from 'src/core/public';
+import { DataSourcePluginSetup } from 'src/plugins/data_source/public';
 import { AuthType, DataSourceAttributes } from './types';
 import { coreMock } from '../../../core/public/mocks';
 import {
@@ -362,3 +363,16 @@ export const createAuthenticationMethod = (
   },
   ...authMethod,
 });
+
+export const mockDataSourcePluginSetupWithShowLocalCluster: DataSourcePluginSetup = {
+  dataSourceEnabled: true,
+  hideLocalCluster: false,
+  noAuthenticationTypeEnabled: true,
+  usernamePasswordAuthEnabled: true,
+  awsSigV4AuthEnabled: true,
+};
+
+export const mockDataSourcePluginSetupWithHideLocalCluster: DataSourcePluginSetup = {
+  ...mockDataSourcePluginSetupWithShowLocalCluster,
+  hideLocalCluster: true,
+};

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -103,8 +103,8 @@ export class DataSourceManagementPlugin
     return {
       registerAuthenticationMethod,
       ui: {
-        DataSourceSelector: createDataSourceSelector(uiSettings),
-        getDataSourceMenu: <T>() => createDataSourceMenu<T>(uiSettings),
+        DataSourceSelector: createDataSourceSelector(uiSettings, dataSource),
+        getDataSourceMenu: <T>() => createDataSourceMenu<T>(uiSettings, dataSource),
       },
     };
   }


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

- Read `data_source.hideLocalCluster` setting from `opensearch_dashboards.yml`, and always use this value to decide if to hide local cluster in `DataSourceSelector` and `DataSourceMenu`. This is expected behaviour because hide/show local cluster in data source visual components should be consistent across anywhere that consumes those components.
- make `hideLocalHost` an optional property of `DataSourceSelector` and `DataSourceMenu`
- Update related unit tests

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
#6336 


## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->



https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/2c224539-8bfa-44f1-b165-c96c999275e9




## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
