### PR TITLE
Validation succeed as long as status code in response is 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Multiple Datasource]Fix bug in data source aggregated view to change it to depend on displayAllCompatibleDataSources property to show the badge value ([#6291](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6291))
 - [BUG][Multiple Datasource]Read hideLocalCluster setting from yml and set in data source selector and data source menu ([#6361](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6361))
 - [BUG] Fix for checkForFunctionProperty so that order does not matter ([#6248](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6248))
+- [BUG][Multiple Datasource] Validation succeed as long as status code in response is 200 ([#6399](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6399))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/data_source/server/routes/data_source_connection_validator.test.ts
+++ b/src/plugins/data_source/server/routes/data_source_connection_validator.test.ts
@@ -165,24 +165,20 @@ describe('DataSourceManagement: data_source_connection_validator.ts', () => {
       expect(validateDataSourcesResponse.statusCode).toBe(200);
     });
 
-    test('failure: opensearch client response code is 200 and response body is empty', async () => {
-      try {
-        const opensearchClient = opensearchServiceMock.createOpenSearchClient();
-        opensearchClient.cat.indices.mockResolvedValue(opensearchServiceMock.createApiResponse());
-        const dataSourceValidator = new DataSourceConnectionValidator(opensearchClient, {
-          auth: {
-            statusCode: 200,
-            body: '',
-            credentials: {
-              service: SigV4ServiceName.OpenSearchServerless,
-            },
+    test('Success: opensearch client response code is 200 and response body is empty', async () => {
+      const opensearchClient = opensearchServiceMock.createOpenSearchClient();
+      opensearchClient.cat.indices.mockResolvedValue(opensearchServiceMock.createApiResponse());
+      const dataSourceValidator = new DataSourceConnectionValidator(opensearchClient, {
+        auth: {
+          statusCode: 200,
+          body: '',
+          credentials: {
+            service: SigV4ServiceName.OpenSearchServerless,
           },
-        });
-        const validateDataSourcesResponse = await dataSourceValidator.validate();
-        expect(validateDataSourcesResponse.statusCode).toBe(200);
-      } catch (e) {
-        expect(e).toBeTruthy();
-      }
+        },
+      });
+      const validateDataSourcesResponse = await dataSourceValidator.validate();
+      expect(validateDataSourcesResponse.statusCode).toBe(200);
     });
 
     test('failure: opensearch client response code is other than 200', async () => {

--- a/src/plugins/data_source/server/routes/data_source_connection_validator.ts
+++ b/src/plugins/data_source/server/routes/data_source_connection_validator.ts
@@ -20,7 +20,7 @@ export class DataSourceConnectionValidator {
         this.dataSourceAttr.auth?.credentials?.service === SigV4ServiceName.OpenSearchServerless
       ) {
         validationResponse = await this.callDataCluster.cat.indices();
-        if (validationResponse?.statusCode === 200 && validationResponse?.body) {
+        if (validationResponse?.statusCode === 200) {
           return validationResponse;
         }
       } else {


### PR DESCRIPTION
### Description
Data source validation should pass as long as response code is `200` even if response body is empty, for example:
```
{
  body: '',
  statusCode: 200,
  headers: {
    'content-type': 'text/plain; charset=UTF-8',
    'content-length': '0',
    'x-envoy-upstream-service-time': '44',
    date: 'Wed, 10 Apr 2024 06:10:28 GMT',
    server: 'aoss-amazon-m',
    'x-request-id': '284bf59f-4601-9ce9-ba7b-2c2282e34c17'
  },
  meta: {
    context: null,
    request: { params: [Object], options: {}, id: 1 },
    name: 'opensearch-js',
    connection: {
      url: 'https://vywd1o523wrumu9h3q05.gamma-us-east-1.aoss.amazonaws.com/',
      id: 'https://vywd1o523wrumu9h3q05.gamma-us-east-1.aoss.amazonaws.com/',
      headers: {},
      deadCount: 0,
      resurrectTimeout: 0,
      _openRequests: 0,
      status: 'alive',
      roles: [Object]
    },
    attempts: 0,
    aborted: false
  }
}
```

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6396

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
