### PR TITLE
[Workspace] fix: Navigate to apps by using hard refresh in collasibleNavHeader

### DIFF
--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
@@ -93,7 +93,7 @@ describe('<WorkspaceMenu />', () => {
     render(<WorkspaceMenu coreStart={coreStartMock} />);
     fireEvent.click(screen.getByText(/select a workspace/i));
     fireEvent.click(screen.getByText(/create workspace/i));
-    expect(coreStartMock.application.navigateToApp).toHaveBeenCalledWith('workspace_create');
+    expect(window.location.assign).toHaveBeenCalledWith('https://test.com/app/workspace_create');
 
     Object.defineProperty(window, 'location', {
       value: originalLocation,
@@ -111,7 +111,7 @@ describe('<WorkspaceMenu />', () => {
     render(<WorkspaceMenu coreStart={coreStartMock} />);
     fireEvent.click(screen.getByText(/select a workspace/i));
     fireEvent.click(screen.getByText(/all workspace/i));
-    expect(coreStartMock.application.navigateToApp).toHaveBeenCalledWith('workspace_list');
+    expect(window.location.assign).toHaveBeenCalledWith('https://test.com/app/workspace_list');
 
     Object.defineProperty(window, 'location', {
       value: originalLocation,

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -104,7 +104,13 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
       }),
       key: WORKSPACE_CREATE_APP_ID,
       onClick: () => {
-        coreStart.application.navigateToApp(WORKSPACE_CREATE_APP_ID);
+        window.location.assign(
+          cleanWorkspaceId(
+            coreStart.application.getUrlForApp(WORKSPACE_CREATE_APP_ID, {
+              absolute: false,
+            })
+          )
+        );
       },
     });
     workspaceListItems.push({
@@ -114,7 +120,13 @@ export const WorkspaceMenu = ({ coreStart }: Props) => {
       }),
       key: WORKSPACE_LIST_APP_ID,
       onClick: () => {
-        coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
+        window.location.assign(
+          cleanWorkspaceId(
+            coreStart.application.getUrlForApp(WORKSPACE_LIST_APP_ID, {
+              absolute: false,
+            })
+          )
+        );
       },
     });
     return workspaceListItems;


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Revert the changes inside [src/plugins/workspace/public/components/workspace_menu](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6427/files#diff-907ad2efa095285762230d1f2131f64d24c6f03e80f2a5a1ea4122a73a4cf20b) from #6427 as it introduces a bug that the left navigation won't close after clicking any of the menu inside the collapsedNavHeader.

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
#### Before fix
![20240424110440519](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/8f31c2a9-9461-47cc-9f20-2f0c95d04715)

#### After fix
![20240424110658463](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/38368d29-91e9-4ce6-99d7-eeee108e8fb0)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
