### PR TITLE
[Workspace] Make dashboards management available

### DIFF
--- a/src/plugins/workspace/opensearch_dashboards.json
+++ b/src/plugins/workspace/opensearch_dashboards.json
@@ -5,8 +5,9 @@
   "ui": true,
   "requiredPlugins": [
     "savedObjects",
-    "opensearchDashboardsReact"
+    "opensearchDashboardsReact",
+    "management"
   ],
-  "optionalPlugins": ["savedObjectsManagement","management"],
+  "optionalPlugins": ["savedObjectsManagement"],
   "requiredBundles": ["opensearchDashboardsReact"]
 }

--- a/src/plugins/workspace/opensearch_dashboards.json
+++ b/src/plugins/workspace/opensearch_dashboards.json
@@ -7,6 +7,6 @@
     "savedObjects",
     "opensearchDashboardsReact"
   ],
-  "optionalPlugins": ["savedObjectsManagement", "management"],
+  "optionalPlugins": ["savedObjectsManagement","management"],
   "requiredBundles": ["opensearchDashboardsReact"]
 }

--- a/src/plugins/workspace/opensearch_dashboards.json
+++ b/src/plugins/workspace/opensearch_dashboards.json
@@ -5,9 +5,8 @@
   "ui": true,
   "requiredPlugins": [
     "savedObjects",
-    "opensearchDashboardsReact",
-    "management"
+    "opensearchDashboardsReact"
   ],
-  "optionalPlugins": ["savedObjectsManagement"],
+  "optionalPlugins": ["savedObjectsManagement", "management"],
   "requiredBundles": ["opensearchDashboardsReact"]
 }

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -3,8 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AppNavLinkStatus } from '../../../core/public';
-import { featureMatchesConfig, isAppAccessibleInWorkspace } from './utils';
+import { AppNavLinkStatus, PublicAppInfo } from '../../../core/public';
+import {
+  featureMatchesConfig,
+  filterWorkspaceConfigurableApps,
+  isAppAccessibleInWorkspace,
+} from './utils';
 
 describe('workspace utils: featureMatchesConfig', () => {
   it('feature configured with `*` should match any features', () => {
@@ -147,5 +151,70 @@ describe('workspace utils: isAppAccessibleInWorkspace', () => {
         { id: 'workspace_id', name: 'workspace name', features: [] }
       )
     ).toBe(true);
+  });
+});
+
+describe('workspace utils: filterWorkspaceConfigurableApps', () => {
+  const defaultApplications = [
+    {
+      appRoute: '/app/dashboards',
+      id: 'dashboards',
+      title: 'Dashboards',
+      category: {
+        id: 'opensearchDashboards',
+        label: 'OpenSearch Dashboards',
+        euiIconType: 'inputOutput',
+        order: 1000,
+      },
+      status: 0,
+      navLinkStatus: 1,
+    },
+    {
+      appRoute: '/app/dev_tools',
+      id: 'dev_tools',
+      title: 'Dev Tools',
+      category: {
+        id: 'management',
+        label: 'Management',
+        order: 5000,
+        euiIconType: 'managementApp',
+      },
+      status: 0,
+      navLinkStatus: 1,
+    },
+    {
+      appRoute: '/app/opensearch_dashboards_overview',
+      id: 'opensearchDashboardsOverview',
+      title: 'Overview',
+      category: {
+        id: 'opensearchDashboards',
+        label: 'Library',
+        euiIconType: 'inputOutput',
+        order: 1000,
+      },
+      navLinkStatus: 1,
+      order: -2000,
+      status: 0,
+    },
+    {
+      appRoute: '/app/management',
+      id: 'management',
+      title: 'Dashboards Management',
+      category: {
+        id: 'management',
+        label: 'Management',
+        order: 5000,
+        euiIconType: 'managementApp',
+      },
+      status: 0,
+      navLinkStatus: 1,
+    },
+  ] as PublicAppInfo[];
+  it('should filters out apps that are not accessible in the workspace', () => {
+    const filteredApps = filterWorkspaceConfigurableApps(defaultApplications);
+    expect(filteredApps.length).toEqual(3);
+    expect(filteredApps[0].id).toEqual('dashboards');
+    expect(filteredApps[1].id).toEqual('opensearchDashboardsOverview');
+    expect(filteredApps[2].id).toEqual('management');
   });
 });

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -12,7 +12,6 @@ import {
   WorkspaceObject,
 } from '../../../core/public';
 import { DEFAULT_SELECTED_FEATURES_IDS } from '../common/constants';
