### PR TITLE
[MD] Add dropdown header to data source single selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [CSP Handler] Update CSP handler to only query and modify frame ancestors instead of all CSP directives ([#6398](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6398))
 - [MD] Add OpenSearch cluster group label to top of single selectable dropdown  ([#6400](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6400))
 - [Workspace] Support workspace in saved objects client in server side. ([#6365](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6365))
+- [MD] Add dropdown header to data source single selector ([#6431](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6431))
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/data_source_management/opensearch_dashboards.json
+++ b/src/plugins/data_source_management/opensearch_dashboards.json
@@ -5,6 +5,6 @@
   "ui": true,
   "requiredPlugins": ["management", "dataSource", "indexPatternManagement"],
   "optionalPlugins": [],
-  "requiredBundles": ["opensearchDashboardsReact", "dataSource"],
+  "requiredBundles": ["opensearchDashboardsReact", "dataSource", "opensearchDashboardsUtils"],
   "extraPublicDirs": ["public/components/utils"]
 }

--- a/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.test.tsx
@@ -5,17 +5,28 @@
 
 import { createDataSourceMenu } from './create_data_source_menu';
 import { MountPoint, SavedObjectsClientContract } from '../../../../../core/public';
-import { coreMock, notificationServiceMock } from '../../../../../core/public/mocks';
+import {
+  applicationServiceMock,
+  coreMock,
+  notificationServiceMock,
+} from '../../../../../core/public/mocks';
 import React from 'react';
-import { act, getByText, render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { DataSourceComponentType, DataSourceSelectableConfig } from './types';
 import { ReactWrapper } from 'enzyme';
 import { mockDataSourcePluginSetupWithShowLocalCluster } from '../../mocks';
+import * as utils from '../utils';
 
 describe('create data source menu', () => {
   let client: SavedObjectsClientContract;
   const notifications = notificationServiceMock.createStartContract();
   const { uiSettings } = coreMock.createSetup();
+
+  beforeAll(() => {
+    jest
+      .spyOn(utils, 'getApplication')
+      .mockImplementation(() => applicationServiceMock.createStartContract());
+  });
 
   beforeEach(() => {
     client = {

--- a/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.tsx
@@ -10,11 +10,13 @@ import { DataSourcePluginSetup } from 'src/plugins/data_source/public';
 import { DataSourceMenu } from './data_source_menu';
 import { DataSourceMenuProps } from './types';
 import { MountPointPortal } from '../../../../opensearch_dashboards_react/public';
+import { getApplication } from '../utils';
 
 export function createDataSourceMenu<T>(
   uiSettings: IUiSettingsClient,
   dataSourcePluginSetup: DataSourcePluginSetup
 ) {
+  const application = getApplication();
   return (props: DataSourceMenuProps<T>) => {
     const { hideLocalCluster } = dataSourcePluginSetup;
     if (props.setMenuMountPoint) {
@@ -25,13 +27,19 @@ export function createDataSourceMenu<T>(
               {...props}
               uiSettings={uiSettings}
               hideLocalCluster={hideLocalCluster}
+              application={application}
             />
           </EuiHeaderLinks>
         </MountPointPortal>
       );
     }
     return (
-      <DataSourceMenu {...props} uiSettings={uiSettings} hideLocalCluster={hideLocalCluster} />
+      <DataSourceMenu
+        {...props}
+        uiSettings={uiSettings}
+        hideLocalCluster={hideLocalCluster}
+        application={application}
+      />
     );
   };
 }

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -19,8 +19,7 @@ import {
 import { DataSourceSelectable } from '../data_source_selectable';
 
 export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement | null {
-  const { componentType, componentConfig, uiSettings, hideLocalCluster } = props;
-
+  const { componentType, componentConfig, uiSettings, hideLocalCluster, application } = props;
   function renderDataSourceView(config: DataSourceViewConfig): ReactElement | null {
     const {
       activeOption,
@@ -81,6 +80,7 @@ export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement |
         hideLocalCluster={hideLocalCluster || false}
         fullWidth={fullWidth}
         uiSettings={uiSettings}
+        application={application}
       />
     );
   }

--- a/src/plugins/data_source_management/public/components/data_source_menu/types.ts
+++ b/src/plugins/data_source_management/public/components/data_source_menu/types.ts
@@ -8,6 +8,7 @@ import {
   SavedObjectsClientContract,
   SavedObject,
   IUiSettingsClient,
+  ApplicationStart,
 } from '../../../../../core/public';
 import { DataSourceAttributes } from '../../types';
 
@@ -32,6 +33,7 @@ export interface DataSourceMenuProps<T = any> {
   componentConfig: T;
   hideLocalCluster?: boolean;
   uiSettings?: IUiSettingsClient;
+  application?: ApplicationStart;
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
 }
 

--- a/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
   display="inlineBlock"
   hasArrow={true}
   id="dataSourceSelectableContextMenuPopover"
+  initialFocus=".euiSelectableSearch"
   isOpen={false}
   ownFocus={true}
   panelPaddingSize="none"
@@ -37,6 +38,12 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
       color="transparent"
       paddingSize="s"
     >
+      <DataSourceDropDownHeader
+        totalDataSourceCount={3}
+      />
+      <EuiHorizontalRule
+        margin="none"
+      />
       <EuiSpacer
         size="s"
       />
@@ -70,6 +77,7 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
         renderOption={[Function]}
         searchProps={
           Object {
+            "compressed": true,
             "placeholder": "Search",
           }
         }
@@ -105,6 +113,7 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
   display="inlineBlock"
   hasArrow={true}
   id="dataSourceSelectableContextMenuPopover"
+  initialFocus=".euiSelectableSearch"
   isOpen={false}
   ownFocus={true}
   panelPaddingSize="none"
@@ -118,6 +127,12 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
       color="transparent"
       paddingSize="s"
     >
+      <DataSourceDropDownHeader
+        totalDataSourceCount={0}
+      />
+      <EuiHorizontalRule
+        margin="none"
+      />
       <EuiSpacer
         size="s"
       />
@@ -130,6 +145,7 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
         renderOption={[Function]}
         searchProps={
           Object {
+            "compressed": true,
             "placeholder": "Search",
           }
         }
@@ -165,6 +181,7 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
   display="inlineBlock"
   hasArrow={true}
   id="dataSourceSelectableContextMenuPopover"
+  initialFocus=".euiSelectableSearch"
   isOpen={false}
   ownFocus={true}
   panelPaddingSize="none"
@@ -178,6 +195,12 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
       color="transparent"
       paddingSize="s"
     >
+      <DataSourceDropDownHeader
+        totalDataSourceCount={0}
+      />
+      <EuiHorizontalRule
+        margin="none"
+      />
       <EuiSpacer
         size="s"
       />
@@ -190,6 +213,7 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
         renderOption={[Function]}
         searchProps={
           Object {
+            "compressed": true,
             "placeholder": "Search",
           }
         }
@@ -274,6 +298,35 @@ Object {
                     class="euiPanel euiPanel--paddingSmall euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow dataSourceSelectableOuiPanel"
                   >
                     <div
+                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiTitle euiTitle--xxxsmall"
+                    >
+                      <div
+                        class="euiFlexItem"
+                      >
+                        DATA SOURCES
+                         (
+                        3
+                        )
+                      </div>
+                      <div
+                        class="dataSourceDropDownHeaderInvisibleFocusable"
+                        tabindex="0"
+                      />
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <button
+                          class="euiLink euiLink--primary"
+                          type="button"
+                        >
+                          Manage
+                        </button>
+                      </div>
+                    </div>
+                    <hr
+                      class="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                    <div
                       class="euiSpacer euiSpacer--s"
                     />
                     <div
@@ -281,7 +334,7 @@ Object {
                       data-test-subj="dataSourceSelectable"
                     >
                       <div
-                        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
@@ -295,7 +348,7 @@ Object {
                             aria-label="Search"
                             aria-owns="generated-id_listbox"
                             autocomplete="off"
-                            class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch"
+                            class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiSelectableSearch"
                             placeholder="Search"
                             role="combobox"
                             type="search"

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
@@ -7,12 +7,13 @@ import { ShallowWrapper, shallow, mount } from 'enzyme';
 import { SavedObjectsClientContract } from '../../../../../core/public';
 import { notificationServiceMock } from '../../../../../core/public/mocks';
 import React from 'react';
-import { DataSourceSelectable, opensearchClusterGroupLabel } from './data_source_selectable';
+import { DataSourceSelectable } from './data_source_selectable';
 import { AuthType } from '../../types';
 import { getDataSourcesWithFieldsResponse, mockResponseForSavedObjectsCalls } from '../../mocks';
 import { render } from '@testing-library/react';
 import * as utils from '../utils';
 import { EuiSelectable } from '@elastic/eui';
+import { dataSourceOptionGroupLabel } from '../utils';
 
 describe('DataSourceSelectable', () => {
   let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
@@ -409,7 +410,7 @@ describe('DataSourceSelectable', () => {
     component.instance().componentDidMount!();
     await nextTick();
     const optionsProp = component.find(EuiSelectable).prop('options');
-    expect(optionsProp[0]).toEqual(opensearchClusterGroupLabel);
+    expect(optionsProp[0]).toEqual(dataSourceOptionGroupLabel.opensearchCluster);
   });
 
   it('should not render opensearch cluster group label, when there is no option availiable', async () => {
@@ -430,5 +431,51 @@ describe('DataSourceSelectable', () => {
     await nextTick();
     const optionsProp = component.find(EuiSelectable).prop('options');
     expect(optionsProp).toEqual([]);
+  });
+
+  it('should render group lablel normally after onChange', async () => {
+    const onSelectedDataSource = jest.fn();
+    component = shallow(
+      <DataSourceSelectable
+        savedObjectsClient={client}
+        notifications={toasts}
+        onSelectedDataSources={onSelectedDataSource}
+        disabled={false}
+        hideLocalCluster={true}
+        fullWidth={false}
+        selectedOption={[{ id: 'test1', label: 'test1' }]}
+      />
+    );
+    const componentInstance = component.instance();
+
+    componentInstance.componentDidMount!();
+    await nextTick();
+    const optionsPropBefore = component.find(EuiSelectable).prop('options');
+    expect(optionsPropBefore).toEqual([
+      dataSourceOptionGroupLabel.opensearchCluster,
+      {
+        id: 'test1',
+        label: 'test1',
+        checked: 'on',
+      },
+      {
+        id: 'test2',
+        label: 'test2',
+      },
+      {
+        id: 'test3',
+        label: 'test3',
+      },
+    ]);
+    componentInstance.onChange([
+      dataSourceOptionGroupLabel.opensearchCluster,
+      { id: 'test2', label: 'test2', checked: 'on' },
+    ]);
+    await nextTick();
+    const optionsPropAfter = component.find(EuiSelectable).prop('options');
+    expect(optionsPropAfter).toEqual([
+      dataSourceOptionGroupLabel.opensearchCluster,
+      { id: 'test2', label: 'test2', checked: 'on' },
+    ]);
   });
 });

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -12,19 +12,27 @@ import {
   EuiButtonEmpty,
   EuiSelectable,
   EuiSpacer,
+  EuiHorizontalRule,
 } from '@elastic/eui';
 import {
+  ApplicationStart,
   IUiSettingsClient,
   SavedObjectsClientContract,
   ToastsStart,
 } from 'opensearch-dashboards/public';
-import { getDataSourcesWithFields, getDefaultDataSource, getFilteredDataSources } from '../utils';
+import {
+  dataSourceOptionGroupLabel,
+  getDataSourcesWithFields,
+  getDefaultDataSource,
+  getFilteredDataSources,
+} from '../utils';
 import { LocalCluster } from '../data_source_selector/data_source_selector';
 import { SavedObject } from '../../../../../core/public';
 import { DataSourceAttributes } from '../../types';
 import { DataSourceGroupLabelOption, DataSourceOption } from '../data_source_menu/types';
 import { DataSourceItem } from '../data_source_item';
 import './data_source_selectable.scss';
+import { DataSourceDropDownHeader } from '../drop_down_header';
 
 interface DataSourceSelectableProps {
   savedObjectsClient: SavedObjectsClientContract;
@@ -33,6 +41,7 @@ interface DataSourceSelectableProps {
   disabled: boolean;
   hideLocalCluster: boolean;
   fullWidth: boolean;
+  application?: ApplicationStart;
   selectedOption?: DataSourceOption[];
   dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
   uiSettings?: IUiSettingsClient;
@@ -193,9 +202,12 @@ export class DataSourceSelectable extends React.Component<
 
   onChange(options: DataSourceOption[]) {
     if (!this._isMounted) return;
+    const optionsWithoutGroupLabel = options.filter(
+      (option) => !option.hasOwnProperty('isGroupLabel')
+    );
     const selectedDataSource = options.find(({ checked }) => checked);
 
-    this.setState({ dataSourceOptions: options });
+    this.setState({ dataSourceOptions: optionsWithoutGroupLabel });
 
     if (selectedDataSource) {
       this.setState({
@@ -213,7 +225,7 @@ export class DataSourceSelectable extends React.Component<
     if (dataSourceOptions.length === 0) {
       optionsWithGroupLabel = [];
     } else {
-      optionsWithGroupLabel = [opensearchClusterGroupLabel, ...dataSourceOptions];
+      optionsWithGroupLabel = [dataSourceOptionGroupLabel.opensearchCluster, ...dataSourceOptions];
     }
     return optionsWithGroupLabel;
   };
@@ -242,6 +254,7 @@ export class DataSourceSelectable extends React.Component<
 
     return (
       <EuiPopover
+        initialFocus={'.euiSelectableSearch'}
         id={'dataSourceSelectableContextMenuPopover'}
         button={button}
         isOpen={this.state.isPopoverOpen}
@@ -252,12 +265,18 @@ export class DataSourceSelectable extends React.Component<
       >
         <EuiContextMenuPanel>
           <EuiPanel className={'dataSourceSelectableOuiPanel'} color="transparent" paddingSize="s">
+            <DataSourceDropDownHeader
+              totalDataSourceCount={this.state.dataSourceOptions.length}
+              application={this.props.application}
+            />
+            <EuiHorizontalRule margin="none" />
             <EuiSpacer size="s" />
             <EuiSelectable
               aria-label="Search"
               searchable
               searchProps={{
                 placeholder: 'Search',
+                compressed: true,
               }}
               options={this.getOptionsWithGroupLabel(this.state.dataSourceOptions)}
               onChange={(newOptions) => this.onChange(newOptions)}

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.test.tsx
@@ -14,7 +14,6 @@ import {
   mockResponseForSavedObjectsCalls,
 } from '../../mocks';
 import { AuthType } from 'src/plugins/data_source/common/data_sources';
-import * as utils from '../utils';
 import { EuiComboBox } from '@elastic/eui';
 
 describe('DataSourceSelector', () => {

--- a/src/plugins/data_source_management/public/components/drop_down_header/__snapshots__/drop_down_header.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/drop_down_header/__snapshots__/drop_down_header.test.tsx.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataSourceDropDownHeader should render correctly with the provided totalDataSourceCount 1`] = `
+<EuiTitle
+  size="xxxs"
+>
+  <EuiFlexGroup
+    responsive={false}
+  >
+    <EuiFlexItem>
+      DATA SOURCES
+       (
+      5
+      )
+    </EuiFlexItem>
+    <div
+      className="dataSourceDropDownHeaderInvisibleFocusable"
+      tabIndex={0}
+    />
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiLink
+        onClick={[Function]}
+      >
+        Manage
+      </EuiLink>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+</EuiTitle>
+`;
+
+exports[`DataSourceDropDownHeader should render the activeDataSourceCount/totalDataSourceCount when both provided 1`] = `
+<DataSourceDropDownHeader
+  activeDataSourceCount={2}
+  totalDataSourceCount={5}
+>
+  <EuiTitle
+    size="xxxs"
+  >
+    <EuiFlexGroup
+      className="euiTitle euiTitle--xxxsmall"
+      responsive={false}
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiTitle euiTitle--xxxsmall"
+      >
+        <EuiFlexItem>
+          <div
+            className="euiFlexItem"
+          >
+            DATA SOURCES
+             (
+            2/5
+            )
+          </div>
+        </EuiFlexItem>
+        <div
+          className="dataSourceDropDownHeaderInvisibleFocusable"
+          tabIndex={0}
+        />
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <EuiLink
+              onClick={[Function]}
+            >
+              <button
+                className="euiLink euiLink--primary"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                Manage
+              </button>
+            </EuiLink>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+  </EuiTitle>
+</DataSourceDropDownHeader>
+`;

--- a/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.scss
+++ b/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.scss
@@ -1,0 +1,3 @@
+.dataSourceDropDownHeaderInvisibleFocusable {
+  opacity: 0;
+}

--- a/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.test.tsx
+++ b/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import { coreMock } from '../../../../../core/public/mocks';
+import { DSM_APP_ID } from '../../plugin';
+import { DataSourceDropDownHeader } from '.';
+
+describe('DataSourceDropDownHeader', () => {
+  it('should render correctly with the provided totalDataSourceCount', () => {
+    const totalDataSourceCount = 5;
+    const wrapper = shallow(
+      <DataSourceDropDownHeader totalDataSourceCount={totalDataSourceCount} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render "DATA SOURCES" when totalDataSourceCount is greater than 1', () => {
+    const totalDataSourceCount = 5;
+    const wrapper = mount(<DataSourceDropDownHeader totalDataSourceCount={totalDataSourceCount} />);
+    expect(wrapper.text()).toContain('DATA SOURCES');
+  });
+
+  it.each([1, 0])(
+    'should render "DATA SOURCE" when totalDataSourceCount is %s',
+    (totalDataSourceCount) => {
+      const wrapper = mount(
+        <DataSourceDropDownHeader totalDataSourceCount={totalDataSourceCount} />
+      );
+      expect(wrapper.text()).toContain('DATA SOURCE');
+    }
+  );
+
+  it('should render the activeDataSourceCount/totalDataSourceCount when both provided', () => {
+    const totalDataSourceCount = 5;
+    const activeDataSourceCount = 2;
+    const wrapper = mount(
+      <DataSourceDropDownHeader
+        totalDataSourceCount={totalDataSourceCount}
+        activeDataSourceCount={activeDataSourceCount}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.text()).toContain(`${activeDataSourceCount}/${totalDataSourceCount}`);
+  });
+
+  it('should call application.navigateToApp when the "Manage" link is clicked', () => {
+    const totalDataSourceCount = 5;
+    const applicationMock = coreMock.createStart().application;
+    const navigateToAppMock = applicationMock.navigateToApp;
+
+    const wrapper = mount(
+      <DataSourceDropDownHeader
+        totalDataSourceCount={totalDataSourceCount}
+        application={applicationMock}
+      />
+    );
+
+    wrapper.find('EuiLink').simulate('click');
+    expect(navigateToAppMock).toHaveBeenCalledWith('management', {
+      path: `opensearch-dashboards/${DSM_APP_ID}`,
+    });
+  });
+});

--- a/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.tsx
+++ b/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import './drop_down_header.scss';
+import { EuiTitle, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
+import React from 'react';
+import { ApplicationStart } from 'opensearch-dashboards/public';
+import { DSM_APP_ID } from '../../plugin';
+
+interface DataSourceOptionItemProps {
+  totalDataSourceCount: number;
+  activeDataSourceCount?: number;
+  application?: ApplicationStart;
+}
+
+export const DataSourceDropDownHeader: React.FC<DataSourceOptionItemProps> = ({
+  activeDataSourceCount,
+  totalDataSourceCount,
+  application,
+}) => {
+  const dataSourceCounterPrefix = totalDataSourceCount === 1 ? 'DATA SOURCE' : 'DATA SOURCES';
+  const dataSourceCounter =
+    activeDataSourceCount !== undefined
+      ? `${activeDataSourceCount}/${totalDataSourceCount}`
+      : totalDataSourceCount;
+
+  return (
+    <EuiTitle size="xxxs">
+      <EuiFlexGroup responsive={false}>
+        <EuiFlexItem>
+          {dataSourceCounterPrefix} ({dataSourceCounter})
+        </EuiFlexItem>
+        <div tabIndex={0} className="dataSourceDropDownHeaderInvisibleFocusable" />
+        <EuiFlexItem grow={false}>
+          <EuiLink
+            onClick={() =>
+              application?.navigateToApp('management', {
+                path: `opensearch-dashboards/${DSM_APP_ID}`,
+              })
+            }
+          >
+            Manage
+          </EuiLink>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiTitle>
+  );
+};

--- a/src/plugins/data_source_management/public/components/drop_down_header/index.ts
+++ b/src/plugins/data_source_management/public/components/drop_down_header/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { DataSourceDropDownHeader } from './drop_down_header';

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -9,8 +9,10 @@ import {
   SavedObject,
   IUiSettingsClient,
   ToastsStart,
+  ApplicationStart,
 } from 'src/core/public';
 import { i18n } from '@osd/i18n';
+import { deepFreeze } from '@osd/std';
 import {
   DataSourceAttributes,
   DataSourceTableItem,
@@ -19,6 +21,8 @@ import {
 } from '../types';
 import { AuthenticationMethodRegistry } from '../auth_registry';
 import { DataSourceOption } from './data_source_menu/types';
+import { DataSourceGroupLabelOption } from './data_source_menu/types';
+import { createGetterSetter } from '../../../opensearch_dashboards_utils/public';
 
 export async function getDataSources(savedObjectsClient: SavedObjectsClientContract) {
   return savedObjectsClient
@@ -279,3 +283,18 @@ export const extractRegisteredAuthTypeCredentials = (
 
   return registeredCredentials;
 };
+
+interface DataSourceOptionGroupLabel {
+  [key: string]: DataSourceGroupLabelOption;
+}
+
+export const dataSourceOptionGroupLabel = deepFreeze<Readonly<DataSourceOptionGroupLabel>>({
+  opensearchCluster: {
+    id: 'opensearchClusterGroupLabel',
+    label: 'OpenSearch cluster',
+    isGroupLabel: true,
+  },
+  // TODO: add other group labels if needed
+});
+
+export const [getApplication, setApplication] = createGetterSetter<ApplicationStart>('Application');

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -21,6 +21,7 @@ import { noAuthCredentialAuthMethod, sigV4AuthMethod, usernamePasswordAuthMethod
 import { DataSourceSelectorProps } from './components/data_source_selector/data_source_selector';
 import { createDataSourceMenu } from './components/data_source_menu/create_data_source_menu';
 import { DataSourceMenuProps } from './components/data_source_menu';
+import { setApplication } from './components/utils';
 
 export interface DataSourceManagementSetupDependencies {
   management: ManagementSetup;
@@ -40,7 +41,7 @@ export interface DataSourceManagementPluginStart {
   getAuthenticationMethodRegistry: () => IAuthenticationMethodRegistry;
 }
 
-const DSM_APP_ID = 'dataSources';
+export const DSM_APP_ID = 'dataSourceManagement';
 
 export class DataSourceManagementPlugin
   implements
@@ -111,6 +112,7 @@ export class DataSourceManagementPlugin
 
   public start(core: CoreStart) {
     this.started = true;
+    setApplication(core.application);
     return {
       getAuthenticationMethodRegistry: () => this.authMethodsRegistry,
     };


### PR DESCRIPTION
### Description
- Add dropdown header to data source single selector. This header includes
  - a counter showing the count of datasource options avaliable
  - a link with text "Manage", that honors SPA(single page application) to redirect to data source management page 
- Fix bug of opensearch cluster group label being rendered multiple times when toggling between options
- Add and update related unit tests

<!-- Describe what this change achieves-->

### Issues Resolved
#6429 
<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/734bbeee-ff2c-400c-94cb-e39497669421)




https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/2a90a064-a279-4f05-bcd6-f0ea2be9a143


<!-- Attach any relevant screenshots. Any change 



to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
