### PR TITLE
fix: register right navigation for dev tool only when console is enabled

### DIFF
--- a/src/plugins/dev_tools/public/plugin.ts
+++ b/src/plugins/dev_tools/public/plugin.ts
@@ -137,19 +137,21 @@ export class DevToolsPlugin implements Plugin<DevToolsSetup> {
   public start(core: CoreStart) {
     if (this.getSortedDevTools().length === 0) {
       this.appStateUpdater.next(() => ({ navLinkStatus: AppNavLinkStatus.hidden }));
+    } else {
+      // Register right navigation for dev tool only when console is enabled.
+      core.chrome.navControls.registerRight({
+        order: RightNavigationOrder.DevTool,
+        mount: toMountPoint(
+          React.createElement(RightNavigationButton, {
+            appId: this.id,
+            iconType: 'consoleApp',
+            title: this.title,
+            application: core.application,
+            http: core.http,
+          })
+        ),
+      });
     }
-    core.chrome.navControls.registerRight({
-      order: RightNavigationOrder.DevTool,
-      mount: toMountPoint(
-        React.createElement(RightNavigationButton, {
-          appId: this.id,
-          iconType: 'consoleApp',
-          title: this.title,
-          application: core.application,
-          http: core.http,
-        })
-      ),
-    });
   }
 
   public stop() {}


### PR DESCRIPTION
### Description

register right navigation for dev tool only when console is enabled

## Screenshot

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/42465692/6ed2747b-16c4-4ba0-b67f-7cfa70d2c8a7)
console is disabled

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/42465692/35706b6a-ec61-4636-a848-d926a76cd76b)
console is enabled


## Testing the changes

1. use `yarn start --console.enabled=false`, dev tool and top right navigation won't be registered.
2. use  `yarn start`, dev tool and top right navigation will both be registered.

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
