### PR TITLE
[MD] Add OpenSearch cluster group label to top of single selectable dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Workspace] Add APIs to support plugin state in request ([#6303](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6303))
 - [Workspace] Filter left nav menu items according to the current workspace ([#6234](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6234))
 - [Multiple Datasource] Refactor data source selector component to include placeholder and add tests ([#6372](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6372))
+- [MD] Add OpenSearch cluster group label to top of single selectable dropdown  ([#6400](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6400))
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/data_source_management/public/components/data_source_menu/types.ts
+++ b/src/plugins/data_source_management/public/components/data_source_menu/types.ts
@@ -16,6 +16,11 @@ export interface DataSourceOption {
   label?: string;
 }
 
+export interface DataSourceGroupLabelOption extends DataSourceOption {
+  label: string;
+  isGroupLabel: true;
+}
+
 export interface DataSourceBaseConfig {
   fullWidth: boolean;
   disabled?: boolean;

--- a/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
@@ -52,6 +52,11 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
         options={
           Array [
             Object {
+              "id": "opensearchClusterGroupLabel",
+              "isGroupLabel": true,
+              "label": "OpenSearch cluster",
+            },
+            Object {
               "checked": "on",
               "id": "",
               "label": "Local cluster",

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
@@ -7,11 +7,12 @@ import { ShallowWrapper, shallow, mount } from 'enzyme';
 import { SavedObjectsClientContract } from '../../../../../core/public';
 import { notificationServiceMock } from '../../../../../core/public/mocks';
 import React from 'react';
-import { DataSourceSelectable } from './data_source_selectable';
+import { DataSourceSelectable, opensearchClusterGroupLabel } from './data_source_selectable';
 import { AuthType } from '../../types';
 import { getDataSourcesWithFieldsResponse, mockResponseForSavedObjectsCalls } from '../../mocks';
-import { getByRole, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import * as utils from '../utils';
+import { EuiSelectable } from '@elastic/eui';
 
 describe('DataSourceSelectable', () => {
   let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
@@ -390,5 +391,44 @@ describe('DataSourceSelectable', () => {
 
     expect(onSelectedDataSource).toBeCalledWith([{ id: 'test2', label: 'test2' }]);
     expect(onSelectedDataSource).toHaveBeenCalled();
+  });
+
+  it('should render opensearch cluster group label at the top of options, when there are options availiable', async () => {
+    const onSelectedDataSource = jest.fn();
+    component = shallow(
+      <DataSourceSelectable
+        savedObjectsClient={client}
+        notifications={toasts}
+        onSelectedDataSources={onSelectedDataSource}
+        disabled={false}
+        hideLocalCluster={false}
+        fullWidth={false}
+      />
+    );
+
+    component.instance().componentDidMount!();
+    await nextTick();
+    const optionsProp = component.find(EuiSelectable).prop('options');
+    expect(optionsProp[0]).toEqual(opensearchClusterGroupLabel);
+  });
+
+  it('should not render opensearch cluster group label, when there is no option availiable', async () => {
+    const onSelectedDataSource = jest.fn();
+    spyOn(utils, 'getDefaultDataSource').and.returnValue([]);
+    component = shallow(
+      <DataSourceSelectable
+        savedObjectsClient={client}
+        notifications={toasts}
+        onSelectedDataSources={onSelectedDataSource}
+        disabled={false}
+        hideLocalCluster={false}
+        fullWidth={false}
+      />
+    );
+
+    component.instance().componentDidMount!();
+    await nextTick();
+    const optionsProp = component.find(EuiSelectable).prop('options');
+    expect(optionsProp).toEqual([]);
   });
 });

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -25,7 +25,7 @@ import { getDataSourcesWithFields, getDefaultDataSource, getFilteredDataSources 
 import { LocalCluster } from '../data_source_selector/data_source_selector';
 import { SavedObject } from '../../../../../core/public';
 import { DataSourceAttributes } from '../../types';
-import { DataSourceOption } from '../data_source_menu/types';
+import { DataSourceGroupLabelOption, DataSourceOption } from '../data_source_menu/types';
 
 interface DataSourceSelectableProps {
   savedObjectsClient: SavedObjectsClientContract;
@@ -49,6 +49,12 @@ interface DataSourceSelectableState {
 interface SelectedDataSourceOption extends DataSourceOption {
   checked?: string;
 }
+
+export const opensearchClusterGroupLabel: DataSourceGroupLabelOption = {
+  id: 'opensearchClusterGroupLabel',
+  label: 'OpenSearch cluster',
+  isGroupLabel: true,
+};
 
 export class DataSourceSelectable extends React.Component<
   DataSourceSelectableProps,
@@ -207,6 +213,16 @@ export class DataSourceSelectable extends React.Component<
     }
   }
 
+  getOptionsWithGroupLabel = (dataSourceOptions: DataSourceOption[]): DataSourceOption[] => {
+    let optionsWithGroupLabel: DataSourceOption[] = [];
+    if (dataSourceOptions.length === 0) {
+      optionsWithGroupLabel = [];
+    } else {
+      optionsWithGroupLabel = [opensearchClusterGroupLabel, ...dataSourceOptions];
+    }
+    return optionsWithGroupLabel;
+  };
+
   render() {
     const button = (
       <>
@@ -248,7 +264,7 @@ export class DataSourceSelectable extends React.Component<
               searchProps={{
                 placeholder: 'Search',
               }}
-              options={this.state.dataSourceOptions}
+              options={this.getOptionsWithGroupLabel(this.state.dataSourceOptions)}
               onChange={(newOptions) => this.onChange(newOptions)}
               singleSelection={true}
               data-test-subj={'dataSourceSelectable'}


### PR DESCRIPTION

### Description

<!-- Describe what this change achieves-->
- when there's options available,  add OpenSearch cluster group label to the top of options in DataSourceSelectable dropdown.
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/0202b78b-e5b9-4d94-ad87-879ee051f844)
- when there's no options, don't render the opensearch cluster group label
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/44f358b7-8ef1-4174-b076-1171b1e6e313)



https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/a6e7fe9d-8f5e-47b8-9d94-5466a4d70d60



### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
part of https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6370

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
