### PR TITLE
[MDS] Modify toast + popover warning to include incompatible datasources

### DIFF
--- a/changelogs/fragments/6678.yml
+++ b/changelogs/fragments/6678.yml
@@ -1,0 +1,2 @@
+fix:
+- [MDS] Add a new message to data source components when there are no compatible datasources ([#6678](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6678))

--- a/src/plugins/data_source_management/public/components/constants.tsx
+++ b/src/plugins/data_source_management/public/components/constants.tsx
@@ -12,3 +12,8 @@ export const LocalCluster: DataSourceOption = {
   }),
   id: '',
 };
+
+export const NO_DATASOURCES_CONNECTED_MESSAGE = 'No data sources connected yet.';
+export const CONNECT_DATASOURCES_MESSAGE = 'Connect your data sources to get started.';
+export const NO_COMPATIBLE_DATASOURCES_MESSAGE = 'No compatible data sources are available.';
+export const ADD_COMPATIBLE_DATASOURCES_MESSAGE = 'Add a compatible data source.';

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
@@ -45,7 +45,7 @@ interface DataSourceAggregatedViewState extends DataSourceBaseState {
   allDataSourcesIdToTitleMap: Map<string, any>;
   switchChecked: boolean;
   defaultDataSource: string | null;
-  hasIncompatibleDataSources: boolean;
+  incompatibleDataSourcesExist: boolean;
 }
 
 interface DataSourceOptionDisplay extends DataSourceOption {
@@ -69,7 +69,7 @@ export class DataSourceAggregatedView extends React.Component<
       showError: false,
       switchChecked: false,
       defaultDataSource: null,
-      hasIncompatibleDataSources: false,
+      incompatibleDataSourcesExist: false,
     };
   }
 
@@ -119,7 +119,7 @@ export class DataSourceAggregatedView extends React.Component<
             changeState: this.onEmptyState.bind(this, !!fetchedDataSources?.length),
             notifications: this.props.notifications,
             application: this.props.application,
-            hasIncompatibleDatasources: !!fetchedDataSources?.length,
+            incompatibleDataSourcesExist: !!fetchedDataSources?.length,
           });
           return;
         }
@@ -136,8 +136,8 @@ export class DataSourceAggregatedView extends React.Component<
       });
   }
 
-  onEmptyState(hasIncompatibleDataSources: boolean) {
-    this.setState({ showEmptyState: true, hasIncompatibleDataSources });
+  onEmptyState(incompatibleDataSourcesExist: boolean) {
+    this.setState({ showEmptyState: true, incompatibleDataSourcesExist });
   }
 
   onError() {
@@ -149,7 +149,7 @@ export class DataSourceAggregatedView extends React.Component<
       return (
         <NoDataSource
           application={this.props.application}
-          hasIncompatibleDatasources={this.state.hasIncompatibleDataSources}
+          incompatibleDataSourcesExist={this.state.incompatibleDataSourcesExist}
         />
       );
     }

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
@@ -45,6 +45,7 @@ interface DataSourceAggregatedViewState extends DataSourceBaseState {
   allDataSourcesIdToTitleMap: Map<string, any>;
   switchChecked: boolean;
   defaultDataSource: string | null;
+  hasIncompatibleDataSources: boolean;
 }
 
 interface DataSourceOptionDisplay extends DataSourceOption {
@@ -68,6 +69,7 @@ export class DataSourceAggregatedView extends React.Component<
       showError: false,
       switchChecked: false,
       defaultDataSource: null,
+      hasIncompatibleDataSources: false,
     };
   }
 
@@ -113,11 +115,12 @@ export class DataSourceAggregatedView extends React.Component<
         }
 
         if (allDataSourcesIdToTitleMap.size === 0) {
-          handleNoAvailableDataSourceError(
-            this.onEmptyState.bind(this),
-            this.props.notifications,
-            this.props.application
-          );
+          handleNoAvailableDataSourceError({
+            changeState: this.onEmptyState.bind(this, !!fetchedDataSources?.length),
+            notifications: this.props.notifications,
+            application: this.props.application,
+            hasIncompatibleDatasources: !!fetchedDataSources?.length,
+          });
           return;
         }
 
@@ -133,8 +136,8 @@ export class DataSourceAggregatedView extends React.Component<
       });
   }
 
