### PR TITLE
fix bug: management section id not match the key defined in capabilities

### DIFF
--- a/src/plugins/management/common/contants.ts
+++ b/src/plugins/management/common/contants.ts
@@ -29,3 +29,17 @@
  */
 
 export const MANAGEMENT_APP_ID = 'management';
+export const DEFAULT_MANAGEMENT_CAPABILITIES = {
+  management: {
+    /*
+     * Management settings correspond to management section/link ids, and should not be changed
+     * without also updating those definitions.
+     */
+    opensearchDashboards: {
+      settings: true,
+      indexPatterns: true,
+      objects: true,
+      dataSources: true,
+    },
+  },
+};

--- a/src/plugins/management/public/management_sections_service.test.ts
+++ b/src/plugins/management/public/management_sections_service.test.ts
@@ -28,6 +28,7 @@
  * under the License.
  */
 
+import { DEFAULT_MANAGEMENT_CAPABILITIES } from '../common/contants';
 import {
   ManagementSectionsService,
   getSectionsServiceStartPrivate,
@@ -104,5 +105,30 @@ describe('ManagementService', () => {
         "test-app-3",
       ]
     `);
+  });
+
+  it('should disable apps register in opensearchDashboards section', () => {
+    const originalDataSourcesCapability =
+      DEFAULT_MANAGEMENT_CAPABILITIES.management.opensearchDashboards.dataSources;
+
+    const setup = managementService.setup();
+
+    // Register app with id dataSources, the app id will be capability id
+    setup.section.opensearchDashboards.registerApp({
+      id: 'dataSources',
+      title: 'Data source',
+      mount: jest.fn(),
+    });
+
+    // Now set dataSources to capability to false should disable
+    // the dataSources app registered in opensearchDashboards section
+    DEFAULT_MANAGEMENT_CAPABILITIES.management.opensearchDashboards.dataSources = false;
+
+    managementService.start({ capabilities: DEFAULT_MANAGEMENT_CAPABILITIES });
+    expect(
+      setup.section.opensearchDashboards.apps.find((app) => app.id === 'dataSources')?.enabled
+    ).toBe(false);
+
+    DEFAULT_MANAGEMENT_CAPABILITIES.management.opensearchDashboards.dataSources = originalDataSourcesCapability;
   });
 });

--- a/src/plugins/management/public/management_sections_service.test.ts
+++ b/src/plugins/management/public/management_sections_service.test.ts
@@ -107,13 +107,15 @@ describe('ManagementService', () => {
     `);
   });
 
-  it('should disable apps register in opensearchDashboards section', () => {
+  it('should disable apps register in predefined opensearchDashboards section', () => {
+    // The management capabilities has `opensearchDashboards` as the key
     const originalDataSourcesCapability =
       DEFAULT_MANAGEMENT_CAPABILITIES.management.opensearchDashboards.dataSources;
 
     const setup = managementService.setup();
 
-    // Register app with id dataSources, the app id will be capability id
+    // The predefined opensearchDashboards section has id `opensearch-dashboards` which
+    // doesn't match the capability id `opensearchDashboards`
     setup.section.opensearchDashboards.registerApp({
       id: 'dataSources',
       title: 'Data source',

--- a/src/plugins/management/public/management_sections_service.ts
+++ b/src/plugins/management/public/management_sections_service.ts
@@ -51,6 +51,10 @@ const [getSectionsServiceStartPrivate, setSectionsServiceStartPrivate] = createG
   ManagementSectionsStartPrivate
 >('SectionsServiceStartPrivate');
 
+const MANAGEMENT_ID_TO_CAPABILITIES: Record<string, string> = {
+  'opensearch-dashboards': 'opensearchDashboards',
+};
+
 export { getSectionsServiceStartPrivate };
 
 export class ManagementSectionsService {
@@ -94,8 +98,9 @@ export class ManagementSectionsService {
 
   start({ capabilities }: SectionsServiceStartDeps) {
     this.getAllSections().forEach((section) => {
-      if (capabilities.management.hasOwnProperty(section.id)) {
-        const sectionCapabilities = capabilities.management[section.id];
+      const capabilityId = MANAGEMENT_ID_TO_CAPABILITIES[section.id] || section.id;
+      if (capabilities.management.hasOwnProperty(capabilityId)) {
+        const sectionCapabilities = capabilities.management[capabilityId];
         section.apps.forEach((app) => {
           if (sectionCapabilities.hasOwnProperty(app.id) && sectionCapabilities[app.id] !== true) {
             app.disable();

--- a/src/plugins/management/public/management_sections_service.ts
+++ b/src/plugins/management/public/management_sections_service.ts
@@ -51,6 +51,18 @@ const [getSectionsServiceStartPrivate, setSectionsServiceStartPrivate] = createG
   ManagementSectionsStartPrivate
 >('SectionsServiceStartPrivate');
 
+/**
+ * The management capabilities has `opensearchDashboards` as the key
+ * While when registering the opensearchDashboards section, the section id is `opensearch-dashboards`
+ * as defined in {@link ManagementSectionId.OpenSearchDashboards} and section id is used as the capability
+ * id. Here we have a mapping so that the section id opensearch-dashboards can mapping correctly back to the
+ * capability id: opensearchDashboards
+ *
+ * Why not directly change the capability id to opensearch-dashboards?
+ * The issue was introduced in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/260
+ * Since then, the capability id `opensearchDashboards` has been used by plugins, having a mapping here
+ * is for backward compatibility
+ */
 const MANAGEMENT_ID_TO_CAPABILITIES: Record<string, string> = {
   'opensearch-dashboards': 'opensearchDashboards',
 };

--- a/src/plugins/management/server/capabilities_provider.ts
+++ b/src/plugins/management/server/capabilities_provider.ts
@@ -28,17 +28,6 @@
  * under the License.
  */
 
-export const capabilitiesProvider = () => ({
-  management: {
-    /*
-     * Management settings correspond to management section/link ids, and should not be changed
-     * without also updating those definitions.
-     */
-    opensearchDashboards: {
-      settings: true,
-      indexPatterns: true,
-      objects: true,
-      dataSources: true,
-    },
-  },
-});
+import { DEFAULT_MANAGEMENT_CAPABILITIES } from '../common/contants';
+
+export const capabilitiesProvider = () => DEFAULT_MANAGEMENT_CAPABILITIES;


### PR DESCRIPTION
### Description

The `Dashboards management` section id(`opensearch-dashboards`) of `Management` category doesn't match the id(`opensearchDashboards`) defined in `capabilities`, the consequence is the following code will never work for apps of `Dashboards management`. Even set the capability of the app to false, the nav link still displayed on the UI(it does redirect to home page when accessing the link).

```typescript
    this.getAllSections().forEach((section) => {
      if (capabilities.management.hasOwnProperty(section.id)) {
        const sectionCapabilities = capabilities.management[section.id];
        section.apps.forEach((app) => {
          if (sectionCapabilities.hasOwnProperty(app.id) && sectionCapabilities[app.id] !== true) {
            app.disable();
          }
        });
      }
    });
```

The original PR introduced the `id` change is https://github.com/opensearch-project/OpenSearch-Dashboards/pull/260
@kavilla do you have more context of changing id from `opensearchDashboards` to `opensearch-dashboards`?

## Changelog

- fix: management section id not match the key defined in capabilities

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
