### PR TITLE
[MDS] Update Selectable props

### DIFF
--- a/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
@@ -45,6 +45,11 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
         aria-label="Search"
         data-test-subj="dataSourceSelectable"
         isPreFiltered={false}
+        listProps={
+          Object {
+            "onFocusBadge": false,
+          }
+        }
         onChange={[Function]}
         options={
           Array [
@@ -71,7 +76,7 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
           }
         }
         searchable={true}
-        singleSelection={true}
+        singleSelection="always"
       >
         <Component />
       </EuiSelectable>
@@ -123,6 +128,11 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
         aria-label="Search"
         data-test-subj="dataSourceSelectable"
         isPreFiltered={false}
+        listProps={
+          Object {
+            "onFocusBadge": false,
+          }
+        }
         onChange={[Function]}
         options={Array []}
         renderOption={[Function]}
@@ -133,7 +143,7 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
           }
         }
         searchable={true}
-        singleSelection={true}
+        singleSelection="always"
       >
         <Component />
       </EuiSelectable>
@@ -185,6 +195,11 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
         aria-label="Search"
         data-test-subj="dataSourceSelectable"
         isPreFiltered={false}
+        listProps={
+          Object {
+            "onFocusBadge": false,
+          }
+        }
         onChange={[Function]}
         options={Array []}
         renderOption={[Function]}
@@ -195,7 +210,7 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
           }
         }
         searchable={true}
-        singleSelection={true}
+        singleSelection="always"
       >
         <Component />
       </EuiSelectable>

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -286,9 +286,12 @@ export class DataSourceSelectable extends React.Component<
                 placeholder: 'Search',
                 compressed: true,
               }}
+              listProps={{
+                onFocusBadge: false,
+              }}
               options={this.state.dataSourceOptions}
               onChange={(newOptions) => this.onChange(newOptions)}
-              singleSelection={true}
+              singleSelection={'always'}
               data-test-subj={'dataSourceSelectable'}
               renderOption={(option) => (
                 <DataSourceItem


### PR DESCRIPTION
### Description

Disables the keyboard icon badge in the `DataSourceSelectable` component. Also sets the `singleSelection` to `"always"`.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/45518171-ed68-4013-b913-b4c39bbf8323

## Testing the changes

Clicked and used `Tab` + arrow keys to check that the icon is disabled.

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
