### PR TITLE
fix thresholds for repeat-contributor to avoid logical confusion on f…

### DIFF
--- a/.github/workflows/github-workflow-badger.yml
+++ b/.github/workflows/github-workflow-badger.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           badges: '[first-time-contributor,repeat-contributor,valued-contributor,seasoned-contributor,all-star-contributor,distinguished-contributor]'
-          thresholds: '[0,3,6,13,25,50]'
+          thresholds: '[0,1,6,13,25,50]'
           badge-type: 'achievement'
           ignore-usernames: '[opensearch-ci-bot, dependabot, opensearch-trigger-bot]'


### PR DESCRIPTION
### Description
current threshold setup for repeat-contributor cause mis-leading to first-time-contributor. even contributor made PR more than once, it still labelled as first-time-contributor

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6242

### Check List

- [x] Commits are signed per the DCO using --signoff
