### PR TITLE
Add default and value check for theme user specific keys

### DIFF
--- a/changelogs/fragments/6714.yml
+++ b/changelogs/fragments/6714.yml
@@ -1,0 +1,2 @@
+fix:
+- Add default and value check for theme user specific keys ([#6714](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6714))

--- a/src/legacy/ui/ui_render/bootstrap/bootstrap.js.hbs
+++ b/src/legacy/ui/ui_render/bootstrap/bootstrap.js.hbs
@@ -11,8 +11,13 @@ if (window.__osdStrictCsp__ && window.__osdCspNotEnforced__) {
     window.console.log("^ A single error about an inline script not firing due to content security policy is expected!");
   }
 
-  var isDarkMode = window.__osdThemeTag__.endsWith('dark');
-  var themeVersion = window.__osdThemeTag__.startsWith('v7') ? 'v7' : 'v8';
+  var isDarkMode = false;
+  var themeVersion = '';
+
+  if (window.__osdThemeTag__) {
+    isDarkMode = window.__osdThemeTag__.endsWith('dark');
+    themeVersion = window.__osdThemeTag__.startsWith('v7') ? 'v7' : 'v8';
+  }  
 
   var loadingMessage = document.getElementById('osd_loading_message');
   loadingMessage.style.display = 'flex';


### PR DESCRIPTION
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6704

## Changelog
- fix: Add default and value check for theme user specific keys

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