-import { MANAGEMENT_APP_ID } from '../../management/public';
 
 /**
  * Checks if a given feature matches the provided feature configuration.
@@ -119,7 +118,7 @@ export const filterWorkspaceConfigurableApps = (applications: PublicAppInfo[]) =
     // If the category is management, only retain Dashboards Management which contains saved objets and index patterns.
     // Saved objets can show all saved objects in the current workspace and index patterns is at workspace level.
     if (category?.id === DEFAULT_APP_CATEGORIES.management.id) {
-      return filterCondition && id === MANAGEMENT_APP_ID;
+      return filterCondition && id === 'management';
     }
     return filterCondition;
   });

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -118,7 +118,7 @@ export const filterWorkspaceConfigurableApps = (applications: PublicAppInfo[]) =
       !DEFAULT_SELECTED_FEATURES_IDS.includes(id);
     // If the category is management, only retain dashboards management.
     if (category?.id === DEFAULT_APP_CATEGORIES.management.id) {
-      return filterCondition && id === 'MANAGEMENT_APP_ID';
+      return filterCondition && id === MANAGEMENT_APP_ID;
     }
     return filterCondition;
   });

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -108,14 +108,18 @@ export function isAppAccessibleInWorkspace(app: App, workspace: WorkspaceObject)
   return false;
 }
 
+// Get all apps that should be displayed in workspace when create/update a workspace.
 export const filterWorkspaceConfigurableApps = (applications: PublicAppInfo[]) => {
   const visibleApplications = applications.filter(({ navLinkStatus, chromeless, category, id }) => {
-    return (
+    const filterCondition =
       navLinkStatus !== AppNavLinkStatus.hidden &&
       !chromeless &&
-      !DEFAULT_SELECTED_FEATURES_IDS.includes(id) &&
-      category?.id !== DEFAULT_APP_CATEGORIES.management.id
-    );
+      !DEFAULT_SELECTED_FEATURES_IDS.includes(id);
+    // If the category is management, only retain dashboards management.
+    if (category?.id === DEFAULT_APP_CATEGORIES.management.id) {
+      return filterCondition && id === 'management';
+    }
+    return filterCondition;
   });
 
   return visibleApplications;

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -116,7 +116,8 @@ export const filterWorkspaceConfigurableApps = (applications: PublicAppInfo[]) =
       navLinkStatus !== AppNavLinkStatus.hidden &&
       !chromeless &&
       !DEFAULT_SELECTED_FEATURES_IDS.includes(id);
-    // If the category is management, only retain dashboards management.
+    // If the category is management, only retain Dashboards Management which contains saved objets and index patterns.
+    // Saved objets can show all saved objects in the current workspace and index patterns is at workspace level.
     if (category?.id === DEFAULT_APP_CATEGORIES.management.id) {
       return filterCondition && id === MANAGEMENT_APP_ID;
     }

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -12,6 +12,7 @@ import {
   WorkspaceObject,
 } from '../../../core/public';
 import { DEFAULT_SELECTED_FEATURES_IDS } from '../common/constants';
+import { MANAGEMENT_APP_ID } from '../../management/public';
 
 /**
  * Checks if a given feature matches the provided feature configuration.
@@ -117,7 +118,7 @@ export const filterWorkspaceConfigurableApps = (applications: PublicAppInfo[]) =
       !DEFAULT_SELECTED_FEATURES_IDS.includes(id);
     // If the category is management, only retain dashboards management.
     if (category?.id === DEFAULT_APP_CATEGORIES.management.id) {
-      return filterCondition && id === 'management';
+      return filterCondition && id === 'MANAGEMENT_APP_ID';
     }
     return filterCondition;
   });


### PR DESCRIPTION
### Description

User can choose the feature of Dashboards Management when user create/update a workspace.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6574

## Screenshot

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/71875999/df2d18b5-e6ce-4a9d-b49f-c5d2f20c5b1a)

## Testing the changes

1. Clone the latest code and run yarn osd bootstrap
2. Modify config/opensearch_dashboards.yml, add workspace.enabled: true
3. Run yarn start --no-base-path
4. Create a workspace choose the feature of Dashboard Management

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace] Make dashboards management available

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
