### PR TITLE
[MDS] TSVB Add import logic

### DIFF
--- a/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
+++ b/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
@@ -330,9 +330,9 @@ describe('#checkConflictsForDataSource', () => {
   ])('will update datasource reference + visState of TSVB visualization', async ({ id }) => {
     const tsvbSavedObject = createTSVBVisualizationObject(id);
     // @ts-expect-error
-    const newVisState = JSON.parse(tsvbSavedObject.attributes.visState);
-    newVisState.params.data_source_id = 'some-datasource-id';
-    const expectedVisState = JSON.stringify(newVisState);
+    const expectedVisState = JSON.parse(tsvbSavedObject.attributes.visState);
+    expectedVisState.params.data_source_id = 'some-datasource-id';
+    const newVisState = JSON.stringify(expectedVisState);
     const params = setupParams({
       objects: [tsvbSavedObject],
       ignoreRegularConflicts: true,
@@ -348,7 +348,7 @@ describe('#checkConflictsForDataSource', () => {
             ...tsvbSavedObject,
             attributes: {
               title: 'some-title',
-              visState: expectedVisState,
+              visState: newVisState,
             },
             id: 'some-datasource-id_some-object-id',
             references: [

--- a/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
+++ b/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
@@ -40,6 +40,23 @@ const createVegaVisualizationObject = (id: string): SavedObjectType => {
   } as SavedObjectType;
 };
 
+const createTSVBVisualizationObject = (id: string): SavedObjectType => {
+  const idParse = id.split('_');
+  const params = idParse.length > 1 ? { data_source_id: idParse[1] } : {};
+  const visState = {
+    type: 'metrics',
+    params,
+  };
+
+  return {
+    type: 'visualization',
+    id,
+    attributes: { title: 'some-title', visState: JSON.stringify(visState) },
+    references:
+      idParse.length > 1 ? [{ id: idParse[1], type: 'data-source', name: 'dataSource' }] : [],
+  } as SavedObjectType;
+};
+
 const getSavedObjectClient = (): SavedObjectsClientContract => {
   const savedObject = {} as SavedObjectsClientContract;
   savedObject.get = jest.fn().mockImplementation((type, id) => {
@@ -294,6 +311,60 @@ describe('#checkConflictsForDataSource', () => {
           [
             `visualization:some-object-id`,
             { id: 'nonexistent-datasource-title-id_some-object-id', omitOriginId: true },
+          ],
+        ]),
+      })
+    );
+  });
+
+  /**
+   * TSVB test cases
+   */
+  it.each([
+    {
+      id: 'some-object-id',
+    },
+    {
+      id: 'old-datasource-id_some-object-id',
+    },
+  ])('will update datasource reference + visState of TSVB visualization', async ({ id }) => {
+    const tsvbSavedObject = createTSVBVisualizationObject(id);
+    // @ts-expect-error
+    const newVisState = JSON.parse(tsvbSavedObject.attributes.visState);
+    newVisState.params.data_source_id = 'some-datasource-id';
+    const expectedVisState = JSON.stringify(newVisState);
+    const params = setupParams({
+      objects: [tsvbSavedObject],
+      ignoreRegularConflicts: true,
+      dataSourceId: 'some-datasource-id',
+      savedObjectsClient: getSavedObjectClient(),
+    });
+    const checkConflictsForDataSourceResult = await checkConflictsForDataSource(params);
+
+    expect(checkConflictsForDataSourceResult).toEqual(
+      expect.objectContaining({
+        filteredObjects: [
+          {
+            ...tsvbSavedObject,
+            attributes: {
+              title: 'some-title',
+              visState: expectedVisState,
+            },
+            id: 'some-datasource-id_some-object-id',
+            references: [
+              {
+                id: 'some-datasource-id',
+                name: 'dataSource',
+                type: 'data-source',
+              },
+            ],
+          },
+        ],
+        errors: [],
+        importIdMap: new Map([
+          [
+            `visualization:some-object-id`,
+            { id: 'some-datasource-id_some-object-id', omitOriginId: true },
           ],
         ]),
       })

--- a/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
+++ b/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
@@ -11,6 +11,7 @@ import {
   checkConflictsForDataSource,
   ConflictsForDataSourceParams,
 } from './check_conflict_for_data_source';
+import { VisualizationObject } from './types';
 
 type SavedObjectType = SavedObject<{ title?: string }>;
 
@@ -40,7 +41,7 @@ const createVegaVisualizationObject = (id: string): SavedObjectType => {
   } as SavedObjectType;
 };
 
-const createTSVBVisualizationObject = (id: string): SavedObjectType => {
+const createTSVBVisualizationObject = (id: string): VisualizationObject => {
   const idParse = id.split('_');
   const params = idParse.length > 1 ? { data_source_id: idParse[1] } : {};
   const visState = {
@@ -54,7 +55,7 @@ const createTSVBVisualizationObject = (id: string): SavedObjectType => {
     attributes: { title: 'some-title', visState: JSON.stringify(visState) },
     references:
       idParse.length > 1 ? [{ id: idParse[1], type: 'data-source', name: 'dataSource' }] : [],
-  } as SavedObjectType;
+  } as VisualizationObject;
 };
 
 const getSavedObjectClient = (): SavedObjectsClientContract => {
@@ -329,7 +330,6 @@ describe('#checkConflictsForDataSource', () => {
     },
   ])('will update datasource reference + visState of TSVB visualization', async ({ id }) => {
     const tsvbSavedObject = createTSVBVisualizationObject(id);
-    // @ts-expect-error
     const expectedVisState = JSON.parse(tsvbSavedObject.attributes.visState);
     expectedVisState.params.data_source_id = 'some-datasource-id';
     const newVisState = JSON.stringify(expectedVisState);

--- a/src/core/server/saved_objects/import/check_conflict_for_data_source.ts
+++ b/src/core/server/saved_objects/import/check_conflict_for_data_source.ts
@@ -96,6 +96,8 @@ export async function checkConflictsForDataSource({
         // Some visualization types will need special modifications, like Vega visualizations
         if (object.type === 'visualization') {
           const vegaSpec = extractVegaSpecFromSavedObject(object);
+          // @ts-expect-error
+          const visStateObject = JSON.parse(object.attributes?.visState);
 
           if (!!vegaSpec && !!dataSourceTitle) {
             const updatedVegaSpec = updateDataSourceNameInVegaSpec({
@@ -103,8 +105,6 @@ export async function checkConflictsForDataSource({
               newDataSourceName: dataSourceTitle,
             });
 
-            // @ts-expect-error
-            const visStateObject = JSON.parse(object.attributes?.visState);
             visStateObject.params.spec = updatedVegaSpec;
 
             // @ts-expect-error
@@ -116,6 +116,25 @@ export async function checkConflictsForDataSource({
                 type: 'data-source',
               });
             }
+          }
+
+          if (visStateObject.type === 'metrics' && !!dataSourceId) {
+            const oldDataSourceId = visStateObject.params.data_source_id;
+            const newReferences = object.references.filter((reference) => {
+              return reference.id !== oldDataSourceId && reference.type === 'data-source';
+            });
+
+            visStateObject.params.data_source_id = dataSourceId;
+
+            newReferences.push({
+              id: dataSourceId,
+              name: 'dataSource',
+              type: 'data-source',
+            });
+
+            // @ts-expect-error
+            object.attributes.visState = JSON.stringify(visStateObject);
+            object.references = newReferences;
           }
         }
 

--- a/src/core/server/saved_objects/import/check_conflict_for_data_source.ts
+++ b/src/core/server/saved_objects/import/check_conflict_for_data_source.ts
@@ -9,6 +9,7 @@ import {
   SavedObjectsImportError,
   SavedObjectsImportRetry,
 } from '../types';
+import { VisualizationObject } from './types';
 import {
   extractVegaSpecFromSavedObject,
   getDataSourceTitleFromId,
@@ -120,10 +121,12 @@ export async function checkConflictsForDataSource({
           }
 
           if (!!dataSourceId) {
-            const { visState, references } = getUpdatedTSVBVisState(object, dataSourceId);
-
-            // @ts-expect-error
-            object.attributes.visState = visState;
+            const visualizationObject = object as VisualizationObject;
+            const { visState, references } = getUpdatedTSVBVisState(
+              visualizationObject,
+              dataSourceId
+            );
+            visualizationObject.attributes.visState = visState;
             object.references = references;
           }
         }

--- a/src/core/server/saved_objects/import/create_saved_objects.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.ts
@@ -35,7 +35,7 @@ import {
   SavedObjectsImportError,
 } from '../types';
 import { extractErrors } from './extract_errors';
-import { CreatedObject } from './types';
+import { CreatedObject, VisualizationObject } from './types';
 import {
   extractVegaSpecFromSavedObject,
   getUpdatedTSVBVisState,
@@ -130,10 +130,13 @@ export const createSavedObjects = async <T>({
             });
           }
 
-          const { visState, references } = getUpdatedTSVBVisState(object, dataSourceId);
+          const visualizationObject = object as VisualizationObject;
+          const { visState, references } = getUpdatedTSVBVisState(
+            visualizationObject,
+            dataSourceId
+          );
 
-          // @ts-expect-error
-          object.attributes.visState = visState;
+          visualizationObject.attributes.visState = visState;
           object.references = references;
         }
 

--- a/src/core/server/saved_objects/import/types.ts
+++ b/src/core/server/saved_objects/import/types.ts
@@ -220,4 +220,4 @@ export interface SavedObjectsResolveImportErrorsOptions {
 
 export type CreatedObject<T> = SavedObject<T> & { destinationId?: string };
 
-export type VisualizationObject<T = any> = SavedObject<T> & { visState: string };
+export type VisualizationObject<T = any> = SavedObject<T> & { attributes: { visState: string } };

--- a/src/core/server/saved_objects/import/types.ts
+++ b/src/core/server/saved_objects/import/types.ts
@@ -219,3 +219,5 @@ export interface SavedObjectsResolveImportErrorsOptions {
 }
 
 export type CreatedObject<T> = SavedObject<T> & { destinationId?: string };
+
+export type VisualizationObject<T = any> = SavedObject<T> & { visState: string };

--- a/src/core/server/saved_objects/import/utils.ts
+++ b/src/core/server/saved_objects/import/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { parse, stringify } from 'hjson';
-import { SavedObject, SavedObjectsClientContract } from '../types';
+import { SavedObject, SavedObjectReference, SavedObjectsClientContract } from '../types';
 import { VisualizationObject } from './types';
 
 /**

--- a/src/core/server/saved_objects/import/utils.ts
+++ b/src/core/server/saved_objects/import/utils.ts
@@ -5,6 +5,7 @@
 
 import { parse, stringify } from 'hjson';
 import { SavedObject, SavedObjectsClientContract } from '../types';
+import { VisualizationObject } from './types';
 
 /**
  * Given a Vega spec, the new datasource (by name), and spacing, update the Vega spec to add the new datasource name to each local cluster query
@@ -21,18 +22,19 @@ export interface UpdateDataSourceNameInVegaSpecProps {
 
 /**
  * Given a visualization saved object and datasource id, return the updated visState and references if the visualization was a TSVB visualization
- * @param {SavedObject} object
+ * @param {VisualizationObject} object
  * @param {string} dataSourceId
  * @returns {{visState: string, references: SavedObjectReference[]}} - the updated stringified visState and references
  */
-export const getUpdatedTSVBVisState = (object: SavedObject, dataSourceId: string) => {
-  // @ts-expect-error
-  const visStateObject = JSON.parse(object.attributes?.visState);
+export const getUpdatedTSVBVisState = (
+  object: VisualizationObject,
+  dataSourceId: string
+): { visState: string; references: SavedObjectReference[] } => {
+  const visStateObject = JSON.parse(object.attributes.visState);
 
   if (visStateObject.type !== 'metrics') {
     return {
-      // @ts-expect-error
-      visState: object.attributes?.visState,
+      visState: object.attributes.visState,
       references: object.references,
     };
   }

--- a/src/plugins/vis_type_timeseries/server/lib/services.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/services.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createGetterSetter } from '../../../opensearch_dashboards_utils/common';
+
+export const [getDataSourceEnabled, setDataSourceEnabled] = createGetterSetter<{
+  enabled: boolean;
+}>('DataSource');

--- a/src/plugins/vis_type_timeseries/server/lib/test_utils/test_params.json
+++ b/src/plugins/vis_type_timeseries/server/lib/test_utils/test_params.json
@@ -1,0 +1,154 @@
+{
+    "withDataSourceFieldNonEmpty": {
+        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+        "type": "timeseries",
+        "series": [
+            {
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "color": "#54B399",
+                "split_mode": "everything",
+                "split_color_mode": "opensearchDashboards",
+                "metrics": [
+                    {
+                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "type": "avg",
+                        "field": "bytes"
+                    }
+                ],
+                "separate_axis": 0,
+                "axis_position": "right",
+                "formatter": "number",
+                "chart_type": "line",
+                "line_width": 1,
+                "point_size": 1,
+                "fill": "",
+                "stacked": "none",
+                "label": "",
+                "type": "timeseries"
+            }
+        ],
+        "time_field": "timestamp",
+        "index_pattern": "opensearch_dashboards_sample_data_logs",
+        "interval": "",
+        "axis_position": "left",
+        "axis_formatter": "number",
+        "axis_scale": "normal",
+        "show_legend": 1,
+        "show_grid": 1,
+        "tooltip_mode": "show_all",
+        "default_index_pattern": "opensearch_dashboards_sample_data_logs",
+        "default_timefield": "timestamp",
+        "isModelInvalid": false,
+        "drop_last_bucket": 0,
+        "data_source_id": "a"
+    },
+    "withDataSourceFieldEmpty": {
+        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+        "type": "timeseries",
+        "series": [
+            {
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "color": "#54B399",
+                "split_mode": "everything",
+                "split_color_mode": "opensearchDashboards",
+                "metrics": [
+                    {
+                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "type": "avg",
+                        "field": "bytes"
+                    }
+                ],
+                "separate_axis": 0,
+                "axis_position": "right",
+                "formatter": "number",
+                "chart_type": "line",
+                "line_width": 1,
+                "point_size": 1,
+                "fill": "",
+                "stacked": "none",
+                "label": "",
+                "type": "timeseries"
+            }
+        ],
+        "time_field": "timestamp",
+        "index_pattern": "opensearch_dashboards_sample_data_logs",
+        "interval": "",
+        "axis_position": "left",
+        "axis_formatter": "number",
+        "axis_scale": "normal",
+        "show_legend": 1,
+        "show_grid": 1,
+        "tooltip_mode": "show_all",
+        "default_index_pattern": "opensearch_dashboards_sample_data_logs",
+        "default_timefield": "timestamp",
+        "isModelInvalid": false,
+        "drop_last_bucket": 0,
+        "data_source_id": ""
+    },
+    "withNoDataSourceField": {
+        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+        "type": "timeseries",
+        "series": [
+            {
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "color": "#54B399",
+                "split_mode": "everything",
+                "split_color_mode": "opensearchDashboards",
+                "metrics": [
+                    {
+                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "type": "avg",
+                        "field": "bytes"
+                    }
+                ],
+                "separate_axis": 0,
+                "axis_position": "right",
+                "formatter": "number",
+                "chart_type": "line",
+                "line_width": 1,
+                "point_size": 1,
+                "fill": "",
+                "stacked": "none",
+                "label": "",
+                "type": "timeseries"
+            }
+        ],
+        "time_field": "timestamp",
+        "index_pattern": "opensearch_dashboards_sample_data_logs",
+        "interval": "",
+        "axis_position": "left",
+        "axis_formatter": "number",
+        "axis_scale": "normal",
+        "show_legend": 1,
+        "show_grid": 1,
+        "tooltip_mode": "show_all",
+        "default_index_pattern": "opensearch_dashboards_sample_data_logs",
+        "default_timefield": "timestamp",
+        "isModelInvalid": false,
+        "drop_last_bucket": 0
+    },
+    "referenceWithValidDataSource": [
+        {
+            "id": "a",
+            "name": "dataSource",
+            "type": "data-source"
+        },
+        {
+            "id": "some-dashboard-id",
+            "name": "some-dashboard",
+            "type": "dashboard"
+        }
+    ],
+    "referenceWithOutdatedDataSource": [
+        {
+            "id": "b",
+            "name": "dataSource",
+            "type": "data-source"
+        },
+        {
+            "id": "some-dashboard-id",
+            "name": "some-dashboard",
+            "type": "dashboard"
+        }
+    ]
+}

--- a/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.test.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.test.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import _ from 'lodash';
+
+import { SavedObjectsClientWrapperOptions } from '../../../../core/server';
+import testParams from './test_utils/test_params.json';
+import { timeSeriesVisualizationClientWrapper } from './timeseries_visualization_client_wrapper';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
+
+jest.mock('./services', () => ({
+  getDataSourceEnabled: jest
+    .fn()
+    .mockReturnValueOnce({ enabled: false })
+    .mockReturnValue({ enabled: true }),
+}));
+
+describe('timeseriesVisualizationClientWrapper()', () => {
+  const client = savedObjectsClientMock.create();
+  client.get = jest.fn().mockImplementation((type: string, id: string) => {
+    if (type === 'data-source' && id === 'non-existent-id') {
+      return Promise.resolve({
+        id,
+        errors: {},
+      });
+    }
+    return Promise.resolve({
+      id,
+      attributes: {
+        title: `${id} DataSource`,
+      },
+    });
+  });
+  const mockedWrapperOptions = {} as SavedObjectsClientWrapperOptions;
+  mockedWrapperOptions.client = client;
+
+  const getAttributesWithParams = (params: any) => {
+    return {
+      title: 'Some TSVB Visualization',
+      visState: JSON.stringify({
+        title: 'Some TSVB Visualization',
+        type: 'metrics',
+        aggs: [],
+        params,
+      }),
+    };
+  };
+
+  beforeEach(() => {
+    client.create.mockClear();
+  });
+
+  test('if MDS is disabled, do not update the datasource references', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldEmpty);
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, { references: [] });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('non-visualization saved object should pass through', async () => {
+    const attributes = {
+      title: 'some-dashboard',
+    };
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('dashboard', attributes, { references: [] });
+
+    expect(client.create).toBeCalledWith(
+      'dashboard',
+      attributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('non-metrics saved object should pass through', async () => {
+    const attributes = {
+      title: 'some-other-visualization',
+      visState: JSON.stringify({
+        title: 'Some other visualization',
+        type: 'vega',
+        aggs: [],
+        params: {},
+      }),
+    };
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, { references: [] });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('if a non-existent datasource id is in the params, remove all datasource references and the field name', async () => {
+    const params = _.clone(testParams.withDataSourceFieldNonEmpty);
+    params.data_source_id = 'non-existent-id';
+    const references = [
+      {
+        id: 'non-existent-id',
+        name: 'dataSource',
+        type: 'data-source',
+      },
+    ];
+    const attributes = getAttributesWithParams(params);
+    const newAttributes = getAttributesWithParams(testParams.withNoDataSourceField);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, { references });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      newAttributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('if a datasource reference is empty and the data_source_id field is an empty string, do not change the object', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldEmpty);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, { references: [] });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('if a datasource reference is empty and the data_source_id field is not present, do not change the object', async () => {
+    const attributes = getAttributesWithParams(testParams.withNoDataSourceField);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, { references: [] });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({ references: [] })
+    );
+  });
+
+  test('if a datasource reference is outdated and the data_source_id field has an empty string, remove the datasource reference', async () => {
+    const attributes = getAttributesWithParams(testParams.withNoDataSourceField);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, {
+      references: testParams.referenceWithOutdatedDataSource,
+    });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({
+        references: [{ id: 'some-dashboard-id', name: 'some-dashboard', type: 'dashboard' }],
+      })
+    );
+  });
+
+  test('if a datasource reference is outdated and the data_source_id field is not present, remove the datasource reference', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldEmpty);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, {
+      references: testParams.referenceWithOutdatedDataSource,
+    });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({
+        references: [{ id: 'some-dashboard-id', name: 'some-dashboard', type: 'dashboard' }],
+      })
+    );
+  });
+
+  test('if the datasource reference is empty and the data_source_id is present, add the datasource reference', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldNonEmpty);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, {
+      references: [{ id: 'some-dashboard-id', name: 'some-dashboard', type: 'dashboard' }],
+    });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({
+        references: expect.arrayContaining(testParams.referenceWithValidDataSource),
+      })
+    );
+  });
+
+  test('if the datasource reference is different from the data_source_id, update the datasource reference', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldNonEmpty);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, {
+      references: testParams.referenceWithOutdatedDataSource,
+    });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({
+        references: expect.arrayContaining(testParams.referenceWithValidDataSource),
+      })
+    );
+  });
+
+  test('if the datasource reference is identical to the data_source_id, do not change anything', async () => {
+    const attributes = getAttributesWithParams(testParams.withDataSourceFieldNonEmpty);
+
+    const wrapper = timeSeriesVisualizationClientWrapper(mockedWrapperOptions);
+    await wrapper.create('visualization', attributes, {
+      references: testParams.referenceWithValidDataSource,
+    });
+
+    expect(client.create).toBeCalledWith(
+      'visualization',
+      attributes,
+      expect.objectContaining({
+        references: expect.arrayContaining(testParams.referenceWithValidDataSource),
+      })
+    );
+  });
+});

--- a/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  SavedObjectsClientContract,
+  SavedObjectsClientWrapperFactory,
+  SavedObjectsClientWrapperOptions,
+  SavedObjectsCreateOptions,
+} from '../../../../core/server';
+import { getDataSourceEnabled } from './services';
+
+export const TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_ID = 'timeseries-visualization-client-wrapper';
+
+export const timeSeriesVisualizationClientWrapper: SavedObjectsClientWrapperFactory = (
+  wrapperOptions: SavedObjectsClientWrapperOptions
+) => {
+  const createForTimeSeries = async <T = unknown>(
+    type: string,
+    attributes: T,
+    options?: SavedObjectsCreateOptions
+  ) => {
+    if (type !== 'visualization' || !getDataSourceEnabled().enabled) {
+      return await wrapperOptions.client.create(type, attributes, options);
+    }
+
+    // @ts-expect-error
+    const visState = JSON.parse(attributes.visState);
+
+    if (visState.type !== 'metrics' || !visState.params) {
+      return await wrapperOptions.client.create(type, attributes, options);
+    }
+
+    const newReferences = options?.references?.filter(
+      (reference) => reference.type !== 'data-source'
+    );
+
+    if (visState.params.data_source_id) {
+      if (await checkIfDataSourceExists(visState.params.data_source_id, wrapperOptions.client)) {
+        newReferences?.push({
+          id: visState.params.data_source_id,
+          name: 'dataSource',
+          type: 'data-source',
+        });
+      } else {
+        delete visState.params.data_source_id;
+      }
+    }
+
+    // @ts-expect-error
+    attributes.visState = JSON.stringify(visState);
+
+    return await wrapperOptions.client.create(type, attributes, {
+      ...options,
+      references: newReferences,
+    });
+  };
+
+  return {
+    ...wrapperOptions.client,
+    create: createForTimeSeries,
+    bulkCreate: wrapperOptions.client.bulkCreate,
+    checkConflicts: wrapperOptions.client.checkConflicts,
+    delete: wrapperOptions.client.delete,
+    find: wrapperOptions.client.find,
+    bulkGet: wrapperOptions.client.bulkGet,
+    get: wrapperOptions.client.get,
+    update: wrapperOptions.client.update,
+    bulkUpdate: wrapperOptions.client.bulkUpdate,
+    errors: wrapperOptions.client.errors,
+    addToNamespaces: wrapperOptions.client.addToNamespaces,
+    deleteFromNamespaces: wrapperOptions.client.deleteFromNamespaces,
+  };
+};
+
+const checkIfDataSourceExists = async (
+  id: string,
+  client: SavedObjectsClientContract
+): Promise<boolean> => {
+  return client.get('data-source', id).then((response) => !!response.attributes);
+};

