### PR TITLE
Improve dynamic configurations by adding cache and simplifying client fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Workspace] Add APIs to support plugin state in request ([#6303](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6303))
 - [Workspace] Filter left nav menu items according to the current workspace ([#6234](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6234))
 - [Multiple Datasource] Refactor data source selector component to include placeholder and add tests ([#6372](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6372))
+- [Dynamic Configurations] Improve dynamic configurations by adding cache and simplifying client fetch ([#6364](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6364))
 - [MD] Add OpenSearch cluster group label to top of single selectable dropdown  ([#6400](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6400))
 
 ### 🐛 Bug Fixes

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -34,11 +34,11 @@
 # opensearchDashboards.configIndex: ".opensearch_dashboards_config"
 
 # Set the value of this setting to true to enable plugin application config. By default it is disabled.
-# application_config.enabled: false
+application_config.enabled: true
 
 # Set the value of this setting to true to enable plugin CSP handler. By default it is disabled.
 # It requires the application config plugin as its dependency.
-# csp_handler.enabled: false
+csp_handler.enabled: true
 
 # The default application to load.
 #opensearchDashboards.defaultAppId: "home"

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -34,11 +34,11 @@
 # opensearchDashboards.configIndex: ".opensearch_dashboards_config"
 
 # Set the value of this setting to true to enable plugin application config. By default it is disabled.
-application_config.enabled: true
+# application_config.enabled: false
 
 # Set the value of this setting to true to enable plugin CSP handler. By default it is disabled.
 # It requires the application config plugin as its dependency.
-csp_handler.enabled: true
+# csp_handler.enabled: false
 
 # The default application to load.
 #opensearchDashboards.defaultAppId: "home"

--- a/src/plugins/application_config/server/opensearch_config_client.test.ts
+++ b/src/plugins/application_config/server/opensearch_config_client.test.ts
@@ -48,7 +48,9 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {};
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       const value = await client.getConfig();
 
@@ -77,7 +79,10 @@ describe('OpenSearch Configuration Client', () => {
           }),
         },
       };
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+
+      const cache = {};
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       await expect(client.getConfig()).rejects.toThrowError(ERROR_MESSAGE);
     });
@@ -99,11 +104,45 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {
+        has: jest.fn().mockReturnValue(false),
+        set: jest.fn(),
+      };
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       const value = await client.getEntityConfig('config1');
 
       expect(value).toBe('value1');
+      expect(cache.set).toBeCalledWith('config1', 'value1');
+    });
+
+    it('return configuration value from cache', async () => {
+      const opensearchClient = {
+        asInternalUser: {
+          get: jest.fn().mockImplementation(() => {
+            return {
+              body: {
+                _source: {
+                  value: 'value1',
+                },
+              },
+            };
+          }),
+        },
+      };
+
+      const cache = {
+        has: jest.fn().mockReturnValue(true),
+        get: jest.fn().mockReturnValue('cachedValue'),
+      };
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
+
+      const value = await client.getEntityConfig('config1');
+
+      expect(value).toBe('cachedValue');
+      expect(cache.get).toBeCalledWith('config1');
     });
 
     it('throws error when input is empty', async () => {
@@ -121,7 +160,9 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {};
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       await expect(client.getEntityConfig(EMPTY_INPUT)).rejects.toThrowError(
         ERROR_MESSSAGE_FOR_EMPTY_INPUT
@@ -151,9 +192,16 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {
+        has: jest.fn().mockReturnValue(false),
+        set: jest.fn(),
+      };
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       await expect(client.getEntityConfig('config1')).rejects.toThrowError(ERROR_MESSAGE);
+
+      expect(cache.set).toBeCalledWith('config1', undefined);
     });
   });
 
@@ -167,11 +215,16 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {
+        del: jest.fn(),
+      };
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       const value = await client.deleteEntityConfig('config1');
 
       expect(value).toBe('config1');
+      expect(cache.del).toBeCalledWith('config1');
     });
 
     it('throws error when input entity is empty', async () => {
@@ -183,7 +236,9 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {};
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       await expect(client.deleteEntityConfig(EMPTY_INPUT)).rejects.toThrowError(
         ERROR_MESSSAGE_FOR_EMPTY_INPUT
@@ -213,11 +268,16 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {
+        del: jest.fn(),
+      };
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       const value = await client.deleteEntityConfig('config1');
 
       expect(value).toBe('config1');
+      expect(cache.del).toBeCalledWith('config1');
     });
 
     it('return deleted document entity when deletion fails due to document not found', async () => {
@@ -241,11 +301,16 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {
+        del: jest.fn(),
+      };
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       const value = await client.deleteEntityConfig('config1');
 
       expect(value).toBe('config1');
+      expect(cache.del).toBeCalledWith('config1');
     });
 
     it('throws error when opensearch throws error', async () => {
@@ -271,7 +336,9 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {};
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       await expect(client.deleteEntityConfig('config1')).rejects.toThrowError(ERROR_MESSAGE);
     });
@@ -287,11 +354,16 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {
+        set: jest.fn(),
+      };
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       const value = await client.updateEntityConfig('config1', 'newValue1');
 
       expect(value).toBe('newValue1');
+      expect(cache.set).toBeCalledWith('config1', 'newValue1');
     });
 
     it('throws error when entity is empty ', async () => {
@@ -303,7 +375,9 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {};
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       await expect(client.updateEntityConfig(EMPTY_INPUT, 'newValue1')).rejects.toThrowError(
         ERROR_MESSSAGE_FOR_EMPTY_INPUT
@@ -319,7 +393,9 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {};
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       await expect(client.updateEntityConfig('config1', EMPTY_INPUT)).rejects.toThrowError(
         ERROR_MESSSAGE_FOR_EMPTY_INPUT
@@ -349,7 +425,9 @@ describe('OpenSearch Configuration Client', () => {
         },
       };
 
-      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger);
+      const cache = {};
+
+      const client = new OpenSearchConfigurationClient(opensearchClient, INDEX_NAME, logger, cache);
 
       await expect(client.updateEntityConfig('config1', 'newValue1')).rejects.toThrowError(
         ERROR_MESSAGE

--- a/src/plugins/application_config/server/plugin.test.ts
+++ b/src/plugins/application_config/server/plugin.test.ts
@@ -6,6 +6,11 @@
 import { of } from 'rxjs';
 import { ApplicationConfigPlugin } from './plugin';
 import { ConfigurationClient } from './types';
+import LRUCache from 'lru-cache';
+import { OpenSearchConfigurationClient } from './opensearch_config_client';
+
+jest.mock('lru-cache');
+jest.mock('./opensearch_config_client');
 
 describe('application config plugin', () => {
   it('throws error when trying to register twice', async () => {
@@ -54,8 +59,8 @@ describe('application config plugin', () => {
 
     setup.registerConfigurationClient(client1);
 
-    const scopedClient = {};
-    expect(setup.getConfigurationClient(scopedClient)).toBe(client1);
+    const request = {};
+    expect(setup.getConfigurationClient(request)).toBe(client1);
 
     const client2: ConfigurationClient = {
       getConfig: jest.fn(),
@@ -71,6 +76,103 @@ describe('application config plugin', () => {
       'Configuration client is already registered! Cannot register again!'
     );
 
-    expect(setup.getConfigurationClient(scopedClient)).toBe(client1);
+    expect(setup.getConfigurationClient(request)).toBe(client1);
+  });
+
+  it('getConfigurationClient returns opensearch client when no external registration', async () => {
+    let capturedLRUCacheConstructorArgs = [];
+
+    const cache = {
+      get: jest.fn(),
+    };
+
+    LRUCache.mockImplementation(function (...args) {
+      capturedLRUCacheConstructorArgs = args;
+      return cache;
+    });
+
+    let capturedConfigurationClientConstructorArgs = [];
+
+    const client: ConfigurationClient = {
+      getConfig: jest.fn(),
+      getEntityConfig: jest.fn(),
+      updateEntityConfig: jest.fn(),
+      deleteEntityConfig: jest.fn(),
+    };
+
+    OpenSearchConfigurationClient.mockImplementation(function (...args) {
+      capturedConfigurationClientConstructorArgs = args;
+      return client;
+    });
+
+    const logger = {
+      info: jest.fn(),
+      error: jest.fn(),
+    };
+
+    const initializerContext = {
+      logger: {
+        get: jest.fn().mockReturnValue(logger),
+      },
+      config: {
+        legacy: {
+          globalConfig$: of({
+            opensearchDashboards: {
+              configIndex: '.osd_test',
+            },
+          }),
+        },
+      },
+    };
+
+    const plugin = new ApplicationConfigPlugin(initializerContext);
+
+    const coreSetup = {
+      http: {
+        createRouter: jest.fn().mockImplementation(() => {
+          return {
+            get: jest.fn(),
+            post: jest.fn(),
+            delete: jest.fn(),
+          };
+        }),
+      },
+    };
+
+    const setup = await plugin.setup(coreSetup);
+
+    const scopedClient = {
+      asCurrentUser: jest.fn(),
+    };
+
+    const coreStart = {
+      opensearch: {
+        client: {
+          asScoped: jest.fn().mockReturnValue(scopedClient),
+        },
+      },
+    };
+
+    await plugin.start(coreStart);
+
+    const request = {};
+
+    expect(setup.getConfigurationClient(request)).toBe(client);
+
+    expect(capturedLRUCacheConstructorArgs).toEqual([
+      {
+        max: 100,
+        maxAge: 600000,
+      },
+    ]);
+
+    expect(capturedConfigurationClientConstructorArgs).toEqual([
+      scopedClient,
+      '.osd_test',
+      logger,
+      cache,
+    ]);
+
+    expect(coreStart.opensearch.client.asScoped).toBeCalledTimes(1);
   });
 });

--- a/src/plugins/application_config/server/plugin.ts
+++ b/src/plugins/application_config/server/plugin.ts
@@ -13,7 +13,6 @@ import {
   CoreStart,
   Plugin,
   Logger,
-  IScopedClusterClient,
   SharedGlobalConfig,
   OpenSearchDashboardsRequest,
   IClusterClient,
@@ -36,7 +35,7 @@ export class ApplicationConfigPlugin
   private configurationIndexName: string;
   private clusterClient: IClusterClient;
 
-  private cache: LRUCache<string, string>;
+  private cache: LRUCache<string, string | undefined>;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.logger = initializerContext.logger.get();
@@ -45,8 +44,8 @@ export class ApplicationConfigPlugin
     this.clusterClient = null;
 
     this.cache = new LRUCache({
-      max: 30,
-      maxAge: 100 * 1000,
+      max: 100, // at most 100 entries
+      maxAge: 10 * 60 * 1000, // 10 mins
     });
   }
 
@@ -62,7 +61,7 @@ export class ApplicationConfigPlugin
     this.configurationClient = configurationClient;
   }
 
-  private getConfigurationClient(request: OpenSearchDashboardsRequest): ConfigurationClient {
+  private getConfigurationClient(request?: OpenSearchDashboardsRequest): ConfigurationClient {
     if (this.configurationClient) {
       return this.configurationClient;
     }

--- a/src/plugins/application_config/server/types.ts
+++ b/src/plugins/application_config/server/types.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IScopedClusterClient, Headers } from 'src/core/server';
+import { Headers, OpenSearchDashboardsRequest } from 'src/core/server';
 
 export interface ApplicationConfigPluginSetup {
-  getConfigurationClient: (inputOpenSearchClient: IScopedClusterClient) => ConfigurationClient;
+  getConfigurationClient: (request?: OpenSearchDashboardsRequest) => ConfigurationClient;
   registerConfigurationClient: (inputConfigurationClient: ConfigurationClient) => void;
 }
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/plugins/csp_handler/server/csp_handlers.test.ts
+++ b/src/plugins/csp_handler/server/csp_handlers.test.ts
@@ -55,6 +55,7 @@ describe('CSP handlers', () => {
     });
 
     expect(configurationClient.getEntityConfig).toBeCalledTimes(1);
+    expect(getConfigurationClient).toBeCalledWith(request);
   });
 
   it('do not add CSP headers when the client returns empty and CSP from YML already has frame-ancestors', async () => {
@@ -89,6 +90,7 @@ describe('CSP handlers', () => {
     expect(toolkit.next).toHaveBeenCalledWith({});
 
     expect(configurationClient.getEntityConfig).toBeCalledTimes(1);
+    expect(getConfigurationClient).toBeCalledWith(request);
   });
 
   it('add frame-ancestors CSP headers when the client returns empty and CSP from YML has no frame-ancestors', async () => {
@@ -128,6 +130,7 @@ describe('CSP handlers', () => {
     });
 
     expect(configurationClient.getEntityConfig).toBeCalledTimes(1);
+    expect(getConfigurationClient).toBeCalledWith(request);
   });
 
   it('do not add CSP headers when the configuration does not exist and CSP from YML already has frame-ancestors', async () => {
@@ -164,6 +167,7 @@ describe('CSP handlers', () => {
     expect(toolkit.next).toBeCalledWith({});
 
     expect(configurationClient.getEntityConfig).toBeCalledTimes(1);
+    expect(getConfigurationClient).toBeCalledWith(request);
   });
 
   it('add frame-ancestors CSP headers when the configuration does not exist and CSP from YML has no frame-ancestors', async () => {
@@ -200,6 +204,7 @@ describe('CSP handlers', () => {
     });
 
     expect(configurationClient.getEntityConfig).toBeCalledTimes(1);
+    expect(getConfigurationClient).toBeCalledWith(request);
   });
 
   it('do not add CSP headers when request dest exists and shall skip', async () => {
@@ -235,6 +240,7 @@ describe('CSP handlers', () => {
     expect(toolkit.next).toBeCalledWith({});
 
     expect(configurationClient.getEntityConfig).toBeCalledTimes(0);
+    expect(getConfigurationClient).toBeCalledTimes(0);
   });
 
   it('do not add CSP headers when request dest does not exist', async () => {
@@ -269,5 +275,6 @@ describe('CSP handlers', () => {
     expect(toolkit.next).toBeCalledWith({});
 
     expect(configurationClient.getEntityConfig).toBeCalledTimes(0);
+    expect(getConfigurationClient).toBeCalledTimes(0);
   });
 });

--- a/src/plugins/csp_handler/server/csp_handlers.ts
+++ b/src/plugins/csp_handler/server/csp_handlers.ts
@@ -30,7 +30,7 @@ const CSP_RULES_CONFIG_KEY = 'csp.rules';
 export function createCspRulesPreResponseHandler(
   core: CoreSetup,
   cspHeader: string,
-  getConfigurationClient: (scopedClusterClient: IScopedClusterClient) => ConfigurationClient,
+  getConfigurationClient: (request?: OpenSearchDashboardsRequest) => ConfigurationClient,
   logger: Logger
 ): OnPreResponseHandler {
   return async (
@@ -46,8 +46,6 @@ export function createCspRulesPreResponseHandler(
       if (!shouldCheckDest.includes(currentDest)) {
         return toolkit.next({});
       }
-
-      const [coreStart] = await core.getStartServices();
 
       const client = getConfigurationClient(request);
 

--- a/src/plugins/csp_handler/server/csp_handlers.ts
+++ b/src/plugins/csp_handler/server/csp_handlers.ts
@@ -49,7 +49,7 @@ export function createCspRulesPreResponseHandler(
 
       const [coreStart] = await core.getStartServices();
 
-      const client = getConfigurationClient(coreStart.opensearch.client.asScoped(request));
+      const client = getConfigurationClient(request);
 
       const cspRules = await client.getEntityConfig(CSP_RULES_CONFIG_KEY, {
         headers: request.headers,


### PR DESCRIPTION
### Description

Address the comments from this issue https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6300

This PR updates the parameters to the ` getConfigurationClient` function and adds a cache.

### Issues Resolved

closes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6300
closes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6341

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

call the get API

```
curl -X GET 'http://localhost:5601/api/appconfig/csp.rules'

{"value":"frame-ancestors https://example-site.org"}%

```

Then call the get API again.

```
curl -X GET 'http://localhost:5601/api/appconfig/csp.rules'

{"value":"frame-ancestors https://example-site.org"}%
```

We find two entries in the logs where the first one doesn't show cache entry but the second one shows cache entry.


```
server    log   [02:13:58.836] [info][server][OpenSearchDashboards][http] http server running at http://localhost:5601
server    log   [02:14:04.440] [info][applicationConfig][plugins] Received a request to get entity config for csp.rules.
server    log   [02:14:04.441] [info][applicationConfig][plugins] Key csp.rules is not found from cache.
server    log   [02:14:07.936] [info][applicationConfig][plugins] Received a request to get entity config for csp.rules.
```

Verified that the CSP rules are set properly.
![Screenshot 2024-04-09 at 19 00 10](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/60111637/1c3310c4-31bd-472b-8324-6bd12a8075fc)

call update API

```
curl 'http://localhost:5601/api/appconfig/csp.rules' -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty' --data-raw '{"newValue":"script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'; frame-ancestors 'self' file://* filesystem:"}'

{"newValue":"script-src unsafe-eval self; worker-src blob: self; style-src unsafe-inline self; frame-ancestors self file://* 
```

call the get API

```
curl -X GET 'http://localhost:5601/api/appconfig/csp.rules'

{"value":"script-src unsafe-eval self; worker-src blob: self; style-src unsafe-inline self; frame-ancestors self file://* filesystem:"}%
```

From the logs, we can see that cache value is used.

```
server    log   [02:21:34.446] [info][applicationConfig][plugins] Received a request to update entity csp.rules with new value script-src unsafe-eval self; worker-src blob: self; style-src unsafe-inline self; frame-ancestors self file://* filesystem:.
server    log   [02:21:39.821] [info][applicationConfig][plugins] Received a request to get entity config for csp.rules.

```

call the delete API

```
curl 'http://localhost:5601/api/appconfig/csp.rules' -X DELETE -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty'

{"deletedEntity":"csp.rules"}%


```

call the get API

```
curl -X GET 'http://localhost:5601/api/appconfig/csp.rules'

{"statusCode":404,"error":"Not Found","message":"Response Error"}%
```

From the log, we can see that cache entry has been removed.

```
server    log   [02:22:10.642] [info][applicationConfig][plugins] Received a request to delete entity csp.rules.
server    log   [02:22:16.856] [info][applicationConfig][plugins] Received a request to get entity config for csp.rules.
server    log   [02:22:16.856] [info][applicationConfig][plugins] Key csp.rules is not found from cache.

```


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
