### PR TITLE
Refactor saved object management plugin to use datasourceManagement ui API to get DataSourceSelector

### DIFF
--- a/changelogs/fragments/6544.yml
+++ b/changelogs/fragments/6544.yml
@@ -1,0 +1,2 @@
+refactor:
+- Refactor saved object management plugin to use datasourceManagement ui API to get DataSourceSelector ([#6544](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6544))

--- a/src/plugins/saved_objects_management/opensearch_dashboards.json
+++ b/src/plugins/saved_objects_management/opensearch_dashboards.json
@@ -11,8 +11,9 @@
     "home",
     "visBuilder",
     "visAugmenter",
-    "dataSource"
+    "dataSource",
+    "dataSourceManagement"
   ],
   "extraPublicDirs": ["public/lib"],
-  "requiredBundles": ["opensearchDashboardsReact", "home", "dataSourceManagement"]
+  "requiredBundles": ["opensearchDashboardsReact", "home"]
 }

--- a/src/plugins/saved_objects_management/public/management_section/mount_section.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/mount_section.tsx
@@ -35,6 +35,7 @@ import { I18nProvider } from '@osd/i18n/react';
 import { i18n } from '@osd/i18n';
 import { EuiLoadingSpinner } from '@elastic/eui';
 import { CoreSetup } from 'src/core/public';
+import { DataSourceManagementPluginSetup } from 'src/plugins/data_source_management/public';
 import { ManagementAppMountParams } from '../../../management/public';
 import { StartDependencies, SavedObjectsManagementPluginStart } from '../plugin';
 import { ISavedObjectsManagementServiceRegistry } from '../services';
@@ -45,7 +46,7 @@ interface MountParams {
   serviceRegistry: ISavedObjectsManagementServiceRegistry;
   mountParams: ManagementAppMountParams;
   dataSourceEnabled: boolean;
-  hideLocalCluster: boolean;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
 }
 
 let allowedObjectTypes: string[] | undefined;
