### PR TITLE
[VisBuilder ] Fix filter and query bugs in the saved objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Multiple Datasource] Fix on data source selectable and readonly component are not consistent ([#6545]https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6545)
 - [BUG][Multiple Datasource] Add validation for title length to be no longer than 32 characters [#6452](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6452))
 - [Dev Tool] Add additional themed styles to ace overrides ([#5327](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5327))
-- [VisBuilder] Allow saving and loading filter and query in saved VisBuilder  ([#6460](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6460))
+- [VisBuilder] Allow saving and loading filter and query in a saved VisBuilder  ([#6460](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6460))
 
 ### 🚞 Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Multiple Datasource] Fix on data source selectable and readonly component are not consistent ([#6545]https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6545)
 - [BUG][Multiple Datasource] Add validation for title length to be no longer than 32 characters [#6452](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6452))
 - [Dev Tool] Add additional themed styles to ace overrides ([#5327](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5327))
+- [BUG][VisBuilder] Allow saving and loading filter and query in saved VisBuilder  ([#6460](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6460))
 
 ### 🚞 Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Multiple Datasource] Fix on data source selectable and readonly component are not consistent ([#6545]https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6545)
 - [BUG][Multiple Datasource] Add validation for title length to be no longer than 32 characters [#6452](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6452))
 - [Dev Tool] Add additional themed styles to ace overrides ([#5327](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5327))
-- [BUG][VisBuilder] Allow saving and loading filter and query in saved VisBuilder  ([#6460](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6460))
+- [VisBuilder] Allow saving and loading filter and query in saved VisBuilder  ([#6460](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6460))
 
 ### 🚞 Infrastructure
 

--- a/src/plugins/vis_builder/public/application/utils/get_top_nav_config.test.tsx
+++ b/src/plugins/vis_builder/public/application/utils/get_top_nav_config.test.tsx
@@ -95,7 +95,10 @@ describe('getOnSave', () => {
             },
           ],
         },
-        "searchSourceFields": Object {},
+        "searchSourceFields": Object {
+          "filter": null,
+          "query": null,
+        },
         "styleState": "",
         "title": "new title",
         "version": 0,

--- a/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
@@ -172,7 +172,7 @@ export const getOnSave = (
     returnToOrigin: boolean;
     newDescription?: string;
   }) => {
-    const { embeddable, toastNotifications, application, history } = services;
+    const { data, embeddable, toastNotifications, application, history } = services;
     const stateTransfer = embeddable.getStateTransfer();
 
     if (!savedVisBuilderVis) {
@@ -183,6 +183,9 @@ export const getOnSave = (
     savedVisBuilderVis.title = newTitle;
     savedVisBuilderVis.description = newDescription;
     savedVisBuilderVis.copyOnSave = newCopyOnSave;
+    const searchSourceInstance = savedVisBuilderVis.searchSourceFields;
+    searchSourceInstance.query = data.query.queryString.getQuery() || null;
+    searchSourceInstance.filter = data.query.filterManager.getFilters() || null;
     const newlyCreated = !savedVisBuilderVis.id || savedVisBuilderVis.copyOnSave;
 
     try {

--- a/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
@@ -35,6 +35,7 @@ export const useSavedVisBuilderVis = (visualizationIdFromUrl: string | undefined
     const {
       application: { navigateToApp },
       chrome,
+      data,
       history,
       http: { basePath },
       toastNotifications,
@@ -61,6 +62,19 @@ export const useSavedVisBuilderVis = (visualizationIdFromUrl: string | undefined
           const { title, state } = getStateFromSavedObject(savedVisBuilderVis);
           chrome.setBreadcrumbs(getEditBreadcrumbs(title, navigateToApp));
           chrome.docTitle.change(title);
+          // sync initial app filters from savedObject to filterManager
+          const filters = savedVisBuilderVis.searchSourceFields.filter;
+          const query =
+            savedVisBuilderVis.searchSourceFields.query || data.query.queryString.getDefaultQuery();
+          const actualFilters = [];
+          if (filters !== undefined) {
+            const result = typeof filters === 'function' ? filters() : filters;
+            if (result !== undefined) {
+              actualFilters.push(...(Array.isArray(result) ? result : [result]));
+            }
+          }
+          data.query.filterManager.setAppFilters(actualFilters);
+          data.query.queryString.setQuery(query);
 
           dispatch(setUIStateState(state.ui));
           dispatch(setStyleState(state.style));

--- a/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
@@ -67,12 +67,10 @@ export const useSavedVisBuilderVis = (visualizationIdFromUrl: string | undefined
           const query =
             savedVisBuilderVis.searchSourceFields.query || data.query.queryString.getDefaultQuery();
           const actualFilters = [];
-          if (filters !== undefined) {
-            const result = typeof filters === 'function' ? filters() : filters;
-            if (result !== undefined) {
-              actualFilters.push(...(Array.isArray(result) ? result : [result]));
-            }
-          }
+          const tempFilters = typeof filters === 'function' ? filters() : filters;
+          (Array.isArray(tempFilters) ? tempFilters : [tempFilters]).forEach((filter) => {
+            if (filter) actualFilters.push(filter);
+          });
           data.query.filterManager.setAppFilters(actualFilters);
           data.query.queryString.setQuery(query);
 

--- a/src/plugins/vis_builder/public/plugin.ts
+++ b/src/plugins/vis_builder/public/plugin.ts
@@ -125,6 +125,10 @@ export class VisBuilderPlugin
 
         // make sure the index pattern list is up to date
         pluginsStart.data.indexPatterns.clearCache();
+        // make sure the filterManager is refreshed
+        const filters = pluginsStart.data.query.filterManager.getFilters();
+        const pinFilters = filters.filter(opensearchFilters.isFilterPinned);
+        pluginsStart.data.query.filterManager.setFilters(pinFilters ? pinFilters : []);
         // make sure a default index pattern exists
         // if not, the page will be redirected to management and visualize won't be rendered
         // TODO: Add the redirect

--- a/src/plugins/vis_builder/public/saved_visualizations/transforms.ts
+++ b/src/plugins/vis_builder/public/saved_visualizations/transforms.ts
@@ -33,14 +33,17 @@ export const saveStateToSavedObject = (
 };
 
 export interface VisBuilderSavedVis
-  extends Pick<VisBuilderSavedObjectAttributes, 'id' | 'title' | 'description'> {
+  extends Pick<
+    VisBuilderSavedObjectAttributes,
+    'id' | 'title' | 'description' | 'searchSourceFields'
+  > {
   state: RenderState;
 }
 
 export const getStateFromSavedObject = (
   obj: VisBuilderSavedObjectAttributes
 ): VisBuilderSavedVis => {
-  const { id, title, description } = obj;
+  const { id, title, description, searchSourceFields } = obj;
   const styleState = JSON.parse(obj.styleState || '{}');
   const uiState = JSON.parse(obj.uiState || '{}');
   const vizStateWithoutIndex = JSON.parse(obj.visualizationState || '');
@@ -74,6 +77,7 @@ export const getStateFromSavedObject = (
     id,
     title,
     description,
+    searchSourceFields,
     state: {
       visualization: visualizationState,
       style: styleState,

--- a/src/plugins/visualizations/public/index.ts
+++ b/src/plugins/visualizations/public/index.ts
@@ -77,3 +77,4 @@ export { ExprVisAPIEvents } from './expressions/vis';
 export { VisualizationListItem } from './vis_types/vis_type_alias_registry';
 export { VISUALIZE_ENABLE_LABS_SETTING } from '../common/constants';
 export { createSavedVisLoader } from './saved_visualizations';
+export { prepareJson } from './legacy/build_pipeline';


### PR DESCRIPTION
### Description
- Save filter and query in vb
- Clean filterManager when start vb
- Add opensearch_dashboards_context to embeddable. This can add filter and query in the expression.

### Issues Resolved
* https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5643 This issue is about filter and query are not saved.

The fix is this part in the src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
```
    const searchSourceInstance = savedVisBuilderVis.searchSourceFields;
    searchSourceInstance.query = data.query.queryString.getQuery() || null;
    searchSourceInstance.filter = data.query.filterManager.getFilters() || null;
    savedVisBuilderVis.searchSourceFields = searchSourceInstance;
```
VisBuilder is using searchSourceFields to save states. This is different from Discover which uses searchSource. This fix will ensure the searchSourceInstance get updated filer and query and allow them to be saved in the saved object.

* https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5644 This issue is about the filter state is not cleaned. So if you add a filter in Discover then open VisBuilder, you will see the same filter loaded. This is not the behavior of other vis.

The fix is in src/plugins/vis_builder/public/plugin.ts to ensure filter state is cleaned if not pin filter.

```
// make sure the filterManager is refreshed
const filters = pluginsStart.data.query.filterManager.getFilters();
const pinFilters = filters.filter(opensearchFilters.isFilterPinned);
pluginsStart.data.query.filterManager.setFilters(pinFilters ? pinFilters : []);
```

* https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5646 This issue is about how to load the filter and query in VisBuilder when they are saved. 

The fix is in src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts 
```
const filters = savedVisBuilderVis.searchSourceFields.filter;
 const query = savedVisBuilderVis.searchSourceFields.query || data.query.queryString.getDefaultQuery();
const actualFilters = [];
if (filters !== undefined) {
       const result = typeof filters === 'function' ? filters() : filters;
       if (result !== undefined) {
            actualFilters.push(...(Array.isArray(result) ? result : [result]));
      }
}
data.query.filterManager.setAppFilters(actualFilters);
data.query.queryString.setQuery(query);
```
Basically it loads filter and query from saved object and do some type check. Then it updates data service.

* https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6512 This is about emdeddable vis builder can't load filter and query

The fix is in src/plugins/vis_builder/public/embeddable/vis_builder_embeddable.tsx and src/plugins/vis_builder/public/embeddable/vis_builder_embeddable_factory.tsx and src/plugins/visualizations/public/index.ts (just export prepareJson method). The bug is due to we don't have `opensearch_dashboards_context` in vis builder which is normally used for filter and quey info. 

## Screenshot
* Filter from other application will not be applied to vis builder. This is consistent with other applications, like discover and table vis. This resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5644.

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/cd3fef23-15b4-4a63-8a1d-a97bf41f3519



* Filter and query can be saved in vis builder saved object. This resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5643 and https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5646.


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/3d5b643f-a91c-4c91-8449-bb9e6c370c51



* When a dashboard loads a saved vis builder, any saved filters and queries will automatically be applied to the embedded vis builder. If new filters or queries are added within the dashboard, these will also apply to the embedded visualization builder. However, these newly added filters and queries will not impact the original settings of the saved vis builder. This is consistent with other applications, like discover and table vis. This resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6512.

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/00ce7611-a175-4eba-94f1-4a26293ee83e

* Also checks and ensures the pinned filter work.

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/cfc7ede7-0ccb-42e4-8c44-70611472de55



## Changelog
- skip

### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
