### PR TITLE
[Workspace] Handle data sources and advanced settings as global object.

### DIFF
--- a/changelogs/fragments/6524.yml
+++ b/changelogs/fragments/6524.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace] Handle data sources and advanced settings as global object. ([#6524](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6524))

--- a/src/plugins/workspace/server/saved_objects/integration_tests/saved_objects_wrapper_for_check_workspace_conflict.test.ts
+++ b/src/plugins/workspace/server/saved_objects/integration_tests/saved_objects_wrapper_for_check_workspace_conflict.test.ts
@@ -5,10 +5,26 @@
 
 import { SavedObject } from 'src/core/types';
 import { isEqual } from 'lodash';
+import packageInfo from '../../../../../../package.json';
 import * as osdTestServer from '../../../../../core/test_helpers/osd_server';
+import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../../../data_source/common';
 
 const dashboard: Omit<SavedObject, 'id'> = {
   type: 'dashboard',
+  attributes: {},
+  references: [],
+};
+
+const dataSource: Omit<SavedObject, 'id'> = {
+  type: DATA_SOURCE_SAVED_OBJECT_TYPE,
+  attributes: {
+    title: 'test data source',
+  },
+  references: [],
+};
+
+const advancedSettings: Omit<SavedObject, 'id'> = {
+  type: 'config',
   attributes: {},
   references: [],
 };
@@ -32,6 +48,9 @@ describe('saved_objects_wrapper_for_check_workspace_conflict integration test', 
       adjustTimeout: (t: number) => jest.setTimeout(t),
       settings: {
         osd: {
+          data_source: {
+            enabled: true,
+          },
           workspace: {
             enabled: true,
           },
@@ -145,6 +164,40 @@ describe('saved_objects_wrapper_for_check_workspace_conflict integration test', 
       });
     });
 
+    it('create disallowed types within workspace', async () => {
+      const createDataSourceResult = await osdTestServer.request
+        .post(root, `/api/saved_objects/${dataSource.type}`)
+        .send({
+          attributes: dataSource.attributes,
+          workspaces: [createdFooWorkspace.id],
+        })
+        .expect(400);
+
+      expect(createDataSourceResult.body).toMatchInlineSnapshot(`
+        Object {
+          "error": "Bad Request",
+          "message": "Unsupported type in workspace: 'data-source' is not allowed to create in workspace.",
+          "statusCode": 400,
+        }
+      `);
+
+      const createConfigResult = await osdTestServer.request
+        .post(root, `/api/saved_objects/config`)
+        .send({
+          attributes: advancedSettings.attributes,
+          workspaces: [createdFooWorkspace.id],
+        })
+        .expect(400);
+
+      expect(createConfigResult.body).toMatchInlineSnapshot(`
+        Object {
+          "error": "Bad Request",
+          "message": "Unsupported type in workspace: 'config' is not allowed to create in workspace.",
+          "statusCode": 400,
+        }
+      `);
+    });
+
     it('bulk create', async () => {
       await clearFooAndBar();
       const createResultFoo = await osdTestServer.request
@@ -252,6 +305,79 @@ describe('saved_objects_wrapper_for_check_workspace_conflict integration test', 
           })
         )
       );
+    });
+
+    it('bulk create with disallowed types in workspace', async () => {
+      await clearFooAndBar();
+
+      // import advanced settings and data sources should throw error
+      const createResultFoo = await osdTestServer.request
+        .post(root, `/w/${createdFooWorkspace.id}/api/saved_objects/_bulk_create`)
+        .send([
+          {
+            ...dataSource,
+            id: 'foo',
+          },
+          {
+            ...advancedSettings,
+            id: packageInfo.version,
+          },
+        ])
+        .expect(200);
+      expect(createResultFoo.body.saved_objects[0].error).toEqual(
+        expect.objectContaining({
+          message:
+            "Unsupported type in workspace: 'data-source' is not allowed to import in workspace.",
+          statusCode: 400,
+        })
+      );
+      expect(createResultFoo.body.saved_objects[1].error).toEqual(
+        expect.objectContaining({
+          message: "Unsupported type in workspace: 'config' is not allowed to import in workspace.",
+          statusCode: 400,
+        })
+      );
+
+      // Data source should not be created
+      await osdTestServer.request
+        .get(
+          root,
+          `/w/${createdFooWorkspace.id}/api/saved_objects/${DATA_SOURCE_SAVED_OBJECT_TYPE}/foo`
+        )
+        .expect(404);
+
+      // Advanced settings should not be created within workspace
+      const findAdvancedSettings = await osdTestServer.request
+        .get(root, `/w/${createdFooWorkspace.id}/api/saved_objects/_find?type=config`)
+        .expect(200);
+      expect(findAdvancedSettings.body.total).toEqual(0);
+    });
+
+    it('bulk create with disallowed types out of workspace', async () => {
+      await clearFooAndBar();
+
+      // import advanced settings and data sources should throw error
+      const createResultFoo = await osdTestServer.request
+        .post(root, `/api/saved_objects/_bulk_create`)
+        .send([
+          {
+            ...advancedSettings,
+            id: packageInfo.version,
+          },
+        ])
+        .expect(200);
+      expect(createResultFoo.body).toEqual({
+        saved_objects: [
+          expect.objectContaining({
+            type: advancedSettings.type,
+          }),
+        ],
+      });
+
+      const findAdvancedSettings = await osdTestServer.request
+        .get(root, `/api/saved_objects/_find?type=${advancedSettings.type}`)
+        .expect(200);
+      expect(findAdvancedSettings.body.total).toEqual(1);
     });
 
     it('checkConflicts when importing ndjson', async () => {

--- a/src/plugins/workspace/server/saved_objects/integration_tests/saved_objects_wrapper_for_check_workspace_conflict.test.ts
+++ b/src/plugins/workspace/server/saved_objects/integration_tests/saved_objects_wrapper_for_check_workspace_conflict.test.ts
@@ -176,7 +176,7 @@ describe('saved_objects_wrapper_for_check_workspace_conflict integration test', 
       expect(createDataSourceResult.body).toMatchInlineSnapshot(`
         Object {
           "error": "Bad Request",
-          "message": "Unsupported type in workspace: 'data-source' is not allowed to create in workspace.",
+          "message": "Unsupported type in workspace: 'data-source' is not allowed to be created in workspace.",
           "statusCode": 400,
         }
       `);
@@ -192,7 +192,7 @@ describe('saved_objects_wrapper_for_check_workspace_conflict integration test', 
       expect(createConfigResult.body).toMatchInlineSnapshot(`
         Object {
           "error": "Bad Request",
-          "message": "Unsupported type in workspace: 'config' is not allowed to create in workspace.",
+          "message": "Unsupported type in workspace: 'config' is not allowed to be created in workspace.",
           "statusCode": 400,
         }
       `);
@@ -327,13 +327,14 @@ describe('saved_objects_wrapper_for_check_workspace_conflict integration test', 
       expect(createResultFoo.body.saved_objects[0].error).toEqual(
         expect.objectContaining({
           message:
-            "Unsupported type in workspace: 'data-source' is not allowed to import in workspace.",
+            "Unsupported type in workspace: 'data-source' is not allowed to be imported in workspace.",
           statusCode: 400,
         })
       );
       expect(createResultFoo.body.saved_objects[1].error).toEqual(
         expect.objectContaining({
-          message: "Unsupported type in workspace: 'config' is not allowed to import in workspace.",
+          message:
+            "Unsupported type in workspace: 'config' is not allowed to be imported in workspace.",
           statusCode: 400,
         })
       );

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.test.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.test.ts
@@ -130,7 +130,7 @@ describe('WorkspaceConflictSavedObjectsClientWrapper', () => {
           }
         )
       ).rejects.toMatchInlineSnapshot(
-        `[Error: Unsupported type in workspace: 'data-source' is not allowed to create in workspace.]`
+        `[Error: Unsupported type in workspace: 'data-source' is not allowed to be created in workspace.]`
       );
 
       await expect(
@@ -145,7 +145,7 @@ describe('WorkspaceConflictSavedObjectsClientWrapper', () => {
           }
         )
       ).rejects.toMatchInlineSnapshot(
-        `[Error: Unsupported type in workspace: 'config' is not allowed to create in workspace.]`
+        `[Error: Unsupported type in workspace: 'config' is not allowed to be created in workspace.]`
       );
     });
   });
