### PR TITLE
Lock Chrome version until ChromeDriver's release pipeline is fixed

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -198,6 +198,28 @@ jobs:
           restore-keys: |
             yarn-
 
+      # Lock Chrome version until ChromeDriver's release pipeline is fixed
+      - name: Download Chrome
+        id: download-chrome
+        uses: abhi1693/setup-browser@v0.3.5
+        with:
+          browser: chrome
+          # v122
+          version: 1250586
+
+      - name: Setup Chrome (Linux)
+        if: matrix.os != 'windows-latest'
+        run: |
+          sudo rm -rf /usr/bin/google-chrome /opt/google/chrome
+          sudo ln -s ${{steps.download-chrome.outputs.path}}/${{steps.download-chrome.outputs.binary}} /usr/bin/google-chrome
+
+      - name: Setup Chrome (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          New-Item -Force -Type Directory "$Env:Programfiles/Google/Chrome/Application"
+          Remove-Item -Recurse -Force "$Env:Programfiles/Google/Chrome/Application/*"
+          Copy-Item -Force -Recurse "${{steps.download-chrome.outputs.path}}/*" "$Env:Programfiles/Google/Chrome/Application"
+
       - name: Setup chromedriver
         run: node scripts/upgrade_chromedriver.js
 
@@ -291,6 +313,28 @@ jobs:
           key: yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             yarn-
+
+      # Lock Chrome version until ChromeDriver's release pipeline is fixed
+      - name: Download Chrome
+        id: download-chrome
+        uses: abhi1693/setup-browser@v0.3.5
+        with:
+          browser: chrome
+          # v122
+          version: 1250586
+
+      - name: Setup Chrome (Linux)
+        if: matrix.os != 'windows-latest'
+        run: |
+          sudo rm -rf /usr/bin/google-chrome /opt/google/chrome
+          sudo ln -s ${{steps.download-chrome.outputs.path}}/${{steps.download-chrome.outputs.binary}} /usr/bin/google-chrome
+
+      - name: Setup Chrome (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          New-Item -Force -Type Directory "$Env:Programfiles/Google/Chrome/Application"
+          Remove-Item -Recurse -Force "$Env:Programfiles/Google/Chrome/Application/*"
+          Copy-Item -Force -Recurse "${{steps.download-chrome.outputs.path}}/*" "$Env:Programfiles/Google/Chrome/Application"
 
       - name: Setup chromedriver
         run: node scripts/upgrade_chromedriver.js


### PR DESCRIPTION
### Description

ChromeDriver hasn't been doing a good job of keeping up with Chrome releases. This has broken our CI. Until confidence in the ChromeDriver release pipeline is restored, this change locks down the version of Chrome we use in our CI.


### The process for identifying the version
1. Look at the ***`Stable`*** column of [Linux](https://chromiumdash.appspot.com/releases?platform=Linux) releases. Linux has a lot less releases than Windows.
2. Hit the ***`i`*** next to the major version you want. From experience, the minor and patch versions don't matter in this process.
3. Take note of ***`Branch Base Position`***. In this case, I was looking for v122 and the number was `1250580`.
4. Open Chromium's snapshot repository for [Windows](https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Win_x64/) and [Linux](https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Linux_x64/). Allow the pages to finish loading the content which can take 15-30 seconds; there is an ugly spinner to let you know it is loading.
5. Enter the Branch Base Position number you took note of on step 3 into the ***`Filter`*** boxes.
6. Remove the right-most digit. It is unlikely that the Branch Base Position number actually matches a snapshot. We will need to look around that number to find an actual snapshot's Branch Base Position number. In this case my filter was `125058`.
7. Find one that exists in both Windows and Linux snapshots. In this case `1250586` was available in both.



## Changelog
- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
