### PR TITLE
fix dynamic config API calls to pass correct input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [BUG][Multiple Datasource]Read hideLocalCluster setting from yml and set in data source selector and data source menu ([#6361](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6361))
 - [BUG][Multiple Datasource] Refactor read-only component to cover more edge cases ([#6416](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6416))
 - [BUG] Fix for checkForFunctionProperty so that order does not matter ([#6248](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6248))
+- [Dynamic Configurations] Fix dynamic config API calls to pass correct input ([#6474](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6474))
 - [BUG][Multiple Datasource] Validation succeed as long as status code in response is 200 ([#6399](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6399))
 - [BUG][Multiple Datasource] Add validation for title length to be no longer than 32 characters [#6452](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6452))
 

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -34,11 +34,11 @@
 # opensearchDashboards.configIndex: ".opensearch_dashboards_config"
 
 # Set the value of this setting to true to enable plugin application config. By default it is disabled.
-# application_config.enabled: false
+application_config.enabled: true
 
 # Set the value of this setting to true to enable plugin CSP handler. By default it is disabled.
 # It requires the application config plugin as its dependency.
-# csp_handler.enabled: false
+csp_handler.enabled: true
 
 # The default application to load.
 #opensearchDashboards.defaultAppId: "home"

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -34,11 +34,11 @@
 # opensearchDashboards.configIndex: ".opensearch_dashboards_config"
 
 # Set the value of this setting to true to enable plugin application config. By default it is disabled.
-application_config.enabled: true
+# application_config.enabled: false
 
 # Set the value of this setting to true to enable plugin CSP handler. By default it is disabled.
 # It requires the application config plugin as its dependency.
-csp_handler.enabled: true
+# csp_handler.enabled: false
 
 # The default application to load.
 #opensearchDashboards.defaultAppId: "home"

--- a/src/plugins/application_config/server/routes/index.test.ts
+++ b/src/plugins/application_config/server/routes/index.test.ts
@@ -79,6 +79,8 @@ describe('application config routes', () => {
         getConfig: jest.fn().mockReturnValue(configurations),
       };
 
+      const getConfigurationClient = jest.fn().mockReturnValue(client);
+
       const request = {};
 
       const okResponse = {
@@ -91,7 +93,12 @@ describe('application config routes', () => {
 
       const logger = loggerMock.create();
 
-      const returnedResponse = await handleGetConfig(client, request, response, logger);
+      const returnedResponse = await handleGetConfig(
+        getConfigurationClient,
+        request,
+        response,
+        logger
+      );
 
       expect(returnedResponse).toBe(okResponse);
 
@@ -100,6 +107,8 @@ describe('application config routes', () => {
           value: configurations,
         },
       });
+
+      expect(getConfigurationClient).toBeCalledWith(request);
     });
 
     it('return error response when client throws error', async () => {
@@ -111,6 +120,8 @@ describe('application config routes', () => {
         }),
       };
 
+      const getConfigurationClient = jest.fn().mockReturnValue(client);
+
       const request = {};
 
       const response = {
@@ -119,7 +130,12 @@ describe('application config routes', () => {
 
       const logger = loggerMock.create();
 
-      const returnedResponse = await handleGetConfig(client, request, response, logger);
+      const returnedResponse = await handleGetConfig(
+        getConfigurationClient,
+        request,
+        response,
+        logger
+      );
 
       expect(returnedResponse).toBe(ERROR_RESPONSE);
 
@@ -131,6 +147,7 @@ describe('application config routes', () => {
       });
 
       expect(logger.error).toBeCalledWith(error);
+      expect(getConfigurationClient).toBeCalledWith(request);
     });
   });
 
@@ -139,6 +156,8 @@ describe('application config routes', () => {
       const client = {
         getEntityConfig: jest.fn().mockReturnValue(ENTITY_VALUE),
       };
+
+      const getConfigurationClient = jest.fn().mockReturnValue(client);
 
       const okResponse = {
         statusCode: 200,
@@ -156,7 +175,12 @@ describe('application config routes', () => {
 
       const logger = loggerMock.create();
 
-      const returnedResponse = await handleGetEntityConfig(client, request, response, logger);
+      const returnedResponse = await handleGetEntityConfig(
+        getConfigurationClient,
+        request,
+        response,
+        logger
+      );
 
       expect(returnedResponse).toBe(okResponse);
 
@@ -165,6 +189,8 @@ describe('application config routes', () => {
           value: ENTITY_VALUE,
         },
       });
+
+      expect(getConfigurationClient).toBeCalledWith(request);
     });
 
     it('return error response when client throws error', async () => {
@@ -175,6 +201,8 @@ describe('application config routes', () => {
           throw error;
         }),
       };
+
+      const getConfigurationClient = jest.fn().mockReturnValue(client);
 
       const request = {
         params: {
@@ -188,7 +216,12 @@ describe('application config routes', () => {
 
       const logger = loggerMock.create();
 
-      const returnedResponse = await handleGetEntityConfig(client, request, response, logger);
+      const returnedResponse = await handleGetEntityConfig(
+        getConfigurationClient,
+        request,
+        response,
+        logger
+      );
 
       expect(returnedResponse).toBe(ERROR_RESPONSE);
 
@@ -200,6 +233,8 @@ describe('application config routes', () => {
       });
 
       expect(logger.error).toBeCalledWith(error);
+
+      expect(getConfigurationClient).toBeCalledWith(request);
     });
   });
 
@@ -208,6 +243,8 @@ describe('application config routes', () => {
       const client = {
         updateEntityConfig: jest.fn().mockReturnValue(ENTITY_NEW_VALUE),
       };
+
+      const getConfigurationClient = jest.fn().mockReturnValue(client);
 
       const okResponse = {
         statusCode: 200,
@@ -228,7 +265,12 @@ describe('application config routes', () => {
 
       const logger = loggerMock.create();
 
-      const returnedResponse = await handleUpdateEntityConfig(client, request, response, logger);
+      const returnedResponse = await handleUpdateEntityConfig(
+        getConfigurationClient,
+        request,
+        response,
+        logger
+      );
 
       expect(returnedResponse).toBe(okResponse);
 
@@ -241,6 +283,8 @@ describe('application config routes', () => {
       });
 
       expect(logger.error).not.toBeCalled();
+
+      expect(getConfigurationClient).toBeCalledWith(request);
     });
 
     it('return error response when client fails', async () => {
@@ -251,6 +295,8 @@ describe('application config routes', () => {
           throw error;
         }),
       };
+
+      const getConfigurationClient = jest.fn().mockReturnValue(client);
 
       const request = {
         params: {
@@ -267,7 +313,12 @@ describe('application config routes', () => {
 
       const logger = loggerMock.create();
 
-      const returnedResponse = await handleUpdateEntityConfig(client, request, response, logger);
+      const returnedResponse = await handleUpdateEntityConfig(
+        getConfigurationClient,
+        request,
+        response,
+        logger
+      );
 
       expect(returnedResponse).toBe(ERROR_RESPONSE);
 
@@ -279,6 +330,8 @@ describe('application config routes', () => {
       });
 
       expect(logger.error).toBeCalledWith(error);
+
+      expect(getConfigurationClient).toBeCalledWith(request);
     });
   });
 
@@ -287,6 +340,8 @@ describe('application config routes', () => {
       const client = {
         deleteEntityConfig: jest.fn().mockReturnValue(ENTITY_NAME),
       };
+
+      const getConfigurationClient = jest.fn().mockReturnValue(client);
 
       const okResponse = {
         statusCode: 200,
@@ -304,7 +359,12 @@ describe('application config routes', () => {
 
       const logger = loggerMock.create();
 
-      const returnedResponse = await handleDeleteEntityConfig(client, request, response, logger);
+      const returnedResponse = await handleDeleteEntityConfig(
+        getConfigurationClient,
+        request,
+        response,
+        logger
+      );
 
       expect(returnedResponse).toBe(okResponse);
 
@@ -317,6 +377,7 @@ describe('application config routes', () => {
       });
 
       expect(logger.error).not.toBeCalled();
+      expect(getConfigurationClient).toBeCalledWith(request);
     });
 
     it('return error response when client fails', async () => {
@@ -327,6 +388,8 @@ describe('application config routes', () => {
           throw error;
         }),
       };
+
+      const getConfigurationClient = jest.fn().mockReturnValue(client);
 
       const request = {
         params: {
@@ -340,7 +403,12 @@ describe('application config routes', () => {
 
       const logger = loggerMock.create();
 
-      const returnedResponse = await handleDeleteEntityConfig(client, request, response, logger);
+      const returnedResponse = await handleDeleteEntityConfig(
+        getConfigurationClient,
+        request,
+        response,
+        logger
+      );
 
       expect(returnedResponse).toBe(ERROR_RESPONSE);
 
@@ -352,6 +420,8 @@ describe('application config routes', () => {
       });
 
       expect(logger.error).toBeCalledWith(error);
+
+      expect(getConfigurationClient).toBeCalledWith(request);
     });
   });
 });

--- a/src/plugins/application_config/server/routes/index.ts
+++ b/src/plugins/application_config/server/routes/index.ts
@@ -23,8 +23,7 @@ export function defineRoutes(
       validate: false,
     },
     async (context, request, response) => {
-      const client = getConfigurationClient(request);
-      return await handleGetConfig(client, request, response, logger);
+      return await handleGetConfig(getConfigurationClient, request, response, logger);
     }
   );
   router.get(
@@ -37,9 +36,7 @@ export function defineRoutes(
       },
     },
     async (context, request, response) => {
-      const client = getConfigurationClient(request);
-
-      return await handleGetEntityConfig(client, request, response, logger);
+      return await handleGetEntityConfig(getConfigurationClient, request, response, logger);
     }
   );
   router.post(
@@ -55,9 +52,7 @@ export function defineRoutes(
       },
     },
     async (context, request, response) => {
-      const client = getConfigurationClient(request);
-
-      return await handleUpdateEntityConfig(client, request, response, logger);
+      return await handleUpdateEntityConfig(getConfigurationClient, request, response, logger);
     }
   );
   router.delete(
@@ -70,20 +65,20 @@ export function defineRoutes(
       },
     },
     async (context, request, response) => {
-      const client = getConfigurationClient(request);
-
-      return await handleDeleteEntityConfig(client, request, response, logger);
+      return await handleDeleteEntityConfig(getConfigurationClient, request, response, logger);
     }
   );
 }
 
 export async function handleGetEntityConfig(
-  client: ConfigurationClient,
+  getConfigurationClient: (request?: OpenSearchDashboardsRequest) => ConfigurationClient,
   request: OpenSearchDashboardsRequest,
   response: OpenSearchDashboardsResponseFactory,
   logger: Logger
 ) {
   logger.info(`Received a request to get entity config for ${request.params.entity}.`);
+
+  const client = getConfigurationClient(request);
 
   try {
     const result = await client.getEntityConfig(request.params.entity, {
@@ -101,7 +96,7 @@ export async function handleGetEntityConfig(
 }
 
 export async function handleUpdateEntityConfig(
-  client: ConfigurationClient,
+  getConfigurationClient: (request?: OpenSearchDashboardsRequest) => ConfigurationClient,
   request: OpenSearchDashboardsRequest,
   response: OpenSearchDashboardsResponseFactory,
   logger: Logger
@@ -109,6 +104,8 @@ export async function handleUpdateEntityConfig(
   logger.info(
     `Received a request to update entity ${request.params.entity} with new value ${request.body.newValue}.`
   );
+
+  const client = getConfigurationClient(request);
 
   try {
     const result = await client.updateEntityConfig(request.params.entity, request.body.newValue, {
@@ -126,12 +123,14 @@ export async function handleUpdateEntityConfig(
 }
 
 export async function handleDeleteEntityConfig(
-  client: ConfigurationClient,
+  getConfigurationClient: (request?: OpenSearchDashboardsRequest) => ConfigurationClient,
   request: OpenSearchDashboardsRequest,
   response: OpenSearchDashboardsResponseFactory,
   logger: Logger
 ) {
   logger.info(`Received a request to delete entity ${request.params.entity}.`);
+
+  const client = getConfigurationClient(request);
 
   try {
     const result = await client.deleteEntityConfig(request.params.entity, {
@@ -149,12 +148,14 @@ export async function handleDeleteEntityConfig(
 }
 
 export async function handleGetConfig(
-  client: ConfigurationClient,
+  getConfigurationClient: (request?: OpenSearchDashboardsRequest) => ConfigurationClient,
   request: OpenSearchDashboardsRequest,
   response: OpenSearchDashboardsResponseFactory,
   logger: Logger
 ) {
   logger.info('Received a request to get all configurations.');
+
+  const client = getConfigurationClient(request);
 
   try {
     const result = await client.getConfig({ headers: request.headers });

--- a/src/plugins/application_config/server/routes/index.ts
+++ b/src/plugins/application_config/server/routes/index.ts
@@ -6,7 +6,6 @@
 import { schema } from '@osd/config-schema';
 import {
   IRouter,
-  IScopedClusterClient,
   Logger,
   OpenSearchDashboardsRequest,
   OpenSearchDashboardsResponseFactory,
@@ -15,7 +14,7 @@ import { ConfigurationClient } from '../types';
 
 export function defineRoutes(
   router: IRouter,
-  getConfigurationClient: (configurationClient: IScopedClusterClient) => ConfigurationClient,
+  getConfigurationClient: (request?: OpenSearchDashboardsRequest) => ConfigurationClient,
   logger: Logger
 ) {
   router.get(
@@ -24,8 +23,7 @@ export function defineRoutes(
       validate: false,
     },
     async (context, request, response) => {
-      const client = getConfigurationClient(context.core.opensearch.client);
-
+      const client = getConfigurationClient(request);
       return await handleGetConfig(client, request, response, logger);
     }
   );
@@ -39,7 +37,7 @@ export function defineRoutes(
       },
     },
     async (context, request, response) => {
-      const client = getConfigurationClient(context.core.opensearch.client);
+      const client = getConfigurationClient(request);
 
       return await handleGetEntityConfig(client, request, response, logger);
     }
@@ -57,7 +55,7 @@ export function defineRoutes(
       },
     },
     async (context, request, response) => {
-      const client = getConfigurationClient(context.core.opensearch.client);
+      const client = getConfigurationClient(request);
 
       return await handleUpdateEntityConfig(client, request, response, logger);
     }
@@ -72,7 +70,7 @@ export function defineRoutes(
       },
     },
     async (context, request, response) => {
-      const client = getConfigurationClient(context.core.opensearch.client);
+      const client = getConfigurationClient(request);
 
       return await handleDeleteEntityConfig(client, request, response, logger);
     }


### PR DESCRIPTION
### Description

During https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6364/files, we simplify the input to `getConfigurationClient` from a client to a request. We were focusing on the use case of other plugins to onboard onto it. However, we also have API use case which we missed during the related PR. So, this PR is to fix the issue by passing request into the function instead of a client. 

Currently it is not failing because the `asScoped` function doesn't fail. Check the code reference here https://github.com/opensearch-project/OpenSearch-Dashboards/blob/eef417c03e7c4d34e85c70edb6c2079528ebc683/src/core/server/opensearch/client/cluster_client.ts#L137 It just treats it as using default headers and then doesn't pass user information to get a real scoped client.

### Issues Resolved

## Screenshot

## Testing the changes

Enable the following in YML.
```
# Set the value of this setting to true to enable plugin application config. By default it is disabled.
application_config.enabled: true

# Set the value of this setting to true to enable plugin CSP handler. By default it is disabled.
# It requires the application config plugin as its dependency.
csp_handler.enabled: true


```

call Get API

```
curl -X GET 'http://localhost:5601/api/appconfig/csp.rules.frame-ancestors'
```
```
{"statusCode":404,"error":"Not Found","message":"Response Error"}%
```

call update API

```
curl 'http://localhost:5601/api/appconfig/csp.rules.frame-ancestors' -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty' --data-raw '{"newValue":"file://* filesystem:"}'
```

```
{"newValue":"file://* filesystem:"}%
```

call get API again

```
curl -X GET 'http://localhost:5601/api/appconfig/csp.rules.frame-ancestors'
```

```
{"value":"file://* filesystem:"}%
```

call delete API

```
curl 'http://localhost:5601/api/appconfig/csp.rules.frame-ancestors' -X DELETE -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty'
```

```
{"deletedEntity":"csp.rules.frame-ancestors"}%
```

call get API again.
```
curl -X GET 'http://localhost:5601/api/appconfig/csp.rules.frame-ancestors'
```

```
{"statusCode":404,"error":"Not Found","message":"Response Error"}%
```




### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
