### PR TITLE
[MDS] Add datasource reference to TSVB

### DIFF
--- a/src/plugins/vis_type_timeseries/server/lib/services.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/services.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createGetterSetter } from '../../../opensearch_dashboards_utils/common';
+
+export const [getDataSourceEnabled, setDataSourceEnabled] = createGetterSetter<{
+  enabled: boolean;
+}>('DataSource');

--- a/src/plugins/vis_type_timeseries/server/lib/test_utils/test_params.json
+++ b/src/plugins/vis_type_timeseries/server/lib/test_utils/test_params.json
@@ -1,0 +1,154 @@
+{
+    "withDataSourceFieldNonEmpty": {
+        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+        "type": "timeseries",
+        "series": [
+            {
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "color": "#54B399",
+                "split_mode": "everything",
+                "split_color_mode": "opensearchDashboards",
+                "metrics": [
+                    {
+                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "type": "avg",
+                        "field": "bytes"
+                    }
+                ],
+                "separate_axis": 0,
+                "axis_position": "right",
+                "formatter": "number",
+                "chart_type": "line",
+                "line_width": 1,
+                "point_size": 1,
+                "fill": "",
+                "stacked": "none",
+                "label": "",
+                "type": "timeseries"
+            }
+        ],
+        "time_field": "timestamp",
+        "index_pattern": "opensearch_dashboards_sample_data_logs",
+        "interval": "",
+        "axis_position": "left",
+        "axis_formatter": "number",
+        "axis_scale": "normal",
+        "show_legend": 1,
+        "show_grid": 1,
+        "tooltip_mode": "show_all",
+        "default_index_pattern": "opensearch_dashboards_sample_data_logs",
+        "default_timefield": "timestamp",
+        "isModelInvalid": false,
+        "drop_last_bucket": 0,
+        "data_source_id": "a"
+    },
+    "withDataSourceFieldEmpty": {
+        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+        "type": "timeseries",
+        "series": [
+            {
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "color": "#54B399",
+                "split_mode": "everything",
+                "split_color_mode": "opensearchDashboards",
+                "metrics": [
+                    {
+                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "type": "avg",
+                        "field": "bytes"
+                    }
+                ],
+                "separate_axis": 0,
+                "axis_position": "right",
+                "formatter": "number",
+                "chart_type": "line",
+                "line_width": 1,
+                "point_size": 1,
+                "fill": "",
+                "stacked": "none",
+                "label": "",
+                "type": "timeseries"
+            }
+        ],
+        "time_field": "timestamp",
+        "index_pattern": "opensearch_dashboards_sample_data_logs",
+        "interval": "",
+        "axis_position": "left",
+        "axis_formatter": "number",
+        "axis_scale": "normal",
+        "show_legend": 1,
+        "show_grid": 1,
+        "tooltip_mode": "show_all",
+        "default_index_pattern": "opensearch_dashboards_sample_data_logs",
+        "default_timefield": "timestamp",
+        "isModelInvalid": false,
+        "drop_last_bucket": 0,
+        "data_source_id": ""
+    },
+    "withNoDataSourceField": {
+        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+        "type": "timeseries",
+        "series": [
+            {
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "color": "#54B399",
+                "split_mode": "everything",
+                "split_color_mode": "opensearchDashboards",
+                "metrics": [
+                    {
+                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "type": "avg",
+                        "field": "bytes"
+                    }
+                ],
+                "separate_axis": 0,
+                "axis_position": "right",
+                "formatter": "number",
+                "chart_type": "line",
+                "line_width": 1,
+                "point_size": 1,
+                "fill": "",
+                "stacked": "none",
+                "label": "",
+                "type": "timeseries"
+            }
+        ],
+        "time_field": "timestamp",
+        "index_pattern": "opensearch_dashboards_sample_data_logs",
+        "interval": "",
+        "axis_position": "left",
+        "axis_formatter": "number",
+        "axis_scale": "normal",
+        "show_legend": 1,
+        "show_grid": 1,
+        "tooltip_mode": "show_all",
+        "default_index_pattern": "opensearch_dashboards_sample_data_logs",
+        "default_timefield": "timestamp",
+        "isModelInvalid": false,
+        "drop_last_bucket": 0
+    },
+    "referenceWithValidDataSource": [
+        {
+            "id": "a",
+            "name": "dataSource",
+            "type": "data-source"
+        },
+        {
+            "id": "some-dashboard-id",
+            "name": "some-dashboard",
+            "type": "dashboard"
+        }
+    ],
+    "referenceWithOutdatedDataSource": [
+        {
+            "id": "b",
+            "name": "dataSource",
+            "type": "data-source"
+        },
+        {
+            "id": "some-dashboard-id",
+            "name": "some-dashboard",
+            "type": "dashboard"
+        }
+    ]
+}