-  onEmptyState() {
-    this.setState({ showEmptyState: true });
+  onEmptyState(hasIncompatibleDataSources: boolean) {
+    this.setState({ showEmptyState: true, hasIncompatibleDataSources });
   }
 
   onError() {
@@ -143,7 +146,12 @@ export class DataSourceAggregatedView extends React.Component<
 
   render() {
     if (this.state.showEmptyState) {
-      return <NoDataSource application={this.props.application} />;
+      return (
+        <NoDataSource
+          application={this.props.application}
+          hasIncompatibleDatasources={this.state.hasIncompatibleDataSources}
+        />
+      );
     }
     if (this.state.showError) {
       return <DataSourceErrorMenu application={this.props.application} />;

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
@@ -34,7 +34,7 @@ interface DataSourceMultiSeletableState extends DataSourceBaseState {
   dataSourceOptions: SelectedDataSourceOption[];
   selectedOptions: SelectedDataSourceOption[];
   defaultDataSource: string | null;
-  hasIncompatibleDatasources: boolean;
+  incompatibleDataSourcesExist: boolean;
 }
 
 export class DataSourceMultiSelectable extends React.Component<
@@ -52,7 +52,7 @@ export class DataSourceMultiSelectable extends React.Component<
       defaultDataSource: null,
       showEmptyState: false,
       showError: false,
-      hasIncompatibleDatasources: false,
+      incompatibleDataSourcesExist: false,
     };
   }
 
@@ -97,7 +97,7 @@ export class DataSourceMultiSelectable extends React.Component<
           notifications: this.props.notifications,
           application: this.props.application,
           callback: this.props.onSelectedDataSources,
-          hasIncompatibleDatasources: !!fetchedDataSources?.length,
+          incompatibleDataSourcesExist: !!fetchedDataSources?.length,
         });
         return;
       }
@@ -118,8 +118,8 @@ export class DataSourceMultiSelectable extends React.Component<
     }
   }
 
-  onEmptyState(hasIncompatibleDatasources: boolean) {
-    this.setState({ showEmptyState: true, hasIncompatibleDatasources });
+  onEmptyState(incompatibleDataSourcesExist: boolean) {
+    this.setState({ showEmptyState: true, incompatibleDataSourcesExist });
   }
 
   onError() {

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
@@ -34,6 +34,7 @@ interface DataSourceMultiSeletableState extends DataSourceBaseState {
   dataSourceOptions: SelectedDataSourceOption[];
   selectedOptions: SelectedDataSourceOption[];
   defaultDataSource: string | null;
+  hasIncompatibleDatasources: boolean;
 }
 
 export class DataSourceMultiSelectable extends React.Component<
@@ -51,6 +52,7 @@ export class DataSourceMultiSelectable extends React.Component<
       defaultDataSource: null,
       showEmptyState: false,
       showError: false,
+      hasIncompatibleDatasources: false,
     };
   }
 
@@ -90,12 +92,13 @@ export class DataSourceMultiSelectable extends React.Component<
       if (!this._isMounted) return;
 
       if (selectedOptions.length === 0) {
-        handleNoAvailableDataSourceError(
-          this.onEmptyState.bind(this),
-          this.props.notifications,
-          this.props.application,
-          this.props.onSelectedDataSources
-        );
+        handleNoAvailableDataSourceError({
+          changeState: this.onEmptyState.bind(this, !!fetchedDataSources?.length),
+          notifications: this.props.notifications,
+          application: this.props.application,
+          callback: this.props.onSelectedDataSources,
+          hasIncompatibleDatasources: !!fetchedDataSources?.length,
+        });
         return;
       }
 
@@ -115,8 +118,8 @@ export class DataSourceMultiSelectable extends React.Component<
     }
   }
 
-  onEmptyState() {
-    this.setState({ showEmptyState: true });
+  onEmptyState(hasIncompatibleDatasources: boolean) {
+    this.setState({ showEmptyState: true, hasIncompatibleDatasources });
   }
 
   onError() {

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
@@ -4,6 +4,7 @@
  */
 
 import { ShallowWrapper, shallow, mount } from 'enzyme';
+import { i18n } from '@osd/i18n';
 import { SavedObjectsClientContract } from '../../../../../core/public';
 import { notificationServiceMock } from '../../../../../core/public/mocks';
 import React from 'react';
@@ -12,6 +13,12 @@ import { AuthType } from '../../types';
 import { getDataSourcesWithFieldsResponse, mockResponseForSavedObjectsCalls } from '../../mocks';
 import { render } from '@testing-library/react';
 import * as utils from '../utils';
+import {
+  NO_DATASOURCES_CONNECTED_MESSAGE,
+  CONNECT_DATASOURCES_MESSAGE,
+  NO_COMPATIBLE_DATASOURCES_MESSAGE,
+  ADD_COMPATIBLE_DATASOURCES_MESSAGE,
+} from '../constants';
 
 describe('DataSourceSelectable', () => {
   let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
@@ -19,6 +26,8 @@ describe('DataSourceSelectable', () => {
   let client: SavedObjectsClientContract;
   const { toasts } = notificationServiceMock.createStartContract();
   const nextTick = () => new Promise((res) => process.nextTick(res));
+  const noDataSourcesConnectedMessage = `${NO_DATASOURCES_CONNECTED_MESSAGE} ${CONNECT_DATASOURCES_MESSAGE}`;
+  const noCompatibleDataSourcesMessage = `${NO_COMPATIBLE_DATASOURCES_MESSAGE} ${ADD_COMPATIBLE_DATASOURCES_MESSAGE}`;
 
   beforeEach(() => {
     client = {
@@ -145,6 +154,7 @@ describe('DataSourceSelectable', () => {
         },
       ],
       showError: false,
+      hasIncompatibleDatasources: false,
     });
 
     containerInstance.onChange([{ id: 'test2', label: 'test2', checked: 'on' }]);
@@ -167,6 +177,7 @@ describe('DataSourceSelectable', () => {
         },
       ],
       showError: false,
+      hasIncompatibleDatasources: false,
     });
 
     expect(onSelectedDataSource).toBeCalledWith([{ id: 'test2', label: 'test2' }]);
@@ -345,6 +356,7 @@ describe('DataSourceSelectable', () => {
         },
       ],
       showError: false,
+      hasIncompatibleDatasources: false,
     });
   });
 
@@ -374,6 +386,7 @@ describe('DataSourceSelectable', () => {
       selectedOption: [],
       showEmptyState: false,
       showError: true,
+      hasIncompatibleDatasources: false,
     });
 
     containerInstance.onChange([{ id: 'test2', label: 'test2', checked: 'on' }]);
@@ -396,27 +409,59 @@ describe('DataSourceSelectable', () => {
         },
       ],
       showError: true,
+      hasIncompatibleDatasources: false,
     });
 
     expect(onSelectedDataSource).toBeCalledWith([{ id: 'test2', label: 'test2' }]);
     expect(onSelectedDataSource).toHaveBeenCalled();
   });
