### PR TITLE
Bump tar from 6.1.13 to 6.2.1

### DIFF
--- a/changelogs/fragments/6492.yml
+++ b/changelogs/fragments/6492.yml
@@ -1,2 +1,2 @@
 security:
-- [opensearch-project/OpenSearch-Dashboards/issues/6488] Bump tar from 6.1.11 to 6.2.1 ([#6492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6492))
+- [CVE-2024-28863] Bump tar from 6.1.11 to 6.2.1 ([#6492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6492))

--- a/changelogs/fragments/6492.yml
+++ b/changelogs/fragments/6492.yml
@@ -1,0 +1,2 @@
+security:
+- [opensearch-project/OpenSearch-Dashboards/issues/6488] Bump tar from 6.1.11 to 6.2.1 ([#6492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6492))

--- a/changelogs/fragments/6492.yml
+++ b/changelogs/fragments/6492.yml
@@ -1,2 +1,2 @@
 security:
-- [opensearch-project/OpenSearch-Dashboards/issues/6488] Bump tar from 6.1.11 to 6.2.1 ([#6492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6492))
+- Bump tar from 6.1.11 to 6.2.1 ([#6492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6492))

--- a/changelogs/fragments/6492.yml
+++ b/changelogs/fragments/6492.yml
@@ -1,2 +1,2 @@
 security:
-- Bump tar from 6.1.11 to 6.2.1 ([#6492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6492))
+- [/OpenSearch-Dashboards/issues/6488] Bump tar from 6.1.11 to 6.2.1 ([#6492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6492))

--- a/changelogs/fragments/6492.yml
+++ b/changelogs/fragments/6492.yml
@@ -1,2 +1,2 @@
 security:
-- [/OpenSearch-Dashboards/issues/6488] Bump tar from 6.1.11 to 6.2.1 ([#6492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6492))
+- [opensearch-project/OpenSearch-Dashboards/issues/6488] Bump tar from 6.1.11 to 6.2.1 ([#6492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6492))

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "**/nth-check": "^2.0.1",
     "**/semver": "^7.5.3",
     "**/set-value": "^4.1.0",
+    "**/tar":"^6.2.1",
     "**/topo/hoek": "npm:@amoo-miki/hoek@6.1.3",
     "**/trim": "^0.0.3",
     "**/typescript": "4.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13255,6 +13255,11 @@ minipass@^4.0.0:
   dependencies:
     yallist "^4.0.0"
 
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
 minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
@@ -17486,26 +17491,14 @@ tar-stream@^2.1.4, tar-stream@^2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@6.1.11:
-  version "6.1.11"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
-  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+tar@6.1.11, tar@^6.0.2, tar@^6.1.11, tar@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
+  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
-    minipass "^3.0.0"
-    minizlib "^2.1.1"
-    mkdirp "^1.0.3"
-    yallist "^4.0.0"
-
-tar@^6.0.2, tar@^6.1.11:
-  version "6.1.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.13.tgz#46e22529000f612180601a6fe0680e7da508847b"
-  integrity sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==
-  dependencies:
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    minipass "^4.0.0"
+    minipass "^5.0.0"
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"


### PR DESCRIPTION
### Description

Bumps the tar package from 6.1.13 to 6.2.1. It is a complete version of https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6397 which is linked to CVE(https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6488) mentioned here.

## Changelog
- security: [CVE-2024-28863] Bump tar from 6.1.11 to 6.2.1

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
