### PR TITLE
[MD] Add endpoint validation to create data source API

### DIFF
--- a/src/plugins/data_source/server/data_source_service.mock.ts
+++ b/src/plugins/data_source/server/data_source_service.mock.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// eslint-disable-next-line @osd/eslint/no-restricted-paths
+import { opensearchClientMock } from '../../../../src/core/server/opensearch/client/mocks';
+import { DataSourceServiceSetup } from './data_source_service';
+
+const dataSourceClient = opensearchClientMock.createInternalClient();
+const create = () =>
+  (({
+    getDataSourceClient: jest.fn(() => Promise.resolve(dataSourceClient)),
+    getDataSourceLegacyClient: jest.fn(),
+  } as unknown) as jest.Mocked<DataSourceServiceSetup>);
+
+export const dataSourceServiceSetupMock = { create };

--- a/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
@@ -16,7 +16,6 @@ import { registerFetchDataSourceMetaDataRoute } from './fetch_data_source_metada
 import { AuthType } from '../../common/data_sources';
 // eslint-disable-next-line @osd/eslint/no-restricted-paths
 import { opensearchClientMock } from '../../../../../src/core/server/opensearch/client/mocks';
-import { index } from 'mathjs';
 
 type SetupServerReturn = UnwrapPromise<ReturnType<typeof setupServer>>;
 

--- a/src/plugins/data_source/server/saved_objects/data_source_saved_objects_client_wrapper.ts
+++ b/src/plugins/data_source/server/saved_objects/data_source_saved_objects_client_wrapper.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  OpenSearchClient,
   SavedObjectsBulkCreateObject,
   SavedObjectsBulkResponse,
   SavedObjectsBulkUpdateObject,
@@ -26,6 +27,10 @@ import {
 import { EncryptionContext, CryptographyServiceSetup } from '../cryptography_service';
 import { isValidURL } from '../util/endpoint_validator';
 import { IAuthenticationMethodRegistry } from '../auth_registry';
+import { DataSourceServiceSetup } from '../data_source_service';
+import { CustomApiSchemaRegistry } from '../schema_registry';
+import { DataSourceConnectionValidator } from '../routes/data_source_connection_validator';
+import { DATA_SOURCE_TITLE_LENGTH_LIMIT } from '../util/constants';
 
 /**
  * Describes the Credential Saved Objects Client Wrapper class,
@@ -139,9 +144,11 @@ export class DataSourceSavedObjectsClientWrapper {
   };
 
   constructor(
+    private dataSourcesService: DataSourceServiceSetup,
     private cryptography: CryptographyServiceSetup,
     private logger: Logger,
     private authRegistryPromise: Promise<IAuthenticationMethodRegistry>,
+    private customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>,
     private endpointBlockedIps?: string[]
   ) {}
 
@@ -252,26 +259,56 @@ export class DataSourceSavedObjectsClientWrapper {
 
   private async validateAttributes<T = unknown>(attributes: T) {
     const { title, endpoint, auth } = attributes;
-    if (!title?.trim?.().length) {
+
+    this.validateTitle(title);
+    await this.validateEndpoint(endpoint, attributes as DataSourceAttributes);
+    await this.validateAuth(auth);
+  }
+
+  private validateTitle(title: string) {
+    if (!title.trim().length) {
       throw SavedObjectsErrorHelpers.createBadRequestError(
         '"title" attribute must be a non-empty string'
       );
     }
 
+    if (title.length > DATA_SOURCE_TITLE_LENGTH_LIMIT) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        `"title" attribute is limited to ${DATA_SOURCE_TITLE_LENGTH_LIMIT} characters`
+      );
+    }
+  }
+
+  private async validateEndpoint(endpoint: string, attributes: DataSourceAttributes) {
     if (!isValidURL(endpoint, this.endpointBlockedIps)) {
       throw SavedObjectsErrorHelpers.createBadRequestError(
         '"endpoint" attribute is not valid or allowed'
       );
     }
+    try {
+      const dataSourceClient: OpenSearchClient = await this.dataSourcesService.getDataSourceClient({
+        savedObjects: {} as any,
+        cryptography: this.cryptography,
+        testClientDataSourceAttr: attributes as DataSourceAttributes,
+        authRegistry: await this.authRegistryPromise,
+        customApiSchemaRegistryPromise: this.customApiSchemaRegistryPromise,
+      });
 
+      const dataSourceValidator = new DataSourceConnectionValidator(dataSourceClient, attributes);
+
+      await dataSourceValidator.validate();
+    } catch (err: any) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        `endpoint is not valid OpenSearch endpoint`
+      );
+    }
+  }
+
+  private async validateAuth<T = unknown>(auth: T) {
     if (!auth) {
       throw SavedObjectsErrorHelpers.createBadRequestError('"auth" attribute is required');
     }
 
-    await this.validateAuth(auth);
-  }
-
-  private async validateAuth<T = unknown>(auth: T) {
     const { type, credentials } = auth;
 
     if (!type) {

--- a/src/plugins/data_source/server/util/constants.ts
+++ b/src/plugins/data_source/server/util/constants.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const DATA_SOURCE_TITLE_LENGTH_LIMIT = 32;


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
 Add endpoint validation to create data source API, by testing if endpoint is reachable, using the same logic as what's behind "test connection" feature

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
#6517 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
![iShot_2024-04-25_15 02 52](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/035c903c-cf33-42b2-a227-349ce64ba05f)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

1. go to create datasource page, and create one with invalid OpenSearch endpoint, e.g. google.com
2. click test connection, it should fail as expected
3. click create data source, it should fail too, as the endpoint is not a valid endpoint
4. switch to use a valid opensearch domain
5. both test connection and create data source should pass

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: Add endpoint validation to create data source API

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