-  it('should render no data source when no data source filtered out and hide local cluster', async () => {
-    const onSelectedDataSource = jest.fn();
-    render(
-      <DataSourceSelectable
-        savedObjectsClient={client}
-        notifications={toasts}
-        onSelectedDataSources={onSelectedDataSource}
-        disabled={false}
-        hideLocalCluster={true}
-        fullWidth={false}
-        selectedOption={[{ id: 'test2' }]}
-        dataSourceFilter={(ds) => false}
-      />
-    );
-    await nextTick();
-    expect(toasts.add).toBeCalled();
-    expect(onSelectedDataSource).toBeCalledWith([]);
-  });
+
+  it.each([
+    {
+      findFunc: jest.fn().mockResolvedValue({ savedObjects: [] }),
+      defaultMessage: noDataSourcesConnectedMessage,
+      selectedOption: undefined,
+    },
+    {
+      findFunc: jest.fn().mockResolvedValue({ savedObjects: [] }),
+      defaultMessage: noDataSourcesConnectedMessage,
+      selectedOption: [{ id: 'test2' }],
+    },
+    {
+      findFunc: jest.fn().mockResolvedValue(getDataSourcesWithFieldsResponse),
+      defaultMessage: noCompatibleDataSourcesMessage,
+      selectedOption: undefined,
+    },
+    {
+      findFunc: jest.fn().mockResolvedValue(getDataSourcesWithFieldsResponse),
+      defaultMessage: noCompatibleDataSourcesMessage,
+      selectedOption: [{ id: 'test2' }],
+    },
+  ])(
+    'should render correct message when there are no datasource options available and local cluster is hidden',
+    async ({ findFunc, selectedOption, defaultMessage }) => {
+      client.find = findFunc;
+      const onSelectedDataSource = jest.fn();
+      render(
+        <DataSourceSelectable
+          savedObjectsClient={client}
+          notifications={toasts}
+          onSelectedDataSources={onSelectedDataSource}
+          disabled={false}
+          hideLocalCluster={true}
+          fullWidth={false}
+          selectedOption={selectedOption}
+          dataSourceFilter={(ds) => false}
+        />
+      );
+      await nextTick();
+
+      expect(toasts.add).toBeCalledWith(
+        expect.objectContaining({
+          title: i18n.translate('dataSource.noAvailableDataSourceError', { defaultMessage }),
+        })
+      );
+      expect(onSelectedDataSource).toBeCalledWith([]);
+    }
+  );
 });

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
@@ -154,7 +154,7 @@ describe('DataSourceSelectable', () => {
         },
       ],
       showError: false,
-      hasIncompatibleDatasources: false,
+      incompatibleDataSourcesExist: false,
     });
 
     containerInstance.onChange([{ id: 'test2', label: 'test2', checked: 'on' }]);
@@ -177,7 +177,7 @@ describe('DataSourceSelectable', () => {
         },
       ],
       showError: false,
-      hasIncompatibleDatasources: false,
+      incompatibleDataSourcesExist: false,
     });
 
     expect(onSelectedDataSource).toBeCalledWith([{ id: 'test2', label: 'test2' }]);
@@ -356,7 +356,7 @@ describe('DataSourceSelectable', () => {
         },
       ],
       showError: false,
-      hasIncompatibleDatasources: false,
+      incompatibleDataSourcesExist: false,
     });
   });
 
@@ -386,7 +386,7 @@ describe('DataSourceSelectable', () => {
       selectedOption: [],
       showEmptyState: false,
       showError: true,
-      hasIncompatibleDatasources: false,
+      incompatibleDataSourcesExist: false,
     });
 
     containerInstance.onChange([{ id: 'test2', label: 'test2', checked: 'on' }]);
