### PR TITLE
Bump `codecov/codecov-action` to v4

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -122,8 +122,9 @@ jobs:
 
       - name: Upload Code Coverage
         id: upload-code-coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./target/opensearch-dashboards-coverage
           flags: ${{ matrix.name }}_${{ matrix.group }}
 


### PR DESCRIPTION
### Description

Bump `codecov/codecov-action` to v4.

PRs originating from forked repos will not need a token:
`The PR is happening in a forked repo. Using tokenless upload.`

However, PRs from within the repo, ie from feature branches or backports, will require a token.

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