--- a/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.test.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.test.ts
@@ -1,0 +1,4 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */

--- a/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.test.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.test.ts
@@ -2,3 +2,232 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+import _ from 'lodash';
+
+import { SavedObjectsClientWrapperOptions } from '../../../../core/server';
+import testParams from './test_utils/test_params.json';
+import { timeSeriesVisualizationClientWrapper } from './timeseries_visualization_client_wrapper';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
+
+jest.mock('./services', () => ({
+  getDataSourceEnabled: jest
+    .fn()
+    .mockReturnValueOnce({ enabled: false })
+    .mockReturnValue({ enabled: true }),
+}));
+
+describe('timeseriesVisualizationClientWrapper()', () => {
+  const client = savedObjectsClientMock.create();
+  client.get = jest.fn().mockImplementation((type: string, id: string) => {
+    if (type === 'data-source' && id === 'non-existent-id') {
+      return Promise.resolve({
+        id,
+        errors: {},
+      });
+    }
+    return Promise.resolve({
+      id,
+      attributes: {
+        title: `${id} DataSource`,
+      },
+    });
+  });
+  const mockedWrapperOptions = {} as SavedObjectsClientWrapperOptions;
+  mockedWrapperOptions.client = client;
+
+  const getAttributesWithParams = (params: any) => {
+    return {
+      title: 'Some TSVB Visualization',
+      visState: JSON.stringify({
+        title: 'Some TSVB Visualization',
+        type: 'metrics',
+        aggs: [],
+        params,
+      }),
+    };
+  };
+
+  beforeEach(() => {
+    client.create.mockClear();
+  });
+
+  test('if MDS is disabled, do not update the datasource references', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldEmpty);
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, { references: [] });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('non-visualization saved object should pass through', async () => {
+    const attributes = {
+      title: 'some-dashboard',
+    };
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('dashboard', attributes, { references: [] });
+
+    expect(client.create).toBeCalledWith(
+      'dashboard',
+      attributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('non-metrics saved object should pass through', async () => {
+    const attributes = {
+      title: 'some-other-visualization',
+      visState: JSON.stringify({
+        title: 'Some other visualization',
+        type: 'vega',
+        aggs: [],
+        params: {},
+      }),
+    };
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, { references: [] });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('if a non-existent datasource id is in the params, remove all datasource references and the field name', async () => {
+    const params = _.clone(testParams.withDataSourceFieldNonEmpty);
+    params.data_source_id = 'non-existent-id';
+    const references = [
+      {
+        id: 'non-existent-id',
+        name: 'dataSource',
+        type: 'data-source',
+      },
+    ];
+    const attributes = getAttributesWithParams(params);
+    const newAttributes = getAttributesWithParams(testParams.withNoDataSourceField);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, { references });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      newAttributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('if a datasource reference is empty and the data_source_id field is an empty string, do not change the object', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldEmpty);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, { references: [] });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('if a datasource reference is empty and the data_source_id field is not present, do not change the object', async () => {
+    const attributes = getAttributesWithParams(testParams.withNoDataSourceField);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, { references: [] });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('if a datasource reference is outdated and the data_source_id field has an empty string, remove the datasource reference', async () => {
+    const attributes = getAttributesWithParams(testParams.withNoDataSourceField);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, {
+      references: testParams.referenceWithOutdatedDataSource,
+    });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({
+        references: [{ id: 'some-dashboard-id', name: 'some-dashboard', type: 'dashboard' }],
+      })
+    );
+  });
+
+  test('if a datasource reference is outdated and the data_source_id field is not present, remove the datasource reference', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldEmpty);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, {
+      references: testParams.referenceWithOutdatedDataSource,
+    });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({
+        references: [{ id: 'some-dashboard-id', name: 'some-dashboard', type: 'dashboard' }],
+      })
+    );
+  });
+
+  test('if the datasource reference is empty and the data_source_id is present, add the datasource reference', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldNonEmpty);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, {
+      references: [{ id: 'some-dashboard-id', name: 'some-dashboard', type: 'dashboard' }],
+    });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({
+        references: expect.arrayContaining(testParams.referenceWithValidDataSource),
+      })
+    );
+  });
+
+  test('if the datasource reference is different from the data_source_id, update the datasource reference', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldNonEmpty);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, {
+      references: testParams.referenceWithOutdatedDataSource,
+    });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({
+        references: expect.arrayContaining(testParams.referenceWithValidDataSource),
+      })
+    );
+  });
+
+  test('if the datasource reference is identical to the data_source_id, do not change anything', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldNonEmpty);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, {
+      references: testParams.referenceWithValidDataSource,
+    });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({
+        references: expect.arrayContaining(testParams.referenceWithValidDataSource),
+      })
+    );
+  });
+});

