### PR TITLE
Add Server Side batching for UI Metric Collectors

### DIFF
--- a/changelogs/fragments/6721.yml
+++ b/changelogs/fragments/6721.yml
@@ -1,0 +1,2 @@
+feat:
+- Add Server Side Batching for UI Metric Colector ([#6721](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6721))

--- a/src/plugins/usage_collection/common/constants.ts
+++ b/src/plugins/usage_collection/common/constants.ts
@@ -30,3 +30,4 @@
 
 export const OPENSEARCH_DASHBOARDS_STATS_TYPE = 'opensearch_dashboards_stats';
 export const DEFAULT_MAXIMUM_WAIT_TIME_FOR_ALL_COLLECTORS_IN_S = 60;
+export const DEFAULT_BATCHING_INTERVAL_FOR_UI_METRIC_IN_S = 60;

--- a/src/plugins/usage_collection/server/config.ts
+++ b/src/plugins/usage_collection/server/config.ts
@@ -30,12 +30,19 @@
 
 import { schema, TypeOf } from '@osd/config-schema';
 import { PluginConfigDescriptor } from 'opensearch-dashboards/server';
-import { DEFAULT_MAXIMUM_WAIT_TIME_FOR_ALL_COLLECTORS_IN_S } from '../common/constants';
+import {
+  DEFAULT_BATCHING_INTERVAL_FOR_UI_METRIC_IN_S,
+  DEFAULT_MAXIMUM_WAIT_TIME_FOR_ALL_COLLECTORS_IN_S,
+} from '../common/constants';
 
 export const configSchema = schema.object({
   uiMetric: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
     debug: schema.boolean({ defaultValue: schema.contextRef('dev') }),
+    batchingIntervalInS: schema.number({
+      min: 0,
+      defaultValue: DEFAULT_BATCHING_INTERVAL_FOR_UI_METRIC_IN_S,
+    }),
   }),
   maximumWaitTimeForAllCollectorsInS: schema.number({
     defaultValue: DEFAULT_MAXIMUM_WAIT_TIME_FOR_ALL_COLLECTORS_IN_S,

--- a/src/plugins/usage_collection/server/plugin.ts
+++ b/src/plugins/usage_collection/server/plugin.ts
@@ -75,6 +75,7 @@ export class UsageCollectionPlugin implements Plugin<CollectorSet> {
         opensearchDashboardsVersion: this.initializerContext.env.packageInfo.version,
         server: core.http.getServerInfo(),
         uuid: this.initializerContext.env.instanceUuid,
+        batchingInterval: config.uiMetric.batchingIntervalInS,
       },
       metrics: core.metrics,
       overallStatus$: core.status.overall$,

--- a/src/plugins/usage_collection/server/report/store_report.test.ts
+++ b/src/plugins/usage_collection/server/report/store_report.test.ts
@@ -80,7 +80,9 @@ describe('store_report', () => {
     expect(savedObjectClient.incrementCounter).toHaveBeenCalledWith(
       'ui-metric',
       'test-app-name:test-event-name',
-      'count'
+      'count',
+      {},
+      3
     );
     expect(savedObjectClient.bulkCreate).toHaveBeenCalledWith([
       {

--- a/src/plugins/usage_collection/server/report/store_report.ts
+++ b/src/plugins/usage_collection/server/report/store_report.ts
@@ -57,11 +57,17 @@ export async function storeReport(
       };
     }),
     ...uiStatsMetrics.map(async ([key, metric]) => {
-      const { appName, eventName } = metric;
+      const { appName, eventName, stats } = metric;
       const savedObjectId = `${appName}:${eventName}`;
       return {
         saved_objects: [
-          await internalRepository.incrementCounter('ui-metric', savedObjectId, 'count'),
+          await internalRepository.incrementCounter(
+            'ui-metric',
+            savedObjectId,
+            'count',
+            {},
+            stats.sum
+          ),
         ],
       };
     }),

--- a/src/plugins/usage_collection/server/routes/index.ts
+++ b/src/plugins/usage_collection/server/routes/index.ts
@@ -56,11 +56,12 @@ export function setupRoutes({
       hostname: string;
       port: number;
     };
+    batchingInterval: number;
   };
   collectorSet: CollectorSet;
   metrics: MetricsServiceSetup;
   overallStatus$: Observable<ServiceStatus>;
 }) {
-  registerUiMetricRoute(router, getSavedObjects);
+  registerUiMetricRoute(router, getSavedObjects, rest.config.batchingInterval);
   registerStatsRoute({ router, ...rest });
 }

--- a/src/plugins/usage_collection/server/routes/report_metrics.ts
+++ b/src/plugins/usage_collection/server/routes/report_metrics.ts
@@ -31,11 +31,16 @@
 import { schema } from '@osd/config-schema';
 import { IRouter, ISavedObjectsRepository } from 'opensearch-dashboards/server';
 import { storeReport, reportSchema } from '../report';
+import { BatchReport } from '../types';
+import { ReportSchemaType } from '../report/schema';
 
 export function registerUiMetricRoute(
   router: IRouter,
-  getSavedObjects: () => ISavedObjectsRepository | undefined
+  getSavedObjects: () => ISavedObjectsRepository | undefined,
+  batchingInterval: number
 ) {
+  let batchReport = { report: {}, startTimestamp: 0 } as BatchReport;
+  const batchingIntervalInMs = batchingInterval * 1000;
   router.post(
     {
       path: '/api/ui_metric/report',
@@ -48,15 +53,84 @@ export function registerUiMetricRoute(
     async (context, req, res) => {
       const { report } = req.body;
       try {
-        const internalRepository = getSavedObjects();
-        if (!internalRepository) {
-          throw Error(`The saved objects client hasn't been initialised yet`);
+        const currTime = Date.now();
+
+        // Add the current report to batchReport
+        batchReport.report = combineReports(report, batchReport.report);
+        // If the time duration since the batchReport startTime is greater than batchInterval then write it to the savedObject
+        if (currTime - batchReport.startTimestamp >= batchingIntervalInMs) {
+          const prevReport = batchReport;
+
+          batchReport = {
+            report: {},
+            startTimestamp: currTime,
+          }; // reseting the batchReport and updating the startTimestamp to current TimeStamp
+
+          if (prevReport) {
+            // Write the previously batched Report to the saved object
+            const internalRepository = getSavedObjects();
+            if (!internalRepository) {
+              throw Error(`The saved objects client hasn't been initialised yet`);
+            }
+            await storeReport(internalRepository, prevReport.report);
+          }
         }
-        await storeReport(internalRepository, report);
+
         return res.ok({ body: { status: 'ok' } });
       } catch (error) {
         return res.ok({ body: { status: 'fail' } });
       }
     }
   );
+}
+
+function combineReports(report1: ReportSchemaType, report2: ReportSchemaType) {
+  // Combines report2 onto the report1 and returns the updated report1
+
+  // Combining User Agents
+  const combinedUserAgent = { ...report2.userAgent, ...report1.userAgent };
+
+  // Combining UI metrics
+  const combinedUIMetric = { ...report1.uiStatsMetrics };
+  if (report2.uiStatsMetrics !== undefined) {
+    for (const key of Object.keys(report2.uiStatsMetrics)) {
+      if (report2.uiStatsMetrics[key]?.stats?.sum === undefined) {
+        continue;
+      } else if (report1.uiStatsMetrics?.[key] === undefined) {
+        combinedUIMetric[key] = report2.uiStatsMetrics[key];
+      } else {
+        const { stats, ...rest } = combinedUIMetric[key];
+        const combinedStats = { ...stats };
+        combinedStats.sum += report2.uiStatsMetrics[key].stats.sum; // Updating the sum since it is field we will be using to update the saved Object
+        combinedUIMetric[key] = { ...rest, stats: combinedStats };
+      }
+    }
+  }
+
+  // Combining Application Usage
+  const combinedApplicationUsage = { ...report1.application_usage };
+  if (report2.application_usage !== undefined) {
+    for (const key of Object.keys(report2.application_usage)) {
+      if (
+        report2.application_usage[key]?.numberOfClicks === undefined ||
+        report2.application_usage[key]?.minutesOnScreen === undefined
+      ) {
+        continue;
+      } else if (report1.application_usage?.[key] === undefined) {
+        combinedApplicationUsage[key] = report2.application_usage[key];
+      } else {
+        const combinedUsage = { ...combinedApplicationUsage[key] };
+        combinedUsage.numberOfClicks += report2.application_usage[key]?.numberOfClicks || 0;
+        combinedUsage.minutesOnScreen += report2.application_usage[key]?.minutesOnScreen || 0;
+        combinedApplicationUsage[key] = combinedUsage;
+      }
+    }
+  }
+
+  return {
+    reportVersion: report1.reportVersion,
+    userAgent: combinedUserAgent,
+    uiStatsMetrics: combinedUIMetric,
+    application_usage: combinedApplicationUsage,
+  } as ReportSchemaType;
 }

--- a/src/plugins/usage_collection/server/types.ts
+++ b/src/plugins/usage_collection/server/types.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReportSchemaType } from './report/schema';
+export interface BatchReport {
+  report: ReportSchemaType;
+  startTimestamp: number;
+}


### PR DESCRIPTION
### Description

This PR introduces Server Side batching of UI metric reports sent by clients to reduce the number of updates taking place at OpenSearch.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6375

## Testing the changes

- Enable UI Metric Collector by setting the usageCollection.uiMetric.enabled to true 
- Ascertain the ui_metric in usage section is empty when you call the `/api/stats?extended=true&legacy=true&exclude_usage=false`
- Make a POST call to the `/api/ui_metric/report` with the following request body `{"report":{"reportVersion":1,"uiStatsMetrics":{"console-count-GET_cat.indices":{"key":"console-count-GET_cat.indices","appName":"console","eventName":"GET_cat.indices","type":"count","stats":{"min":0,"max":1,"avg":0.5,"sum":21}}}}}`
- Call `/api/stats?extended=true&legacy=true&exclude_usage=false` and verify that it has an entry `{"key":"GET_cat.indices","value":21}`
-  Make a POST call to the `/api/ui_metric/report` with the following request body `{"report":{"reportVersion":1,"uiStatsMetrics":{"console-count-GET_cat.indices":{"key":"console-count-GET_cat.indices","appName":"console","eventName":"GET_cat.indices","type":"count","stats":{"min":0,"max":1,"avg":0.5,"sum":21}}}}}`
-  Call `/api/stats?extended=true&legacy=true&exclude_usage=false` and verify that it has an entry `{"key":"GET_cat.indices","value":21}` the count shouldn't have been updated
- Wait for a period of 60s. And Make a POST call to the `/api/ui_metric/report` with the following request body `{"report":{"reportVersion":1,"uiStatsMetrics":{"console-count-GET_cat.indices":{"key":"console-count-GET_cat.indices","appName":"console","eventName":"GET_cat.indices","type":"count","stats":{"min":0,"max":1,"avg":0.5,"sum":21}}}}}`
- -  Call `/api/stats?extended=true&legacy=true&exclude_usage=false` and verify that it has an entry `{"key":"GET_cat.indices","value":63}` the count should be updated to the latest value

OR

You can pull in changes **https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1267** update the flag `"UIMETRIC_ENABLED": true` and run the following command `yarn cypress run --spec cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/telemetry/server.spec.js` . This test automates the above mentioned steps.

## Changelog
- feat: Add Server Side Batching for UI Metric Colector

<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
