### PR TITLE
[BUG] Fix permission check failed with empty workspace for find method

### DIFF
--- a/changelogs/fragments/6527.yml
+++ b/changelogs/fragments/6527.yml
@@ -1,0 +1,2 @@
+fix:
+- Permission check failed with empty workspace for find method ([#6527](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6527))

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
@@ -189,7 +189,7 @@ describe('WorkspaceIdConsumerWrapper', () => {
       await mockedWrapperClient.find({
         type: ['dashboard', 'visualization'],
       });
-      // empty workspace array will de deleted
+      // empty workspace array will get deleted
       expect(mockedClient.find).toBeCalledWith({
         type: ['dashboard', 'visualization'],
         workspacesSearchOperator: 'OR',

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
@@ -176,5 +176,24 @@ describe('WorkspaceIdConsumerWrapper', () => {
         workspacesSearchOperator: 'AND',
       });
     });
+
+    it(`Should not pass a empty workspace array`, async () => {
+      const workspaceIdConsumerWrapper = new WorkspaceIdConsumerWrapper(true);
+      const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+      updateWorkspaceState(mockRequest, {});
+      const mockedWrapperClient = workspaceIdConsumerWrapper.wrapperFactory({
+        client: mockedClient,
+        typeRegistry: requestHandlerContext.savedObjects.typeRegistry,
+        request: mockRequest,
+      });
+      await mockedWrapperClient.find({
+        type: ['dashboard', 'visualization'],
+      });
+      // empty workspace array will de deleted
+      expect(mockedClient.find).toBeCalledWith({
+        type: ['dashboard', 'visualization'],
+        workspacesSearchOperator: 'OR',
+      });
+    });
   });
 });

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
@@ -97,6 +97,9 @@ export class WorkspaceIdConsumerWrapper {
             findOptions.workspaces.splice(index, 1);
           }
         }
+        if (findOptions.workspaces && findOptions.workspaces.length === 0) {
+          delete findOptions.workspaces;
+        }
         return wrapperOptions.client.find(findOptions);
       },
       bulkGet: wrapperOptions.client.bulkGet,

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
@@ -560,6 +560,52 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           },
         });
       });
+      it('should call client.find with ACLSearchParams if no workspaces is provided', async () => {
+        const { wrapper, clientMock } = generateWorkspaceSavedObjectsClientWrapper();
+        // no workspaces
+        await wrapper.find({
+          type: 'dashboards',
+        });
+        expect(clientMock.find).toHaveBeenCalledWith({
+          type: 'dashboards',
+          ACLSearchParams: {
+            principals: {
+              users: ['user-1'],
+            },
+            permissionModes: ['read', 'write'],
+          },
+        });
+
+        // workspace is undefined
+        await wrapper.find({
+          type: 'dashboards',
+          workspaces: undefined,
+        });
+        expect(clientMock.find).toHaveBeenCalledWith({
+          type: 'dashboards',
+          ACLSearchParams: {
+            principals: {
+              users: ['user-1'],
+            },
+            permissionModes: ['read', 'write'],
+          },
+        });
+
+        // empty workspace array
+        await wrapper.find({
+          type: 'dashboards',
+          workspaces: [],
+        });
+        expect(clientMock.find).toHaveBeenCalledWith({
+          type: 'dashboards',
+          ACLSearchParams: {
+            principals: {
+              users: ['user-1'],
+            },
+            permissionModes: ['read', 'write'],
+          },
+        });
+      });
       it('should call client.find with only read permission if find workspace and permissionModes provided', async () => {
         const { wrapper, clientMock } = generateWorkspaceSavedObjectsClientWrapper();
         await wrapper.find({

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
@@ -576,12 +576,13 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           },
         });
 
-        // workspace is undefined
+        // workspaces parameter is undefined
+        clientMock.find.mockReset();
         await wrapper.find({
           type: 'dashboards',
           workspaces: undefined,
         });
-        expect(clientMock.find).toHaveBeenCalledWith({
+        expect(clientMock.find).toHaveBeenLastCalledWith({
           type: 'dashboards',
           ACLSearchParams: {
             principals: {
@@ -591,13 +592,15 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           },
         });
 
-        // empty workspace array
+        // empty workspaces array
+        clientMock.find.mockReset();
         await wrapper.find({
           type: 'dashboards',
           workspaces: [],
         });
-        expect(clientMock.find).toHaveBeenCalledWith({
+        expect(clientMock.find).toHaveBeenLastCalledWith({
           type: 'dashboards',
+          workspaces: [],
           ACLSearchParams: {
             principals: {
               users: ['user-1'],

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -466,7 +466,7 @@ export class WorkspaceSavedObjectsClientWrapper {
           })
         ).saved_objects.map((item) => item.id);
 
-        if (options.workspaces) {
+        if (options.workspaces && options.workspaces.length > 0) {
           const permittedWorkspaces = options.workspaces.filter((item) =>
             permittedWorkspaceIds.includes(item)
           );


### PR DESCRIPTION
### Description

when doing permission check, it will filter workspace list and verify there at least have 1 workspace user have permission, otherwise it will throw exception.

The bug is that, if we pass an empty array, that will go through this check and throw exception.

### Issues Resolved

#6528

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: permission check failed with empty workspace for find method

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
