### PR TITLE
Fix test in PR 6360

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_listing/__snapshots__/dashboard_listing.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing/__snapshots__/dashboard_listing.test.tsx.snap
@@ -813,6 +813,9 @@ exports[`dashboard listing hideWriteControls 1`] = `
                     "tls": "https://opensearch.org/docs/mocked-test-branch/dashboards/install/tls/",
                   },
                   "introduction": "https://opensearch.org/docs/mocked-test-branch/dashboards/index/",
+                  "management": Object {
+                    "advancedSettings": "https://opensearch.org/docs/mocked-test-branch/dashboards/management/advanced-settings/",
+                  },
                   "mapTiles": "https://opensearch.org/docs/mocked-test-branch/dashboards/maptiles",
                   "notebooks": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/dashboards/notebooks",
@@ -1955,6 +1958,9 @@ exports[`dashboard listing render table listing with initial filters from URL 1`
                     "tls": "https://opensearch.org/docs/mocked-test-branch/dashboards/install/tls/",
                   },
                   "introduction": "https://opensearch.org/docs/mocked-test-branch/dashboards/index/",
+                  "management": Object {
+                    "advancedSettings": "https://opensearch.org/docs/mocked-test-branch/dashboards/management/advanced-settings/",
+                  },
                   "mapTiles": "https://opensearch.org/docs/mocked-test-branch/dashboards/maptiles",
                   "notebooks": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/dashboards/notebooks",
@@ -3158,6 +3164,9 @@ exports[`dashboard listing renders call to action when no dashboards exist 1`] =
                     "tls": "https://opensearch.org/docs/mocked-test-branch/dashboards/install/tls/",
                   },
                   "introduction": "https://opensearch.org/docs/mocked-test-branch/dashboards/index/",
+                  "management": Object {
+                    "advancedSettings": "https://opensearch.org/docs/mocked-test-branch/dashboards/management/advanced-settings/",
+                  },
                   "mapTiles": "https://opensearch.org/docs/mocked-test-branch/dashboards/maptiles",
                   "notebooks": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/dashboards/notebooks",
@@ -4361,6 +4370,9 @@ exports[`dashboard listing renders table rows 1`] = `
                     "tls": "https://opensearch.org/docs/mocked-test-branch/dashboards/install/tls/",
                   },
                   "introduction": "https://opensearch.org/docs/mocked-test-branch/dashboards/index/",
+                  "management": Object {
+                    "advancedSettings": "https://opensearch.org/docs/mocked-test-branch/dashboards/management/advanced-settings/",
+                  },
                   "mapTiles": "https://opensearch.org/docs/mocked-test-branch/dashboards/maptiles",
                   "notebooks": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/dashboards/notebooks",
@@ -5564,6 +5576,9 @@ exports[`dashboard listing renders warning when listingLimit is exceeded 1`] = `
                     "tls": "https://opensearch.org/docs/mocked-test-branch/dashboards/install/tls/",
                   },
                   "introduction": "https://opensearch.org/docs/mocked-test-branch/dashboards/index/",
+                  "management": Object {
+                    "advancedSettings": "https://opensearch.org/docs/mocked-test-branch/dashboards/management/advanced-settings/",
+                  },
                   "mapTiles": "https://opensearch.org/docs/mocked-test-branch/dashboards/maptiles",
                   "notebooks": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/dashboards/notebooks",

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
@@ -705,6 +705,9 @@ exports[`Dashboard top nav render in embed mode 1`] = `
                     "tls": "https://opensearch.org/docs/mocked-test-branch/dashboards/install/tls/",
                   },
                   "introduction": "https://opensearch.org/docs/mocked-test-branch/dashboards/index/",
+                  "management": Object {
+                    "advancedSettings": "https://opensearch.org/docs/mocked-test-branch/dashboards/management/advanced-settings/",
+                  },
                   "mapTiles": "https://opensearch.org/docs/mocked-test-branch/dashboards/maptiles",
                   "notebooks": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/dashboards/notebooks",
@@ -1673,6 +1676,9 @@ exports[`Dashboard top nav render in embed mode, and force hide filter bar 1`] =
                     "tls": "https://opensearch.org/docs/mocked-test-branch/dashboards/install/tls/",
                   },
                   "introduction": "https://opensearch.org/docs/mocked-test-branch/dashboards/index/",
+                  "management": Object {
+                    "advancedSettings": "https://opensearch.org/docs/mocked-test-branch/dashboards/management/advanced-settings/",
+                  },
                   "mapTiles": "https://opensearch.org/docs/mocked-test-branch/dashboards/maptiles",
                   "notebooks": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/dashboards/notebooks",
@@ -2641,6 +2647,9 @@ exports[`Dashboard top nav render in embed mode, components can be forced show b
                     "tls": "https://opensearch.org/docs/mocked-test-branch/dashboards/install/tls/",
                   },
                   "introduction": "https://opensearch.org/docs/mocked-test-branch/dashboards/index/",
+                  "management": Object {
+                    "advancedSettings": "https://opensearch.org/docs/mocked-test-branch/dashboards/management/advanced-settings/",
+                  },
                   "mapTiles": "https://opensearch.org/docs/mocked-test-branch/dashboards/maptiles",
                   "notebooks": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/dashboards/notebooks",
@@ -3609,6 +3618,9 @@ exports[`Dashboard top nav render in full screen mode with appended URL param bu
                     "tls": "https://opensearch.org/docs/mocked-test-branch/dashboards/install/tls/",
                   },
                   "introduction": "https://opensearch.org/docs/mocked-test-branch/dashboards/index/",
+                  "management": Object {
+                    "advancedSettings": "https://opensearch.org/docs/mocked-test-branch/dashboards/management/advanced-settings/",
+                  },
                   "mapTiles": "https://opensearch.org/docs/mocked-test-branch/dashboards/maptiles",
                   "notebooks": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/dashboards/notebooks",
@@ -4577,6 +4589,9 @@ exports[`Dashboard top nav render in full screen mode, no componenets should be 
                     "tls": "https://opensearch.org/docs/mocked-test-branch/dashboards/install/tls/",
                   },
                   "introduction": "https://opensearch.org/docs/mocked-test-branch/dashboards/index/",
+                  "management": Object {
+                    "advancedSettings": "https://opensearch.org/docs/mocked-test-branch/dashboards/management/advanced-settings/",
+                  },
                   "mapTiles": "https://opensearch.org/docs/mocked-test-branch/dashboards/maptiles",
                   "notebooks": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/dashboards/notebooks",
@@ -5545,6 +5560,9 @@ exports[`Dashboard top nav render with all components 1`] = `
                     "tls": "https://opensearch.org/docs/mocked-test-branch/dashboards/install/tls/",
                   },
                   "introduction": "https://opensearch.org/docs/mocked-test-branch/dashboards/index/",
+                  "management": Object {
+                    "advancedSettings": "https://opensearch.org/docs/mocked-test-branch/dashboards/management/advanced-settings/",
+                  },
                   "mapTiles": "https://opensearch.org/docs/mocked-test-branch/dashboards/maptiles",
                   "notebooks": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/dashboards/notebooks",


### PR DESCRIPTION
### Description

This PR updates two snapshots
1. src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.test.tsx this one breaks due to #6360
2. src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.test.tsx this one breaks due to #6360 

### Issues Resolved


## Screenshot


## Testing the changes


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