@@ -61,7 +62,7 @@ export const mountManagementSection = async ({
   mountParams,
   serviceRegistry,
   dataSourceEnabled,
-  hideLocalCluster,
+  dataSourceManagement,
 }: MountParams) => {
   const [coreStart, { data, uiActions }, pluginStart] = await core.getStartServices();
   const { element, history, setBreadcrumbs } = mountParams;
@@ -113,7 +114,7 @@ export const mountManagementSection = async ({
                   allowedTypes={allowedObjectTypes}
                   setBreadcrumbs={setBreadcrumbs}
                   dataSourceEnabled={dataSourceEnabled}
-                  hideLocalCluster={hideLocalCluster}
+                  dataSourceManagement={dataSourceManagement}
                 />
               </Suspense>
             </RedirectToHomeIfUnauthorized>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/flyout.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/flyout.test.tsx.snap
@@ -528,7 +528,7 @@ Array [
 ]
 `;
 
-exports[`Flyout should render cluster selector and import options when local cluster option is hidden 1`] = `
+exports[`Flyout should render cluster selector and import options when datasource is enabled 1`] = `
 <EuiFlyout
   onClose={[MockFunction]}
   size="s"
@@ -600,7 +600,7 @@ exports[`Flyout should render cluster selector and import options when local clu
           <DataSourceSelector
             disabled={false}
             fullWidth={true}
-            hideLocalCluster={true}
+            isClearable={false}
             notifications={
               Object {
                 "add": [MockFunction],
@@ -666,161 +666,6 @@ exports[`Flyout should render cluster selector and import options when local clu
         <EuiButton
           data-test-subj="importSavedObjectsImportBtn"
           disabled={true}
-          fill={true}
-          isLoading={false}
-          onClick={[Function]}
-          size="s"
-        >
-          <FormattedMessage
-            defaultMessage="Import"
-            id="savedObjectsManagement.objectsTable.flyout.import.confirmButtonLabel"
-            values={Object {}}
-          />
-        </EuiButton>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </EuiFlyoutFooter>
-</EuiFlyout>
-`;
-
-exports[`Flyout should render cluster selector and import options when local cluster option is not hidden 1`] = `
-<EuiFlyout
-  onClose={[MockFunction]}
-  size="s"
->
-  <EuiFlyoutHeader
-    hasBorder={true}
-  >
-    <EuiTitle
-      size="m"
-    >
-      <h2>
-        <FormattedMessage
-          defaultMessage="Import saved objects"
-          id="savedObjectsManagement.objectsTable.flyout.importSavedObjectTitle"
-          values={Object {}}
-        />
-      </h2>
-    </EuiTitle>
-  </EuiFlyoutHeader>
-  <EuiFlyoutBody>
-    <EuiForm>
-      <EuiFormRow
-        describedByIds={Array []}
-        display="row"
-        fullWidth={true}
-        hasChildLabel={true}
-        hasEmptyLabelSpace={false}
-        label={
-          <FormattedMessage
-            defaultMessage="Select file"
-            id="savedObjectsManagement.objectsTable.flyout.selectFileToImportFormRowLabel"
-            values={Object {}}
-          />
-        }
-        labelType="label"
-      >
-        <EuiFilePicker
-          accept=".ndjson, .json"
-          compressed={false}
-          display="large"
-          fullWidth={true}
-          initialPromptText={
-            <FormattedMessage
-              defaultMessage="Import"
-              id="savedObjectsManagement.objectsTable.flyout.importPromptText"
-              values={Object {}}
-            />
-          }
-          onChange={[Function]}
-        />
-      </EuiFormRow>
-      <div
-        className="savedObjectImportControlForDataSource"
-      >
-        <EuiSpacer />
-        <EuiFormFieldset
-          legend={
-            Object {
-              "children": <EuiTitle
-                size="xs"
-              >
-                <span>
-                  Import options
-                </span>
-              </EuiTitle>,
-            }
-          }
-        >
-          <DataSourceSelector
-            disabled={false}
-            fullWidth={true}
-            hideLocalCluster={false}
-            notifications={
-              Object {
-                "add": [MockFunction],
-                "addDanger": [MockFunction],
-                "addError": [MockFunction],
-                "addInfo": [MockFunction],
-                "addSuccess": [MockFunction],
-                "addWarning": [MockFunction],
-                "get$": [MockFunction],
-                "remove": [MockFunction],
-              }
-            }
-            onSelectedDataSource={[Function]}
-          />
-        </EuiFormFieldset>
-        <EuiSpacer />
-        <EuiFormRow
-          describedByIds={Array []}
-          display="row"
-          fullWidth={true}
-          hasChildLabel={true}
-          hasEmptyLabelSpace={false}
-          labelType="label"
-        >
-          <ImportModeControl
-            initialValues={
-              Object {
-                "createNewCopies": true,
-                "overwrite": true,
-              }
-            }
-            isLegacyFile={false}
-            optionLabel="Conflict management"
-            updateSelection={[Function]}
-          />
-        </EuiFormRow>
-      </div>
-    </EuiForm>
-  </EuiFlyoutBody>
-  <EuiFlyoutFooter>
-    <EuiFlexGroup
-      justifyContent="spaceBetween"
-    >
-      <EuiFlexItem
-        grow={false}
-      >
-        <EuiButtonEmpty
-          data-test-subj="importSavedObjectsCancelBtn"
-          disabled={false}
-          onClick={[MockFunction]}
-          size="s"
-        >
-          <FormattedMessage
-            defaultMessage="Cancel"
-            id="savedObjectsManagement.objectsTable.flyout.import.cancelButtonLabel"
-            values={Object {}}
-          />
-        </EuiButtonEmpty>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
-      >
-        <EuiButton
-          data-test-subj="importSavedObjectsImportBtn"
-          disabled={false}
           fill={true}
           isLoading={false}
           onClick={[Function]}

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.test.tsx
@@ -55,6 +55,12 @@ const legacyMockFile = ({
   path: '/home/foo.json',
 } as unknown) as File;
 
+const dataSourceManagementMock = {
+  ui: {
+    DataSourceSelector: () => <div>Mock DataSourceSelector</div>,
+  },
+};
+
 describe('Flyout', () => {
   let defaultProps: FlyoutProps;
 
@@ -99,27 +105,11 @@ describe('Flyout', () => {
     expect(component).toMatchSnapshot();
   });
 
-  it('should render cluster selector and import options when local cluster option is not hidden', async () => {
+  it('should render cluster selector and import options when datasource is enabled', async () => {
     const component = shallowRender({
       ...defaultProps,
       dataSourceEnabled: true,
-      hideLocalCluster: false,
-      notifications: notificationServiceMock.createStartContract(),
-    });
-
-    // Ensure all promises resolve
-    await new Promise((resolve) => process.nextTick(resolve));
-    // Ensure the state changes are reflected
-    component.update();
-
-    expect(component).toMatchSnapshot();
-  });
-
-  it('should render cluster selector and import options when local cluster option is hidden', async () => {
-    const component = shallowRender({
-      ...defaultProps,
-      dataSourceEnabled: true,
-      hideLocalCluster: true,
+      dataSourceManagement: dataSourceManagementMock,
       notifications: notificationServiceMock.createStartContract(),
     });
 

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
@@ -54,8 +54,13 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
-import { OverlayStart, HttpStart } from 'src/core/public';
-import { DataSourceSelector } from '../../../../../data_source_management/public';
+import {
+  OverlayStart,
+  HttpStart,
+  NotificationsStart,
+  SavedObjectsClientContract,
+} from 'src/core/public';
+import { DataSourceManagementPluginSetup } from 'src/plugins/data_source_management/public';
 import {
   IndexPatternsContract,
   IIndexPattern,
@@ -80,6 +85,7 @@ import { FailedImportConflict, RetryDecision } from '../../../lib/resolve_import
 import { OverwriteModal } from './overwrite_modal';
 import { ImportModeControl, ImportMode } from './import_mode_control';
 import { ImportSummary } from './import_summary';
+
 const CREATE_NEW_COPIES_DEFAULT = true;
 const OVERWRITE_ALL_DEFAULT = true;
 
@@ -94,9 +100,9 @@ export interface FlyoutProps {
   http: HttpStart;
   search: DataPublicPluginStart['search'];
   dataSourceEnabled: boolean;
-  hideLocalCluster: boolean;
   savedObjects: SavedObjectsClientContract;
   notifications: NotificationsStart;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
 }
 
 export interface FlyoutState {
@@ -811,6 +817,7 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
   }
 
   renderImportControlForDataSource(importMode: ImportMode, isLegacyFile: boolean) {
+    const DataSourceSelector = this.props.dataSourceManagement!.ui.DataSourceSelector;
     return (
       <div className="savedObjectImportControlForDataSource">
         <EuiSpacer />
@@ -828,8 +835,8 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
             notifications={this.props.notifications.toasts}
             onSelectedDataSource={this.onSelectedDataSourceChange}
             disabled={!this.props.dataSourceEnabled}
-            hideLocalCluster={this.props.hideLocalCluster}
             fullWidth={true}
+            isClearable={false}
           />
         </EuiFormFieldset>
         <EuiSpacer />
@@ -855,7 +862,8 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
     let confirmButton;
 
     let importButtonDisabled = false;
-    if (this.props.dataSourceEnabled && this.props.hideLocalCluster && !selectedDataSourceId) {
+    // If a data source is enabled, the import button should be disabled when there's no selected data source
+    if (this.props.dataSourceEnabled && selectedDataSourceId === undefined) {
       importButtonDisabled = true;
     }
 

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -58,6 +58,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
+import { DataSourceManagementPluginSetup } from 'src/plugins/data_source_management/public';
 import {
   SavedObjectsClientContract,
   SavedObjectsFindOptions,
@@ -121,7 +122,7 @@ export interface SavedObjectsTableProps {
   canGoInApp: (obj: SavedObjectWithMetadata) => boolean;
   dateFormat: string;
   dataSourceEnabled: boolean;
-  hideLocalCluster: boolean;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
 }
 
 export interface SavedObjectsTableState {
@@ -650,9 +651,9 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
         overlays={this.props.overlays}
         search={this.props.search}
         dataSourceEnabled={this.props.dataSourceEnabled}
-        hideLocalCluster={this.props.hideLocalCluster}
         savedObjects={this.props.savedObjectsClient}
         notifications={this.props.notifications}
+        dataSourceManagement={this.props.dataSourceManagement}
       />
     );
   }

--- a/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/saved_objects_table_page.tsx
@@ -32,11 +32,13 @@ import React, { useEffect } from 'react';
 import { get } from 'lodash';
 import { i18n } from '@osd/i18n';
 import { CoreStart, ChromeBreadcrumb } from 'src/core/public';
+import { DataSourceManagementPluginSetup } from 'src/plugins/data_source_management/public';
 import { DataPublicPluginStart } from '../../../data/public';
 import {
   ISavedObjectsManagementServiceRegistry,
   SavedObjectsManagementActionServiceStart,
   SavedObjectsManagementColumnServiceStart,
+  SavedObjectsManagementNamespaceServiceStart,
 } from '../services';
 import { SavedObjectsTable } from './objects_table';
 
@@ -50,7 +52,7 @@ const SavedObjectsTablePage = ({
   namespaceRegistry,
   setBreadcrumbs,
   dataSourceEnabled,
-  hideLocalCluster,
+  dataSourceManagement,
 }: {
   coreStart: CoreStart;
   dataStart: DataPublicPluginStart;
@@ -61,7 +63,7 @@ const SavedObjectsTablePage = ({
   namespaceRegistry: SavedObjectsManagementNamespaceServiceStart;
   setBreadcrumbs: (crumbs: ChromeBreadcrumb[]) => void;
   dataSourceEnabled: boolean;
-  hideLocalCluster: boolean;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
 }) => {
   const capabilities = coreStart.application.capabilities;
   const itemsPerPage = coreStart.uiSettings.get<number>('savedObjects:perPage', 50);
@@ -108,7 +110,7 @@ const SavedObjectsTablePage = ({
         return inAppUrl ? Boolean(get(capabilities, inAppUrl.uiCapabilitiesPath)) : false;
       }}
       dataSourceEnabled={dataSourceEnabled}
-      hideLocalCluster={hideLocalCluster}
+      dataSourceManagement={dataSourceManagement}
     />
   );
 };

--- a/src/plugins/saved_objects_management/public/plugin.ts
+++ b/src/plugins/saved_objects_management/public/plugin.ts
@@ -32,6 +32,7 @@ import { i18n } from '@osd/i18n';
 import { CoreSetup, CoreStart, Plugin } from 'src/core/public';
 
 import { DataSourcePluginSetup } from 'src/plugins/data_source/public';
+import { DataSourceManagementPluginSetup } from 'src/plugins/data_source_management/public';
 import { VisBuilderStart } from '../../vis_builder/public';
 import { ManagementSetup } from '../../management/public';
 import { UiActionsSetup, UiActionsStart } from '../../ui_actions/public';
@@ -79,6 +80,7 @@ export interface SetupDependencies {
   home?: HomePublicPluginSetup;
   uiActions: UiActionsSetup;
   dataSource?: DataSourcePluginSetup;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
 }
 
 export interface StartDependencies {
@@ -107,7 +109,7 @@ export class SavedObjectsManagementPlugin
 
   public setup(
     core: CoreSetup<StartDependencies, SavedObjectsManagementPluginStart>,
-    { home, management, uiActions, dataSource }: SetupDependencies
+    { home, management, uiActions, dataSource, dataSourceManagement }: SetupDependencies
   ): SavedObjectsManagementPluginSetup {
     const actionSetup = this.actionService.setup();
     const columnSetup = this.columnService.setup();
@@ -144,7 +146,7 @@ export class SavedObjectsManagementPlugin
           serviceRegistry: this.serviceRegistry,
           mountParams,
           dataSourceEnabled: !!dataSource,
-          hideLocalCluster: dataSource?.hideLocalCluster ?? false,
+          dataSourceManagement,
         });
       },
     });


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
- Add `dataSourceManagement` as an optional plugin of saved obeect manamgent plugin
- get picker compoenent by `const DataSourceSelector = dataSourceManagement.ui `, instead of direct inport
- Make Datasource selector non-clearable
- remove the usage of `hideLocalCluster`, and no need pass to DataSourceSelector as props
- this change will also let the default label to be rendered successfully


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6369
fix https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6546

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- With datasource enabled and localCluster hidden and no avaliable data sources. It should disable the import button

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/2b6425ca-caba-4c44-b645-3610cd2db086)

- With datasource enabled, and localCluster shown, no other avaliable data sources.
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/0923fcd1-a1f8-4a13-847e-d1fde3255678)


- With datasource enabled, and LocalCluster shown, with other data sources
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/b6160c1d-8e3b-43dc-9104-eac0e5a810d0)


- With data source disabled
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/8702f82d-67ef-4eca-8daf-896c6a0b1a38)




## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- refactor: refactor saved object management plugin to use datasourceManagement ui API to get DataSourceSelector

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
