### PR TITLE
[BUG] Allow Save in Top Nav Menu to capture filter and query

### DIFF
--- a/changelogs/fragments/6636.yml
+++ b/changelogs/fragments/6636.yml
@@ -1,0 +1,2 @@
+fix:
+- [BUG] Allow Save in Top Nav Menu to capture filter and query ([#6636](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6636))


### PR DESCRIPTION
### Description

Before this PR, can't save when filter or query change. 
After this PR: 
1) if the canvas is empty, can not save filter and query updates. This is expected due to empty canvas error `The canvas is empty. Add some aggregations before saving` 
2) if the canvas is not empty, can save filter and query updates.


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/e2c970a1-b6d6-4829-9020-14d8e389878c

3) for embedded vis builder in dashboard, when edit vb, update filter and query can also enable save button


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/ac20eae8-0ded-4817-a56f-24156b0eb75f





### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5645


## Testing the changes
We will need to add some cypress tests. Here is the meta issue to track https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6635

## Changelog
- fix: [BUG] Allow Save in Top Nav Menu to capture filter and query

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
