### PR TITLE
Remove duplicate data source attribute interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Remove unused Sass in `tile_map` plugin ([#4110](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4110))
 - [Multiple Datasource] Move data source selectable to its own folder, fix test and a few type errors for data source selectable component ([#6287](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6287))
 - Remove KUI usage in `disabled_lab_visualization` ([#5462](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5462))
+- [Multiple Datasource] Remove duplicate data source attribute interface from `data_source_management` ([#6437](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6437))
 
 ### 🔩 Tests
 

--- a/src/plugins/data_source/common/data_sources/types.ts
+++ b/src/plugins/data_source/common/data_sources/types.ts
@@ -9,12 +9,13 @@ export interface DataSourceAttributes extends SavedObjectAttributes {
   title: string;
   description?: string;
   endpoint: string;
+  dataSourceVersion?: string;
+  installedPlugins?: string[];
   auth: {
-    type: AuthType;
+    type: AuthType | string;
     credentials: UsernamePasswordTypedContent | SigV4Content | undefined | AuthTypeContent;
   };
   lastUpdatedTime?: string;
-  name: AuthType | string;
 }
 
 export interface AuthTypeContent {

--- a/src/plugins/data_source/server/client/configure_client_utils.ts
+++ b/src/plugins/data_source/server/client/configure_client_utils.ts
@@ -141,6 +141,5 @@ export const getAuthenticationMethod = (
   dataSourceAttr: DataSourceAttributes,
   authRegistry?: IAuthenticationMethodRegistry
 ): AuthenticationMethod => {
-  const name = dataSourceAttr.name ?? dataSourceAttr.auth.type;
-  return authRegistry?.getAuthenticationMethod(name) as AuthenticationMethod;
+  return authRegistry?.getAuthenticationMethod(dataSourceAttr.auth.type) as AuthenticationMethod;
 };

--- a/src/plugins/data_source_management/public/types.ts
+++ b/src/plugins/data_source_management/public/types.ts
@@ -14,8 +14,8 @@ import {
   HttpSetup,
 } from 'src/core/public';
 import { ManagementAppMountParams } from 'src/plugins/management/public';
-import { SavedObjectAttributes } from 'src/core/types';
 import { i18n } from '@osd/i18n';
+import { AuthType } from '../../data_source/common/data_sources';
 import { SigV4ServiceName } from '../../data_source/common/data_sources';
 import { OpenSearchDashboardsReactContextValue } from '../../opensearch_dashboards_react/public';
 import { AuthenticationMethodRegistry } from './auth_registry';
@@ -52,13 +52,6 @@ export interface ToastMessageItem {
 export type DataSourceManagementContextValue = OpenSearchDashboardsReactContextValue<
   DataSourceManagementContext
 >;
-
-/* Datasource types */
-export enum AuthType {
-  NoAuth = 'no_auth',
-  UsernamePasswordType = 'username_password',
-  SigV4 = 'sigv4',
-}
 
 export const defaultAuthType = AuthType.UsernamePasswordType;
 
@@ -136,35 +129,14 @@ export const credentialSourceOptions = [
   sigV4CredentialOption,
 ];
 
-export interface DataSourceAttributes extends SavedObjectAttributes {
-  title: string;
-  description?: string;
-  endpoint?: string;
-  dataSourceVersion?: string;
-  installedPlugins?: string[];
-  auth: {
-    type: AuthType | string;
-    credentials:
-      | UsernamePasswordTypedContent
-      | SigV4Content
-      | { [key: string]: string }
-      | undefined;
-  };
-}
-
-export interface UsernamePasswordTypedContent extends SavedObjectAttributes {
-  username: string;
-  password?: string;
-}
-
-export interface SigV4Content extends SavedObjectAttributes {
-  accessKey: string;
-  secretKey: string;
-  region: string;
-  service?: SigV4ServiceName;
-}
-
 export interface MenuPanelItem {
   name?: string;
   disabled: boolean;
 }
+
+export {
+  AuthType,
+  UsernamePasswordTypedContent,
+  SigV4Content,
+  DataSourceAttributes,
+} from '../../data_source/common/data_sources';


### PR DESCRIPTION
### Description

Removed duplicate data source attribute interface from data source management plugin.

### Issues Resolved

Partially resolves #6204

## Screenshot


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/63824432/e3294170-0ff5-4602-9c00-85ad15487517

Above recording performs following steps and verify this changes doesn't introduce regressions.
- Create data source with `Username & Password` authentication type.
- Verify Test connection works while creating data source.
- Go to View/Edit data source screen.
- Verify Test connection still works.
- Change title of data source and save. Data source management page reflects modified changes.
- Using dev tool, verify all the attributes of data source including data source version, installed plugin list etc are saved in system index (Dashboards meta storage).

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
