### PR TITLE
Extract the button component for datasource picker to avoid duplicate code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Workspace] Add permission tab to workspace create update page ([#6378](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6378))
 - [Workspace] Hide datasource and advanced settings menu in dashboard management when in workspace. ([#6455](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6455))
 - [Multiple Datasource] Modify selectable picker to remove group label and close popover after selection ([#6515](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6515))
+- [Multiple Datasource] Extract the button component for datasource picker to avoid duplicate code ([#6559](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6559))
 - [Workspace] Add workspaces filter to saved objects page. ([#6458](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6458))
 
 ### 🐛 Bug Fixes

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/__snapshots__/data_source_aggregated_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/__snapshots__/data_source_aggregated_view.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -129,7 +129,7 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -259,7 +259,7 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -377,7 +377,7 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -501,7 +501,7 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -625,7 +625,7 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -755,7 +755,7 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -873,7 +873,7 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -997,7 +997,7 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -1084,7 +1084,7 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -1171,7 +1171,7 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -1258,7 +1258,7 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -1345,7 +1345,7 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -1432,7 +1432,7 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -1519,7 +1519,7 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -1606,7 +1606,7 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -1693,7 +1693,7 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />
@@ -1780,7 +1780,7 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <PopoverButton
+      <DataSourceMenuPopoverButton
         className="dataSourceAggregatedView"
         onClick={[Function]}
       />

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/__snapshots__/data_source_aggregated_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/__snapshots__/data_source_aggregated_view.test.tsx.snap
@@ -5,14 +5,9 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -134,14 +129,9 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -269,14 +259,9 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -392,14 +377,9 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -521,14 +501,9 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -650,14 +625,9 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -785,14 +755,9 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -908,14 +873,9 @@ exports[`DataSourceAggregatedView: read active view (displayAllCompatibleDataSou
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -1037,14 +997,9 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -1129,14 +1084,9 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -1221,14 +1171,9 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -1313,14 +1258,9 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -1405,14 +1345,9 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -1497,14 +1432,9 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -1589,14 +1519,9 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -1681,14 +1606,9 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -1773,14 +1693,9 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}
@@ -1865,14 +1780,9 @@ exports[`DataSourceAggregatedView: read all view (displayAllCompatibleDataSource
   <EuiPopover
     anchorPosition="downLeft"
     button={
-      <EuiButtonEmpty
-        aria-label="dataSourceAggregatedViewMenuButton"
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        iconSide="left"
-        iconType="database"
+      <PopoverButton
+        className="dataSourceAggregatedView"
         onClick={[Function]}
-        size="s"
       />
     }
     closePopover={[Function]}

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
@@ -34,6 +34,7 @@ import { DataSourceOption } from '../data_source_menu/types';
 import { DataSourceItem } from '../data_source_item';
 import { DataSourceDropDownHeader } from '../drop_down_header';
 import './data_source_aggregated_view.scss';
+import { PopoverButton } from '../popover_button/popover_button';
 
 interface DataSourceAggregatedViewProps {
   savedObjectsClient: SavedObjectsClientContract;
@@ -155,19 +156,6 @@ export class DataSourceAggregatedView extends React.Component<
     if (this.state.showError) {
       return <DataSourceErrorMenu application={this.props.application} />;
     }
-    const button = (
-      <EuiButtonEmpty
-        className="euiHeaderLink"
-        data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
-        aria-label={i18n.translate('dataSourceAggregatedView.dataSourceOptionsButtonAriaLabel', {
-          defaultMessage: 'dataSourceAggregatedViewMenuButton',
-        })}
-        iconType="database"
-        iconSide="left"
-        size="s"
-        onClick={this.onDataSourcesClick.bind(this)}
-      />
-    );
 
     let items: DataSourceOptionDisplay[] = [];
 
@@ -216,7 +204,12 @@ export class DataSourceAggregatedView extends React.Component<
       <>
         <EuiPopover
           id={'dataSourceSViewContextMenuPopover'}
-          button={button}
+          button={
+            <PopoverButton
+              className={'dataSourceAggregatedView'}
+              onClick={this.onDataSourcesClick.bind(this)}
+            />
+          }
           isOpen={this.state.isPopoverOpen}
           closePopover={this.closePopover.bind(this)}
           panelPaddingSize="none"

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
@@ -4,15 +4,7 @@
  */
 
 import React from 'react';
-import {
-  EuiButtonEmpty,
-  EuiContextMenuPanel,
-  EuiPanel,
-  EuiPopover,
-  EuiSelectable,
-  EuiSwitch,
-} from '@elastic/eui';
-import { i18n } from '@osd/i18n';
+import { EuiContextMenuPanel, EuiPanel, EuiPopover, EuiSelectable, EuiSwitch } from '@elastic/eui';
 import {
   ApplicationStart,
   IUiSettingsClient,
@@ -34,7 +26,7 @@ import { DataSourceOption } from '../data_source_menu/types';
 import { DataSourceItem } from '../data_source_item';
 import { DataSourceDropDownHeader } from '../drop_down_header';
 import './data_source_aggregated_view.scss';
-import { PopoverButton } from '../popover_button/popover_button';
+import { DataSourceMenuPopoverButton } from '../popover_button/popover_button';
 
 interface DataSourceAggregatedViewProps {
   savedObjectsClient: SavedObjectsClientContract;
@@ -205,7 +197,7 @@ export class DataSourceAggregatedView extends React.Component<
         <EuiPopover
           id={'dataSourceSViewContextMenuPopover'}
           button={
-            <PopoverButton
+            <DataSourceMenuPopoverButton
               className={'dataSourceAggregatedView'}
               onClick={this.onDataSourcesClick.bind(this)}
             />

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
@@ -123,9 +123,9 @@ Object {
           class="euiPopover__anchor"
         >
           <button
-            aria-label="dataSourceMenuButton"
-            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink dataSourceComponentButtonTitle"
-            data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+            aria-label="dataSourceSelectableButton"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small dataSourceComponentButtonTitle"
+            data-test-subj="dataSourceSelectableButton"
             type="button"
           >
             <span
@@ -155,9 +155,9 @@ Object {
         class="euiPopover__anchor"
       >
         <button
-          aria-label="dataSourceMenuButton"
-          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink dataSourceComponentButtonTitle"
-          data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+          aria-label="dataSourceSelectableButton"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small dataSourceComponentButtonTitle"
+          data-test-subj="dataSourceSelectableButton"
           type="button"
         >
           <span
@@ -252,9 +252,9 @@ Object {
               class="euiPopover__anchor"
             >
               <button
-                aria-label="dataSourceMenuButton"
-                class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink dataSourceComponentButtonTitle"
-                data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+                aria-label="dataSourceSelectableButton"
+                class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small dataSourceComponentButtonTitle"
+                data-test-subj="dataSourceSelectableButton"
                 type="button"
               >
                 <span

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
@@ -76,9 +76,9 @@ Object {
           class="euiPopover__anchor"
         >
           <button
-            aria-label="dataSourceAggregatedViewMenuButton"
-            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
-            data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+            aria-label="dataSourceAggregatedViewButton"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small dataSourceComponentButtonTitle"
+            data-test-subj="dataSourceAggregatedViewButton"
             type="button"
           >
             <span
@@ -107,9 +107,9 @@ Object {
         class="euiPopover__anchor"
       >
         <button
-          aria-label="dataSourceAggregatedViewMenuButton"
-          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink"
-          data-test-subj="dataSourceAggregatedViewContextMenuHeaderLink"
+          aria-label="dataSourceAggregatedViewButton"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small dataSourceComponentButtonTitle"
+          data-test-subj="dataSourceAggregatedViewButton"
           type="button"
         >
           <span

--- a/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <PopoverButton
+    <DataSourceMenuPopoverButton
       className="dataSourceSelectable"
       label="Local cluster"
       onClick={[Function]}
@@ -80,7 +80,7 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <PopoverButton
+    <DataSourceMenuPopoverButton
       className="dataSourceSelectable"
       label=""
       onClick={[Function]}
@@ -140,7 +140,7 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <PopoverButton
+    <DataSourceMenuPopoverButton
       className="dataSourceSelectable"
       label=""
       onClick={[Function]}

--- a/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
@@ -4,20 +4,11 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <React.Fragment>
-      <EuiButtonEmpty
-        aria-label="dataSourceMenuButton"
-        className="euiHeaderLink dataSourceComponentButtonTitle"
-        data-test-subj="dataSourceSelectableContextMenuHeaderLink"
-        disabled={false}
-        iconSide="left"
-        iconType="database"
-        onClick={[Function]}
-        size="s"
-      >
-        Local cluster
-      </EuiButtonEmpty>
-    </React.Fragment>
+    <PopoverButton
+      className="dataSourceSelectable"
+      label="Local cluster"
+      onClick={[Function]}
+    />
   }
   closePopover={[Function]}
   data-test-subj="dataSourceSelectableContextMenuPopover"
@@ -89,18 +80,11 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <React.Fragment>
-      <EuiButtonEmpty
-        aria-label="dataSourceMenuButton"
-        className="euiHeaderLink dataSourceComponentButtonTitle"
-        data-test-subj="dataSourceSelectableContextMenuHeaderLink"
-        disabled={false}
-        iconSide="left"
-        iconType="database"
-        onClick={[Function]}
-        size="s"
-      />
-    </React.Fragment>
+    <PopoverButton
+      className="dataSourceSelectable"
+      label=""
+      onClick={[Function]}
+    />
   }
   closePopover={[Function]}
   data-test-subj="dataSourceSelectableContextMenuPopover"
@@ -156,18 +140,11 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <React.Fragment>
-      <EuiButtonEmpty
-        aria-label="dataSourceMenuButton"
-        className="euiHeaderLink dataSourceComponentButtonTitle"
-        data-test-subj="dataSourceSelectableContextMenuHeaderLink"
-        disabled={false}
-        iconSide="left"
-        iconType="database"
-        onClick={[Function]}
-        size="s"
-      />
-    </React.Fragment>
+    <PopoverButton
+      className="dataSourceSelectable"
+      label=""
+      onClick={[Function]}
+    />
   }
   closePopover={[Function]}
   data-test-subj="dataSourceSelectableContextMenuPopover"
@@ -233,9 +210,9 @@ Object {
           class="euiPopover__anchor"
         >
           <button
-            aria-label="dataSourceMenuButton"
-            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink dataSourceComponentButtonTitle"
-            data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+            aria-label="dataSourceSelectableButton"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small dataSourceComponentButtonTitle"
+            data-test-subj="dataSourceSelectableButton"
             type="button"
           >
             <span
@@ -404,9 +381,9 @@ Object {
         class="euiPopover__anchor"
       >
         <button
-          aria-label="dataSourceMenuButton"
-          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiHeaderLink dataSourceComponentButtonTitle"
-          data-test-subj="dataSourceSelectableContextMenuHeaderLink"
+          aria-label="dataSourceSelectableButton"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small dataSourceComponentButtonTitle"
+          data-test-subj="dataSourceSelectableButton"
           type="button"
         >
           <span

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
@@ -12,8 +12,6 @@ import { AuthType } from '../../types';
 import { getDataSourcesWithFieldsResponse, mockResponseForSavedObjectsCalls } from '../../mocks';
 import { render } from '@testing-library/react';
 import * as utils from '../utils';
-import { EuiSelectable } from '@elastic/eui';
-import { dataSourceOptionGroupLabel } from '../utils';
 
 describe('DataSourceSelectable', () => {
   let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
@@ -103,7 +101,7 @@ describe('DataSourceSelectable', () => {
 
     await nextTick();
 
-    const button = await container.findByTestId('dataSourceSelectableContextMenuHeaderLink');
+    const button = await container.findByTestId('dataSourceSelectableButton');
     button.click();
 
     expect(container.getByTestId('dataSourceSelectableContextMenuPopover')).toBeVisible();
@@ -192,7 +190,7 @@ describe('DataSourceSelectable', () => {
     );
 
     await nextTick();
-    const button = await container.findByTestId('dataSourceSelectableContextMenuHeaderLink');
+    const button = await container.findByTestId('dataSourceSelectableButton');
     expect(button).toHaveTextContent('test2');
   });
 
@@ -211,7 +209,7 @@ describe('DataSourceSelectable', () => {
       />
     );
     await nextTick();
-    const button = await container.findByTestId('dataSourceSelectableContextMenuHeaderLink');
+    const button = await container.findByTestId('dataSourceSelectableButton');
     expect(button).toHaveTextContent('test2');
   });
 
@@ -230,7 +228,7 @@ describe('DataSourceSelectable', () => {
       />
     );
     await nextTick();
-    const button = await container.findByTestId('dataSourceSelectableContextMenuHeaderLink');
+    const button = await container.findByTestId('dataSourceSelectableButton');
     expect(button).toHaveTextContent('');
     expect(toasts.addWarning).toBeCalledWith('Data source with id: undefined is not available');
   });
@@ -250,7 +248,7 @@ describe('DataSourceSelectable', () => {
       />
     );
     await nextTick();
-    const button = await container.findByTestId('dataSourceSelectableContextMenuHeaderLink');
+    const button = await container.findByTestId('dataSourceSelectableButton');
     expect(button).toHaveTextContent('');
     expect(toasts.addWarning).toBeCalledWith('Data source with id: undefined is not available');
   });

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -9,7 +9,6 @@ import {
   EuiPopover,
   EuiContextMenuPanel,
   EuiPanel,
-  EuiButtonEmpty,
   EuiSelectable,
   EuiPopoverTitle,
 } from '@elastic/eui';
@@ -37,7 +36,7 @@ import './data_source_selectable.scss';
 import { DataSourceDropDownHeader } from '../drop_down_header';
 import '../button_title.scss';
 import './data_source_selectable.scss';
-import { PopoverButton } from '../popover_button/popover_button';
+import { DataSourceMenuPopoverButton } from '../popover_button/popover_button';
 
 interface DataSourceSelectableProps {
   savedObjectsClient: SavedObjectsClientContract;
@@ -261,7 +260,7 @@ export class DataSourceSelectable extends React.Component<
         initialFocus={'.euiSelectableSearch'}
         id={'dataSourceSelectableContextMenuPopover'}
         button={
-          <PopoverButton
+          <DataSourceMenuPopoverButton
             className={'dataSourceSelectable'}
             label={label}
             onClick={this.onClick.bind(this)}

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -37,6 +37,7 @@ import './data_source_selectable.scss';
 import { DataSourceDropDownHeader } from '../drop_down_header';
 import '../button_title.scss';
 import './data_source_selectable.scss';
+import { PopoverButton } from '../popover_button/popover_button';
 
 interface DataSourceSelectableProps {
   savedObjectsClient: SavedObjectsClientContract;
@@ -249,32 +250,23 @@ export class DataSourceSelectable extends React.Component<
       return <DataSourceErrorMenu application={this.props.application} />;
     }
 
-    const button = (
-      <>
-        <EuiButtonEmpty
-          className={'euiHeaderLink dataSourceComponentButtonTitle'}
-          onClick={this.onClick.bind(this)}
-          data-test-subj="dataSourceSelectableContextMenuHeaderLink"
-          aria-label={i18n.translate('dataSourceSelectable.dataSourceOptionsButtonAriaLabel', {
-            defaultMessage: 'dataSourceMenuButton',
-          })}
-          iconType="database"
-          iconSide="left"
-          size="s"
-          disabled={this.props.disabled || false}
-        >
-          {this.state.selectedOption &&
-            this.state.selectedOption.length > 0 &&
-            this.state.selectedOption[0]?.label}
-        </EuiButtonEmpty>
-      </>
-    );
+    const label =
+      (this.state.selectedOption &&
+        this.state.selectedOption.length > 0 &&
+        this.state.selectedOption[0]?.label) ||
+      '';
 
     return (
       <EuiPopover
         initialFocus={'.euiSelectableSearch'}
         id={'dataSourceSelectableContextMenuPopover'}
-        button={button}
+        button={
+          <PopoverButton
+            className={'dataSourceSelectable'}
+            label={label}
+            onClick={this.onClick.bind(this)}
+          />
+        }
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover.bind(this)}
         panelPaddingSize="none"

--- a/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`DataSourceView Should render successfully when provided datasource has 
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <PopoverButton
+    <DataSourceMenuPopoverButton
       className="dataSourceView"
       label=""
       onClick={[Function]}
@@ -32,7 +32,6 @@ exports[`DataSourceView Should render successfully when provided datasource has 
       paddingSize="none"
     >
       <EuiSelectable
-        compressed={true}
         data-test-subj="dataSourceView"
         isPreFiltered={false}
         options={
@@ -59,117 +58,7 @@ exports[`DataSourceView Should return error when provided datasource has been fi
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <React.Fragment>
-      <EuiButtonEmpty
-        aria-label="dataSourceViewButton"
-        className="dataSourceComponentButtonTitle"
-        data-test-subj="dataSourceViewButton"
-        iconSide="left"
-        iconType="database"
-        onClick={[Function]}
-        size="s"
-      >
-        
-      </EuiButtonEmpty>
-    </React.Fragment>
-  }
-  closePopover={[Function]}
-  display="inlineBlock"
-  hasArrow={true}
-  id="dataSourceViewPopover"
-  isOpen={false}
-  ownFocus={true}
-  panelPaddingSize="none"
->
-  <DataSourceDropDownHeader
-    totalDataSourceCount={1}
-  />
-  <EuiContextMenuPanel
-    className="dataSourceViewOuiPanel"
-    hasFocus={true}
-    items={Array []}
-  >
-    <EuiPanel
-      borderRadius="none"
-      color="subdued"
-      paddingSize="none"
-    >
-      <EuiSelectable
-        compressed={true}
-        data-test-subj="dataSourceView"
-        isPreFiltered={false}
-        options={Array []}
-        renderOption={[Function]}
-        searchable={false}
-        singleSelection={true}
-      >
-        <Component />
-      </EuiSelectable>
-    </EuiPanel>
-  </EuiContextMenuPanel>
-</EuiPopover>
-`;
-
-exports[`DataSourceView When selected option is local cluster and hide local Cluster is true, should return error 1`] = `
-<EuiPopover
-  anchorPosition="downLeft"
-  button={
-    <React.Fragment>
-      <EuiButtonEmpty
-        aria-label="dataSourceViewButton"
-        className="dataSourceComponentButtonTitle"
-        data-test-subj="dataSourceViewButton"
-        iconSide="left"
-        iconType="database"
-        onClick={[Function]}
-        size="s"
-      >
-        
-      </EuiButtonEmpty>
-    </React.Fragment>
-  }
-  closePopover={[Function]}
-  display="inlineBlock"
-  hasArrow={true}
-  id="dataSourceViewPopover"
-  isOpen={false}
-  ownFocus={true}
-  panelPaddingSize="none"
->
-  <DataSourceDropDownHeader
-    totalDataSourceCount={1}
-  />
-  <EuiContextMenuPanel
-    className="dataSourceViewOuiPanel"
-    hasFocus={true}
-    items={Array []}
-  >
-    <EuiPanel
-      borderRadius="none"
-      color="subdued"
-      paddingSize="none"
-    >
-      <EuiSelectable
-        compressed={true}
-        data-test-subj="dataSourceView"
-        isPreFiltered={false}
-        options={Array []}
-        renderOption={[Function]}
-        searchable={false}
-        singleSelection={true}
-      >
-        <Component />
-      </EuiSelectable>
-    </EuiPanel>
-  </EuiContextMenuPanel>
-</EuiPopover>
-`;
-
-exports[`DataSourceView should call getDataSourceById when only pass id with no label 1`] = `
-<EuiPopover
-  anchorPosition="downLeft"
-  button={
-    <PopoverButton
+    <DataSourceMenuPopoverButton
       className="dataSourceView"
       label=""
       onClick={[Function]}
@@ -197,7 +86,98 @@ exports[`DataSourceView should call getDataSourceById when only pass id with no 
       paddingSize="none"
     >
       <EuiSelectable
-        compressed={true}
+        data-test-subj="dataSourceView"
+        isPreFiltered={false}
+        options={Array []}
+        renderOption={[Function]}
+        searchable={false}
+        singleSelection={true}
+      >
+        <Component />
+      </EuiSelectable>
+    </EuiPanel>
+  </EuiContextMenuPanel>
+</EuiPopover>
+`;
+
+exports[`DataSourceView When selected option is local cluster and hide local Cluster is true, should return error 1`] = `
+<EuiPopover
+  anchorPosition="downLeft"
+  button={
+    <DataSourceMenuPopoverButton
+      className="dataSourceView"
+      label=""
+      onClick={[Function]}
+    />
+  }
+  closePopover={[Function]}
+  display="inlineBlock"
+  hasArrow={true}
+  id="dataSourceViewPopover"
+  isOpen={false}
+  ownFocus={true}
+  panelPaddingSize="none"
+>
+  <DataSourceDropDownHeader
+    totalDataSourceCount={1}
+  />
+  <EuiContextMenuPanel
+    className="dataSourceViewOuiPanel"
+    hasFocus={true}
+    items={Array []}
+  >
+    <EuiPanel
+      borderRadius="none"
+      color="subdued"
+      paddingSize="none"
+    >
+      <EuiSelectable
+        data-test-subj="dataSourceView"
+        isPreFiltered={false}
+        options={Array []}
+        renderOption={[Function]}
+        searchable={false}
+        singleSelection={true}
+      >
+        <Component />
+      </EuiSelectable>
+    </EuiPanel>
+  </EuiContextMenuPanel>
+</EuiPopover>
+`;
+
+exports[`DataSourceView should call getDataSourceById when only pass id with no label 1`] = `
+<EuiPopover
+  anchorPosition="downLeft"
+  button={
+    <DataSourceMenuPopoverButton
+      className="dataSourceView"
+      label=""
+      onClick={[Function]}
+    />
+  }
+  closePopover={[Function]}
+  display="inlineBlock"
+  hasArrow={true}
+  id="dataSourceViewPopover"
+  isOpen={false}
+  ownFocus={true}
+  panelPaddingSize="none"
+>
+  <DataSourceDropDownHeader
+    totalDataSourceCount={1}
+  />
+  <EuiContextMenuPanel
+    className="dataSourceViewOuiPanel"
+    hasFocus={true}
+    items={Array []}
+  >
+    <EuiPanel
+      borderRadius="none"
+      color="subdued"
+      paddingSize="none"
+    >
+      <EuiSelectable
         data-test-subj="dataSourceView"
         isPreFiltered={false}
         options={
@@ -226,7 +206,7 @@ exports[`DataSourceView should render normally with local cluster not hidden 1`]
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <PopoverButton
+    <DataSourceMenuPopoverButton
       className="dataSourceView"
       label="test1"
       onClick={[Function]}
@@ -254,7 +234,6 @@ exports[`DataSourceView should render normally with local cluster not hidden 1`]
       paddingSize="none"
     >
       <EuiSelectable
-        compressed={true}
         data-test-subj="dataSourceView"
         isPreFiltered={false}
         options={

--- a/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
@@ -4,17 +4,11 @@ exports[`DataSourceView Should render successfully when provided datasource has 
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <React.Fragment>
-      <EuiButtonEmpty
-        aria-label="dataSourceViewButton"
-        className="dataSourceComponentButtonTitle"
-        data-test-subj="dataSourceViewButton"
-        iconSide="left"
-        iconType="database"
-        onClick={[Function]}
-        size="s"
-      />
-    </React.Fragment>
+    <PopoverButton
+      className="dataSourceView"
+      label=""
+      onClick={[Function]}
+    />
   }
   closePopover={[Function]}
   display="inlineBlock"
@@ -175,17 +169,11 @@ exports[`DataSourceView should call getDataSourceById when only pass id with no 
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <React.Fragment>
-      <EuiButtonEmpty
-        aria-label="dataSourceViewButton"
-        className="dataSourceComponentButtonTitle"
-        data-test-subj="dataSourceViewButton"
-        iconSide="left"
-        iconType="database"
-        onClick={[Function]}
-        size="s"
-      />
-    </React.Fragment>
+    <PopoverButton
+      className="dataSourceView"
+      label=""
+      onClick={[Function]}
+    />
   }
   closePopover={[Function]}
   display="inlineBlock"
@@ -238,19 +226,11 @@ exports[`DataSourceView should render normally with local cluster not hidden 1`]
 <EuiPopover
   anchorPosition="downLeft"
   button={
-    <React.Fragment>
-      <EuiButtonEmpty
-        aria-label="dataSourceViewButton"
-        className="dataSourceComponentButtonTitle"
-        data-test-subj="dataSourceViewButton"
-        iconSide="left"
-        iconType="database"
-        onClick={[Function]}
-        size="s"
-      >
-        test1
-      </EuiButtonEmpty>
-    </React.Fragment>
+    <PopoverButton
+      className="dataSourceView"
+      label="test1"
+      onClick={[Function]}
+    />
   }
   closePopover={[Function]}
   display="inlineBlock"

--- a/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
@@ -25,6 +25,7 @@ import { DataSourceDropDownHeader } from '../drop_down_header';
 import { DataSourceItem } from '../data_source_item';
 import { LocalCluster } from '../constants';
 import './data_source_view.scss';
+import { PopoverButton } from '../popover_button/popover_button';
 
 interface DataSourceViewProps {
   fullWidth: boolean;
@@ -141,7 +142,10 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
     if (this.state.showError) {
       return <DataSourceErrorMenu application={this.props.application} />;
     }
-    const label = this.state.selectedOption.length > 0 ? this.state.selectedOption[0].label : '';
+    const label =
+      this.state.selectedOption.length > 0 && this.state.selectedOption[0].label
+        ? this.state.selectedOption[0].label
+        : '';
     const options =
       this.state.selectedOption.length > 0
         ? this.state.selectedOption.map((option) => ({
@@ -151,28 +155,16 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
           }))
         : [];
 
-    const button = (
-      <>
-        <EuiButtonEmpty
-          className="dataSourceComponentButtonTitle"
-          data-test-subj="dataSourceViewButton"
-          onClick={this.onClick.bind(this)}
-          aria-label={i18n.translate('dataSourceView.dataSourceOptionsViewAriaLabel', {
-            defaultMessage: 'dataSourceViewButton',
-          })}
-          iconType="database"
-          iconSide="left"
-          size="s"
-        >
-          {label}
-        </EuiButtonEmpty>
-      </>
-    );
-
     return (
       <EuiPopover
         id={'dataSourceViewPopover'}
-        button={button}
+        button={
+          <PopoverButton
+            className={'dataSourceView'}
+            label={label}
+            onClick={this.onClick.bind(this)}
+          />
+        }
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover.bind(this)}
         panelPaddingSize="none"

--- a/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
@@ -25,7 +25,7 @@ import { DataSourceDropDownHeader } from '../drop_down_header';
 import { DataSourceItem } from '../data_source_item';
 import { LocalCluster } from '../constants';
 import './data_source_view.scss';
-import { PopoverButton } from '../popover_button/popover_button';
+import { DataSourceMenuPopoverButton } from '../popover_button/popover_button';
 
 interface DataSourceViewProps {
   fullWidth: boolean;
@@ -159,7 +159,7 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
       <EuiPopover
         id={'dataSourceViewPopover'}
         button={
-          <PopoverButton
+          <DataSourceMenuPopoverButton
             className={'dataSourceView'}
             label={label}
             onClick={this.onClick.bind(this)}
@@ -177,7 +177,6 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
               options={options}
               singleSelection={true}
               data-test-subj={'dataSourceView'}
-              compressed={true}
               renderOption={(option) => (
                 <DataSourceItem
                   option={option}

--- a/src/plugins/data_source_management/public/components/popover_button/popover_button.test.tsx
+++ b/src/plugins/data_source_management/public/components/popover_button/popover_button.test.tsx
@@ -5,24 +5,28 @@
 
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { PopoverButton } from './popover_button';
+import { DataSourceMenuPopoverButton } from './popover_button';
 
 describe('Test on PopoverButton', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
   it('renders without crashing', () => {
-    shallow(<PopoverButton className="random" label="button-name" onClick={jest.fn()} />);
+    shallow(
+      <DataSourceMenuPopoverButton className="random" label="button-name" onClick={jest.fn()} />
+    );
   });
 
   it('renders the label correctly', () => {
     const label = 'Test Label';
-    const component = mount(<PopoverButton className="random" label={label} onClick={jest.fn()} />);
+    const component = mount(
+      <DataSourceMenuPopoverButton className="random" label={label} onClick={jest.fn()} />
+    );
     expect(component.find('EuiButtonEmpty').text()).toBe(label);
   });
 
   it('calls onClick when button is clicked', () => {
-    const component = mount(<PopoverButton className="random" onClick={jest.fn()} />);
+    const component = mount(<DataSourceMenuPopoverButton className="random" onClick={jest.fn()} />);
     component.find('.dataSourceComponentButtonTitle').first().simulate('click');
     expect(component.find('EuiButtonEmpty').text()).toBe('');
   });

--- a/src/plugins/data_source_management/public/components/popover_button/popover_button.test.tsx
+++ b/src/plugins/data_source_management/public/components/popover_button/popover_button.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { PopoverButton } from './popover_button';
+
+describe('Test on PopoverButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('renders without crashing', () => {
+    shallow(<PopoverButton className="random" label="button-name" onClick={jest.fn()} />);
+  });
+
+  it('renders the label correctly', () => {
+    const label = 'Test Label';
+    const component = mount(<PopoverButton className="random" label={label} onClick={jest.fn()} />);
+    expect(component.find('EuiButtonEmpty').text()).toBe(label);
+  });
+
+  it('calls onClick when button is clicked', () => {
+    const component = mount(<PopoverButton className="random" onClick={jest.fn()} />);
+    component.find('.dataSourceComponentButtonTitle').first().simulate('click');
+    expect(component.find('EuiButtonEmpty').text()).toBe('');
+  });
+});

--- a/src/plugins/data_source_management/public/components/popover_button/popover_button.tsx
+++ b/src/plugins/data_source_management/public/components/popover_button/popover_button.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import React from 'react';
+import { EuiButtonEmpty } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+
+interface PopoverButtonProps {
+  className: string;
+  label?: string;
+  onClick: () => void;
+}
+
+export const PopoverButton: React.FC<PopoverButtonProps> = ({ className, label, onClick }) => {
+  return (
+    <>
+      <EuiButtonEmpty
+        className={`dataSourceComponentButtonTitle`}
+        data-test-subj={`${className}Button`}
+        onClick={onClick}
+        aria-label={i18n.translate(`${className}.dataSourceOptionsViewAriaLabel`, {
+          defaultMessage: `${className}Button`,
+        })}
+        iconType="database"
+        iconSide="left"
+        size="s"
+      >
+        {label ? label : null}
+      </EuiButtonEmpty>
+    </>
+  );
+};

--- a/src/plugins/data_source_management/public/components/popover_button/popover_button.tsx
+++ b/src/plugins/data_source_management/public/components/popover_button/popover_button.tsx
@@ -6,13 +6,17 @@ import React from 'react';
 import { EuiButtonEmpty } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 
-interface PopoverButtonProps {
+interface DataSourceMenuPopoverButtonProps {
   className: string;
   label?: string;
   onClick: () => void;
 }
 
-export const PopoverButton: React.FC<PopoverButtonProps> = ({ className, label, onClick }) => {
+export const DataSourceMenuPopoverButton: React.FC<DataSourceMenuPopoverButtonProps> = ({
+  className,
+  label,
+  onClick,
+}) => {
   return (
     <>
       <EuiButtonEmpty


### PR DESCRIPTION
### Description

Extract the button component for datasource picker to avoid duplicate code

## Screenshot
<img width="347" alt="Screenshot 2024-04-19 at 11 07 44 AM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/4979dbd7-cbe0-4f13-b529-c0388dd25aa3">
<img width="330" alt="Screenshot 2024-04-19 at 11 07 51 AM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/abfd835e-a448-408d-8104-25f156423b8b">
<img width="306" alt="Screenshot 2024-04-19 at 11 07 58 AM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/a01a9881-6795-4903-a7f2-567d3156e77e">


## Testing the changes
* Add multiple datasources and click on button to see if it work as expected

## Changelog
- fix: Extract the button component for datasource picker to avoid duplicate code


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
