### PR TITLE
Hide datasource and settings menu in dashboard management when in workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Workspace] Support workspace in saved objects client in server side. ([#6365](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6365))
 - [MD] Add dropdown header to data source single selector ([#6431](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6431))
 - [Workspace] Add permission tab to workspace create update page ([#6378](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6378))
+- [Workspace] Hide datasource and advanced settings menu in dashboard management when in workspace. ([#6455](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6455))
 
 ### 🐛 Bug Fixes
 

--- a/src/plugins/workspace/opensearch_dashboards.json
+++ b/src/plugins/workspace/opensearch_dashboards.json
@@ -7,6 +7,6 @@
     "savedObjects",
     "opensearchDashboardsReact"
   ],
-  "optionalPlugins": ["savedObjectsManagement"],
+  "optionalPlugins": ["savedObjectsManagement","management"],
   "requiredBundles": ["opensearchDashboardsReact"]
 }

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -10,6 +10,7 @@ import { applicationServiceMock, chromeServiceMock, coreMock } from '../../../co
 import { WorkspacePlugin } from './plugin';
 import { WORKSPACE_FATAL_ERROR_APP_ID, WORKSPACE_OVERVIEW_APP_ID } from '../common/constants';
 import { savedObjectsManagementPluginMock } from '../../saved_objects_management/public/mocks';
+import { managementPluginMock } from '../../management/public/mocks';
 
 describe('Workspace plugin', () => {
   const getSetupMock = () => ({
@@ -26,6 +27,7 @@ describe('Workspace plugin', () => {
     const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(setupMock, {
       savedObjectsManagement: savedObjectManagementSetupMock,
+      management: managementPluginMock.createSetupContract(),
     });
     expect(setupMock.application.register).toBeCalledTimes(4);
     expect(WorkspaceClientMock).toBeCalledTimes(1);
@@ -74,7 +76,9 @@ describe('Workspace plugin', () => {
     });
 
     const workspacePlugin = new WorkspacePlugin();
-    await workspacePlugin.setup(setupMock, {});
+    await workspacePlugin.setup(setupMock, {
+      management: managementPluginMock.createSetupContract(),
+    });
     expect(setupMock.application.register).toBeCalledTimes(4);
     expect(WorkspaceClientMock).toBeCalledTimes(1);
     expect(workspaceClientMock.enterWorkspace).toBeCalledWith('workspaceId');
@@ -128,7 +132,9 @@ describe('Workspace plugin', () => {
     });
 
     const workspacePlugin = new WorkspacePlugin();
-    await workspacePlugin.setup(setupMock, {});
+    await workspacePlugin.setup(setupMock, {
+      management: managementPluginMock.createSetupContract(),
+    });
     currentAppIdSubscriber?.next(WORKSPACE_FATAL_ERROR_APP_ID);
     expect(applicationStartMock.navigateToApp).toBeCalledWith(WORKSPACE_OVERVIEW_APP_ID);
     windowSpy.mockRestore();
@@ -137,7 +143,9 @@ describe('Workspace plugin', () => {
   it('#setup register workspace dropdown menu when setup', async () => {
     const setupMock = coreMock.createSetup();
     const workspacePlugin = new WorkspacePlugin();
-    await workspacePlugin.setup(setupMock, {});
+    await workspacePlugin.setup(setupMock, {
+      management: managementPluginMock.createSetupContract(),
+    });
     expect(setupMock.chrome.registerCollapsibleNavHeader).toBeCalledTimes(1);
   });
 });

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -79,7 +79,7 @@ export class WorkspacePlugin implements Plugin<{}, {}, WorkspacePluginSetupDeps>
   }
 
   /**
-   * If workspace is enabled and user has entered workspace, hide advance settings and dataSource menu and disable
+   * If workspace is enabled and user has entered workspace, hide advance settings and dataSource menu by disabling the corresponding apps.
    */
   private disableManagementApps(core: CoreSetup, management: ManagementSetup) {
     const currentWorkspaceId$ = core.workspaces.currentWorkspaceId$;


### PR DESCRIPTION
### Description

Hide datasource and settings menu in dashboard management when in workspace

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6453

## Screenshot

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/42465692/9cfaee90-2a8c-4c6c-8d70-d027baa8abf2)
In workspace

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/42465692/94e516e2-07f0-401f-b8b3-e3e51158e9e7)
Not in workspace

## Testing the changes

When set workspace feature enabled in YML and entering workspace, the data source and advanced settings menu will be hidden. These two menus will show after exiting workspace.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
