### PR TITLE
Fix wrong data source management filter id

### DIFF
--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -113,7 +113,7 @@ export class WorkspacePlugin implements Plugin<{}, {}, WorkspacePluginSetupDeps>
     this.managementCurrentWorkspaceIdSubscription = currentWorkspaceId$.subscribe(
       (currentWorkspaceId) => {
         if (currentWorkspaceId) {
-          ['settings', 'dataSources'].forEach((appId) =>
+          ['settings', 'dataSourceManagement'].forEach((appId) =>
             management.sections.section.opensearchDashboards.getApp(appId)?.disable()
           );
         }


### PR DESCRIPTION
### Description

When user is in workspace ,dashboard management section will filter data source management menu. Currently the filter logic judges wrong id, which is data source instead data source management.

## Screenshot

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/42465692/115c6156-a530-4b7b-83b3-f0fa2f68971d)


## Changelog
- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
