### PR TITLE
[Workspace] Hide dashboard overview

### DIFF
--- a/changelogs/fragments/6625.yml
+++ b/changelogs/fragments/6625.yml
@@ -1,0 +1,2 @@
+fix:
+- [Workspace] Hide dashboard overview ([#6625](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6625))

--- a/changelogs/fragments/6625.yml
+++ b/changelogs/fragments/6625.yml
@@ -1,2 +1,2 @@
-fix:
+feat:
 - [Workspace] Hide dashboard overview ([#6625](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6625))

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -238,6 +238,7 @@ describe('workspace utils: filterWorkspaceConfigurableApps', () => {
       navLinkStatus: 1,
       order: -2000,
       status: 0,
+      workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
     },
     {
       appRoute: '/app/management',
@@ -255,9 +256,8 @@ describe('workspace utils: filterWorkspaceConfigurableApps', () => {
   ] as PublicAppInfo[];
   it('should filters out apps that are not accessible in the workspace', () => {
     const filteredApps = filterWorkspaceConfigurableApps(defaultApplications);
-    expect(filteredApps.length).toEqual(3);
+    expect(filteredApps.length).toEqual(2);
     expect(filteredApps[0].id).toEqual('dashboards');
-    expect(filteredApps[1].id).toEqual('opensearchDashboardsOverview');
-    expect(filteredApps[2].id).toEqual('management');
+    expect(filteredApps[1].id).toEqual('management');
   });
 });

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -118,18 +118,21 @@ export function isAppAccessibleInWorkspace(app: App, workspace: WorkspaceObject)
 
 // Get all apps that should be displayed in workspace when create/update a workspace.
 export const filterWorkspaceConfigurableApps = (applications: PublicAppInfo[]) => {
-  const visibleApplications = applications.filter(({ navLinkStatus, chromeless, category, id }) => {
-    const filterCondition =
-      navLinkStatus !== AppNavLinkStatus.hidden &&
-      !chromeless &&
-      !DEFAULT_SELECTED_FEATURES_IDS.includes(id);
-    // If the category is management, only retain Dashboards Management which contains saved objets and index patterns.
-    // Saved objets can show all saved objects in the current workspace and index patterns is at workspace level.
-    if (category?.id === DEFAULT_APP_CATEGORIES.management.id) {
-      return filterCondition && id === 'management';
+  const visibleApplications = applications.filter(
+    ({ navLinkStatus, chromeless, category, id, workspaceAvailability }) => {
+      const filterCondition =
+        navLinkStatus !== AppNavLinkStatus.hidden &&
+        !chromeless &&
+        !DEFAULT_SELECTED_FEATURES_IDS.includes(id) &&
+        workspaceAvailability !== WorkspaceAvailability.outsideWorkspace;
+      // If the category is management, only retain Dashboards Management which contains saved objets and index patterns.
+      // Saved objets can show all saved objects in the current workspace and index patterns is at workspace level.
+      if (category?.id === DEFAULT_APP_CATEGORIES.management.id) {
+        return filterCondition && id === 'management';
+      }
+      return filterCondition;
     }
-    return filterCondition;
-  });
+  );
 
   return visibleApplications;
 };


### PR DESCRIPTION
### Description

User can not choose the feature of dashboard overview when create/update a workspace.

### Issues Resolved

closes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6624

## Screenshot

<img width="1032" alt="image" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/71875999/87fc5942-6787-4aa4-b22b-9fd5d92d22a4">


## Testing the changes
1. Clone the latest code and run yarn osd bootstrap
2. Modify config/opensearch_dashboards.yml, add workspace.enabled: true
3. Run yarn start --no-base-path
4. Create/update a workspace

## Changelog
- feat: [Workspace] Hide dashboard overview
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