--- a/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  SavedObjectsClientWrapperFactory,
+  SavedObjectsClientWrapperOptions,
+  SavedObjectsCreateOptions,
+} from '../../../../core/server';
+import { getDataSourceEnabled } from './services';
+
+export const TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_ID = 'timeseries-visualization-client-wrapper';
+
+export const timeSeriesVisualizationClientWrapper: SavedObjectsClientWrapperFactory = (
+  wrapperOptions: SavedObjectsClientWrapperOptions
+) => {
+  const createForTimeSeries = async <T = unknown>(
+    type: string,
+    attributes: T,
+    options?: SavedObjectsCreateOptions
+  ) => {
+    if (type !== 'visualization' || !getDataSourceEnabled().enabled) {
+      return await wrapperOptions.client.create(type, attributes, options);
+    }
+
+    // @ts-expect-error
+    const visState = JSON.parse(attributes.visState);
+
+    if (visState.type !== 'metrics' || !visState.params) {
+      return await wrapperOptions.client.create(type, attributes, options);
+    }
+
+    const newReferences = options?.references?.filter(
+      (reference) => reference.type !== 'data-source'
+    );
+
+    if (visState.params.data_source_id) {
+      newReferences?.push({
+        id: visState.params.data_source_id,
+        name: 'dataSource',
+        type: 'data-source',
+      });
+    }
+
+    return await wrapperOptions.client.create(type, attributes, {
+      ...options,
+      references: newReferences,
+    });
+  };
+
+  return {
+    ...wrapperOptions.client,
+    create: createForTimeSeries,
+    bulkCreate: wrapperOptions.client.bulkCreate,
+    checkConflicts: wrapperOptions.client.checkConflicts,
+    delete: wrapperOptions.client.delete,
+    find: wrapperOptions.client.find,
+    bulkGet: wrapperOptions.client.bulkGet,
+    get: wrapperOptions.client.get,
+    update: wrapperOptions.client.update,
+    bulkUpdate: wrapperOptions.client.bulkUpdate,
+    errors: wrapperOptions.client.errors,
+    addToNamespaces: wrapperOptions.client.addToNamespaces,
+    deleteFromNamespaces: wrapperOptions.client.deleteFromNamespaces,
+  };
+};

--- a/src/plugins/vis_type_timeseries/server/plugin.ts
+++ b/src/plugins/vis_type_timeseries/server/plugin.ts
@@ -51,6 +51,11 @@ import { visDataRoutes } from './routes/vis';
 import { fieldsRoutes } from './routes/fields';
 import { SearchStrategyRegistry } from './lib/search_strategies';
 import { uiSettings } from './ui_settings';
+import { setDataSourceEnabled } from './lib/services';
+import {
+  TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_ID,
+  timeSeriesVisualizationClientWrapper,
+} from './lib/timeseries_visualization_client_wrapper';
 
 export interface LegacySetup {
   server: Server;
@@ -114,6 +119,13 @@ export class VisTypeTimeseriesPlugin implements Plugin<VisTypeTimeseriesSetup> {
       router,
       searchStrategyRegistry,
     };
+
+    setDataSourceEnabled({ enabled: !!plugins.dataSource });
+    core.savedObjects.addClientWrapper(
+      11,
+      TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_ID,
+      timeSeriesVisualizationClientWrapper
+    );
 
     (async () => {
       const validationTelemetry = await this.validationTelementryService.setup(core, {


### PR DESCRIPTION
### Description

This PR adds datasource references to TSVB visualizations, which are needed to successfully export/import the object in MDS world.

### Issues Resolved

Partially addresses #6290

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/96f1711f-bee7-44b6-8034-6dd385bfc1a0

## Testing the changes

1. Add sample data
2. Navigate to the TSVB edit page and change the datasource 
3. Go to saved objects management page and navigate to the visualization
4. In references, this should be modified to add the correct datasource
5. If the datasource is updated in the TSVB edit page, so too will the datasource reference
6. If the local cluster is used, the datasource reference will be removed.

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
