### PR TITLE
[MDS] Refactor DataSourceAggregatedView

### DIFF
--- a/examples/multiple_data_source_examples/public/application.tsx
+++ b/examples/multiple_data_source_examples/public/application.tsx
@@ -11,7 +11,7 @@ import { CoreStart, AppMountParameters } from '../../../src/core/public';
 import { Home } from './components/home';
 
 export const renderApp = (
-  { notifications, http, savedObjects, application }: CoreStart,
+  { notifications, http, savedObjects, application, uiSettings }: CoreStart,
   dataSource: DataSourcePluginSetup,
   dataSourceManagement: DataSourceManagementPluginSetup,
   { appBasePath, element, setHeaderActionMenu }: AppMountParameters,
@@ -28,6 +28,7 @@ export const renderApp = (
       dataSourceManagement={dataSourceManagement}
       navigateToApp={application.navigateToApp}
       navigation={navigation}
+      uiSettings={uiSettings}
     />,
     element
   );

--- a/examples/multiple_data_source_examples/public/components/data_source_list_active_example.tsx
+++ b/examples/multiple_data_source_examples/public/components/data_source_list_active_example.tsx
@@ -28,6 +28,7 @@ interface DataSourceListActiveExampleProps {
   notifications: CoreStart['notifications'];
   setActionMenu?: (menuMount: MountPoint | undefined) => void;
   dataSourceManagement: DataSourceManagementPluginSetup;
+  uiSettings: CoreStart['uiSettings'];
 }
 
 export const DataSourceListActiveExample = ({
@@ -36,6 +37,7 @@ export const DataSourceListActiveExample = ({
   notifications,
   setActionMenu,
   dataSourceManagement,
+  uiSettings,
 }: DataSourceListActiveExampleProps) => {
   const DataSourceMenu = dataSourceManagement.ui.getDataSourceMenu<
     DataSourceAggregatedViewConfig
@@ -106,7 +108,10 @@ export const DataSourceListActiveExample = ({
               fullWidth: false,
               savedObjects: savedObjects.client,
               notifications,
-              displayAllCompatibleDataSources: true,
+              displayAllCompatibleDataSources: false,
+              // To see selected options, obtain the datasource id and paste it here. Note that this needs to be defined when displayAllCompatibleDataSources is false
+              activeDataSourceIds: [],
+              uiSettings,
             }}
           />
         )}

--- a/examples/multiple_data_source_examples/public/components/data_source_list_all_example.tsx
+++ b/examples/multiple_data_source_examples/public/components/data_source_list_all_example.tsx
@@ -28,6 +28,7 @@ interface DataSourceListAllExampleProps {
   notifications: CoreStart['notifications'];
   setActionMenu?: (menuMount: MountPoint | undefined) => void;
   dataSourceManagement: DataSourceManagementPluginSetup;
+  uiSettings: CoreStart['uiSettings'];
 }
 
 export const DataSourceListAllExample = ({
@@ -36,6 +37,7 @@ export const DataSourceListAllExample = ({
   notifications,
   setActionMenu,
   dataSourceManagement,
+  uiSettings,
 }: DataSourceListAllExampleProps) => {
   const DataSourceMenu = dataSourceManagement.ui.getDataSourceMenu<
     DataSourceAggregatedViewConfig
@@ -100,6 +102,7 @@ export const DataSourceListAllExample = ({
               savedObjects: savedObjects.client,
               notifications,
               displayAllCompatibleDataSources: true,
+              uiSettings,
             }}
           />
         )}

--- a/examples/multiple_data_source_examples/public/components/home.tsx
+++ b/examples/multiple_data_source_examples/public/components/home.tsx
@@ -22,6 +22,7 @@ export interface HomeProps {
   notifications: CoreStart['notifications'];
   http: CoreStart['http'];
   savedObjects: CoreStart['savedObjects'];
+  uiSettings: CoreStart['uiSettings'];
   dataSourceEnabled: boolean;
   dataSourceManagement: DataSourceManagementPluginSetup;
   navigateToApp: CoreStart['application']['navigateToApp'];
@@ -65,6 +66,7 @@ export const Home = ({
   basename,
   notifications,
   savedObjects,
+  uiSettings,
   dataSourceEnabled,
   setActionMenu,
   dataSourceManagement,
@@ -133,6 +135,7 @@ export const Home = ({
           dataSourceEnabled={dataSourceEnabled}
           setActionMenu={setActionMenu}
           dataSourceManagement={dataSourceManagement}
+          uiSettings={uiSettings}
         />
       ),
     },
@@ -146,6 +149,7 @@ export const Home = ({
           dataSourceEnabled={dataSourceEnabled}
           setActionMenu={setActionMenu}
           dataSourceManagement={dataSourceManagement}
+          uiSettings={uiSettings}
         />
       ),
     },

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/__snapshots__/data_source_aggregated_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/__snapshots__/data_source_aggregated_view.test.tsx.snap
@@ -1,543 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DataSourceAggregatedView should render normally with data source filter 1`] = `
-<DataSourceAggregatedView
-  dataSourceFilter={[Function]}
-  displayAllCompatibleDataSources={true}
-  fullWidth={false}
-  hideLocalCluster={false}
-  notifications={
-    Object {
-      "add": [MockFunction],
-      "addDanger": [MockFunction],
-      "addError": [MockFunction],
-      "addInfo": [MockFunction],
-      "addSuccess": [MockFunction],
-      "addWarning": [MockFunction],
-      "get$": [MockFunction],
-      "remove": [MockFunction],
-    }
-  }
-  savedObjectsClient={
-    Object {
-      "find": [MockFunction] {
-        "calls": Array [
-          Array [
-            Object {
-              "fields": Array [
-                "id",
-                "title",
-                "auth.type",
-              ],
-              "perPage": 10000,
-              "type": "data-source",
-            },
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": Promise {},
-          },
-        ],
-      },
-    }
-  }
->
-  <EuiButtonEmpty
-    aria-label="dataSourceAggregatedViewMenuButton"
-    className="euiHeaderLink"
-    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-    disabled={true}
-    iconSide="left"
-    iconType="database"
-    size="s"
-  >
-    <button
-      aria-label="dataSourceAggregatedViewMenuButton"
-      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty-isDisabled euiHeaderLink"
-      data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-      disabled={true}
-      type="button"
-    >
-      <EuiButtonContent
-        className="euiButtonEmpty__content"
-        iconSide="left"
-        iconSize="m"
-        iconType="database"
-        textProps={
-          Object {
-            "className": "euiButtonEmpty__text",
-          }
-        }
-      >
-        <span
-          className="euiButtonContent euiButtonEmpty__content"
-        >
-          <EuiIcon
-            className="euiButtonContent__icon"
-            color="inherit"
-            size="m"
-            type="database"
-          >
-            <span
-              className="euiButtonContent__icon"
-              color="inherit"
-              data-euiicon-type="database"
-              size="m"
-            />
-          </EuiIcon>
-          <span
-            className="euiButtonEmpty__text"
-          >
-            Data sources
-          </span>
-        </span>
-      </EuiButtonContent>
-    </button>
-  </EuiButtonEmpty>
-  <EuiNotificationBadge
-    color="subdued"
-  >
-    <span
-      className="euiNotificationBadge euiNotificationBadge--subdued"
-    >
-      All
-    </span>
-  </EuiNotificationBadge>
-  <EuiPopover
-    anchorPosition="downLeft"
-    button={
-      <EuiButtonIcon
-        aria-label="show data sources"
-        data-test-subj="dataSourceAggregatedViewInfoButton"
-        display="empty"
-        iconType="iInCircle"
-        onClick={[Function]}
-      />
-    }
-    closePopover={[Function]}
-    display="inlineBlock"
-    hasArrow={true}
-    id="dataSourceSViewContextMenuPopover"
-    isOpen={false}
-    ownFocus={true}
-    panelPaddingSize="none"
-  >
-    <div
-      className="euiPopover euiPopover--anchorDownLeft"
-      id="dataSourceSViewContextMenuPopover"
-    >
-      <div
-        className="euiPopover__anchor"
-      >
-        <EuiButtonIcon
-          aria-label="show data sources"
-          data-test-subj="dataSourceAggregatedViewInfoButton"
-          display="empty"
-          iconType="iInCircle"
-          onClick={[Function]}
-        >
-          <button
-            aria-label="show data sources"
-            className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-            data-test-subj="dataSourceAggregatedViewInfoButton"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <EuiIcon
-              aria-hidden="true"
-              className="euiButtonIcon__icon"
-              color="inherit"
-              size="m"
-              type="iInCircle"
-            >
-              <span
-                aria-hidden="true"
-                className="euiButtonIcon__icon"
-                color="inherit"
-                data-euiicon-type="iInCircle"
-                size="m"
-              />
-            </EuiIcon>
-          </button>
-        </EuiButtonIcon>
-      </div>
-    </div>
-  </EuiPopover>
-</DataSourceAggregatedView>
-`;
-
-exports[`DataSourceAggregatedView should render normally with local cluster and actice selections 1`] = `
-<DataSourceAggregatedView
-  activeDataSourceIds={
-    Array [
-      "test1",
-    ]
-  }
-  displayAllCompatibleDataSources={false}
-  fullWidth={false}
-  hideLocalCluster={false}
-  notifications={
-    Object {
-      "add": [MockFunction],
-      "addDanger": [MockFunction],
-      "addError": [MockFunction],
-      "addInfo": [MockFunction],
-      "addSuccess": [MockFunction],
-      "addWarning": [MockFunction],
-      "get$": [MockFunction],
-      "remove": [MockFunction],
-    }
-  }
-  savedObjectsClient={
-    Object {
-      "find": [MockFunction] {
-        "calls": Array [
-          Array [
-            Object {
-              "fields": Array [
-                "id",
-                "title",
-                "auth.type",
-              ],
-              "perPage": 10000,
-              "type": "data-source",
-            },
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": Promise {},
-          },
-        ],
-      },
-    }
-  }
->
-  <EuiButtonEmpty
-    aria-label="dataSourceAggregatedViewMenuButton"
-    className="euiHeaderLink"
-    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-    disabled={true}
-    iconSide="left"
-    iconType="database"
-    size="s"
-  >
-    <button
-      aria-label="dataSourceAggregatedViewMenuButton"
-      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty-isDisabled euiHeaderLink"
-      data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-      disabled={true}
-      type="button"
-    >
-      <EuiButtonContent
-        className="euiButtonEmpty__content"
-        iconSide="left"
-        iconSize="m"
-        iconType="database"
-        textProps={
-          Object {
-            "className": "euiButtonEmpty__text",
-          }
-        }
-      >
-        <span
-          className="euiButtonContent euiButtonEmpty__content"
-        >
-          <EuiIcon
-            className="euiButtonContent__icon"
-            color="inherit"
-            size="m"
-            type="database"
-          >
-            <span
-              className="euiButtonContent__icon"
-              color="inherit"
-              data-euiicon-type="database"
-              size="m"
-            />
-          </EuiIcon>
-          <span
-            className="euiButtonEmpty__text"
-          >
-            Data sources
-          </span>
-        </span>
-      </EuiButtonContent>
-    </button>
-  </EuiButtonEmpty>
-  <EuiNotificationBadge
-    color="subdued"
-  >
-    <span
-      className="euiNotificationBadge euiNotificationBadge--subdued"
-    >
-      1
-    </span>
-  </EuiNotificationBadge>
-  <EuiPopover
-    anchorPosition="downLeft"
-    button={
-      <EuiButtonIcon
-        aria-label="show data sources"
-        data-test-subj="dataSourceAggregatedViewInfoButton"
-        display="empty"
-        iconType="iInCircle"
-        onClick={[Function]}
-      />
-    }
-    closePopover={[Function]}
-    display="inlineBlock"
-    hasArrow={true}
-    id="dataSourceSViewContextMenuPopover"
-    isOpen={false}
-    ownFocus={true}
-    panelPaddingSize="none"
-  >
-    <div
-      className="euiPopover euiPopover--anchorDownLeft"
-      id="dataSourceSViewContextMenuPopover"
-    >
-      <div
-        className="euiPopover__anchor"
-      >
-        <EuiButtonIcon
-          aria-label="show data sources"
-          data-test-subj="dataSourceAggregatedViewInfoButton"
-          display="empty"
-          iconType="iInCircle"
-          onClick={[Function]}
-        >
-          <button
-            aria-label="show data sources"
-            className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-            data-test-subj="dataSourceAggregatedViewInfoButton"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <EuiIcon
-              aria-hidden="true"
-              className="euiButtonIcon__icon"
-              color="inherit"
-              size="m"
-              type="iInCircle"
-            >
-              <span
-                aria-hidden="true"
-                className="euiButtonIcon__icon"
-                color="inherit"
-                data-euiicon-type="iInCircle"
-                size="m"
-              />
-            </EuiIcon>
-          </button>
-        </EuiButtonIcon>
-      </div>
-    </div>
-  </EuiPopover>
-</DataSourceAggregatedView>
-`;
-
-exports[`DataSourceAggregatedView should render normally with local cluster hidden and all options 1`] = `
-<DataSourceAggregatedView
-  activeDataSourceIds={Array []}
-  displayAllCompatibleDataSources={false}
-  fullWidth={false}
-  hideLocalCluster={true}
-  notifications={
-    Object {
-      "add": [MockFunction],
-      "addDanger": [MockFunction],
-      "addError": [MockFunction],
-      "addInfo": [MockFunction],
-      "addSuccess": [MockFunction],
-      "addWarning": [MockFunction],
-      "get$": [MockFunction],
-      "remove": [MockFunction],
-    }
-  }
-  savedObjectsClient={
-    Object {
-      "find": [MockFunction] {
-        "calls": Array [
-          Array [
-            Object {
-              "fields": Array [
-                "id",
-                "title",
-                "auth.type",
-              ],
-              "perPage": 10000,
-              "type": "data-source",
-            },
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": Promise {},
-          },
-        ],
-      },
-    }
-  }
->
-  <EuiButtonEmpty
-    aria-label="dataSourceAggregatedViewMenuButton"
-    className="euiHeaderLink"
-    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-    disabled={true}
-    iconSide="left"
-    iconType="database"
-    size="s"
-  >
-    <button
-      aria-label="dataSourceAggregatedViewMenuButton"
-      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty-isDisabled euiHeaderLink"
-      data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-      disabled={true}
-      type="button"
-    >
-      <EuiButtonContent
-        className="euiButtonEmpty__content"
-        iconSide="left"
-        iconSize="m"
-        iconType="database"
-        textProps={
-          Object {
-            "className": "euiButtonEmpty__text",
-          }
-        }
-      >
-        <span
-          className="euiButtonContent euiButtonEmpty__content"
-        >
-          <EuiIcon
-            className="euiButtonContent__icon"
-            color="inherit"
-            size="m"
-            type="database"
-          >
-            <span
-              className="euiButtonContent__icon"
-              color="inherit"
-              data-euiicon-type="database"
-              size="m"
-            />
-          </EuiIcon>
-          <span
-            className="euiButtonEmpty__text"
-          >
-            Data sources
-          </span>
-        </span>
-      </EuiButtonContent>
-    </button>
-  </EuiButtonEmpty>
-  <EuiNotificationBadge
-    color="subdued"
-  >
-    <span
-      className="euiNotificationBadge euiNotificationBadge--subdued"
-    >
-      0
-    </span>
-  </EuiNotificationBadge>
-  <EuiPopover
-    anchorPosition="downLeft"
-    button={
-      <EuiButtonIcon
-        aria-label="show data sources"
-        data-test-subj="dataSourceAggregatedViewInfoButton"
-        display="empty"
-        iconType="iInCircle"
-        onClick={[Function]}
-      />
-    }
-    closePopover={[Function]}
-    display="inlineBlock"
-    hasArrow={true}
-    id="dataSourceSViewContextMenuPopover"
-    isOpen={false}
-    ownFocus={true}
-    panelPaddingSize="none"
-  >
-    <div
-      className="euiPopover euiPopover--anchorDownLeft"
-      id="dataSourceSViewContextMenuPopover"
-    >
-      <div
-        className="euiPopover__anchor"
-      >
-        <EuiButtonIcon
-          aria-label="show data sources"
-          data-test-subj="dataSourceAggregatedViewInfoButton"
-          display="empty"
-          iconType="iInCircle"
-          onClick={[Function]}
-        >
-          <button
-            aria-label="show data sources"
-            className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-            data-test-subj="dataSourceAggregatedViewInfoButton"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <EuiIcon
-              aria-hidden="true"
-              className="euiButtonIcon__icon"
-              color="inherit"
-              size="m"
-              type="iInCircle"
-            >
-              <span
-                aria-hidden="true"
-                className="euiButtonIcon__icon"
-                color="inherit"
-                data-euiicon-type="iInCircle"
-                size="m"
-              />
-            </EuiIcon>
-          </button>
-        </EuiButtonIcon>
-      </div>
-    </div>
-  </EuiPopover>
-</DataSourceAggregatedView>
-`;
-
-exports[`DataSourceAggregatedView should render normally with local cluster not hidden and all options 1`] = `
+exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSources is set to false) should render normally with local cluster and active selections configured 1`] = `
 <Fragment>
-  <EuiButtonEmpty
-    aria-label="dataSourceAggregatedViewMenuButton"
-    className="euiHeaderLink"
-    data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-    disabled={true}
-    iconSide="left"
-    iconType="database"
-    size="s"
-  >
-    Data sources
-  </EuiButtonEmpty>
-  <EuiNotificationBadge
-    color="subdued"
-  >
-    All
-  </EuiNotificationBadge>
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonIcon
-        aria-label="show data sources"
-        data-test-subj="dataSourceAggregatedViewInfoButton"
-        display="empty"
-        iconType="iInCircle"
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
         onClick={[Function]}
+        size="s"
       />
     }
     closePopover={[Function]}
@@ -548,246 +23,2075 @@ exports[`DataSourceAggregatedView should render normally with local cluster not 
     ownFocus={true}
     panelPaddingSize="none"
   >
-    <EuiContextMenu
-      initialPanelId={0}
-      panels={
-        Array [
-          Object {
-            "id": 0,
-            "items": Array [],
-            "title": "Data sources (0)",
-          },
-        ]
-      }
-      size="m"
-    />
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          activeDataSourceCount={1}
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={3}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={
+              Array [
+                Object {
+                  "checked": "on",
+                  "disabled": true,
+                  "id": "test2",
+                  "label": "test2",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test3",
+                  "label": "test3",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "",
+                  "label": "Local cluster",
+                },
+              ]
+            }
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="m"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        hasShadow={false}
+      >
+        <EuiSwitch
+          checked={false}
+          className="dataSourceAggregatedViewOuiSwitch"
+          compressed={true}
+          label="Used on this page (1)"
+          onChange={[Function]}
+        />
+      </EuiPanel>
+    </EuiContextMenuPanel>
   </EuiPopover>
 </Fragment>
 `;
 
-exports[`DataSourceAggregatedView should render popup when clicking on info icon 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": <body>
-    <div>
-      <button
+exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSources is set to false) should render normally with local cluster and active selections configured 2`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
         aria-label="dataSourceAggregatedViewMenuButton"
-        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty-isDisabled euiHeaderLink"
+        className="euiHeaderLink"
         data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        disabled=""
-        type="button"
-      >
-        <span
-          class="euiButtonContent euiButtonEmpty__content"
-        >
-          <span
-            class="euiButtonContent__icon"
-            color="inherit"
-            data-euiicon-type="database"
-          />
-          <span
-            class="euiButtonEmpty__text"
-          >
-            Data sources
-          </span>
-        </span>
-      </button>
-      <span
-        class="euiNotificationBadge euiNotificationBadge--subdued"
-      >
-        1
-      </span>
-      <div
-        class="euiPopover euiPopover--anchorDownLeft"
-        id="dataSourceSViewContextMenuPopover"
-      >
-        <div
-          class="euiPopover__anchor"
-        >
-          <button
-            aria-label="show data sources"
-            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-            data-test-subj="dataSourceAggregatedViewInfoButton"
-            type="button"
-          >
-            <span
-              aria-hidden="true"
-              class="euiButtonIcon__icon"
-              color="inherit"
-              data-euiicon-type="iInCircle"
-            />
-          </button>
-        </div>
-      </div>
-    </div>
-    <div>
-      <div
-        data-eui="EuiFocusTrap"
-      >
-        <div
-          aria-describedby="generated-id"
-          aria-live="off"
-          aria-modal="true"
-          class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom"
-          role="dialog"
-          style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
-          tabindex="0"
-        >
-          <div
-            class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-            style="left: 10px; top: 0px;"
-          />
-          <p
-            class="euiScreenReaderOnly"
-            id="generated-id"
-          >
-            You are in a dialog. To close this dialog, hit escape.
-          </p>
-          <div>
-            <div
-              class="euiContextMenu"
-              style="height: 0px;"
-            >
-              <div
-                class="euiContextMenuPanel euiContextMenu__panel"
-                tabindex="-1"
-              >
-                <div
-                  class="euiContextMenuPanelTitle"
-                >
-                  <span
-                    class="euiContextMenu__itemLayout"
-                  >
-                    Selected data sources
-                  </span>
-                </div>
-                <div>
-                  <div>
-                    <button
-                      class="euiContextMenuItem euiContextMenuItem-isDisabled"
-                      disabled=""
-                      type="button"
-                    >
-                      <span
-                        class="euiContextMenu__itemLayout"
-                      >
-                        <span
-                          class="euiContextMenuItem__text"
-                        >
-                          test1
-                        </span>
-                      </span>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
-    <button
-      aria-label="dataSourceAggregatedViewMenuButton"
-      class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty-isDisabled euiHeaderLink"
-      data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-      disabled=""
-      type="button"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
     >
-      <span
-        class="euiButtonContent euiButtonEmpty__content"
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
       >
-        <span
-          class="euiButtonContent__icon"
-          color="inherit"
-          data-euiicon-type="database"
+        <DataSourceDropDownHeader
+          activeDataSourceCount={2}
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={4}
         />
-        <span
-          class="euiButtonEmpty__text"
-        >
-          Data sources
-        </span>
-      </span>
-    </button>
-    <span
-      class="euiNotificationBadge euiNotificationBadge--subdued"
-    >
-      1
-    </span>
-    <div
-      class="euiPopover euiPopover--anchorDownLeft"
-      id="dataSourceSViewContextMenuPopover"
-    >
-      <div
-        class="euiPopover__anchor"
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
       >
-        <button
-          aria-label="show data sources"
-          class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-          data-test-subj="dataSourceAggregatedViewInfoButton"
-          type="button"
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
         >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="iInCircle"
-          />
-        </button>
-      </div>
-    </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+          <EuiSelectable
+            isPreFiltered={false}
+            options={
+              Array [
+                Object {
+                  "checked": "on",
+                  "disabled": true,
+                  "id": "test1",
+                  "label": "test1",
+                },
+                Object {
+                  "checked": "on",
+                  "disabled": true,
+                  "id": "test2",
+                  "label": "test2",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test3",
+                  "label": "test3",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "",
+                  "label": "Local cluster",
+                },
+              ]
+            }
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="m"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        hasShadow={false}
+      >
+        <EuiSwitch
+          checked={false}
+          className="dataSourceAggregatedViewOuiSwitch"
+          compressed={true}
+          label="Used on this page (2)"
+          onChange={[Function]}
+        />
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSources is set to false) should render normally with local cluster and active selections configured 3`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          activeDataSourceCount={1}
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={2}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={
+              Array [
+                Object {
+                  "checked": "on",
+                  "disabled": true,
+                  "id": "test2",
+                  "label": "test2",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test3",
+                  "label": "test3",
+                },
+              ]
+            }
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="m"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        hasShadow={false}
+      >
+        <EuiSwitch
+          checked={false}
+          className="dataSourceAggregatedViewOuiSwitch"
+          compressed={true}
+          label="Used on this page (1)"
+          onChange={[Function]}
+        />
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSources is set to false) should render normally with local cluster and active selections configured 4`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          activeDataSourceCount={2}
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={3}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={
+              Array [
+                Object {
+                  "checked": "on",
+                  "disabled": true,
+                  "id": "test1",
+                  "label": "test1",
+                },
+                Object {
+                  "checked": "on",
+                  "disabled": true,
+                  "id": "test2",
+                  "label": "test2",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test3",
+                  "label": "test3",
+                },
+              ]
+            }
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="m"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        hasShadow={false}
+      >
+        <EuiSwitch
+          checked={false}
+          className="dataSourceAggregatedViewOuiSwitch"
+          compressed={true}
+          label="Used on this page (2)"
+          onChange={[Function]}
+        />
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSources is set to false) should render normally with local cluster and active selections configured 5`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          activeDataSourceCount={0}
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={3}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={
+              Array [
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test2",
+                  "label": "test2",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test3",
+                  "label": "test3",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "",
+                  "label": "Local cluster",
+                },
+              ]
+            }
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="m"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        hasShadow={false}
+      >
+        <EuiSwitch
+          checked={false}
+          className="dataSourceAggregatedViewOuiSwitch"
+          compressed={true}
+          label="Used on this page (0)"
+          onChange={[Function]}
+        />
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSources is set to false) should render normally with local cluster and active selections configured 6`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          activeDataSourceCount={0}
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={4}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={
+              Array [
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test1",
+                  "label": "test1",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test2",
+                  "label": "test2",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test3",
+                  "label": "test3",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "",
+                  "label": "Local cluster",
+                },
+              ]
+            }
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="m"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        hasShadow={false}
+      >
+        <EuiSwitch
+          checked={false}
+          className="dataSourceAggregatedViewOuiSwitch"
+          compressed={true}
+          label="Used on this page (0)"
+          onChange={[Function]}
+        />
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSources is set to false) should render normally with local cluster and active selections configured 7`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          activeDataSourceCount={0}
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={2}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={
+              Array [
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test2",
+                  "label": "test2",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test3",
+                  "label": "test3",
+                },
+              ]
+            }
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="m"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        hasShadow={false}
+      >
+        <EuiSwitch
+          checked={false}
+          className="dataSourceAggregatedViewOuiSwitch"
+          compressed={true}
+          label="Used on this page (0)"
+          onChange={[Function]}
+        />
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSources is set to false) should render normally with local cluster and active selections configured 8`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          activeDataSourceCount={0}
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={3}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={
+              Array [
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test1",
+                  "label": "test1",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test2",
+                  "label": "test2",
+                },
+                Object {
+                  "checked": undefined,
+                  "disabled": true,
+                  "id": "test3",
+                  "label": "test3",
+                },
+              ]
+            }
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="m"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        hasShadow={false}
+      >
+        <EuiSwitch
+          checked={false}
+          className="dataSourceAggregatedViewOuiSwitch"
+          compressed={true}
+          label="Used on this page (0)"
+          onChange={[Function]}
+        />
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSources is set to true) should render normally with local cluster configured, default datasource removed or added, and if activeDataSourceIds is present or filtered out 1`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={0}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={Array []}
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSources is set to true) should render normally with local cluster configured, default datasource removed or added, and if activeDataSourceIds is present or filtered out 2`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={0}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={Array []}
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSources is set to true) should render normally with local cluster configured, default datasource removed or added, and if activeDataSourceIds is present or filtered out 3`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={0}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={Array []}
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSources is set to true) should render normally with local cluster configured, default datasource removed or added, and if activeDataSourceIds is present or filtered out 4`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={0}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={Array []}
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSources is set to true) should render normally with local cluster configured, default datasource removed or added, and if activeDataSourceIds is present or filtered out 5`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={0}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={Array []}
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSources is set to true) should render normally with local cluster configured, default datasource removed or added, and if activeDataSourceIds is present or filtered out 6`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={0}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={Array []}
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSources is set to true) should render normally with local cluster configured, default datasource removed or added, and if activeDataSourceIds is present or filtered out 7`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={0}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={Array []}
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSources is set to true) should render normally with local cluster configured, default datasource removed or added, and if activeDataSourceIds is present or filtered out 8`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={0}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={Array []}
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSources is set to true) should render normally with local cluster configured, default datasource removed or added, and if activeDataSourceIds is present or filtered out 9`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={0}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={Array []}
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
+`;
+
+exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSources is set to true) should render normally with local cluster configured, default datasource removed or added, and if activeDataSourceIds is present or filtered out 10`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonEmpty
+        aria-label="dataSourceAggregatedViewMenuButton"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        iconSide="left"
+        iconType="database"
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceSViewContextMenuPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <EuiContextMenuPanel
+      hasFocus={true}
+      items={Array []}
+    >
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        color="transparent"
+        hasBorder={false}
+        paddingSize="s"
+      >
+        <DataSourceDropDownHeader
+          application={
+            Object {
+              "applications$": BehaviorSubject {
+                "_isScalar": false,
+                "_value": Map {},
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [],
+                "thrownError": null,
+              },
+              "capabilities": Object {
+                "catalogue": Object {},
+                "management": Object {},
+                "navLinks": Object {},
+                "workspaces": Object {},
+              },
+              "currentAppId$": Observable {
+                "_isScalar": false,
+                "source": Subject {
+                  "_isScalar": false,
+                  "closed": false,
+                  "hasError": false,
+                  "isStopped": false,
+                  "observers": Array [],
+                  "thrownError": null,
+                },
+              },
+              "getUrlForApp": [MockFunction],
+              "navigateToApp": [MockFunction],
+              "navigateToUrl": [MockFunction],
+              "registerMountContext": [MockFunction],
+            }
+          }
+          totalDataSourceCount={0}
+        />
+      </EuiPanel>
+      <EuiPanel
+        borderRadius="none"
+        className="dataSourceAggregatedViewOuiPanel"
+        hasShadow={false}
+        paddingSize="none"
+      >
+        <EuiPanel
+          borderRadius="none"
+          className="dataSourceAggregatedViewOuiPanel"
+          color="subdued"
+          paddingSize="s"
+        >
+          <EuiSelectable
+            isPreFiltered={false}
+            options={Array []}
+            renderOption={[Function]}
+            searchable={false}
+            singleSelection={false}
+          >
+            <Component />
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiPanel>
+    </EuiContextMenuPanel>
+  </EuiPopover>
+</Fragment>
 `;

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.scss
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.scss
@@ -1,0 +1,19 @@
+.dataSourceAggregatedViewOuiPanel {
+  width: 300px;
+
+  .dataSourceAggregatedViewOuiFlexGroup {
+    .dataSourceAggregatedViewOuiFlexItem {
+      color: grey;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+      display: inline-block;
+    }
+  }
+
+  .dataSourceAggregatedViewOuiSwitch {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.test.tsx
@@ -3,124 +3,269 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ShallowWrapper, mount, shallow } from 'enzyme';
+import { ShallowWrapper, shallow } from 'enzyme';
 import React from 'react';
 import { DataSourceAggregatedView } from './data_source_aggregated_view';
-import { SavedObjectsClientContract } from '../../../../../core/public';
-import { notificationServiceMock } from '../../../../../core/public/mocks';
-import { getDataSourcesWithFieldsResponse, mockResponseForSavedObjectsCalls } from '../../mocks';
-import { render } from '@testing-library/react';
+import { SavedObject, SavedObjectsClientContract } from '../../../../../core/public';
+import {
+  applicationServiceMock,
+  notificationServiceMock,
+  uiSettingsServiceMock,
+} from '../../../../../core/public/mocks';
+import {
+  getDataSourcesWithFieldsResponse,
+  mockResponseForSavedObjectsCalls,
+  mockUiSettingsCalls,
+} from '../../mocks';
+import * as utils from '../utils';
+import { EuiSelectable, EuiSwitch } from '@elastic/eui';
+import { DataSourceAttributes } from '../../types';
 
-describe('DataSourceAggregatedView', () => {
+describe('DataSourceAggregatedView: read all view (displayAllCompatibleDataSources is set to true)', () => {
   let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
   let client: SavedObjectsClientContract;
   const { toasts } = notificationServiceMock.createStartContract();
+  const uiSettings = uiSettingsServiceMock.createStartContract();
+  const application = applicationServiceMock.createStartContract();
+  const nextTick = () => new Promise((res) => process.nextTick(res));
 
   beforeEach(() => {
     client = {
       find: jest.fn().mockResolvedValue([]),
     } as any;
     mockResponseForSavedObjectsCalls(client, 'find', getDataSourcesWithFieldsResponse);
+    mockUiSettingsCalls(uiSettings, 'get', 'test1');
+    jest.spyOn(utils, 'getApplication').mockReturnValue(application);
   });
 
-  it('should render normally with local cluster not hidden and all options', () => {
-    component = shallow(
-      <DataSourceAggregatedView
-        fullWidth={false}
-        hideLocalCluster={false}
-        savedObjectsClient={client}
-        notifications={toasts}
-        displayAllCompatibleDataSources={true}
-      />
-    );
-    expect(component).toMatchSnapshot();
-    expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
-      perPage: 10000,
-      type: 'data-source',
-    });
-    expect(toasts.addWarning).toBeCalledTimes(0);
+  it.each([
+    {
+      filter: (ds: SavedObject<DataSourceAttributes>) => {
+        return ds.id !== 'test1';
+      },
+      activeDataSourceIds: undefined,
+      hideLocalCluster: false,
+    },
+    {
+      filter: (ds: SavedObject<DataSourceAttributes>) => {
+        return ds.id !== 'test1';
+      },
+      activeDataSourceIds: ['non-existent-id'],
+      hideLocalCluster: false,
+    },
+    {
+      filter: undefined,
+      activeDataSourceIds: undefined,
+      hideLocalCluster: false,
+    },
+    {
+      filter: undefined,
+      activeDataSourceIds: ['non-existent-id'],
+      hideLocalCluster: false,
+    },
+    {
+      filter: undefined,
+      activeDataSourceIds: ['test1'],
+      hideLocalCluster: false,
+    },
+    {
+      filter: (ds: SavedObject<DataSourceAttributes>) => {
+        return ds.id !== 'test1';
+      },
+      activeDataSourceIds: undefined,
+      hideLocalCluster: true,
+    },
+    {
+      filter: (ds: SavedObject<DataSourceAttributes>) => {
+        return ds.id !== 'test1';
+      },
+      activeDataSourceIds: ['non-existent-id'],
+      hideLocalCluster: true,
+    },
+    {
+      filter: undefined,
+      activeDataSourceIds: undefined,
+      hideLocalCluster: true,
+    },
+    {
+      filter: undefined,
+      activeDataSourceIds: ['non-existent-id'],
+      hideLocalCluster: true,
+    },
+    {
+      filter: undefined,
+      activeDataSourceIds: ['test1'],
+      hideLocalCluster: true,
+    },
+  ])(
+    'should render normally with local cluster configured, default datasource removed or added, and if activeDataSourceIds is present or filtered out',
+    async ({ filter, activeDataSourceIds, hideLocalCluster }) => {
+      component = shallow(
+        <DataSourceAggregatedView
+          fullWidth={false}
+          hideLocalCluster={hideLocalCluster}
+          savedObjectsClient={client}
+          notifications={toasts}
+          displayAllCompatibleDataSources={true}
+          uiSettings={uiSettings}
+          activeDataSourceIds={activeDataSourceIds}
+          dataSourceFilter={filter}
+        />
+      );
+
+      // Renders normally
+      expect(component).toMatchSnapshot();
+      expect(client.find).toBeCalledWith({
+        fields: ['id', 'title', 'auth.type'],
+        perPage: 10000,
+        type: 'data-source',
+      });
+      expect(toasts.addWarning).toBeCalledTimes(0);
+      await nextTick();
+
+      // Renders correctly for hide local cluster configuration
+      if (!hideLocalCluster) {
+        expect(component.find(EuiSelectable).prop('options')).toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: '' })])
+        );
+      } else {
+        expect(component.find(EuiSelectable).prop('options')).not.toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: '' })])
+        );
+      }
+
+      // Renders correctly when default datasource is filtered out or not
+      if (!filter) {
+        expect(component.find(EuiSelectable).prop('options')).toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: 'test1' })])
+        );
+      } else {
+        expect(component.find(EuiSelectable).prop('options')).not.toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: 'test1' })])
+        );
+      }
+
+      // All renders should not have a switch
+      expect(component.find(EuiSwitch).exists()).toBeFalsy();
+    }
+  );
+});
+
+describe('DataSourceAggregatedView: read active view (displayAllCompatibleDataSources is set to false)', () => {
+  let client: SavedObjectsClientContract;
+  const { toasts } = notificationServiceMock.createStartContract();
+  const uiSettings = uiSettingsServiceMock.createStartContract();
+  const nextTick = () => new Promise((res) => process.nextTick(res));
+
+  beforeEach(() => {
+    client = {
+      find: jest.fn().mockResolvedValue([]),
+    } as any;
+    mockResponseForSavedObjectsCalls(client, 'find', getDataSourcesWithFieldsResponse);
+    mockUiSettingsCalls(uiSettings, 'get', 'test1');
   });
 
-  it('should render normally with local cluster hidden and all options', () => {
-    const container = mount(
-      <DataSourceAggregatedView
-        fullWidth={false}
-        hideLocalCluster={true}
-        savedObjectsClient={client}
-        notifications={toasts}
-        displayAllCompatibleDataSources={false}
-        activeDataSourceIds={[]}
-      />
-    );
-    expect(container).toMatchSnapshot();
-    expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
-      perPage: 10000,
-      type: 'data-source',
-    });
-    expect(toasts.addWarning).toBeCalledTimes(0);
-    const badge = container.find('EuiNotificationBadge').text();
-    expect(badge).toEqual('0');
-  });
+  it.each([
+    {
+      filter: (ds: SavedObject<DataSourceAttributes>) => {
+        return ds.id !== 'test1';
+      },
+      hideLocalCluster: false,
+      activeDataSourceIds: ['test1', 'test2'],
+    },
+    {
+      filter: undefined,
+      hideLocalCluster: false,
+      activeDataSourceIds: ['test1', 'test2'],
+    },
+    {
+      filter: (ds: SavedObject<DataSourceAttributes>) => {
+        return ds.id !== 'test1';
+      },
+      hideLocalCluster: true,
+      activeDataSourceIds: ['test1', 'test2'],
+    },
+    {
+      filter: undefined,
+      hideLocalCluster: true,
+      activeDataSourceIds: ['test1', 'test2'],
+    },
+    {
+      filter: (ds: SavedObject<DataSourceAttributes>) => {
+        return ds.id !== 'test1';
+      },
+      hideLocalCluster: false,
+      activeDataSourceIds: [],
+    },
+    {
+      filter: undefined,
+      hideLocalCluster: false,
+      activeDataSourceIds: [],
+    },
+    {
+      filter: (ds: SavedObject<DataSourceAttributes>) => {
+        return ds.id !== 'test1';
+      },
+      hideLocalCluster: true,
+      activeDataSourceIds: [],
+    },
+    {
+      filter: undefined,
+      hideLocalCluster: true,
+      activeDataSourceIds: [],
+    },
+  ])(
+    'should render normally with local cluster and active selections configured',
+    async ({ filter, hideLocalCluster, activeDataSourceIds }) => {
+      const component = shallow(
+        <DataSourceAggregatedView
+          fullWidth={false}
+          hideLocalCluster={hideLocalCluster}
+          savedObjectsClient={client}
+          notifications={toasts}
+          displayAllCompatibleDataSources={false}
+          activeDataSourceIds={activeDataSourceIds}
+          dataSourceFilter={filter}
+          uiSettings={uiSettings}
+        />
+      );
+      await nextTick();
 
-  it('should render normally with local cluster and actice selections', () => {
-    const container = mount(
-      <DataSourceAggregatedView
-        fullWidth={false}
-        hideLocalCluster={false}
-        savedObjectsClient={client}
-        notifications={toasts}
-        displayAllCompatibleDataSources={false}
-        activeDataSourceIds={['test1']}
-      />
-    );
-    expect(container).toMatchSnapshot();
-    expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
-      perPage: 10000,
-      type: 'data-source',
-    });
-    expect(toasts.addWarning).toBeCalledTimes(0);
-    const badge = container.find('EuiNotificationBadge').text();
-    expect(badge).toEqual('1');
-  });
+      // Should render normally
+      expect(component).toMatchSnapshot();
+      expect(client.find).toBeCalledWith({
+        fields: ['id', 'title', 'auth.type'],
+        perPage: 10000,
+        type: 'data-source',
+      });
+      expect(toasts.addWarning).toBeCalledTimes(0);
 
