### PR TITLE
Fix link checker on `threedubmedia.com`

### DIFF
--- a/.lycheeexclude
+++ b/.lycheeexclude
@@ -127,3 +127,4 @@ https://sass-lang.com/*
 http://api.jquery.com/*
 http://brandonaaron.net
 https://www.circl.lu/doc/misp/
+http://threedubmedia.com/


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
http://threedubmedia.com/ seems to out of work and breaks the link-checker on 2.x. Ignore this link.
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/1c06ec4e-094b-4f59-bbfe-2b694645f2ad)


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
