### PR TITLE
[OE] Support compression for requests

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -30,7 +30,7 @@ env:
   TEST_REPO: ${{ inputs.test_repo != '' && inputs.test_repo || 'opensearch-project/opensearch-dashboards-functional-test' }}
   TEST_BRANCH: "${{ inputs.test_branch != '' && inputs.test_branch || github.base_ref }}"
   FTR_PATH: 'ftr'
-  START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch --savedObjects.maxImportPayloadBytes=10485760 --server.maxPayloadBytes=1759977 --logging.json=false --data.search.aggs.shardDelay.enabled=true  --csp.warnLegacyBrowsers=false'
+  START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch --savedObjects.maxImportPayloadBytes=10485760 --server.maxPayloadBytes=1759977 --logging.json=false --data.search.aggs.shardDelay.enabled=true  --csp.warnLegacyBrowsers=false --server.compression.enabled=true --opensearch.compression=true'
   OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot -E cluster.routing.allocation.disk.threshold_enabled=false'
   CYPRESS_BROWSER: 'chromium'
   CYPRESS_VISBUILDER_ENABLED: true

--- a/changelogs/fragments/6366.yml
+++ b/changelogs/fragments/6366.yml
@@ -1,0 +1,2 @@
+feat:
+- Support compressing traffic with `opensearch.compression: true` or `opensearch.compress: 'gzip'` ([#6366](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6366))

--- a/src/core/server/opensearch/client/client_config.ts
+++ b/src/core/server/opensearch/client/client_config.ts
@@ -53,6 +53,7 @@ export type OpenSearchClientConfig = Pick<
   | 'username'
   | 'password'
   | 'disablePrototypePoisoningProtection'
+  | 'compression'
 > & {
   memoryCircuitBreaker?:
     | OpenSearchConfig['memoryCircuitBreaker']
@@ -118,6 +119,10 @@ export function parseClientOptions(config: OpenSearchClientConfig, scoped: boole
 
   if (config.disablePrototypePoisoningProtection != null) {
     clientOptions.disablePrototypePoisoningProtection = config.disablePrototypePoisoningProtection;
+  }
+
+  if (config.compression) {
+    clientOptions.compression = 'gzip';
   }
 
   return clientOptions;

--- a/src/core/server/opensearch/client/client_config.ts
+++ b/src/core/server/opensearch/client/client_config.ts
@@ -122,7 +122,7 @@ export function parseClientOptions(config: OpenSearchClientConfig, scoped: boole
   }
 
   if (config.compression) {
-    clientOptions.compression = 'gzip';
+    clientOptions.compression = config.compression;
   }
 
   return clientOptions;

--- a/src/core/server/opensearch/opensearch_config.test.ts
+++ b/src/core/server/opensearch/opensearch_config.test.ts
@@ -71,6 +71,7 @@ test('set correct defaults', () => {
   expect(configValue).toMatchInlineSnapshot(`
     OpenSearchConfig {
       "apiVersion": "7.x",
+      "compression": undefined,
       "customHeaders": Object {},
       "disablePrototypePoisoningProtection": undefined,
       "healthCheckDelay": "PT2.5S",

--- a/src/core/server/opensearch/opensearch_config.ts
+++ b/src/core/server/opensearch/opensearch_config.ts
@@ -32,12 +32,14 @@ import { schema, TypeOf } from '@osd/config-schema';
 import { Duration } from 'moment';
 import { readFileSync } from 'fs';
 import { ConfigDeprecationProvider } from 'src/core/server';
+import { ClientOptions } from '@opensearch-project/opensearch';
 import { readPkcs12Keystore, readPkcs12Truststore } from '../utils';
 import { ServiceConfigDescriptor } from '../internal_types';
 
 const hostURISchema = schema.uri({ scheme: ['http', 'https'] });
 
 export const DEFAULT_API_VERSION = '7.x';
+export const DEFAULT_COMPRESSION = 'gzip';
 
 export type OpenSearchConfigType = TypeOf<typeof configSchema>;
 type SslConfigSchema = OpenSearchConfigType['ssl'];
@@ -131,7 +133,9 @@ export const configSchema = schema.object({
   healthCheck: schema.object({ delay: schema.duration({ defaultValue: 2500 }) }),
   ignoreVersionMismatch: schema.boolean({ defaultValue: false }),
   disablePrototypePoisoningProtection: schema.maybe(schema.boolean({ defaultValue: false })),
-  compression: schema.maybe(schema.boolean({ defaultValue: false })),
+  compression: schema.maybe(
+    schema.oneOf([schema.literal(DEFAULT_COMPRESSION), schema.boolean({ defaultValue: false })])
+  ),
 });
 
 const deprecations: ConfigDeprecationProvider = ({ renameFromRoot, renameFromRootWithoutMap }) => [
@@ -318,7 +322,7 @@ export class OpenSearchConfig {
    * Specifies whether the client should use compression to engine
    * or not.
    */
-  public readonly compression?: boolean;
+  public readonly compression?: ClientOptions['compression'];
 
   constructor(rawConfig: OpenSearchConfigType) {
     this.ignoreVersionMismatch = rawConfig.ignoreVersionMismatch;
@@ -341,7 +345,12 @@ export class OpenSearchConfig {
     this.password = rawConfig.password;
     this.customHeaders = rawConfig.customHeaders;
     this.disablePrototypePoisoningProtection = rawConfig.disablePrototypePoisoningProtection;
-    this.compression = rawConfig.compression;
+    this.compression =
+      typeof rawConfig.compression === 'boolean' && rawConfig.compression
+        ? DEFAULT_COMPRESSION
+        : typeof rawConfig.compression === 'string'
+        ? rawConfig.compression
+        : undefined;
 
     const { alwaysPresentCertificate, verificationMode } = rawConfig.ssl;
     const { key, keyPassphrase, certificate, certificateAuthorities } = readKeyAndCerts(rawConfig);

--- a/src/core/server/opensearch/opensearch_config.ts
+++ b/src/core/server/opensearch/opensearch_config.ts
@@ -131,6 +131,7 @@ export const configSchema = schema.object({
   healthCheck: schema.object({ delay: schema.duration({ defaultValue: 2500 }) }),
   ignoreVersionMismatch: schema.boolean({ defaultValue: false }),
   disablePrototypePoisoningProtection: schema.maybe(schema.boolean({ defaultValue: false })),
+  compression: schema.maybe(schema.boolean({ defaultValue: false })),
 });
 
 const deprecations: ConfigDeprecationProvider = ({ renameFromRoot, renameFromRootWithoutMap }) => [
@@ -313,6 +314,12 @@ export class OpenSearchConfig {
    */
   public readonly disablePrototypePoisoningProtection?: boolean;
 
+  /**
+   * Specifies whether the client should use compression to engine
+   * or not.
+   */
+  public readonly compression?: boolean;
+
   constructor(rawConfig: OpenSearchConfigType) {
     this.ignoreVersionMismatch = rawConfig.ignoreVersionMismatch;
     this.apiVersion = rawConfig.apiVersion;
@@ -334,6 +341,7 @@ export class OpenSearchConfig {
     this.password = rawConfig.password;
     this.customHeaders = rawConfig.customHeaders;
     this.disablePrototypePoisoningProtection = rawConfig.disablePrototypePoisoningProtection;
+    this.compression = rawConfig.compression;
 
     const { alwaysPresentCertificate, verificationMode } = rawConfig.ssl;
     const { key, keyPassphrase, certificate, certificateAuthorities } = readKeyAndCerts(rawConfig);


### PR DESCRIPTION
### Description

Support compressing traffic with `opensearch.compression: true` or `opensearch.compress: 'gzip'`.

Also, set compression in the Node server and OpenSearch traffic for CI.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5296

## Changelog
- feat: Support compressing traffic with `opensearch.compression: true` or `opensearch.compress: 'gzip'`

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
