### PR TITLE
Refactor read-only component to cover more edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Multiple Datasource] Fix sslConfig for multiple datasource to handle when certificateAuthorities is unset ([#6282](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6282))
 - [BUG][Multiple Datasource]Fix bug in data source aggregated view to change it to depend on displayAllCompatibleDataSources property to show the badge value ([#6291](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6291))
 - [BUG][Multiple Datasource]Read hideLocalCluster setting from yml and set in data source selector and data source menu ([#6361](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6361))
+- [BUG][Multiple Datasource] Refactor read-only component to cover more edge cases ([#6416](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6416))
 - [BUG] Fix for checkForFunctionProperty so that order does not matter ([#6248](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6248))
 - [BUG][Multiple Datasource] Validation succeed as long as status code in response is 200 ([#6399](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6399))
 

--- a/examples/multiple_data_source_examples/public/components/data_source_view_example.tsx
+++ b/examples/multiple_data_source_examples/public/components/data_source_view_example.tsx
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   EuiBasicTable,
   EuiPageBody,
@@ -34,8 +34,11 @@ export const DataSourceViewExample = ({
   dataSourceEnabled,
   setActionMenu,
   dataSourceManagement,
+  notifications,
+  savedObjects,
 }: DataSourceViewExampleProps) => {
   const DataSourceMenu = dataSourceManagement.ui.getDataSourceMenu<DataSourceViewConfig>();
+  const [selectedDataSources, setSelectedDataSources] = useState<string[]>([]);
   const data: ComponentProp[] = [
     {
       name: 'savedObjects',
@@ -68,19 +71,31 @@ export const DataSourceViewExample = ({
     },
   ];
 
+  const renderDataSourceComponent = useMemo(() => {
+    return (
+      <DataSourceMenu
+        setMenuMountPoint={setActionMenu}
+        componentType={'DataSourceView'}
+        componentConfig={{
+          notifications,
+          savedObjects: savedObjects.client,
+          fullWidth: false,
+          activeOption: [{ id: '' }],
+          dataSourceFilter: (ds) => {
+            return true;
+          },
+          onSelectedDataSources: (ds) => {
+            setSelectedDataSources(ds);
+          },
+        }}
+      />
+    );
+  }, [setActionMenu, notifications, savedObjects]);
+
   return (
     <EuiPageBody component="main">
       <EuiPageHeader>
-        {dataSourceEnabled && (
-          <DataSourceMenu
-            setMenuMountPoint={setActionMenu}
-            componentType={'DataSourceView'}
-            componentConfig={{
-              fullWidth: false,
-              activeOption: [{ id: 'example id', label: 'example data source' }],
-            }}
-          />
-        )}
+        {dataSourceEnabled && renderDataSourceComponent}
         <EuiPageHeaderSection>
           <EuiTitle size="l">
             <h1>Data Source View Example</h1>

--- a/src/plugins/data_source_management/public/components/constants.tsx
+++ b/src/plugins/data_source_management/public/components/constants.tsx
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import { DataSourceOption } from './data_source_menu/types';
+
+export const LocalCluster: DataSourceOption = {
+  label: i18n.translate('dataSource.localCluster', {
+    defaultMessage: 'Local cluster',
+  }),
+  id: '',
+};

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`DataSourceMenu can render data source view when only pass id in the activeOption 1`] = `
 <DataSourceView
   fullWidth={true}
+  hideLocalCluster={false}
   notifications={
     Object {
       "add": [MockFunction],
@@ -33,6 +34,7 @@ exports[`DataSourceMenu can render data source view when only pass id in the act
 exports[`DataSourceMenu can render data source view when provide activeOption 1`] = `
 <DataSourceView
   fullWidth={true}
+  hideLocalCluster={false}
   notifications={
     Object {
       "add": [MockFunction],
@@ -408,6 +410,7 @@ exports[`DataSourceMenu should render data source selectable only with local clu
 exports[`DataSourceMenu should render data source view if not pass saved object or notification 1`] = `
 <DataSourceView
   fullWidth={true}
+  hideLocalCluster={false}
   notifications={
     Object {
       "add": [MockFunction],
@@ -426,6 +429,7 @@ exports[`DataSourceMenu should render data source view if not pass saved object 
 exports[`DataSourceMenu should render data source view only 1`] = `
 <DataSourceView
   fullWidth={true}
+  hideLocalCluster={false}
   notifications={
     Object {
       "add": [MockFunction],

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -22,13 +22,24 @@ export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement |
   const { componentType, componentConfig, uiSettings, hideLocalCluster } = props;
 
   function renderDataSourceView(config: DataSourceViewConfig): ReactElement | null {
-    const { activeOption, fullWidth, savedObjects, notifications } = config;
+    const {
+      activeOption,
+      fullWidth,
+      savedObjects,
+      notifications,
+      dataSourceFilter,
+      onSelectedDataSources,
+    } = config;
     return (
       <DataSourceView
         fullWidth={fullWidth}
         selectedOption={activeOption}
         savedObjectsClient={savedObjects}
         notifications={notifications?.toasts}
+        hideLocalCluster={hideLocalCluster || false}
+        dataSourceFilter={dataSourceFilter}
+        onSelectedDataSources={onSelectedDataSources}
+        uiSettings={uiSettings}
       />
     );
   }

--- a/src/plugins/data_source_management/public/components/data_source_menu/types.ts
+++ b/src/plugins/data_source_management/public/components/data_source_menu/types.ts
@@ -47,6 +47,8 @@ export interface DataSourceViewConfig extends DataSourceBaseConfig {
   activeOption: DataSourceOption[];
   savedObjects?: SavedObjectsClientContract;
   notifications?: NotificationsStart;
+  dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
+  onSelectedDataSources?: (dataSources: DataSourceOption[]) => void;
 }
 
 export interface DataSourceAggregatedViewConfig extends DataSourceBaseConfig {

--- a/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
@@ -1,5 +1,148 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DataSourceView Should render successfully when provided datasource has not been filtered out 1`] = `
+<Fragment>
+  <EuiButtonEmpty
+    aria-label="dataSourceViewMenuButton"
+    className="euiHeaderLink"
+    data-test-subj="dataSourceViewContextMenuHeaderLink"
+    disabled={true}
+    iconSide="left"
+    iconType="database"
+    size="s"
+  />
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonIcon
+        aria-label="Next"
+        display="empty"
+        iconType="iInCircle"
+        onClick={[Function]}
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenu
+      initialPanelId={0}
+      panels={
+        Array [
+          Object {
+            "id": 0,
+            "items": Array [
+              Object {
+                "disabled": true,
+                "name": undefined,
+              },
+            ],
+            "title": "Selected data source",
+          },
+        ]
+      }
+      size="m"
+    />
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceView Should return error when provided datasource has been filtered out 1`] = `
+<Fragment>
+  <EuiButtonEmpty
+    aria-label="dataSourceViewMenuButton"
+    className="euiHeaderLink"
+    data-test-subj="dataSourceViewContextMenuHeaderLink"
+    disabled={true}
+    iconSide="left"
+    iconType="database"
+    size="s"
+  />
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonIcon
+        aria-label="Next"
+        display="empty"
+        iconType="iInCircle"
+        onClick={[Function]}
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenu
+      initialPanelId={0}
+      panels={
+        Array [
+          Object {
+            "id": 0,
+            "items": Array [],
+            "title": "Selected data source",
+          },
+        ]
+      }
+      size="m"
+    />
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceView When selected option is local cluster and hide local Cluster is true, should return error 1`] = `
+<Fragment>
+  <EuiButtonEmpty
+    aria-label="dataSourceViewMenuButton"
+    className="euiHeaderLink"
+    data-test-subj="dataSourceViewContextMenuHeaderLink"
+    disabled={true}
+    iconSide="left"
+    iconType="database"
+    size="s"
+  />
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonIcon
+        aria-label="Next"
+        display="empty"
+        iconType="iInCircle"
+        onClick={[Function]}
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenu
+      initialPanelId={0}
+      panels={
+        Array [
+          Object {
+            "id": 0,
+            "items": Array [],
+            "title": "Selected data source",
+          },
+        ]
+      }
+      size="m"
+    />
+  </EuiPopover>
+</Fragment>
+`;
+
 exports[`DataSourceView should call getDataSourceById when only pass id no label 1`] = `
 <Fragment>
   <EuiButtonEmpty
@@ -86,12 +229,7 @@ exports[`DataSourceView should call notification warning when there is data sour
         Array [
           Object {
             "id": 0,
-            "items": Array [
-              Object {
-                "disabled": true,
-                "name": undefined,
-              },
-            ],
+            "items": Array [],
             "title": "Selected data source",
           },
         ]
@@ -177,9 +315,7 @@ Object {
           />
           <span
             class="euiButtonEmpty__text"
-          >
-            test1
-          </span>
+          />
         </span>
       </button>
       <div
@@ -223,9 +359,7 @@ Object {
         />
         <span
           class="euiButtonEmpty__text"
-        >
-          test1
-        </span>
+        />
       </span>
     </button>
     <div

--- a/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
@@ -143,7 +143,7 @@ exports[`DataSourceView When selected option is local cluster and hide local Clu
 </Fragment>
 `;
 
-exports[`DataSourceView should call getDataSourceById when only pass id no label 1`] = `
+exports[`DataSourceView should call getDataSourceById when only pass id with no label 1`] = `
 <Fragment>
   <EuiButtonEmpty
     aria-label="dataSourceViewMenuButton"

--- a/src/plugins/data_source_management/public/components/data_source_view/data_source_view.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_view/data_source_view.test.tsx
@@ -85,7 +85,7 @@ describe('DataSourceView', () => {
     expect(toasts.addWarning).toBeCalledTimes(0);
     expect(utils.getDataSourceById).toBeCalledTimes(1);
   });
-  it('should call getDataSourceById when only pass id no label', async () => {
+  it('should call getDataSourceById when only pass id with no label', async () => {
     spyOn(utils, 'getDataSourceById').and.returnValue([{ id: 'test1', label: 'test1' }]);
     component = shallow(
       <DataSourceView

--- a/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
@@ -7,15 +7,25 @@ import React from 'react';
 import { i18n } from '@osd/i18n';
 import { EuiPopover, EuiButtonEmpty, EuiButtonIcon, EuiContextMenu } from '@elastic/eui';
 import { SavedObjectsClientContract, ToastsStart } from 'opensearch-dashboards/public';
+import { IUiSettingsClient } from 'src/core/public';
 import { DataSourceOption } from '../data_source_menu/types';
-import { getDataSourceById } from '../utils';
+import {
+  getDataSourceById,
+  handleDataSourceFetchError,
+  handleNoAvailableDataSourceError,
+} from '../utils';
 import { MenuPanelItem } from '../../types';
+import { LocalCluster } from '../constants';
 
 interface DataSourceViewProps {
   fullWidth: boolean;
   selectedOption: DataSourceOption[];
+  hideLocalCluster: boolean;
   savedObjectsClient?: SavedObjectsClientContract;
   notifications?: ToastsStart;
+  uiSettings?: IUiSettingsClient;
+  dataSourceFilter?: (dataSource: any) => boolean;
+  onSelectedDataSources?: (dataSources: DataSourceOption[]) => void;
 }
 
 interface DataSourceViewState {
@@ -40,33 +50,60 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
   }
   async componentDidMount() {
     this._isMounted = true;
-    const selectedOption = this.props.selectedOption;
-    // early return if not possible to fetch data source
 
+    const selectedOption = this.props.selectedOption;
     const option = selectedOption[0];
     const optionId = option.id;
+
+    if (optionId === '' && !this.props.hideLocalCluster) {
+      this.setState({
+        selectedOption: [LocalCluster],
+      });
+      if (this.props.onSelectedDataSources) {
+        this.props.onSelectedDataSources([LocalCluster]);
+      }
+      return;
+    }
+
+    if (
+      (optionId === '' && this.props.hideLocalCluster) ||
+      (this.props.dataSourceFilter &&
+        this.props.selectedOption.filter(this.props.dataSourceFilter).length === 0)
+    ) {
+      this.setState({
+        selectedOption: [],
+      });
+      if (this.props.onSelectedDataSources) {
+        this.props.onSelectedDataSources([]);
+      }
+      handleNoAvailableDataSourceError(this.props.notifications!);
+      return;
+    }
+
     if (!option.label) {
       try {
-        const title = (await getDataSourceById(optionId, this.props.savedObjectsClient)).title;
-        if (!title) {
-          this.props.notifications.addWarning(
-            i18n.translate('dataSource.fetchDataSourceError', {
-              defaultMessage: `Data source with id ${optionId} is not available`,
-            })
-          );
-        } else {
-          if (!this._isMounted) return;
-          this.setState({
-            selectedOption: [{ id: optionId, label: title }],
-          });
+        const selectedDataSource = await getDataSourceById(
+          optionId,
+          this.props.savedObjectsClient!
+        );
+        if (!this._isMounted) return;
+        this.setState({
+          selectedOption: [{ id: optionId, label: selectedDataSource.title }],
+        });
+        if (this.props.onSelectedDataSources) {
+          this.props.onSelectedDataSources([{ id: optionId, label: selectedDataSource.title }]);
         }
       } catch (error) {
-        this.props.notifications.addWarning(
-          i18n.translate('dataSource.fetchDataSourceError', {
-            defaultMessage: `Failed to fetch data source due to ${error}`,
-          })
-        );
+        this.setState({
+          selectedOption: [],
+        });
+        if (this.props.onSelectedDataSources) {
+          this.props.onSelectedDataSources([]);
+        }
+        handleDataSourceFetchError(this.props.notifications!);
       }
+    } else if (this.props.onSelectedDataSources) {
+      this.props.onSelectedDataSources([option]);
     }
   }
 

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -8,7 +8,9 @@ import {
   SavedObjectsClientContract,
   SavedObject,
   IUiSettingsClient,
+  ToastsStart,
 } from 'src/core/public';
+import { i18n } from '@osd/i18n';
 import {
   DataSourceAttributes,
   DataSourceTableItem,
@@ -79,6 +81,22 @@ export async function setFirstDataSourceAsDefault(
   }
 }
 
+export function handleDataSourceFetchError(notifications: ToastsStart) {
+  notifications.addWarning(
+    i18n.translate('dataSource.fetchDataSourceError', {
+      defaultMessage: `Failed to fetch data source`,
+    })
+  );
+}
+
+export function handleNoAvailableDataSourceError(notifications: ToastsStart) {
+  notifications.addWarning(
+    i18n.translate('dataSource.noAvailableDataSourceError', {
+      defaultMessage: `Data source is not available`,
+    })
+  );
+}
+
 export function getFilteredDataSources(
   dataSources: Array<SavedObject<DataSourceAttributes>>,
   filter = (ds: SavedObject<DataSourceAttributes>) => true
@@ -129,16 +147,20 @@ export async function getDataSourceById(
   id: string,
   savedObjectsClient: SavedObjectsClientContract
 ) {
-  return savedObjectsClient.get('data-source', id).then((response) => {
-    const attributes: any = response?.attributes || {};
-    return {
-      id: response.id,
-      title: attributes.title,
-      endpoint: attributes.endpoint,
-      description: attributes.description || '',
-      auth: attributes.auth,
-    };
-  });
+  const response = await savedObjectsClient.get('data-source', id);
+
+  if (!response || response.error) {
+    throw new Error('Unable to find data source');
+  }
+
+  const attributes: any = response?.attributes || {};
+  return {
+    id: response.id,
+    title: attributes.title,
+    endpoint: attributes.endpoint,
+    description: attributes.description || '',
+    auth: attributes.auth,
+  };
 }
 
 export async function createSingleDataSource(

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -315,6 +315,17 @@ export const getDataSourceByIdWithoutCredential = {
   references: [],
 };
 
+export const getDataSourceByIdWithError = {
+  attributes: {
+    ...getDataSourceByIdWithCredential.attributes,
+    Error: {
+      statusCode: 404,
+      errorMessage: 'Unable to find data source',
+    },
+  },
+  references: [],
+};
+
 export const mockResponseForSavedObjectsCalls = (
   savedObjectsClient: SavedObjectsClientContract,
   savedObjectsMethodName: 'get' | 'find' | 'create' | 'delete' | 'update',


### PR DESCRIPTION
### Description

Refactor read-only component to cover more edge cases

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6393

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes
1. activeOption={[{id: ''}]} with hideLocalCluster is set to true in yaml 
     Toast: Data source is not available
<img width="354" alt="Screenshot 2024-04-12 at 2 36 37 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/a0f30bc6-dece-4851-b4cc-72ab26200dc3">


2. activeOption={[{id: 'invalid'}]}
    Toast: Failed to fetch data source
<img width="361" alt="Screenshot 2024-04-12 at 2 37 25 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/d01798da-fd72-47e8-830e-848918ca9c58">


3. activeOption={[{id: ''}]}   with hideLocalCluster is set to false in yaml 
     Show local cluster
<img width="276" alt="Screenshot 2024-04-12 at 2 38 25 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/12a9ceae-38a7-487a-8cd5-edd537177563">


4. activeOption={[{id: 'valid id'}]}  
    show selected cluster
<img width="303" alt="Screenshot 2024-04-12 at 2 39 39 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/52957409-abca-4bbc-a974-18e845ec20e5">


5. activeOption={[{id: 'valid id', iabel:"show label"}]} 
   show selected cluster with label name

<img width="298" alt="Screenshot 2024-04-12 at 2 40 20 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/1ac41d8f-7b6d-4a7d-a536-b754780eca74">

6. When valid id pass in, but it has been filtered out
    activeOption: [{ id: '6304d1d0-f826-11ee-ab60-439c91fde80b', label:'show label' }],
    dataSourceFilter: (ds) => {return ds.id != '6304d1d0-f826-11ee-ab60-439c91fde80b'},
   toast: datasource is not available
<img width="339" alt="Screenshot 2024-04-12 at 2 40 37 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/65fbaf5c-1d6d-4c0e-88a5-88304c534af5">


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