-  it('should render normally with data source filter', () => {
-    const container = mount(
-      <DataSourceAggregatedView
-        fullWidth={false}
-        hideLocalCluster={false}
-        savedObjectsClient={client}
-        notifications={toasts}
-        displayAllCompatibleDataSources={true}
-        dataSourceFilter={(ds) => ds.attributes.auth.type !== 'no_auth'}
-      />
-    );
-    expect(container).toMatchSnapshot();
-    expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
-      perPage: 10000,
-      type: 'data-source',
-    });
-    expect(toasts.addWarning).toBeCalledTimes(0);
-    const badge = container.find('EuiNotificationBadge').text();
-    expect(badge).toEqual('All');
-  });
+      // Should render only active options
+      const euiSwitch = component.find(EuiSwitch);
+      expect(euiSwitch.exists()).toBeTruthy();
+      euiSwitch.prop('onChange')({ target: { checked: true } });
+      const expectedOptions = activeDataSourceIds.length
+        ? [
+            {
+              id: 'test2',
+              label: 'test2',
+              disabled: true,
+              checked: 'on',
+            },
+          ]
+        : [];
 
-  it('should render popup when clicking on info icon', async () => {
-    const container = render(
-      <DataSourceAggregatedView
-        fullWidth={false}
-        hideLocalCluster={false}
-        savedObjectsClient={client}
-        notifications={toasts}
-        displayAllCompatibleDataSources={false}
-        activeDataSourceIds={['test1']}
-      />
-    );
-    const infoIcon = await container.findByTestId('dataSourceAggregatedViewInfoButton');
-    infoIcon.click();
-    expect(container).toMatchSnapshot();
-  });
+      if (!filter && activeDataSourceIds.length) {
+        expectedOptions.push({
+          id: 'test1',
+          label: 'test1',
+          disabled: true,
+          checked: 'on',
+        });
+      }
+      expect(component.find(EuiSelectable).prop('options')).toEqual(
+        expect.arrayContaining(expectedOptions)
+      );
+    }
+  );
 });

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
@@ -6,19 +6,28 @@
 import React from 'react';
 import {
   EuiButtonEmpty,
-  EuiButtonIcon,
-  EuiContextMenu,
-  EuiNotificationBadge,
+  EuiContextMenuPanel,
+  EuiPanel,
   EuiPopover,
+  EuiSelectable,
+  EuiSwitch,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
-import { SavedObjectsClientContract, ToastsStart } from 'opensearch-dashboards/public';
-import { getDataSourcesWithFields, handleDataSourceFetchError } from '../utils';
+import {
+  IUiSettingsClient,
+  SavedObjectsClientContract,
+  ToastsStart,
+} from 'opensearch-dashboards/public';
+import { getApplication, getDataSourcesWithFields, handleDataSourceFetchError } from '../utils';
 import { SavedObject } from '../../../../../core/public';
 import { DataSourceAttributes } from '../../types';
 import { NoDataSource } from '../no_data_source';
 import { DataSourceErrorMenu } from '../data_source_error_menu';
 import { DataSourceBaseState } from '../data_source_menu/types';
+import { DataSourceOption } from '../data_source_menu/types';
+import { DataSourceItem } from '../data_source_item';
+import { DataSourceDropDownHeader } from '../drop_down_header';
+import './data_source_aggregated_view.scss';
 
 interface DataSourceAggregatedViewProps {
   savedObjectsClient: SavedObjectsClientContract;
@@ -28,11 +37,19 @@ interface DataSourceAggregatedViewProps {
   activeDataSourceIds?: string[];
   dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
   displayAllCompatibleDataSources: boolean;
+  uiSettings?: IUiSettingsClient;
 }
 
 interface DataSourceAggregatedViewState extends DataSourceBaseState {
   isPopoverOpen: boolean;
   allDataSourcesIdToTitleMap: Map<string, any>;
+  switchChecked: boolean;
+  defaultDataSource: string | null;
+}
+
+interface DataSourceOptionDisplay extends DataSourceOption {
+  disabled?: boolean;
+  checked?: string;
 }
 
 export class DataSourceAggregatedView extends React.Component<
@@ -49,6 +66,8 @@ export class DataSourceAggregatedView extends React.Component<
       allDataSourcesIdToTitleMap: new Map(),
       showEmptyState: false,
       showError: false,
+      switchChecked: false,
+      defaultDataSource: null,
     };
   }
 
