### PR TITLE
[Workspace] Add workspaceAvailability field into application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Workspace] Hide datasource and advanced settings menu in dashboard management when in workspace. ([#6455](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6455))
 - [Multiple Datasource] Modify selectable picker to remove group label and close popover after selection ([#6515](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6515))
 - [Workspace] Add workspaces filter to saved objects page. ([#6458](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6458))
+- [Workspace] Allow making apps available in workspaces using `workspaceAvailability` ([#6427](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6427))
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Workspace] Hide datasource and advanced settings menu in dashboard management when in workspace. ([#6455](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6455))
 - [Multiple Datasource] Modify selectable picker to remove group label and close popover after selection ([#6515](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6515))
 - [Workspace] Add workspaces filter to saved objects page. ([#6458](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6458))
-- [Workspace] Allow making apps available in workspaces using `workspaceAvailability` ([#6427](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6427))
 
 ### 🐛 Bug Fixes
 

--- a/changelogs/fragments/6427.yml
+++ b/changelogs/fragments/6427.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace] Allow making apps available in workspaces using `workspaceAvailability` ([#6427](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6427))

--- a/src/core/public/application/application_service.test.ts
+++ b/src/core/public/application/application_service.test.ts
@@ -50,7 +50,7 @@ import {
   AppNavLinkStatus,
   AppStatus,
   AppUpdater,
-  WorkspaceAccessibility,
+  WorkspaceAvailability,
 } from './types';
 import { act } from 'react-dom/test-utils';
 import { workspacesServiceMock } from '../mocks';
@@ -570,7 +570,7 @@ describe('#start()', () => {
         Symbol(),
         createApp({
           id: 'app1',
-          workspaceAccessibility: WorkspaceAccessibility.NO,
+          workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
         })
       );
       const { getUrlForApp } = await service.start({
@@ -825,7 +825,7 @@ describe('#start()', () => {
         Symbol(),
         createApp({
           id: 'app1',
-          workspaceAccessibility: WorkspaceAccessibility.NO,
+          workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
         })
       );
       const workspaces = workspacesServiceMock.createStartContract();

--- a/src/core/public/application/application_service.test.ts
+++ b/src/core/public/application/application_service.test.ts
@@ -570,7 +570,7 @@ describe('#start()', () => {
         Symbol(),
         createApp({
           id: 'app1',
-          workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
+          workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
         })
       );
       const { getUrlForApp } = await service.start({
@@ -825,7 +825,7 @@ describe('#start()', () => {
         Symbol(),
         createApp({
           id: 'app1',
-          workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
+          workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
         })
       );
       const workspaces = workspacesServiceMock.createStartContract();

--- a/src/core/public/application/application_service.test.ts
+++ b/src/core/public/application/application_service.test.ts
@@ -808,7 +808,7 @@ describe('#start()', () => {
       `);
     });
 
-    it('navigate by using window.location.assign if navigate to a app not accessible within a workspace', async () => {
+    it('refresh the page if navigate to a app not accessible within a workspace', async () => {
       // Save the original assign method
       const originalLocation = window.location;
       delete (window as any).location;

--- a/src/core/public/application/application_service.tsx
+++ b/src/core/public/application/application_service.tsx
@@ -54,7 +54,7 @@ import {
   InternalApplicationStart,
   Mounter,
   NavigateToAppOptions,
-  WorkspaceAccessibility,
+  WorkspaceAvailability,
 } from './types';
 import { getLeaveAction, isConfirmAction } from './application_leave';
 import { appendAppPath, parseAppUrl, relativeToAbsolute, getAppInfo } from './utils';
@@ -265,9 +265,9 @@ export class ApplicationService {
         const targetApp = applications$.value.get(appId);
         if (
           workspaces.currentWorkspaceId$.value &&
-          targetApp?.workspaceAccessibility === WorkspaceAccessibility.NO
+          targetApp?.workspaceAvailability === WorkspaceAvailability.outOfWorkspace
         ) {
-          // If user is inside a workspace and the target app is not accessible within a workspace
+          // If user is inside a workspace and the target app is not available within a workspace
           // refresh the page by doing a hard navigation
           window.location.assign(
             http.basePath.prepend(getAppUrl(availableMounters, appId, path), {
@@ -314,7 +314,8 @@ export class ApplicationService {
       ) => {
         const targetApp = applications$.value.get(appId);
         const relUrl = http.basePath.prepend(getAppUrl(availableMounters, appId, path), {
-          withoutClientBasePath: targetApp?.workspaceAccessibility === WorkspaceAccessibility.NO,
+          withoutClientBasePath:
+            targetApp?.workspaceAvailability === WorkspaceAvailability.outOfWorkspace,
         });
         return absolute ? relativeToAbsolute(relUrl) : relUrl;
       },

--- a/src/core/public/application/application_service.tsx
+++ b/src/core/public/application/application_service.tsx
@@ -265,7 +265,7 @@ export class ApplicationService {
         const targetApp = applications$.value.get(appId);
         if (
           workspaces.currentWorkspaceId$.value &&
-          targetApp?.workspaceAvailability === WorkspaceAvailability.outOfWorkspace
+          targetApp?.workspaceAvailability === WorkspaceAvailability.outsideWorkspace
         ) {
           // If user is inside a workspace and the target app is not available within a workspace
           // refresh the page by doing a hard navigation
@@ -315,7 +315,7 @@ export class ApplicationService {
         const targetApp = applications$.value.get(appId);
         const relUrl = http.basePath.prepend(getAppUrl(availableMounters, appId, path), {
           withoutClientBasePath:
-            targetApp?.workspaceAvailability === WorkspaceAvailability.outOfWorkspace,
+            targetApp?.workspaceAvailability === WorkspaceAvailability.outsideWorkspace,
         });
         return absolute ? relativeToAbsolute(relUrl) : relUrl;
       },

--- a/src/core/public/application/index.ts
+++ b/src/core/public/application/index.ts
@@ -54,4 +54,5 @@ export {
   // Internal types
   InternalApplicationSetup,
   InternalApplicationStart,
+  WorkspaceAccessibility,
 } from './types';

--- a/src/core/public/application/index.ts
+++ b/src/core/public/application/index.ts
@@ -54,5 +54,5 @@ export {
   // Internal types
   InternalApplicationSetup,
   InternalApplicationStart,
-  WorkspaceAccessibility,
+  WorkspaceAvailability,
 } from './types';

--- a/src/core/public/application/integration_tests/application_service.test.tsx
+++ b/src/core/public/application/integration_tests/application_service.test.tsx
@@ -41,6 +41,7 @@ import { overlayServiceMock } from '../../overlays/overlay_service.mock';
 import { AppMountParameters } from '../types';
 import { Observable } from 'rxjs';
 import { MountPoint } from 'opensearch-dashboards/public';
+import { workspacesServiceMock } from '../../mocks';
 
 const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
 
@@ -67,7 +68,11 @@ describe('ApplicationService', () => {
       context: contextServiceMock.createSetupContract(),
       history: history as any,
     };
-    startDeps = { http, overlays: overlayServiceMock.createStartContract() };
+    startDeps = {
+      http,
+      overlays: overlayServiceMock.createStartContract(),
+      workspaces: workspacesServiceMock.createStartContract(),
+    };
     service = new ApplicationService();
   });
 

--- a/src/core/public/application/types.ts
+++ b/src/core/public/application/types.ts
@@ -104,6 +104,22 @@ export type AppUpdatableFields = Pick<App, 'status' | 'navLinkStatus' | 'tooltip
 export type AppUpdater = (app: App) => Partial<AppUpdatableFields> | undefined;
 
 /**
+ * Visibilities of the application based on if user is within a workspace
+ *
+ * @public
+ */
+export enum WorkspaceAccessibility {
+  /**
+   * The application is not accessible when user is in a workspace.
+   */
+  NO = 0,
+  /**
+   * The application is only accessible when user is in a workspace.
+   */
+  YES = 1,
+}
+
+/**
  * @public
  */
 export interface App<HistoryLocationState = unknown> {
@@ -245,6 +261,12 @@ export interface App<HistoryLocationState = unknown> {
    * ```
    */
   exactRoute?: boolean;
+
+  /**
+   * Declare if page is accessible when inside a workspace.
+   * Defaults to undefined to indicate the application can be accessible within or out of workspace.
+   */
+  workspaceAccessibility?: WorkspaceAccessibility;
 }
 
 /**

--- a/src/core/public/application/types.ts
+++ b/src/core/public/application/types.ts
@@ -112,15 +112,11 @@ export enum WorkspaceAvailability {
   /**
    * The application is not accessible when user is in a workspace.
    */
-  outOfWorkspace = 2,
+  outsideWorkspace = 2,
   /**
    * The application is only accessible when user is in a workspace.
    */
-  inWorkspace = 1,
-  /**
-   * The application is accessible when user is in or not in a workspace.
-   */
-  both = 0,
+  insideWorkspace = 1,
 }
 
 /**
@@ -268,7 +264,8 @@ export interface App<HistoryLocationState = unknown> {
 
   /**
    * Declare if page is available when inside a workspace.
-   * Defaults to WorkspaceAvailability.both to indicate the application is available within or out of workspace.
+   * Defaults to WorkspaceAvailability.outsideWorkspace | WorkspaceAvailability.insideWorkspace,
+   * indicating the application is available within or out of workspace.
    */
   workspaceAvailability?: WorkspaceAvailability;
 }

--- a/src/core/public/application/types.ts
+++ b/src/core/public/application/types.ts
@@ -108,15 +108,19 @@ export type AppUpdater = (app: App) => Partial<AppUpdatableFields> | undefined;
  *
  * @public
  */
-export enum WorkspaceAccessibility {
+export enum WorkspaceAvailability {
   /**
    * The application is not accessible when user is in a workspace.
    */
-  NO = 0,
+  outOfWorkspace = 2,
   /**
    * The application is only accessible when user is in a workspace.
    */
-  YES = 1,
+  inWorkspace = 1,
+  /**
+   * The application is accessible when user is in or not in a workspace.
+   */
+  both = 0,
 }
 
 /**
@@ -263,10 +267,10 @@ export interface App<HistoryLocationState = unknown> {
   exactRoute?: boolean;
 
   /**
-   * Declare if page is accessible when inside a workspace.
-   * Defaults to undefined to indicate the application can be accessible within or out of workspace.
+   * Declare if page is available when inside a workspace.
+   * Defaults to WorkspaceAvailability.both to indicate the application is available within or out of workspace.
    */
-  workspaceAccessibility?: WorkspaceAccessibility;
+  workspaceAvailability?: WorkspaceAvailability;
 }
 
 /**

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -268,7 +268,7 @@ export class ChromeService {
           forceAppSwitcherNavigation$={navLinks.getForceAppSwitcherNavigation$()}
           helpExtension$={helpExtension$.pipe(takeUntil(this.stop$))}
           helpSupportUrl$={helpSupportUrl$.pipe(takeUntil(this.stop$))}
-          homeHref={http.basePath.prepend('/app/home')}
+          homeHref={application.getUrlForApp('home')}
           isVisible$={this.isVisible$}
           opensearchDashboardsVersion={injectedMetadata.getOpenSearchDashboardsVersion()}
           navLinks$={navLinks.getNavLinks$()}

--- a/src/core/public/chrome/nav_links/to_nav_link.test.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.test.ts
@@ -28,7 +28,12 @@
  * under the License.
  */
 
-import { PublicAppInfo, AppNavLinkStatus, AppStatus } from '../../application';
+import {
+  PublicAppInfo,
+  AppNavLinkStatus,
+  AppStatus,
+  WorkspaceAccessibility,
+} from '../../application';
 import { toNavLink } from './to_nav_link';
 
 import { httpServiceMock } from '../../mocks';
@@ -171,6 +176,40 @@ describe('toNavLink', () => {
       expect.objectContaining({
         disabled: true,
         hidden: false,
+      })
+    );
+  });
+
+  it('uses the workspaceVisibility of the application to construct the url', () => {
+    const httpMock = httpServiceMock.createStartContract({
+      basePath: '/base_path',
+      clientBasePath: '/client_base_path',
+    });
+    expect(
+      toNavLink(
+        app({
+          workspaceAccessibility: WorkspaceAccessibility.NO,
+        }),
+        httpMock.basePath
+      ).properties
+    ).toEqual(
+      expect.objectContaining({
+        url: 'http://localhost/base_path/app/some-id',
+        baseUrl: 'http://localhost/base_path/app/some-id',
+      })
+    );
+
+    expect(
+      toNavLink(
+        app({
+          workspaceAccessibility: WorkspaceAccessibility.YES,
+        }),
+        httpMock.basePath
+      ).properties
+    ).toEqual(
+      expect.objectContaining({
+        url: 'http://localhost/base_path/client_base_path/app/some-id',
+        baseUrl: 'http://localhost/base_path/client_base_path/app/some-id',
       })
     );
   });

--- a/src/core/public/chrome/nav_links/to_nav_link.test.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.test.ts
@@ -180,7 +180,7 @@ describe('toNavLink', () => {
     );
   });
 
-  it('uses the workspaceVisibility of the application to construct the url', () => {
+  it('uses the workspaceAvailability of the application to construct the url', () => {
     const httpMock = httpServiceMock.createStartContract({
       basePath: '/base_path',
       clientBasePath: '/client_base_path',

--- a/src/core/public/chrome/nav_links/to_nav_link.test.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.test.ts
@@ -32,7 +32,7 @@ import {
   PublicAppInfo,
   AppNavLinkStatus,
   AppStatus,
-  WorkspaceAccessibility,
+  WorkspaceAvailability,
 } from '../../application';
 import { toNavLink } from './to_nav_link';
 
@@ -188,7 +188,7 @@ describe('toNavLink', () => {
     expect(
       toNavLink(
         app({
-          workspaceAccessibility: WorkspaceAccessibility.NO,
+          workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
         }),
         httpMock.basePath
       ).properties
@@ -202,7 +202,7 @@ describe('toNavLink', () => {
     expect(
       toNavLink(
         app({
-          workspaceAccessibility: WorkspaceAccessibility.YES,
+          workspaceAvailability: WorkspaceAvailability.inWorkspace,
         }),
         httpMock.basePath
       ).properties

--- a/src/core/public/chrome/nav_links/to_nav_link.test.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.test.ts
@@ -188,7 +188,7 @@ describe('toNavLink', () => {
     expect(
       toNavLink(
         app({
-          workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
+          workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
         }),
         httpMock.basePath
       ).properties
@@ -202,7 +202,7 @@ describe('toNavLink', () => {
     expect(
       toNavLink(
         app({
-          workspaceAvailability: WorkspaceAvailability.inWorkspace,
+          workspaceAvailability: WorkspaceAvailability.insideWorkspace,
         }),
         httpMock.basePath
       ).properties

--- a/src/core/public/chrome/nav_links/to_nav_link.test.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.test.ts
@@ -199,10 +199,27 @@ describe('toNavLink', () => {
       })
     );
 
+    // When app is accessible inside workspace or outside workspace.
     expect(
       toNavLink(
         app({
           workspaceAvailability: WorkspaceAvailability.insideWorkspace,
+        }),
+        httpMock.basePath
+      ).properties
+    ).toEqual(
+      expect.objectContaining({
+        url: 'http://localhost/base_path/client_base_path/app/some-id',
+        baseUrl: 'http://localhost/base_path/client_base_path/app/some-id',
+      })
+    );
+
+    expect(
+      toNavLink(
+        app({
+          workspaceAvailability:
+            // eslint-disable-next-line no-bitwise
+            WorkspaceAvailability.insideWorkspace | WorkspaceAvailability.outsideWorkspace,
         }),
         httpMock.basePath
       ).properties

--- a/src/core/public/chrome/nav_links/to_nav_link.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.ts
@@ -28,14 +28,22 @@
  * under the License.
  */
 
-import { PublicAppInfo, AppNavLinkStatus, AppStatus } from '../../application';
+import {
+  PublicAppInfo,
+  AppNavLinkStatus,
+  AppStatus,
+  WorkspaceAccessibility,
+} from '../../application';
 import { IBasePath } from '../../http';
 import { NavLinkWrapper } from './nav_link';
 import { appendAppPath } from '../../application/utils';
 
 export function toNavLink(app: PublicAppInfo, basePath: IBasePath): NavLinkWrapper {
   const useAppStatus = app.navLinkStatus === AppNavLinkStatus.default;
-  const relativeBaseUrl = basePath.prepend(app.appRoute!);
+  let relativeBaseUrl = basePath.prepend(app.appRoute!);
+  if (app.workspaceAccessibility === WorkspaceAccessibility.NO) {
+    relativeBaseUrl = basePath.prepend(app.appRoute!, { withoutClientBasePath: true });
+  }
   const url = relativeToAbsolute(appendAppPath(relativeBaseUrl, app.defaultPath));
   const baseUrl = relativeToAbsolute(relativeBaseUrl);
 

--- a/src/core/public/chrome/nav_links/to_nav_link.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.ts
@@ -41,7 +41,7 @@ import { appendAppPath } from '../../application/utils';
 export function toNavLink(app: PublicAppInfo, basePath: IBasePath): NavLinkWrapper {
   const useAppStatus = app.navLinkStatus === AppNavLinkStatus.default;
   let relativeBaseUrl = basePath.prepend(app.appRoute!);
-  if (app.workspaceAvailability === WorkspaceAvailability.outOfWorkspace) {
+  if (app.workspaceAvailability === WorkspaceAvailability.outsideWorkspace) {
     relativeBaseUrl = basePath.prepend(app.appRoute!, { withoutClientBasePath: true });
   }
   const url = relativeToAbsolute(appendAppPath(relativeBaseUrl, app.defaultPath));

--- a/src/core/public/chrome/nav_links/to_nav_link.ts
+++ b/src/core/public/chrome/nav_links/to_nav_link.ts
@@ -32,7 +32,7 @@ import {
   PublicAppInfo,
   AppNavLinkStatus,
   AppStatus,
-  WorkspaceAccessibility,
+  WorkspaceAvailability,
 } from '../../application';
 import { IBasePath } from '../../http';
 import { NavLinkWrapper } from './nav_link';
@@ -41,7 +41,7 @@ import { appendAppPath } from '../../application/utils';
 export function toNavLink(app: PublicAppInfo, basePath: IBasePath): NavLinkWrapper {
   const useAppStatus = app.navLinkStatus === AppNavLinkStatus.default;
   let relativeBaseUrl = basePath.prepend(app.appRoute!);
-  if (app.workspaceAccessibility === WorkspaceAccessibility.NO) {
+  if (app.workspaceAvailability === WorkspaceAvailability.outOfWorkspace) {
     relativeBaseUrl = basePath.prepend(app.appRoute!, { withoutClientBasePath: true });
   }
   const url = relativeToAbsolute(appendAppPath(relativeBaseUrl, app.defaultPath));

--- a/src/core/public/core_system.ts
+++ b/src/core/public/core_system.ts
@@ -226,8 +226,8 @@ export class CoreSystem {
         overlays,
         targetDomElement: notificationsTargetDomElement,
       });
-      const application = await this.application.start({ http, overlays });
       const workspaces = this.workspaces.start();
+      const application = await this.application.start({ http, overlays, workspaces });
       const chrome = await this.chrome.start({
         application,
         docLinks,

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -134,7 +134,7 @@ export {
   AppUpdater,
   ScopedHistory,
   NavigateToAppOptions,
-  WorkspaceAccessibility,
+  WorkspaceAvailability,
 } from './application';
 
 export {

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -134,6 +134,7 @@ export {
   AppUpdater,
   ScopedHistory,
   NavigateToAppOptions,
+  WorkspaceAccessibility,
 } from './application';
 
 export {

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -135,7 +135,7 @@ export class HomePublicPlugin
         const { renderApp } = await import('./application');
         return await renderApp(params.element, coreStart, params.history);
       },
-      workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
+      workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
     });
     urlForwarding.forwardApp('home', 'home');
 

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -56,7 +56,7 @@ import { DataPublicPluginStart } from '../../data/public';
 import { TelemetryPluginStart } from '../../telemetry/public';
 import { UsageCollectionSetup } from '../../usage_collection/public';
 import { UrlForwardingSetup, UrlForwardingStart } from '../../url_forwarding/public';
-import { AppNavLinkStatus } from '../../../core/public';
+import { AppNavLinkStatus, WorkspaceAccessibility } from '../../../core/public';
 import { PLUGIN_ID, HOME_APP_BASE_PATH } from '../common/constants';
 import { DataSourcePluginStart } from '../../data_source/public';
 import { workWithDataSection } from './application/components/homepage/sections/work_with_data';
@@ -135,6 +135,7 @@ export class HomePublicPlugin
         const { renderApp } = await import('./application');
         return await renderApp(params.element, coreStart, params.history);
       },
+      workspaceAccessibility: WorkspaceAccessibility.NO,
     });
     urlForwarding.forwardApp('home', 'home');
 

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -56,7 +56,7 @@ import { DataPublicPluginStart } from '../../data/public';
 import { TelemetryPluginStart } from '../../telemetry/public';
 import { UsageCollectionSetup } from '../../usage_collection/public';
 import { UrlForwardingSetup, UrlForwardingStart } from '../../url_forwarding/public';
-import { AppNavLinkStatus, WorkspaceAccessibility } from '../../../core/public';
+import { AppNavLinkStatus, WorkspaceAvailability } from '../../../core/public';
 import { PLUGIN_ID, HOME_APP_BASE_PATH } from '../common/constants';
 import { DataSourcePluginStart } from '../../data_source/public';
 import { workWithDataSection } from './application/components/homepage/sections/work_with_data';
@@ -135,7 +135,7 @@ export class HomePublicPlugin
         const { renderApp } = await import('./application');
         return await renderApp(params.element, coreStart, params.history);
       },
-      workspaceAccessibility: WorkspaceAccessibility.NO,
+      workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
     });
     urlForwarding.forwardApp('home', 'home');
 

--- a/src/plugins/opensearch_dashboards_overview/public/plugin.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/plugin.ts
@@ -40,6 +40,7 @@ import {
   AppStatus,
   AppNavLinkStatus,
   Branding,
+  WorkspaceAccessibility,
 } from '../../../core/public';
 import {
   OpenSearchDashboardsOverviewPluginSetup,
@@ -106,6 +107,7 @@ export class OpenSearchDashboardsOverviewPlugin
         // Render the application
         return renderApp(coreStart, depsStart as AppPluginStartDependencies, params);
       },
+      workspaceAccessibility: WorkspaceAccessibility.NO,
     });
 
     if (home) {

--- a/src/plugins/opensearch_dashboards_overview/public/plugin.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/plugin.ts
@@ -40,7 +40,7 @@ import {
   AppStatus,
   AppNavLinkStatus,
   Branding,
-  WorkspaceAccessibility,
+  WorkspaceAvailability,
 } from '../../../core/public';
 import {
   OpenSearchDashboardsOverviewPluginSetup,
@@ -107,7 +107,7 @@ export class OpenSearchDashboardsOverviewPlugin
         // Render the application
         return renderApp(coreStart, depsStart as AppPluginStartDependencies, params);
       },
-      workspaceAccessibility: WorkspaceAccessibility.NO,
+      workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
     });
 
     if (home) {

--- a/src/plugins/opensearch_dashboards_overview/public/plugin.ts
+++ b/src/plugins/opensearch_dashboards_overview/public/plugin.ts
@@ -107,7 +107,7 @@ export class OpenSearchDashboardsOverviewPlugin
         // Render the application
         return renderApp(coreStart, depsStart as AppPluginStartDependencies, params);
       },
-      workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
+      workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
     });
 
     if (home) {

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
@@ -93,7 +93,7 @@ describe('<WorkspaceMenu />', () => {
     render(<WorkspaceMenu coreStart={coreStartMock} />);
     fireEvent.click(screen.getByText(/select a workspace/i));
     fireEvent.click(screen.getByText(/create workspace/i));
-    expect(window.location.assign).toHaveBeenCalledWith('https://test.com/app/workspace_create');
+    expect(coreStartMock.application.navigateToApp).toHaveBeenCalledWith('workspace_create');
 
     Object.defineProperty(window, 'location', {
       value: originalLocation,
@@ -111,7 +111,7 @@ describe('<WorkspaceMenu />', () => {
     render(<WorkspaceMenu coreStart={coreStartMock} />);
     fireEvent.click(screen.getByText(/select a workspace/i));
     fireEvent.click(screen.getByText(/all workspace/i));
-    expect(window.location.assign).toHaveBeenCalledWith('https://test.com/app/workspace_list');
+    expect(coreStartMock.application.navigateToApp).toHaveBeenCalledWith('workspace_list');
 
     Object.defineProperty(window, 'location', {
       value: originalLocation,

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -104,13 +104,7 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
       }),
       key: WORKSPACE_CREATE_APP_ID,
       onClick: () => {
-        window.location.assign(
-          cleanWorkspaceId(
-            coreStart.application.getUrlForApp(WORKSPACE_CREATE_APP_ID, {
-              absolute: false,
-            })
-          )
-        );
+        coreStart.application.navigateToApp(WORKSPACE_CREATE_APP_ID);
       },
     });
     workspaceListItems.push({
@@ -120,13 +114,7 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
       }),
       key: WORKSPACE_LIST_APP_ID,
       onClick: () => {
-        window.location.assign(
-          cleanWorkspaceId(
-            coreStart.application.getUrlForApp(WORKSPACE_LIST_APP_ID, {
-              absolute: false,
-            })
-          )
-        );
+        coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
       },
     });
     return workspaceListItems;

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -16,6 +16,7 @@ import {
   AppUpdater,
   AppStatus,
   PublicAppInfo,
+  WorkspaceAccessibility,
 } from '../../../core/public';
 import {
   WORKSPACE_FATAL_ERROR_APP_ID,
@@ -199,6 +200,7 @@ export class WorkspacePlugin implements Plugin<{}, {}, WorkspacePluginSetupDeps>
         const { renderCreatorApp } = await import('./application');
         return mountWorkspaceApp(params, renderCreatorApp);
       },
+      workspaceAccessibility: WorkspaceAccessibility.NO,
     });
 
     // update
@@ -244,6 +246,7 @@ export class WorkspacePlugin implements Plugin<{}, {}, WorkspacePluginSetupDeps>
         const { renderListApp } = await import('./application');
         return mountWorkspaceApp(params, renderListApp);
       },
+      workspaceAccessibility: WorkspaceAccessibility.NO,
     });
 
     /**

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -16,7 +16,7 @@ import {
   AppUpdater,
   AppStatus,
   PublicAppInfo,
-  WorkspaceAccessibility,
+  WorkspaceAvailability,
 } from '../../../core/public';
 import {
   WORKSPACE_FATAL_ERROR_APP_ID,
@@ -200,7 +200,7 @@ export class WorkspacePlugin implements Plugin<{}, {}, WorkspacePluginSetupDeps>
         const { renderCreatorApp } = await import('./application');
         return mountWorkspaceApp(params, renderCreatorApp);
       },
-      workspaceAccessibility: WorkspaceAccessibility.NO,
+      workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
     });
 
     // update
@@ -246,7 +246,7 @@ export class WorkspacePlugin implements Plugin<{}, {}, WorkspacePluginSetupDeps>
         const { renderListApp } = await import('./application');
         return mountWorkspaceApp(params, renderListApp);
       },
-      workspaceAccessibility: WorkspaceAccessibility.NO,
+      workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
     });
 
     /**

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -200,7 +200,7 @@ export class WorkspacePlugin implements Plugin<{}, {}, WorkspacePluginSetupDeps>
         const { renderCreatorApp } = await import('./application');
         return mountWorkspaceApp(params, renderCreatorApp);
       },
-      workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
+      workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
     });
 
     // update
@@ -246,7 +246,7 @@ export class WorkspacePlugin implements Plugin<{}, {}, WorkspacePluginSetupDeps>
         const { renderListApp } = await import('./application');
         return mountWorkspaceApp(params, renderListApp);
       },
-      workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
+      workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
     });
 
     /**

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -9,7 +9,7 @@ import {
   filterWorkspaceConfigurableApps,
   isAppAccessibleInWorkspace,
 } from './utils';
-import { WorkspaceAccessibility } from '../../../core/public';
+import { WorkspaceAvailability } from '../../../core/public';
 
 describe('workspace utils: featureMatchesConfig', () => {
   it('feature configured with `*` should match any features', () => {
@@ -154,14 +154,14 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
     ).toBe(true);
   });
 
-  it('An app is not accessible if its workspaceAccessibility is no', () => {
+  it('An app is not accessible if its workspaceAvailability is outOfWorkspace', () => {
     expect(
       isAppAccessibleInWorkspace(
         {
           id: 'home',
           title: 'Any app',
           mount: jest.fn(),
-          workspaceAccessibility: WorkspaceAccessibility.NO,
+          workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
         },
         { id: 'workspace_id', name: 'workspace name', features: [] }
       )

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -9,6 +9,7 @@ import {
   filterWorkspaceConfigurableApps,
   isAppAccessibleInWorkspace,
 } from './utils';
+import { WorkspaceAccessibility } from '../../../core/public';
 
 describe('workspace utils: featureMatchesConfig', () => {
   it('feature configured with `*` should match any features', () => {
@@ -151,6 +152,20 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
         { id: 'workspace_id', name: 'workspace name', features: [] }
       )
     ).toBe(true);
+  });
+
+  it('An app is not accessible if its workspaceAccessibility is no', () => {
+    expect(
+      isAppAccessibleInWorkspace(
+        {
+          id: 'home',
+          title: 'Any app',
+          mount: jest.fn(),
+          workspaceAccessibility: WorkspaceAccessibility.NO,
+        },
+        { id: 'workspace_id', name: 'workspace name', features: [] }
+      )
+    ).toBe(false);
   });
 });
 

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -188,7 +188,8 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
           title: 'Any app',
           mount: jest.fn(),
           // eslint-disable-next-line no-bitwise
-          workspaceAvailability: WorkspaceAvailability.insideWorkspace | WorkspaceAvailability.outsideWorkspace,
+          workspaceAvailability:
+            WorkspaceAvailability.insideWorkspace | WorkspaceAvailability.outsideWorkspace,
         },
         { id: 'workspace_id', name: 'workspace name', features: [] }
       )

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -167,7 +167,6 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
       )
     ).toBe(false);
   });
-  
   it('An app is accessible within a workspace if its workspaceAvailability is insideWorkspace', () => {
     expect(
       isAppAccessibleInWorkspace(

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -167,6 +167,35 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
       )
     ).toBe(false);
   });
+  
+  it('An app is accessible within a workspace if its workspaceAvailability is insideWorkspace', () => {
+    expect(
+      isAppAccessibleInWorkspace(
+        {
+          id: 'home',
+          title: 'Any app',
+          mount: jest.fn(),
+          workspaceAvailability: WorkspaceAvailability.insideWorkspace,
+        },
+        { id: 'workspace_id', name: 'workspace name', features: [] }
+      )
+    ).toBe(true);
+  });
+  
+  it('An app is accessible within a workspace if its workspaceAvailability is inside and outsideWorkspace', () => {
+    expect(
+      isAppAccessibleInWorkspace(
+        {
+          id: 'home',
+          title: 'Any app',
+          mount: jest.fn(),
+          // eslint-disable-next-line no-bitwise
+          workspaceAvailability: WorkspaceAvailability.insideWorkspace | WorkspaceAvailability.outsideWorkspace,
+        },
+        { id: 'workspace_id', name: 'workspace name', features: [] }
+      )
+    ).toBe(true);
+  });
 });
 
 describe('workspace utils: filterWorkspaceConfigurableApps', () => {

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -176,7 +176,7 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
           mount: jest.fn(),
           workspaceAvailability: WorkspaceAvailability.insideWorkspace,
         },
-        { id: 'workspace_id', name: 'workspace name', features: [] }
+        { id: 'workspace_id', name: 'workspace name', features: ['home'] }
       )
     ).toBe(true);
   });
@@ -191,7 +191,7 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
             // eslint-disable-next-line no-bitwise
             WorkspaceAvailability.insideWorkspace | WorkspaceAvailability.outsideWorkspace,
         },
-        { id: 'workspace_id', name: 'workspace name', features: [] }
+        { id: 'workspace_id', name: 'workspace name', features: ['home'] }
       )
     ).toBe(true);
   });

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -154,7 +154,7 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
     ).toBe(true);
   });
 
-  it('An app is not accessible if its workspaceAvailability is outOfWorkspace', () => {
+  it('An app is not accessible if its workspaceAvailability is outsideWorkspace', () => {
     expect(
       isAppAccessibleInWorkspace(
         {

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -154,7 +154,7 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
     ).toBe(true);
   });
 
-  it('An app is not accessible if its workspaceAvailability is outsideWorkspace', () => {
+  it('An app is not accessible within a workspace if its workspaceAvailability is outsideWorkspace', () => {
     expect(
       isAppAccessibleInWorkspace(
         {

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -180,7 +180,6 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
       )
     ).toBe(true);
   });
-  
   it('An app is accessible within a workspace if its workspaceAvailability is inside and outsideWorkspace', () => {
     expect(
       isAppAccessibleInWorkspace(

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -187,8 +187,8 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
           id: 'home',
           title: 'Any app',
           mount: jest.fn(),
-          // eslint-disable-next-line no-bitwise
           workspaceAvailability:
+            // eslint-disable-next-line no-bitwise
             WorkspaceAvailability.insideWorkspace | WorkspaceAvailability.outsideWorkspace,
         },
         { id: 'workspace_id', name: 'workspace name', features: [] }

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -161,7 +161,7 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
           id: 'home',
           title: 'Any app',
           mount: jest.fn(),
-          workspaceAvailability: WorkspaceAvailability.outOfWorkspace,
+          workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
         },
         { id: 'workspace_id', name: 'workspace name', features: [] }
       )

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -75,7 +75,7 @@ export const featureMatchesConfig = (featureConfigs: string[]) => ({
  */
 export function isAppAccessibleInWorkspace(app: App, workspace: WorkspaceObject) {
   /**
-   * App is not accessible within workspace if it explicitly declare itself as WorkspaceAvailability.outOfWorkspace
+   * App is not accessible within workspace if it explicitly declare itself as WorkspaceAvailability.outsideWorkspace
    */
   if (app.workspaceAvailability === WorkspaceAvailability.outsideWorkspace) {
     return false;

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -77,7 +77,7 @@ export function isAppAccessibleInWorkspace(app: App, workspace: WorkspaceObject)
   /**
    * App is not accessible within workspace if it explicitly declare itself as WorkspaceAvailability.outOfWorkspace
    */
-  if (app.workspaceAvailability === WorkspaceAvailability.outOfWorkspace) {
+  if (app.workspaceAvailability === WorkspaceAvailability.outsideWorkspace) {
     return false;
   }
 

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_APP_CATEGORIES,
   PublicAppInfo,
   WorkspaceObject,
+  WorkspaceAccessibility,
 } from '../../../core/public';
 import { DEFAULT_SELECTED_FEATURES_IDS } from '../common/constants';
 
@@ -73,6 +74,13 @@ export const featureMatchesConfig = (featureConfigs: string[]) => ({
  * Check if an app is accessible in a workspace based on the workspace configured features
  */
 export function isAppAccessibleInWorkspace(app: App, workspace: WorkspaceObject) {
+  /**
+   * App is not accessible within workspace if it explicitly declare itself as workspaceAccessibility.No
+   */
+  if (app.workspaceAccessibility === WorkspaceAccessibility.NO) {
+    return false;
+  }
+
   /**
    * When workspace has no features configured, all apps are considered to be accessible
    */

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_APP_CATEGORIES,
   PublicAppInfo,
   WorkspaceObject,
-  WorkspaceAccessibility,
+  WorkspaceAvailability,
 } from '../../../core/public';
 import { DEFAULT_SELECTED_FEATURES_IDS } from '../common/constants';
 
@@ -75,9 +75,9 @@ export const featureMatchesConfig = (featureConfigs: string[]) => ({
  */
 export function isAppAccessibleInWorkspace(app: App, workspace: WorkspaceObject) {
   /**
-   * App is not accessible within workspace if it explicitly declare itself as workspaceAccessibility.No
+   * App is not accessible within workspace if it explicitly declare itself as WorkspaceAvailability.outOfWorkspace
    */
-  if (app.workspaceAccessibility === WorkspaceAccessibility.NO) {
+  if (app.workspaceAvailability === WorkspaceAvailability.outOfWorkspace) {
     return false;
   }
 


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Home page, as well as workspace create page / workspace list page, which is supposed to be only visited out of any workspace, now is enabled to be accessed by clicking the home icon or enter the url manually in the browser.

This PR introduces a new field `workspaceAvailability` inside App, which indicates the availability of the application based on workspace. This field can bring two benefits:
1. When navigate between apps, plugins and core application are using the `navigateToApp` method. By using the workspaceAvailability field, workspace is able to do the hard navigation in a central place.
2. The workspaceAvailability field can be used in workspace create page to filter applications that should not be visible inside workspace. For now we filter out home overview page and all the pages under management section by hard code, which is not elegant and not extensible.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
closes #6362 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
### 1. Clicking home icon will exist workspace.
![20240407094009141](https://github.com/ruanyl/OpenSearch-Dashboards/assets/13493605/f6937943-2d95-4bfb-b8ca-27631ce436a4)

### 2. Apps with `workspaceAvailability.outOfWorkspace` is inaccessible within workspace
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/3db34b85-f721-4544-960f-b9e0ddaa9a34)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
- Using the branch to bootstrap
- enabled `workspace.enabled` to true
- Start OSD by using `yarn start --no-base-path` to make sure no random base path will be appended
- Navigate to devTools
- Insert test workspaces by calling
```
PUT .kibana/_doc/workspace:foo
{
  "type": "workspace",
  "workspace": {
    "name": "foo"
  }
}
```
- Visit the homepage inside workspace: `http://localhost:5601/w/foo/app/home`
- You will find an error page will be found saying the application can not be found.
- Go into a page within workspace `http://localhost:5601/w/foo/app/workspace_update`
- Clicking the home icon in the top navigation
- You will you being navigated to home page out of workspace.

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace] Allow making apps available in workspaces using `workspaceAvailability`

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