@@ -409,7 +409,7 @@ describe('DataSourceSelectable', () => {
         },
       ],
       showError: true,
-      hasIncompatibleDatasources: false,
+      incompatibleDataSourcesExist: false,
     });
 
     expect(onSelectedDataSource).toBeCalledWith([{ id: 'test2', label: 'test2' }]);

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -54,9 +54,9 @@ interface DataSourceSelectableProps {
 interface DataSourceSelectableState extends DataSourceBaseState {
   dataSourceOptions: DataSourceOption[];
   isPopoverOpen: boolean;
-  selectedOption?: DataSourceOption[];
   defaultDataSource: string | null;
   incompatibleDataSourcesExist: boolean;
+  selectedOption?: DataSourceOption[];
 }
 
 export class DataSourceSelectable extends React.Component<

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -56,6 +56,7 @@ interface DataSourceSelectableState extends DataSourceBaseState {
   isPopoverOpen: boolean;
   selectedOption?: DataSourceOption[];
   defaultDataSource: string | null;
+  hasIncompatibleDatasources: boolean;
 }
 
 export class DataSourceSelectable extends React.Component<
@@ -74,6 +75,7 @@ export class DataSourceSelectable extends React.Component<
       defaultDataSource: null,
       showEmptyState: false,
       showError: false,
+      hasIncompatibleDatasources: false,
     };
 
     this.onChange.bind(this);
@@ -187,12 +189,13 @@ export class DataSourceSelectable extends React.Component<
       }
 
       if (dataSourceOptions.length === 0) {
-        handleNoAvailableDataSourceError(
-          this.onEmptyState.bind(this),
-          this.props.notifications,
-          this.props.application,
-          this.props.onSelectedDataSources
-        );
+        handleNoAvailableDataSourceError({
+          changeState: this.onEmptyState.bind(this, !!fetchedDataSources?.length),
+          notifications: this.props.notifications,
+          application: this.props.application,
+          callback: this.props.onSelectedDataSources,
+          hasIncompatibleDatasources: !!fetchedDataSources?.length,
+        });
         return;
       }
 
@@ -214,8 +217,8 @@ export class DataSourceSelectable extends React.Component<
     }
   }
 
-  onEmptyState() {
-    this.setState({ showEmptyState: true });
+  onEmptyState(hasIncompatibleDatasources: boolean) {
+    this.setState({ showEmptyState: true, hasIncompatibleDatasources });
   }
 
   onError() {
@@ -242,7 +245,12 @@ export class DataSourceSelectable extends React.Component<
 
   render() {
     if (this.state.showEmptyState) {
-      return <NoDataSource application={this.props.application} />;
+      return (
+        <NoDataSource
+          application={this.props.application}
+          hasIncompatibleDatasources={this.state.hasIncompatibleDatasources}
+        />
+      );
     }
 
     if (this.state.showError) {

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -56,7 +56,7 @@ interface DataSourceSelectableState extends DataSourceBaseState {
   isPopoverOpen: boolean;
   selectedOption?: DataSourceOption[];
   defaultDataSource: string | null;
-  hasIncompatibleDatasources: boolean;
+  incompatibleDataSourcesExist: boolean;
 }
 
 export class DataSourceSelectable extends React.Component<
@@ -75,7 +75,7 @@ export class DataSourceSelectable extends React.Component<
       defaultDataSource: null,
       showEmptyState: false,
       showError: false,
-      hasIncompatibleDatasources: false,
+      incompatibleDataSourcesExist: false,
     };
 
     this.onChange.bind(this);
@@ -194,7 +194,7 @@ export class DataSourceSelectable extends React.Component<
           notifications: this.props.notifications,
           application: this.props.application,
           callback: this.props.onSelectedDataSources,
-          hasIncompatibleDatasources: !!fetchedDataSources?.length,
+          incompatibleDataSourcesExist: !!fetchedDataSources?.length,
         });
         return;
       }
@@ -217,8 +217,8 @@ export class DataSourceSelectable extends React.Component<
     }
   }
 