@@ -56,8 +75,12 @@ export class DataSourceAggregatedView extends React.Component<
     this._isMounted = false;
   }
 
-  onClick() {
+  onDataSourcesClick() {
     this.setState({ ...this.state, isPopoverOpen: !this.state.isPopoverOpen });
+  }
+
+  onSwitchClick(e) {
+    this.setState({ ...this.state, switchChecked: e.target.checked });
   }
 
   closePopover() {
@@ -68,6 +91,8 @@ export class DataSourceAggregatedView extends React.Component<
     this._isMounted = true;
     getDataSourcesWithFields(this.props.savedObjectsClient, ['id', 'title', 'auth.type'])
       .then((fetchedDataSources) => {
+        const allDataSourcesIdToTitleMap = new Map();
+
         if (fetchedDataSources?.length) {
           let filteredDataSources = fetchedDataSources;
           if (this.props.dataSourceFilter) {
@@ -75,22 +100,23 @@ export class DataSourceAggregatedView extends React.Component<
               this.props.dataSourceFilter!(ds)
             );
           }
-          const allDataSourcesIdToTitleMap = new Map();
 
           filteredDataSources.forEach((ds) => {
             allDataSourcesIdToTitleMap.set(ds.id, ds.attributes!.title || '');
           });
 
-          if (!this.props.hideLocalCluster) {
-            allDataSourcesIdToTitleMap.set('', 'Local cluster');
-          }
-
           if (!this._isMounted) return;
-          this.setState({
-            ...this.state,
-            allDataSourcesIdToTitleMap,
-          });
         }
+
+        if (!this.props.hideLocalCluster) {
+          allDataSourcesIdToTitleMap.set('', 'Local cluster');
+        }
+
+        this.setState({
+          ...this.state,
+          allDataSourcesIdToTitleMap,
+          defaultDataSource: this.props.uiSettings?.get('defaultDataSource', null) ?? null,
+        });
       })
       .catch(() => {
         handleDataSourceFetchError(this.onError.bind(this), this.props.notifications);
@@ -109,65 +135,64 @@ export class DataSourceAggregatedView extends React.Component<
       return <DataSourceErrorMenu />;
     }
     const button = (
-      <EuiButtonIcon
-        data-test-subj="dataSourceAggregatedViewInfoButton"
-        iconType="iInCircle"
-        display="empty"
-        aria-label="show data sources"
-        onClick={this.onClick.bind(this)}
+      <EuiButtonEmpty
+        className="euiHeaderLink"
+        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+        aria-label={i18n.translate('dataSourceAggregatedView.dataSourceOptionsButtonAriaLabel', {
+          defaultMessage: 'dataSourceAggregatedViewMenuButton',
+        })}
+        iconType="database"
+        iconSide="left"
+        size="s"
+        onClick={this.onDataSourcesClick.bind(this)}
       />
     );
 
-    let items = [];
+    let items: DataSourceOptionDisplay[] = [];
 
     // only display active data sources
-    if (this.props.displayAllCompatibleDataSources) {
-      items = [...this.state.allDataSourcesIdToTitleMap.values()].map((title) => {
-        return {
-          name: title,
-          disabled: true,
-        };
-      });
+    if (!this.props.displayAllCompatibleDataSources && this.state.switchChecked) {
+      items = this.props
+        .activeDataSourceIds!.filter((id) => this.state.allDataSourcesIdToTitleMap.has(id))
+        .map((id) => {
+          return {
+            id,
+            label: this.state.allDataSourcesIdToTitleMap.get(id),
+            disabled: true,
+            checked: 'on',
+          };
+        });
     } else {
-      items = this.props.activeDataSourceIds!.map((id) => {
-        return {
-          name: this.state.allDataSourcesIdToTitleMap.get(id),
+      this.state.allDataSourcesIdToTitleMap.forEach((label, id) => {
+        items.push({
+          id,
+          label,
           disabled: true,
-        };
+          checked:
+            !this.props.displayAllCompatibleDataSources &&
+            this.props.activeDataSourceIds &&
+            this.props.activeDataSourceIds.length &&
+            this.props.activeDataSourceIds.includes(id)
+              ? 'on'
+              : undefined,
+        });
       });
     }
 
-    const title = this.props.displayAllCompatibleDataSources
-      ? `Data sources (${this.state.allDataSourcesIdToTitleMap.size})`
-      : 'Selected data sources';
+    const numSelectedItems = items.filter((item) => item.checked === 'on').length;
 
-    const panels = [
-      {
-        id: 0,
-        title,
-        items,
-      },
-    ];
+    const titleComponent = (
+      <DataSourceDropDownHeader
+        totalDataSourceCount={this.state.allDataSourcesIdToTitleMap.size}
+        activeDataSourceCount={
+          !this.props.displayAllCompatibleDataSources ? numSelectedItems : undefined
+        }
+        application={getApplication()}
+      />
+    );
 
     return (
       <>
-        <EuiButtonEmpty
-          className="euiHeaderLink"
-          data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-          aria-label={i18n.translate('dataSourceAggregatedView.dataSourceOptionsButtonAriaLabel', {
-            defaultMessage: 'dataSourceAggregatedViewMenuButton',
-          })}
-          iconType="database"
-          iconSide="left"
-          size="s"
-          disabled={true}
-        >
-          {'Data sources'}
-        </EuiButtonEmpty>
-        <EuiNotificationBadge color={'subdued'}>
-          {(this.props.displayAllCompatibleDataSources && 'All') ||
-            this.props.activeDataSourceIds!.length}
-        </EuiNotificationBadge>
         <EuiPopover
           id={'dataSourceSViewContextMenuPopover'}
           button={button}
@@ -176,7 +201,60 @@ export class DataSourceAggregatedView extends React.Component<
           panelPaddingSize="none"
           anchorPosition="downLeft"
         >
-          <EuiContextMenu initialPanelId={0} panels={panels} />
+          <EuiContextMenuPanel>
+            <EuiPanel
+              className={'dataSourceAggregatedViewOuiPanel'}
+              borderRadius="none"
+              hasBorder={false}
+              color="transparent"
+              paddingSize="s"
+            >
+              {titleComponent}
+            </EuiPanel>
+            <EuiPanel
+              className={'dataSourceAggregatedViewOuiPanel'}
+              paddingSize="none"
+              borderRadius="none"
+              hasShadow={false}
+            >
+              <EuiPanel
+                className={'dataSourceAggregatedViewOuiPanel'}
+                color="subdued"
+                paddingSize="s"
+                borderRadius="none"
+              >
+                <EuiSelectable
+                  options={items}
+                  renderOption={(option) => (
+                    <DataSourceItem
+                      className={'dataSourceAggregatedView'}
+                      option={option}
+                      defaultDataSource={this.state.defaultDataSource}
+                    />
+                  )}
+                >
+                  {(list) => list}
+                </EuiSelectable>
+              </EuiPanel>
+            </EuiPanel>
+            {!this.props.displayAllCompatibleDataSources && (
+              <EuiPanel
+                className={'dataSourceAggregatedViewOuiPanel'}
+                color="transparent"
+                hasBorder={false}
+                hasShadow={false}
+                borderRadius="m"
+              >
+                <EuiSwitch
+                  className="dataSourceAggregatedViewOuiSwitch"
+                  label={`Used on this page (${numSelectedItems})`}
+                  checked={this.state.switchChecked}
+                  onChange={(e) => this.onSwitchClick(e)}
+                  compressed={true}
+                />
+              </EuiPanel>
+            )}
+          </EuiContextMenuPanel>
         </EuiPopover>
       </>
     );

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
@@ -116,6 +116,7 @@ export class DataSourceAggregatedView extends React.Component<
           ...this.state,
           allDataSourcesIdToTitleMap,
           defaultDataSource: this.props.uiSettings?.get('defaultDataSource', null) ?? null,
+          showEmptyState: allDataSourcesIdToTitleMap.size === 0,
         });
       })
       .catch(() => {

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
@@ -68,33 +68,6 @@ Object {
   "asFragment": [Function],
   "baseElement": <body>
     <div>
-      <button
-        aria-label="dataSourceAggregatedViewMenuButton"
-        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty-isDisabled euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        disabled=""
-        type="button"
-      >
-        <span
-          class="euiButtonContent euiButtonEmpty__content"
-        >
-          <span
-            class="euiButtonContent__icon"
-            color="inherit"
-            data-euiicon-type="database"
-          />
-          <span
-            class="euiButtonEmpty__text"
-          >
-            Data sources
-          </span>
-        </span>
-      </button>
-      <span
-        class="euiNotificationBadge euiNotificationBadge--subdued"
-      >
-        All
-      </span>
       <div
         class="euiPopover euiPopover--anchorDownLeft"
         id="dataSourceSViewContextMenuPopover"
@@ -103,50 +76,29 @@ Object {
           class="euiPopover__anchor"
         >
           <button
-            aria-label="show data sources"
-            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-            data-test-subj="dataSourceAggregatedViewInfoButton"
+            aria-label="dataSourceAggregatedViewMenuButton"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
+            data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
             type="button"
           >
             <span
-              aria-hidden="true"
-              class="euiButtonIcon__icon"
-              color="inherit"
-              data-euiicon-type="iInCircle"
-            />
+              class="euiButtonContent euiButtonEmpty__content"
+            >
+              <span
+                class="euiButtonContent__icon"
+                color="inherit"
+                data-euiicon-type="database"
+              />
+              <span
+                class="euiButtonEmpty__text"
+              />
+            </span>
           </button>
         </div>
       </div>
     </div>
   </body>,
   "container": <div>
-    <button
-      aria-label="dataSourceAggregatedViewMenuButton"
-      class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty-isDisabled euiHeaderLink"
-      data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-      disabled=""
-      type="button"
-    >
-      <span
-        class="euiButtonContent euiButtonEmpty__content"
-      >
-        <span
-          class="euiButtonContent__icon"
-          color="inherit"
-          data-euiicon-type="database"
-        />
-        <span
-          class="euiButtonEmpty__text"
-        >
-          Data sources
-        </span>
-      </span>
-    </button>
-    <span
-      class="euiNotificationBadge euiNotificationBadge--subdued"
-    >
-      All
-    </span>
     <div
       class="euiPopover euiPopover--anchorDownLeft"
       id="dataSourceSViewContextMenuPopover"
@@ -155,17 +107,23 @@ Object {
         class="euiPopover__anchor"
       >
         <button
-          aria-label="show data sources"
-          class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-          data-test-subj="dataSourceAggregatedViewInfoButton"
+          aria-label="dataSourceAggregatedViewMenuButton"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
+          data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
           type="button"
         >
           <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="iInCircle"
-          />
+            class="euiButtonContent euiButtonEmpty__content"
+          >
+            <span
+              class="euiButtonContent__icon"
+              color="inherit"
+              data-euiicon-type="database"
+            />
+            <span
+              class="euiButtonEmpty__text"
+            />
+          </span>
         </button>
       </div>
     </div>

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.test.tsx
@@ -5,17 +5,19 @@
 
 import { ShallowWrapper, shallow } from 'enzyme';
 import { SavedObjectsClientContract } from '../../../../../core/public';
-import { notificationServiceMock } from '../../../../../core/public/mocks';
+import { applicationServiceMock, notificationServiceMock } from '../../../../../core/public/mocks';
 import React from 'react';
 import { DataSourceMenu } from './data_source_menu';
 import { render } from '@testing-library/react';
 import { DataSourceComponentType } from './types';
+import * as utils from '../utils';
 
 describe('DataSourceMenu', () => {
   let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
 
   let client: SavedObjectsClientContract;
   const notifications = notificationServiceMock.createStartContract();
+  const application = applicationServiceMock.createStartContract();
 
   beforeEach(() => {
     client = {
@@ -112,6 +114,7 @@ describe('DataSourceMenu', () => {
   });
 
   it('should render data source aggregated view', () => {
+    jest.spyOn(utils, 'getApplication').mockReturnValue(application);
     const container = render(
       <DataSourceMenu
         componentType={DataSourceComponentType.DataSourceAggregatedView}

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -105,7 +105,8 @@ export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement |
         notifications={notifications!.toasts}
         activeDataSourceIds={activeDataSourceIds}
         dataSourceFilter={dataSourceFilter}
-        displayAllCompatibleDataSources={displayAllCompatibleDataSources || false}
+        displayAllCompatibleDataSources={displayAllCompatibleDataSources}
+        uiSettings={uiSettings}
       />
     );
   }

--- a/src/plugins/data_source_management/public/components/data_source_menu/types.ts
+++ b/src/plugins/data_source_management/public/components/data_source_menu/types.ts
@@ -59,13 +59,22 @@ export interface DataSourceViewConfig extends DataSourceBaseConfig {
   onSelectedDataSources?: (dataSources: DataSourceOption[]) => void;
 }
 
-export interface DataSourceAggregatedViewConfig extends DataSourceBaseConfig {
+interface DataSourceAggregatedViewBaseConfig extends DataSourceBaseConfig {
   savedObjects: SavedObjectsClientContract;
   notifications: NotificationsStart;
-  activeDataSourceIds?: string[];
-  displayAllCompatibleDataSources?: boolean;
   dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
+  uiSettings?: IUiSettingsClient;
 }
+
+export type DataSourceAggregatedViewConfig =
+  | (DataSourceAggregatedViewBaseConfig & {
+      activeDataSourceIds: string[];
+      displayAllCompatibleDataSources: false;
+    })
+  | (DataSourceAggregatedViewBaseConfig & {
+      activeDataSourceIds?: string[];
+      displayAllCompatibleDataSources: true;
+    });
 
 export interface DataSourceSelectableConfig extends DataSourceBaseConfig {
   onSelectedDataSources: (dataSources: DataSourceOption[]) => void;


### PR DESCRIPTION
### Description

Based on discussion from UX, this PR will refactor the `DataSourceAggregatedView`. 

**TODO:**
- [x] Add support for the Empty state (when there are no datasource connections and local cluster is hidden) 

### Issues Resolved

N/A

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/cdfb6a2d-c153-4159-bc25-ec37393729a3

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/94f09d29-457d-41ea-bc3d-4e809a052da7

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/c9aa5664-d44c-483f-98ab-e1e967009e0d)

## Testing the changes

Used the developer example plugin to test 3 scenarios of `DataSourceAggregatedView`:
- **When there is an `activeDataSourceId` and `displayAllCompatibleDataSources: false`**: This will render the switch to show only the selected components
- **When nothing is selected and `displayAllCompatibleDataSources: false`**: This will render the switch and show an empty state
- **When `displayAllCompatibleDataSources: true`**: The `activeDataSourceIds` is ignored, all datasources are unchecked, and no switch will be rendered. 
- **If no datasource connections**: The `NoDataSources` component is rendered

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