@@ -347,14 +347,15 @@ describe('WorkspaceConflictSavedObjectsClientWrapper', () => {
       });
       expect(result.saved_objects[0].error).toEqual(
         expect.objectContaining({
-          message: "Unsupported type in workspace: 'config' is not allowed to import in workspace.",
+          message:
+            "Unsupported type in workspace: 'config' is not allowed to be imported in workspace.",
           statusCode: 400,
         })
       );
       expect(result.saved_objects[1].error).toEqual(
         expect.objectContaining({
           message:
-            "Unsupported type in workspace: 'data-source' is not allowed to import in workspace.",
+            "Unsupported type in workspace: 'data-source' is not allowed to be imported in workspace.",
           statusCode: 400,
         })
       );
@@ -474,7 +475,6 @@ describe('WorkspaceConflictSavedObjectsClientWrapper', () => {
       });
       expect(mockedClient.find).toBeCalledWith({
         type: DATA_SOURCE_SAVED_OBJECT_TYPE,
-        workspaces: null,
       });
     });
   });

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
@@ -73,7 +73,7 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
         // For 2.14, data source can only be created without workspace info
         // config can not be created inside a workspace
         throw SavedObjectsErrorHelpers.decorateBadRequestError(
-          new Error(`'${type}' is not allowed to create in workspace.`),
+          new Error(`'${type}' is not allowed to be created in workspace.`),
           'Unsupported type in workspace'
         );
       }
