### PR TITLE
[Workspace] Fix: optimization on handling invalid workspace id in workspace_ui_settings wrapper

### DIFF
--- a/changelogs/fragments/6669.yml
+++ b/changelogs/fragments/6669.yml
@@ -1,0 +1,2 @@
+fix:
+- Optimization on handling invalid workspace id in workspace_ui_settings wrapper ([#6669](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6669))

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -94,7 +94,7 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     );
     this.proxyWorkspaceTrafficToRealHandler(core);
 
-    const workspaceUiSettingsClientWrapper = new WorkspaceUiSettingsClientWrapper();
+    const workspaceUiSettingsClientWrapper = new WorkspaceUiSettingsClientWrapper(this.logger);
     this.workspaceUiSettingsClientWrapper = workspaceUiSettingsClientWrapper;
     core.savedObjects.addClientWrapper(
       PRIORITY_FOR_WORKSPACE_UI_SETTINGS_WRAPPER,

--- a/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.test.ts
@@ -172,7 +172,7 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
       type: 'config',
     });
     expect(logger.error).toBeCalledWith(
-      `Unable to get workspaceObject on id: ${invalidWorkspaceId}`
+      `Unable to get workspaceObject with id: ${invalidWorkspaceId}`
     );
   });
 });

--- a/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.test.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { loggerMock } from '@osd/logging/target/mocks';
 import { httpServerMock, savedObjectsClientMock, coreMock } from '../../../../core/server/mocks';
 import { WorkspaceUiSettingsClientWrapper } from './workspace_ui_settings_client_wrapper';
 import { WORKSPACE_TYPE } from '../../../../core/server';
@@ -17,6 +18,7 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
     const getClientMock = jest.fn().mockReturnValue(clientMock);
     const requestHandlerContext = coreMock.createRequestHandlerContext();
     const requestMock = httpServerMock.createOpenSearchDashboardsRequest();
+    const logger = loggerMock.create();
 
     clientMock.get.mockImplementation(async (type, id) => {
       if (type === 'config') {
@@ -43,7 +45,7 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
       return Promise.reject();
     });
 
-    const wrapper = new WorkspaceUiSettingsClientWrapper();
+    const wrapper = new WorkspaceUiSettingsClientWrapper(logger);
     wrapper.setScopedClient(getClientMock);
 
     return {
@@ -53,6 +55,7 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
         typeRegistry: requestHandlerContext.savedObjects.typeRegistry,
       }),
       clientMock,
+      logger,
     };
   };
 
@@ -134,6 +137,42 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
         defaultIndex: 'new-index-id',
       },
       {}
+    );
+  });
+
+  it('should not throw error if the workspace id is not valid', async () => {
+    const invalidWorkspaceId = 'invalid-workspace-id';
+    // Currently in a workspace
+    jest
+      .spyOn(utils, 'getWorkspaceState')
+      .mockReturnValue({ requestWorkspaceId: invalidWorkspaceId });
+
+    const { wrappedClient, clientMock, logger } = createWrappedClient();
+    clientMock.get.mockImplementation(async (type, id) => {
+      if (type === 'config') {
+        return Promise.resolve({
+          id,
+          references: [],
+          type: 'config',
+          attributes: {
+            defaultIndex: 'default-index-global',
+          },
+        });
+      }
+      return Promise.reject('not found');
+    });
+
+    const config = await wrappedClient.get('config', '3.0.0');
+    expect(config).toEqual({
+      attributes: {
+        defaultIndex: 'default-index-global',
+      },
+      id: '3.0.0',
+      references: [],
+      type: 'config',
+    });
+    expect(logger.error).toBeCalledWith(
+      `Unable to get workspaceObject on id: ${invalidWorkspaceId}`
     );
   });
 });

--- a/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
@@ -63,7 +63,7 @@ export class WorkspaceUiSettingsClientWrapper {
           options
         );
 
-        let workspaceObject: SavedObject<WorkspaceAttribute> | null = null
+        let workspaceObject: SavedObject<WorkspaceAttribute> | null = null;
 
         try {
           workspaceObject = await this.getWorkspaceTypeEnabledClient(wrapperOptions.request).get<
@@ -72,7 +72,7 @@ export class WorkspaceUiSettingsClientWrapper {
         } catch (e) {
           this.logger.error(`Unable to get workspaceObject with id: ${requestWorkspaceId}`);
         }
-        
+
         configObject.attributes = {
           ...configObject.attributes,
           ...(workspaceObject ? workspaceObject.attributes.uiSettings : {}),
@@ -80,7 +80,7 @@ export class WorkspaceUiSettingsClientWrapper {
 
         configObject.attributes = {
           ...configObject.attributes,
-          ...workspaceObject.attributes.uiSettings,
+          ...workspaceObject?.attributes.uiSettings,
         };
 
         return configObject as SavedObject<T>;

--- a/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
@@ -78,11 +78,6 @@ export class WorkspaceUiSettingsClientWrapper {
           ...(workspaceObject ? workspaceObject.attributes.uiSettings : {}),
         };
 
-        configObject.attributes = {
-          ...configObject.attributes,
-          ...workspaceObject?.attributes.uiSettings,
-        };
-
         return configObject as SavedObject<T>;
       }
 

--- a/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
@@ -70,7 +70,7 @@ export class WorkspaceUiSettingsClientWrapper {
             WorkspaceAttribute
           >(WORKSPACE_TYPE, requestWorkspaceId);
         } catch (e) {
-          this.logger.error(`Unable to get workspaceObject on id: ${requestWorkspaceId}`);
+          this.logger.error(`Unable to get workspaceObject with id: ${requestWorkspaceId}`);
         }
         
         configObject.attributes = {

--- a/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
@@ -63,15 +63,7 @@ export class WorkspaceUiSettingsClientWrapper {
           options
         );
 
-        let workspaceObject: SavedObject<WorkspaceAttribute> = {
-          id: requestWorkspaceId,
-          type: 'workspace',
-          attributes: {
-            id: requestWorkspaceId,
-            name: '',
-          },
-          references: [],
-        };
+        let workspaceObject: SavedObject<WorkspaceAttribute> | null = null
 
         try {
           workspaceObject = await this.getWorkspaceTypeEnabledClient(wrapperOptions.request).get<
@@ -80,6 +72,11 @@ export class WorkspaceUiSettingsClientWrapper {
         } catch (e) {
           this.logger.error(`Unable to get workspaceObject on id: ${requestWorkspaceId}`);
         }
+        
+        configObject.attributes = {
+          ...configObject.attributes,
+          ...(workspaceObject ? workspaceObject.attributes.uiSettings : {}),
+        };
 
         configObject.attributes = {
           ...configObject.attributes,


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
A new wrapper, workspace_ui_settings, has been introduced by workspace plugin. When a user attempts to access an invalid workspace, OSD will display plain JSON instead of a user-friendly web page. This PR primarily addresses the issue by adding a `try catch` wrapper to the `client.get` method.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
### Before fix
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/f1ed8b39-6672-4d6f-83f3-8750bbf34e7c)

### After fix
<img width="1724" alt="image" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/572111df-4434-4a4e-a77d-454e33248341">

As well as an error log in OSD:

<img width="844" alt="image" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/13493605/0cd4496b-e591-42ba-85ff-885707b46c75">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
- Use the branch to bootstrap and enable workspace feature flag
- Type an invalid url like `http://localhost:5601/w/123/app/workspace_overview`
- An error page with error message saying: `Saved object [workspace/123] not found` should be found.

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: optimization on handling invalid workspace id in workspace_ui_settings wrapper

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