--- a/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/timeseries_visualization_client_wrapper.ts
@@ -13,6 +13,10 @@ import {
 import { getDataSourceEnabled } from './services';
 
 export const TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_ID = 'timeseries-visualization-client-wrapper';
+/**
+ * A lower priority number means that a wrapper will be first to execute.
+ * In this case, since this wrapper does not have any conflicts with other wrappers, it is set to 11.
+ * */
 export const TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_PRIORITY = 11;
 
 export const timeSeriesVisualizationClientWrapper: SavedObjectsClientWrapperFactory = (
@@ -27,8 +31,8 @@ export const timeSeriesVisualizationClientWrapper: SavedObjectsClientWrapperFact
       return await wrapperOptions.client.create(type, attributes, options);
     }
 
-    // @ts-expect-error
-    const visState = JSON.parse(attributes.visState);
+    const tsvbAttributes = attributes as T & { visState: string };
+    const visState = JSON.parse(tsvbAttributes.visState);
 
     if (visState.type !== 'metrics' || !visState.params) {
       return await wrapperOptions.client.create(type, attributes, options);
@@ -55,8 +59,7 @@ export const timeSeriesVisualizationClientWrapper: SavedObjectsClientWrapperFact
       }
     }
 
-    // @ts-expect-error
-    attributes.visState = JSON.stringify(visState);
+    tsvbAttributes.visState = JSON.stringify(visState);
 
     return await wrapperOptions.client.create(type, attributes, {
       ...options,

--- a/src/plugins/vis_type_timeseries/server/plugin.ts
+++ b/src/plugins/vis_type_timeseries/server/plugin.ts
@@ -55,6 +55,7 @@ import { setDataSourceEnabled } from './lib/services';
 import {
   TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_ID,
   timeSeriesVisualizationClientWrapper,
+  TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_PRIORITY,
 } from './lib/timeseries_visualization_client_wrapper';
 
 export interface LegacySetup {
@@ -122,7 +123,7 @@ export class VisTypeTimeseriesPlugin implements Plugin<VisTypeTimeseriesSetup> {
 
     setDataSourceEnabled({ enabled: !!plugins.dataSource });
     core.savedObjects.addClientWrapper(
-      11,
+      TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_PRIORITY,
       TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_ID,
       timeSeriesVisualizationClientWrapper
     );

--- a/src/plugins/vis_type_timeseries/server/plugin.ts
+++ b/src/plugins/vis_type_timeseries/server/plugin.ts
@@ -51,6 +51,11 @@ import { visDataRoutes } from './routes/vis';
 import { fieldsRoutes } from './routes/fields';
 import { SearchStrategyRegistry } from './lib/search_strategies';
 import { uiSettings } from './ui_settings';
+import { setDataSourceEnabled } from './lib/services';
+import {
+  TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_ID,
+  timeSeriesVisualizationClientWrapper,
+} from './lib/timeseries_visualization_client_wrapper';
 
 export interface LegacySetup {
   server: Server;
@@ -114,6 +119,13 @@ export class VisTypeTimeseriesPlugin implements Plugin<VisTypeTimeseriesSetup> {
       router,
       searchStrategyRegistry,
     };
+
+    setDataSourceEnabled({ enabled: !!plugins.dataSource });
+    core.savedObjects.addClientWrapper(
+      11,
+      TIMESERIES_VISUALIZATION_CLIENT_WRAPPER_ID,
+      timeSeriesVisualizationClientWrapper
+    );
 
     (async () => {
       const validationTelemetry = await this.validationTelementryService.setup(core, {


### PR DESCRIPTION
### Description

This PR adds datasource references to TSVB visualizations, which are needed to successfully export/import the object in MDS world. This PR also adds import logic to select a datasource.

### Issues Resolved

Closes #6290

## Testing the changes

### Adding datasource reference

**Recording:**

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/96f1711f-bee7-44b6-8034-6dd385bfc1a0

**Test case steps:**
1. Add sample data
2. Navigate to the TSVB edit page and change the datasource 
3. Go to saved objects management page and navigate to the visualization
4. In references, this should be modified to add the correct datasource
5. If the datasource is updated in the TSVB edit page, so too will the datasource reference
6. If the local cluster is used, the datasource reference will be removed.

### For import logic

**Test cases:**
1. Non-MDS TSVB visualization import to `Source B` and create new object
    - This should append `Source B` to references and should use `Source B` as the datasource to query from

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/eb249935-13ca-4d99-8a5a-20e6189fbf8c

2. Non-MDS TSVB visualization import to `Source B` and overwrite old object
    - This should append `Source B` to references and should use `Source B` as the datasource to query from

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/06d65180-90b3-4434-8244-3472d8230d98


3. MDS TSVB visualization import to `Source A` and create new object
    - This should update `Source B` to `Source A` in references and should use `Source A` as the datasource to query from

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/b7f1e663-f461-42a6-8206-662b14b5129c

4. MDS TSVB visualization import to `Source A` and override old object
    - This should update `Source B` to `Source A` in references and should use `Source A` as the datasource to query from

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/0bae86bf-12b7-4fad-a654-7ae455b0a23a

## Changelog
- feat: [MDS] Add import logic to TSVB visualizations

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