@@ -267,7 +267,7 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
             ...item,
             error: {
               ...SavedObjectsErrorHelpers.decorateBadRequestError(
-                new Error(`'${item.type}' is not allowed to import in workspace.`),
+                new Error(`'${item.type}' is not allowed to be imported in workspace.`),
                 'Unsupported type in workspace'
               ).output.payload,
               metadata: { isNotOverwritable: true },

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
@@ -52,7 +52,8 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
   }
   private formatFindParams(options: SavedObjectsFindOptions): SavedObjectsFindOptions {
     const isListingDataSource = this.isDataSourceType(options.type);
-    return isListingDataSource ? { ...options, workspaces: null } : options;
+    const { workspaces, ...otherOptions } = options;
+    return isListingDataSource ? otherOptions : options;
   }
 
   /**

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
@@ -263,8 +263,6 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
         saved_objects: [
           ...objectsConflictWithWorkspace,
           ...disallowedSavedObjects.map((item) => ({
-            references: [],
-            id: '',
             ...item,
             error: {
               ...SavedObjectsErrorHelpers.decorateBadRequestError(


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
This PR handles data sources and advanced settings specially to make `global objects` will be correctly handled inside workspace.

For 2.14:
- Always list data sources from global.
- Prevent data sources being created inside workspace.
- Prevent data sources being imported inside workspace.

For the long future:
- Prevent advanced settings being created inside workspace.
- Prevent advanced settings being imported inside workspace.

For the visualizations and dashboards that rely on the data sources, when importing, the reference id won't be regenerated per https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/core/server/saved_objects/import/regenerate_ids.ts#L41. So if users import visualizations along with data sources into a workspace, only the visualizations will be imported and it will try to reference a should-existing global data source.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
closes #6523 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
### Import data source
![image](https://github.com/ruanyl/OpenSearch-Dashboards/assets/13493605/fd7a9b1e-163e-4179-8687-a12c294cc646)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
- Change the `yml` file to enable workspace and data sources.
```
workspace.enabled: true
data_source.enabled: true
```
- Goes to advanced settings page, which will create an advanced settings objects automatically.
- Goes to saved objects management page, export all the objects
- Create a workspace
- Enter the workspace
- Goes to the  saved objects management page inside the workspace
- Import objects
- There should be a error beside advanced settings saying the object can not be created inside workspace. 

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace] Handle data sources and advanced settings as global object.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