-  onEmptyState(hasIncompatibleDatasources: boolean) {
-    this.setState({ showEmptyState: true, hasIncompatibleDatasources });
+  onEmptyState(incompatibleDataSourcesExist: boolean) {
+    this.setState({ showEmptyState: true, incompatibleDataSourcesExist });
   }
 
   onError() {
@@ -248,7 +248,7 @@ export class DataSourceSelectable extends React.Component<
       return (
         <NoDataSource
           application={this.props.application}
-          hasIncompatibleDatasources={this.state.hasIncompatibleDatasources}
+          incompatibleDataSourcesExist={this.state.incompatibleDataSourcesExist}
         />
       );
     }

--- a/src/plugins/data_source_management/public/components/no_data_source/__snapshots__/no_data_source.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/no_data_source/__snapshots__/no_data_source.test.tsx.snap
@@ -83,7 +83,90 @@ exports[`NoDataSource should render correctly with the provided totalDataSourceC
 </EuiPopover>
 `;
 
-exports[`NoDataSource should render normally 1`] = `
+exports[`NoDataSource should render normally when hasIncompatibleDatasources is %b 1`] = `
+<EuiPopover
+  anchorPosition="downLeft"
+  button={
+    <EuiButtonIcon
+      aria-label="dataSourceEmptyMenuHeaderLink"
+      className="euiHeaderLink"
+      data-test-subj="dataSourceEmptyMenuHeaderLink"
+      iconType={[Function]}
+      onClick={[Function]}
+      size="s"
+    />
+  }
+  closePopover={[Function]}
+  data-test-subj="dataSourceEmptyStatePopover"
+  display="inlineBlock"
+  hasArrow={true}
+  id="dataSourceEmptyStatePopover"
+  isOpen={false}
+  ownFocus={true}
+  panelPaddingSize="none"
+>
+  <DataSourceDropDownHeader
+    totalDataSourceCount={0}
+  />
+  <EuiPanel
+    className="dataSourceEmptyStatePanel"
+    data-test-subj="dataSourceEmptyStatePanel"
+    hasBorder={false}
+    hasShadow={false}
+  >
+    <EuiFlexGroup
+      justifyContent="center"
+    >
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiText
+          size="s"
+          textAlign="center"
+        >
+          <FormattedMessage
+            defaultMessage="No data sources connected yet."
+            id="dataSourcesManagement.dataSourceEmptyMenu.noData"
+            values={Object {}}
+          />
+        </EuiText>
+        <EuiText
+          size="s"
+          textAlign="center"
+        >
+          <FormattedMessage
+            defaultMessage="Connect your data sources to get started."
+            id="dataSourcesManagement.dataSourceEmptyMenu.connect"
+            values={Object {}}
+          />
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    <EuiFlexGroup
+      justifyContent="center"
+    >
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiButton
+          data-test-subj="dataSourceEmptyStateManageDataSourceButton"
+          fill={false}
+          onClick={[Function]}
+          size="s"
+        >
+          <FormattedMessage
+            defaultMessage="Manage data sources"
+            id="dataSourcesManagement.dataSourceMenu.manageDataSource"
+            values={Object {}}
+          />
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiPanel>
+</EuiPopover>
+`;
+
+exports[`NoDataSource should render normally when hasIncompatibleDatasources is %b 2`] = `
 <EuiPopover
   anchorPosition="downLeft"
   button={

--- a/src/plugins/data_source_management/public/components/no_data_source/__snapshots__/no_data_source.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/no_data_source/__snapshots__/no_data_source.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`NoDataSource should render correctly with the provided totalDataSourceC
 </EuiPopover>
 `;
 
-exports[`NoDataSource should render normally when hasIncompatibleDatasources is %b 1`] = `
+exports[`NoDataSource should render normally when incompatibleDataSourcesExist is %b 1`] = `
 <EuiPopover
   anchorPosition="downLeft"
   button={
@@ -166,7 +166,7 @@ exports[`NoDataSource should render normally when hasIncompatibleDatasources is 
 </EuiPopover>
 `;
 
-exports[`NoDataSource should render normally when hasIncompatibleDatasources is %b 2`] = `
+exports[`NoDataSource should render normally when incompatibleDataSourcesExist is %b 2`] = `
 <EuiPopover
   anchorPosition="downLeft"
   button={

--- a/src/plugins/data_source_management/public/components/no_data_source/no_data_source.test.tsx
+++ b/src/plugins/data_source_management/public/components/no_data_source/no_data_source.test.tsx
@@ -16,14 +16,20 @@ describe('NoDataSource', () => {
   const nextTick = () => new Promise((res) => process.nextTick(res));
 
   it('should render correctly with the provided totalDataSourceCount', () => {
-    const wrapper = shallow(<NoDataSource totalDataSourceCount={totalDataSourceCount} />);
+    const wrapper = shallow(
+      <NoDataSource totalDataSourceCount={totalDataSourceCount} hasIncompatibleDatasource={false} />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should display popover when click "No data sources" button', async () => {
     const applicationMock = coreMock.createStart().application;
     const container = render(
-      <NoDataSource totalDataSourceCount={totalDataSourceCount} application={applicationMock} />
+      <NoDataSource
+        totalDataSourceCount={totalDataSourceCount}
+        application={applicationMock}
+        hasIncompatibleDatasource={false}
+      />
     );
 
     await nextTick();
@@ -39,7 +45,11 @@ describe('NoDataSource', () => {
     const navigateToAppMock = applicationMock.navigateToApp;
 
     const container = render(
-      <NoDataSource totalDataSourceCount={totalDataSourceCount} application={applicationMock} />
+      <NoDataSource
+        totalDataSourceCount={totalDataSourceCount}
+        application={applicationMock}
+        hasIncompatibleDatasource={false}
+      />
     );
 
     await nextTick();
@@ -55,8 +65,16 @@ describe('NoDataSource', () => {
     });
   });
 
-  it('should render normally', () => {
-    component = shallow(<NoDataSource totalDataSourceCount={0} />);
-    expect(component).toMatchSnapshot();
-  });
+  it.each([false, true])(
+    'should render normally when hasIncompatibleDatasources is %b',
+    (hasIncompatibleDatasources) => {
+      component = shallow(
+        <NoDataSource
+          totalDataSourceCount={0}
+          hasIncompatibleDatasource={hasIncompatibleDatasources}
+        />
+      );
+      expect(component).toMatchSnapshot();
+    }
+  );
 });

--- a/src/plugins/data_source_management/public/components/no_data_source/no_data_source.test.tsx
+++ b/src/plugins/data_source_management/public/components/no_data_source/no_data_source.test.tsx
@@ -66,12 +66,12 @@ describe('NoDataSource', () => {
   });
 
   it.each([false, true])(
-    'should render normally when hasIncompatibleDatasources is %b',
-    (hasIncompatibleDatasources) => {
+    'should render normally when incompatibleDataSourcesExist is %b',
+    (incompatibleDataSourcesExist) => {
       component = shallow(
         <NoDataSource
           totalDataSourceCount={0}
-          hasIncompatibleDatasource={hasIncompatibleDatasources}
+          hasIncompatibleDatasource={incompatibleDataSourcesExist}
         />
       );
       expect(component).toMatchSnapshot();

--- a/src/plugins/data_source_management/public/components/no_data_source/no_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/no_data_source/no_data_source.tsx
@@ -20,12 +20,22 @@ import { FormattedMessage } from 'react-intl';
 import { DataSourceDropDownHeader } from '../drop_down_header';
 import { DSM_APP_ID } from '../../plugin';
 import { EmptyIcon } from '../custom_database_icon';
+import {
+  ADD_COMPATIBLE_DATASOURCES_MESSAGE,
+  CONNECT_DATASOURCES_MESSAGE,
+  NO_COMPATIBLE_DATASOURCES_MESSAGE,
+  NO_DATASOURCES_CONNECTED_MESSAGE,
+} from '../constants';
 
 interface DataSourceDropDownHeaderProps {
   application?: ApplicationStart;
+  hasIncompatibleDatasources: boolean;
 }
 
-export const NoDataSource: React.FC<DataSourceDropDownHeaderProps> = ({ application }) => {
+export const NoDataSource: React.FC<DataSourceDropDownHeaderProps> = ({
+  application,
+  hasIncompatibleDatasources,
+}) => {
   const [showPopover, setShowPopover] = useState<boolean>(false);
   const button = (
     <EuiButtonIcon
@@ -63,7 +73,11 @@ export const NoDataSource: React.FC<DataSourceDropDownHeaderProps> = ({ applicat
         {
           <FormattedMessage
             id="dataSourcesManagement.dataSourceEmptyMenu.noData"
-            defaultMessage="No data sources connected yet."
+            defaultMessage={
+              hasIncompatibleDatasources
+                ? NO_COMPATIBLE_DATASOURCES_MESSAGE
+                : NO_DATASOURCES_CONNECTED_MESSAGE
+            }
           />
         }
       </EuiText>
@@ -72,7 +86,11 @@ export const NoDataSource: React.FC<DataSourceDropDownHeaderProps> = ({ applicat
         {
           <FormattedMessage
             id="dataSourcesManagement.dataSourceEmptyMenu.connect"
-            defaultMessage="Connect your data sources to get started."
+            defaultMessage={
+              hasIncompatibleDatasources
+                ? ADD_COMPATIBLE_DATASOURCES_MESSAGE
+                : CONNECT_DATASOURCES_MESSAGE
+            }
           />
         }
       </EuiText>

--- a/src/plugins/data_source_management/public/components/no_data_source/no_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/no_data_source/no_data_source.tsx
@@ -28,8 +28,8 @@ import {
 } from '../constants';
 
 interface DataSourceDropDownHeaderProps {
-  application?: ApplicationStart;
   incompatibleDataSourcesExist: boolean;
+  application?: ApplicationStart;
 }
 
 export const NoDataSource: React.FC<DataSourceDropDownHeaderProps> = ({

--- a/src/plugins/data_source_management/public/components/no_data_source/no_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/no_data_source/no_data_source.tsx
@@ -29,12 +29,12 @@ import {
 
 interface DataSourceDropDownHeaderProps {
   application?: ApplicationStart;
-  hasIncompatibleDatasources: boolean;
+  incompatibleDataSourcesExist: boolean;
 }
 
 export const NoDataSource: React.FC<DataSourceDropDownHeaderProps> = ({
   application,
-  hasIncompatibleDatasources,
+  incompatibleDataSourcesExist,
 }) => {
   const [showPopover, setShowPopover] = useState<boolean>(false);
   const button = (
@@ -74,7 +74,7 @@ export const NoDataSource: React.FC<DataSourceDropDownHeaderProps> = ({
           <FormattedMessage
             id="dataSourcesManagement.dataSourceEmptyMenu.noData"
             defaultMessage={
-              hasIncompatibleDatasources
+              incompatibleDataSourcesExist
                 ? NO_COMPATIBLE_DATASOURCES_MESSAGE
                 : NO_DATASOURCES_CONNECTED_MESSAGE
             }
@@ -87,7 +87,7 @@ export const NoDataSource: React.FC<DataSourceDropDownHeaderProps> = ({
           <FormattedMessage
             id="dataSourcesManagement.dataSourceEmptyMenu.connect"
             defaultMessage={
-              hasIncompatibleDatasources
+              incompatibleDataSourcesExist
                 ? ADD_COMPATIBLE_DATASOURCES_MESSAGE
                 : CONNECT_DATASOURCES_MESSAGE
             }

--- a/src/plugins/data_source_management/public/components/utils.test.ts
+++ b/src/plugins/data_source_management/public/components/utils.test.ts
@@ -101,21 +101,21 @@ describe('DataSourceManagement: Utils.ts', () => {
 
     test.each([
       {
-        hasIncompatibleDatasources: false,
+        incompatibleDataSourcesExist: false,
         defaultMessage: noDataSourcesConnectedMessage,
       },
       {
-        hasIncompatibleDatasources: true,
+        incompatibleDataSourcesExist: true,
         defaultMessage: noCompatibleDataSourcesMessage,
       },
     ])(
       'should send warning when data source is not available',
-      ({ hasIncompatibleDatasources, defaultMessage }) => {
+      ({ incompatibleDataSourcesExist, defaultMessage }) => {
         const changeState = jest.fn();
         handleNoAvailableDataSourceError({
           changeState,
           notifications: toasts,
-          hasIncompatibleDatasources,
+          incompatibleDataSourcesExist,
         });
         expect(toasts.add).toBeCalledTimes(1);
         expect(toasts.add).toBeCalledWith(

--- a/src/plugins/data_source_management/public/components/utils.test.ts
+++ b/src/plugins/data_source_management/public/components/utils.test.ts
@@ -42,10 +42,17 @@ import {
   sigV4AuthMethod,
   usernamePasswordAuthMethod,
 } from '../types';
-import { HttpStart, SavedObject } from 'opensearch-dashboards/public';
+import { HttpStart, IToasts, SavedObject } from 'opensearch-dashboards/public';
+import { i18n } from '@osd/i18n';
 import { AuthenticationMethod, AuthenticationMethodRegistry } from '../auth_registry';
 import { deepEqual } from 'assert';
 import { DataSourceAttributes } from 'src/plugins/data_source/common/data_sources';
+import {
+  ADD_COMPATIBLE_DATASOURCES_MESSAGE,
+  CONNECT_DATASOURCES_MESSAGE,
+  NO_COMPATIBLE_DATASOURCES_MESSAGE,
+  NO_DATASOURCES_CONNECTED_MESSAGE,
+} from './constants';
 
 const { savedObjects } = coreMock.createStart();
 const { uiSettings } = coreMock.createStart();
@@ -84,13 +91,40 @@ describe('DataSourceManagement: Utils.ts', () => {
   });
 
   describe('Handle no available data source error', () => {
-    const { toasts } = notificationServiceMock.createStartContract();
+    let toasts: IToasts;
+    const noDataSourcesConnectedMessage = `${NO_DATASOURCES_CONNECTED_MESSAGE} ${CONNECT_DATASOURCES_MESSAGE}`;
+    const noCompatibleDataSourcesMessage = `${NO_COMPATIBLE_DATASOURCES_MESSAGE} ${ADD_COMPATIBLE_DATASOURCES_MESSAGE}`;
 
-    test('should  send warning when data source is not available', () => {
-      const changeState = jest.fn();
-      handleNoAvailableDataSourceError(changeState, toasts);
-      expect(toasts.add).toBeCalledTimes(1);
+    beforeEach(() => {
+      toasts = notificationServiceMock.createStartContract().toasts;
     });
+
+    test.each([
+      {
+        hasIncompatibleDatasources: false,
+        defaultMessage: noDataSourcesConnectedMessage,
+      },
+      {
+        hasIncompatibleDatasources: true,
+        defaultMessage: noCompatibleDataSourcesMessage,
+      },
+    ])(
+      'should send warning when data source is not available',
+      ({ hasIncompatibleDatasources, defaultMessage }) => {
+        const changeState = jest.fn();
+        handleNoAvailableDataSourceError({
+          changeState,
+          notifications: toasts,
+          hasIncompatibleDatasources,
+        });
+        expect(toasts.add).toBeCalledTimes(1);
+        expect(toasts.add).toBeCalledWith(
+          expect.objectContaining({
+            title: i18n.translate('dataSource.noAvailableDataSourceError', { defaultMessage }),
+          })
+        );
+      }
+    );
   });
 
   describe('Get data source by ID', () => {

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -25,6 +25,12 @@ import { DataSourceGroupLabelOption } from './data_source_menu/types';
 import { createGetterSetter } from '../../../opensearch_dashboards_utils/public';
 import { toMountPoint } from '../../../opensearch_dashboards_react/public';
 import { getManageDataSourceButton, getReloadButton } from './toast_button';
+import {
+  ADD_COMPATIBLE_DATASOURCES_MESSAGE,
+  CONNECT_DATASOURCES_MESSAGE,
+  NO_COMPATIBLE_DATASOURCES_MESSAGE,
+  NO_DATASOURCES_CONNECTED_MESSAGE,
+} from './constants';
 
 export async function getDataSources(savedObjectsClient: SavedObjectsClientContract) {
   return savedObjectsClient
@@ -87,18 +93,25 @@ export async function setFirstDataSourceAsDefault(
   }
 }
 
-export function handleNoAvailableDataSourceError(
-  changeState: () => void,
-  notifications: ToastsStart,
-  application?: ApplicationStart,
-  callback?: (ds: DataSourceOption[]) => void
-) {
+export interface HandleNoAvailableDataSourceErrorProps {
+  changeState: () => void;
+  notifications: ToastsStart;
+  application?: ApplicationStart;
+  callback?: (ds: DataSourceOption[]) => void;
+  hasIncompatibleDatasources: boolean;
+}
+
+export function handleNoAvailableDataSourceError(props: HandleNoAvailableDataSourceErrorProps) {
+  const { changeState, notifications, application, callback, hasIncompatibleDatasources } = props;
+
+  const defaultMessage = hasIncompatibleDatasources
+    ? `${NO_COMPATIBLE_DATASOURCES_MESSAGE} ${ADD_COMPATIBLE_DATASOURCES_MESSAGE}`
+    : `${NO_DATASOURCES_CONNECTED_MESSAGE} ${CONNECT_DATASOURCES_MESSAGE}`;
+
   changeState();
   if (callback) callback([]);
   notifications.add({
-    title: i18n.translate('dataSource.noAvailableDataSourceError', {
-      defaultMessage: 'No data sources connected yet. Connect your data sources to get started.',
-    }),
+    title: i18n.translate('dataSource.noAvailableDataSourceError', { defaultMessage }),
     text: toMountPoint(getManageDataSourceButton(application)),
     color: 'warning',
   });

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -98,13 +98,13 @@ export interface HandleNoAvailableDataSourceErrorProps {
   notifications: ToastsStart;
   application?: ApplicationStart;
   callback?: (ds: DataSourceOption[]) => void;
-  hasIncompatibleDatasources: boolean;
+  incompatibleDataSourcesExist: boolean;
 }
 
 export function handleNoAvailableDataSourceError(props: HandleNoAvailableDataSourceErrorProps) {
-  const { changeState, notifications, application, callback, hasIncompatibleDatasources } = props;
+  const { changeState, notifications, application, callback, incompatibleDataSourcesExist } = props;
 
-  const defaultMessage = hasIncompatibleDatasources
+  const defaultMessage = incompatibleDataSourcesExist
     ? `${NO_COMPATIBLE_DATASOURCES_MESSAGE} ${ADD_COMPATIBLE_DATASOURCES_MESSAGE}`
     : `${NO_DATASOURCES_CONNECTED_MESSAGE} ${CONNECT_DATASOURCES_MESSAGE}`;
 

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -96,9 +96,9 @@ export async function setFirstDataSourceAsDefault(
 export interface HandleNoAvailableDataSourceErrorProps {
   changeState: () => void;
   notifications: ToastsStart;
+  incompatibleDataSourcesExist: boolean;
   application?: ApplicationStart;
   callback?: (ds: DataSourceOption[]) => void;
-  incompatibleDataSourcesExist: boolean;
 }
 
 export function handleNoAvailableDataSourceError(props: HandleNoAvailableDataSourceErrorProps) {


### PR DESCRIPTION
### Description

This PR modifies the toast + popover message to cover the edge case that datasources exist but all datasources are filtered out by the `dataSourceFilter` for the multi-select, selectable, and aggregated view (both read-all and read-select) components

### Issues Resolved
N/A

## Screenshot

Toast message + popover should be shown below.

## Testing the changes

### Note
All testing was done when `data_sources.enabled: true` and `data_source.hideLocalCluster: true` (these are the only two configurations that can show the `NoDataSources` component + toast.

Both cases should show the `Manage data sources` button.

### When there are no datasources added
- This should show the message `No data sources connected yet. Connect your data sources to get started.` 

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/84ca805f-c2a8-49ee-8d63-025553092b2d)

![Screenshot 2024-04-29 at 11 52 59 AM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/2ca3361e-bb82-411d-9335-5cfef1924614)

### When datasources are added, but the `dataSourceFilter = (_) => false`
- This should show the message `No compatible data sources are available. Add a compatible data source.`

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/31dbab14-420a-466b-aa8c-cdadcdcc39ac)

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/2116c8e5-45d4-4b1e-a7d6-c7a81ef88d2d)

## Changelog
- fix: [MDS] Add a new message to data source components when there are no compatible datasources

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
