### PR TITLE
[Workspace] Fix: keep disallowed types when importing with overwrite

### DIFF
--- a/changelogs/fragments/6668.yml
+++ b/changelogs/fragments/6668.yml
@@ -1,0 +1,2 @@
+fix:
+- Keep disallowed types when importing with overwrite ([#6668](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6668))

--- a/src/plugins/workspace/server/saved_objects/integration_tests/saved_objects_wrapper_for_check_workspace_conflict.test.ts
+++ b/src/plugins/workspace/server/saved_objects/integration_tests/saved_objects_wrapper_for_check_workspace_conflict.test.ts
@@ -23,6 +23,12 @@ const dataSource: Omit<SavedObject, 'id'> = {
   references: [],
 };
 
+const indexPattern: Omit<SavedObject, 'id'> = {
+  type: 'index-pattern',
+  attributes: {},
+  references: [],
+};
+
 const advancedSettings: Omit<SavedObject, 'id'> = {
   type: 'config',
   attributes: {},
@@ -437,6 +443,94 @@ describe('saved_objects_wrapper_for_check_workspace_conflict integration test', 
 
       await Promise.all(
         [...createResultFoo.body.saved_objects, ...createResultBar.body.saved_objects].map((item) =>
+          deleteItem({
+            type: item.type,
+            id: item.id,
+          })
+        )
+      );
+    });
+
+    it('checkConflicts when importing disallowed types', async () => {
+      await clearFooAndBar();
+      // Create data source through saved objects client will do a connection validation
+      // Use OpenSearch API to create the saved objects directly
+      await osdTestServer.request
+        .post(root, `/api/console/proxy?path=.kibana%2F_doc%2Fdata-source%3Afoo&method=PUT`)
+        .send({
+          type: dataSource.type,
+          [dataSource.type]: {},
+        })
+        .expect(201);
+
+      await osdTestServer.request
+        .post(root, `/api/saved_objects/${indexPattern.type}/foo`)
+        .send({
+          attributes: indexPattern.attributes,
+          references: [
+            {
+              id: 'foo',
+              type: dataSource.type,
+              name: 'dataSource',
+            },
+          ],
+        })
+        .expect(200);
+
+      const getResultFoo = await getItem({
+        type: dataSource.type,
+        id: 'foo',
+      });
+      const getResultBar = await getItem({
+        type: indexPattern.type,
+        id: 'foo',
+      });
+
+      /**
+       * import with workspaces when conflicts
+       */
+      const importWithWorkspacesResult = await osdTestServer.request
+        .post(
+          root,
+          `/api/saved_objects/_import?workspaces=${createdFooWorkspace.id}&overwrite=true&dataSourceEnabled=true`
+        )
+        .attach(
+          'file',
+          Buffer.from(
+            [JSON.stringify(getResultFoo.body), JSON.stringify(getResultBar.body)].join('\n'),
+            'utf-8'
+          ),
+          'tmp.ndjson'
+        )
+        .expect(200);
+
+      expect(importWithWorkspacesResult.body.success).toEqual(false);
+      expect(importWithWorkspacesResult.body.errors.length).toEqual(1);
+      expect(importWithWorkspacesResult.body.errors[0].id).toEqual('foo');
+      expect(importWithWorkspacesResult.body.errors[0].error.type).toEqual('unknown');
+      expect(importWithWorkspacesResult.body.successCount).toEqual(1);
+
+      const [indexPatternImportResult] = importWithWorkspacesResult.body.successResults;
+      const getImportIndexPattern = await getItem({
+        type: indexPatternImportResult.type,
+        id: indexPatternImportResult.destinationId,
+      });
+
+      // The references to disallowed types should be kept
+      expect(getImportIndexPattern.body.references).toEqual([
+        {
+          id: 'foo',
+          type: dataSource.type,
+          name: 'dataSource',
+        },
+      ]);
+
+      await Promise.all(
+        [
+          { id: 'foo', type: indexPattern.type },
+          { id: 'foo', type: dataSource.type },
+          { id: indexPatternImportResult.destinationId, type: indexPattern.type },
+        ].map((item) =>
           deleteItem({
             type: item.type,
             id: item.id,

--- a/src/plugins/workspace/server/saved_objects/integration_tests/saved_objects_wrapper_for_check_workspace_conflict.test.ts
+++ b/src/plugins/workspace/server/saved_objects/integration_tests/saved_objects_wrapper_for_check_workspace_conflict.test.ts
@@ -453,8 +453,9 @@ describe('saved_objects_wrapper_for_check_workspace_conflict integration test', 
 
     it('checkConflicts when importing disallowed types', async () => {
       await clearFooAndBar();
-      // Create data source through saved objects client will do a connection validation
-      // Use OpenSearch API to create the saved objects directly
+      // Create data source through OpenSearch API directly
+      // or the saved objects API will do connection validation on the data source
+      // which will not pass as it is a dummy data source without endpoint and credentials
       await osdTestServer.request
         .post(root, `/api/console/proxy?path=.kibana%2F_doc%2Fdata-source%3Afoo&method=PUT`)
         .send({

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
@@ -289,11 +289,33 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
         return { errors: [] };
       }
 
+      const { workspaces } = options;
+
+      const disallowedSavedObjects: SavedObjectsCheckConflictsObject[] = [];
+      const allowedSavedObjects: SavedObjectsCheckConflictsObject[] = [];
+      objects.forEach((item) => {
+        const isImportIntoWorkspace = workspaces?.length;
+        // config can not be created inside a workspace
+        if (this.isConfigType(item.type) && isImportIntoWorkspace) {
+          disallowedSavedObjects.push(item);
+          return;
+        }
+
+        // For 2.14, data source can only be created without workspace info
+        if (this.isDataSourceType(item.type) && isImportIntoWorkspace) {
+          disallowedSavedObjects.push(item);
+          return;
+        }
+
+        allowedSavedObjects.push(item);
+        return;
+      });
+
       /**
        * Workspace conflict only happens when target workspaces params present.
        */
       if (options.workspaces) {
-        const bulkGetDocs: any[] = objects.map((object) => {
+        const bulkGetDocs: any[] = allowedSavedObjects.map((object) => {
           const { type, id } = object;
 
           return {
@@ -335,7 +357,7 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
         }
       }
 
-      const objectsNoWorkspaceConflictError = objects.filter(
+      const objectsNoWorkspaceConflictError = allowedSavedObjects.filter(
         (item) =>
           !objectsConflictWithWorkspace.find(
             (errorItems) =>
@@ -355,7 +377,7 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
       /**
        * Bypass those objects that are not conflict on workspaces
        */
-      const realBulkCreateResult = await wrapperOptions.client.checkConflicts(
+      const realCheckConflictsResult = await wrapperOptions.client.checkConflicts(
         objectsNoWorkspaceConflictError,
         options
       );
@@ -364,8 +386,21 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
        * Merge results from two conflict check.
        */
       const result: SavedObjectsCheckConflictsResponse = {
-        ...realBulkCreateResult,
-        errors: [...objectsConflictWithWorkspace, ...realBulkCreateResult.errors],
+        ...realCheckConflictsResult,
+        errors: [
+          ...objectsConflictWithWorkspace,
+          ...disallowedSavedObjects.map((item) => ({
+            ...item,
+            error: {
+              ...SavedObjectsErrorHelpers.decorateBadRequestError(
+                new Error(`'${item.type}' is not allowed to be imported in workspace.`),
+                'Unsupported type in workspace'
+              ).output.payload,
+              metadata: { isNotOverwritable: true },
+            },
+          })),
+          ...(realCheckConflictsResult?.errors || []),
+        ],
       };
 
       return result;

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
@@ -294,7 +294,7 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
       const disallowedSavedObjects: SavedObjectsCheckConflictsObject[] = [];
       const allowedSavedObjects: SavedObjectsCheckConflictsObject[] = [];
       objects.forEach((item) => {
-        const isImportIntoWorkspace = workspaces?.length;
+        const isImportIntoWorkspace = !!workspaces?.length;
         // config can not be created inside a workspace
         if (this.isConfigType(item.type) && isImportIntoWorkspace) {
           disallowedSavedObjects.push(item);


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
When importing data sources and configuration into a workspace with overwrite: true, we will prevent the creation of such objects. However, to ensure that objects dependent on the disallowed ones continue to function properly, we must leave their references untouched.

#### How the changes can keep the references untouched.
When user tries to import with `overwrite: true`, the logic will go into https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/core/server/saved_objects/import/check_conflicts.ts#L90, and in order to keep the references untouched, we just need to make sure the logic won't go into the branch of https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/core/server/saved_objects/import/check_conflicts.ts#L105 , which sets a new id reference to the current item. And the result it is consumed comes from the `savedObjectsClient.checkConflicts()`, which can be wrapped by savedObjectsClientWrapper mechanism to intercept special logic on specific objects.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
### Before fix
![20240429125045381](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/782f80a7-4fed-49b9-8103-dd9d3402b267)

### After fix
![20240429125522801](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/967151b9-9c24-4bfe-a799-e29a3a0df1d9)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
There is a integration test case, named `checkConflicts when importing disallowed types` inside `src/plugins/workspace/server/saved_objects/integration_tests/saved_objects_wrapper_for_check_workspace_conflict.test.ts` to cover this case.

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: keep disallowed types when importing with overwrite

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
