### PR TITLE
[Multiple Datasource Test] Add test for error_menu, item, data_source_multi_selectable

### DIFF
--- a/changelogs/fragments/6752.yml
+++ b/changelogs/fragments/6752.yml
@@ -1,0 +1,2 @@
+fix:
+- Add test for data_source_error_menu, data_source_item, data_source_multi_selectable ([#6752](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6752))

--- a/src/plugins/data_source_management/public/components/data_source_error_menu/__snapshots__/data_source_error_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_error_menu/__snapshots__/data_source_error_menu.test.tsx.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataSourceErrorMenu renders without crashing 1`] = `
+<Fragment>
+  <EuiPopover
+    anchorPosition="downLeft"
+    button={
+      <EuiButtonIcon
+        aria-label="dataSourceErrorMenuHeaderLink"
+        className="euiHeaderLink"
+        data-test-subj="dataSourceErrorMenuHeaderLink"
+        iconType={[Function]}
+        onClick={[Function]}
+        size="s"
+      />
+    }
+    closePopover={[Function]}
+    data-test-subj="dataSourceErrorPopover"
+    display="inlineBlock"
+    hasArrow={true}
+    id="dataSourceErrorPopover"
+    isOpen={false}
+    ownFocus={true}
+    panelPaddingSize="none"
+  >
+    <DataSourceDropDownHeader
+      application={
+        Object {
+          "applications$": BehaviorSubject {
+            "_isScalar": false,
+            "_value": Map {},
+            "closed": false,
+            "hasError": false,
+            "isStopped": false,
+            "observers": Array [],
+            "thrownError": null,
+          },
+          "capabilities": Object {
+            "catalogue": Object {},
+            "management": Object {},
+            "navLinks": Object {},
+            "workspaces": Object {},
+          },
+          "currentAppId$": Observable {
+            "_isScalar": false,
+            "source": Subject {
+              "_isScalar": false,
+              "closed": false,
+              "hasError": false,
+              "isStopped": false,
+              "observers": Array [],
+              "thrownError": null,
+            },
+          },
+          "getUrlForApp": [MockFunction],
+          "navigateToApp": [MockFunction],
+          "navigateToUrl": [MockFunction],
+          "registerMountContext": [MockFunction],
+        }
+      }
+      totalDataSourceCount={0}
+    />
+    <EuiPanel
+      className="dataSourceEmptyStatePanel"
+      data-test-subj="datasourceTableEmptyState"
+      hasBorder={false}
+      hasShadow={false}
+    >
+      <EuiText
+        size="s"
+        textAlign="center"
+      >
+        Failed to fetch data sources
+      </EuiText>
+    </EuiPanel>
+    <EuiPopoverFooter>
+      <EuiFlexGroup
+        justifyContent="spaceAround"
+      >
+        <EuiFlexItem>
+          <EuiButton
+            data-test-subj="dataSourceErrorRefreshButton"
+            fill={false}
+            iconType="refresh"
+            onClick={[Function]}
+            size="s"
+          >
+            Refresh the page
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPopoverFooter>
+  </EuiPopover>
+</Fragment>
+`;

--- a/src/plugins/data_source_management/public/components/data_source_error_menu/data_source_error_menu.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_error_menu/data_source_error_menu.test.tsx
@@ -4,9 +4,7 @@
  */
 
 import React from 'react';
-import { mount, shallow } from 'enzyme';
-import { ApplicationStart } from 'opensearch-dashboards/public';
-import { EuiButton, EuiButtonIcon, EuiPopover } from '@elastic/eui';
+import { shallow } from 'enzyme';
 import { DataSourceErrorMenu } from './data_source_error_menu';
 import { coreMock } from '../../../../../core/public/mocks';
 import { render } from '@testing-library/react';
@@ -23,5 +21,8 @@ describe('DataSourceErrorMenu', () => {
     const iconButton = container.getByTestId('dataSourceErrorMenuHeaderLink');
     iconButton.click();
     expect(container.getByTestId('dataSourceErrorPopover')).toBeVisible();
+    expect(container.getByTestId('datasourceTableEmptyState')).toHaveTextContent(
+      'Failed to fetch data sources'
+    );
   });
 });

--- a/src/plugins/data_source_management/public/components/data_source_error_menu/data_source_error_menu.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_error_menu/data_source_error_menu.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import { ApplicationStart } from 'opensearch-dashboards/public';
+import { EuiButton, EuiButtonIcon, EuiPopover } from '@elastic/eui';
+import { DataSourceErrorMenu } from './data_source_error_menu';
+import { coreMock } from '../../../../../core/public/mocks';
+import { render } from '@testing-library/react';
+
+describe('DataSourceErrorMenu', () => {
+  const applicationMock = coreMock.createStart().application;
+  it('renders without crashing', () => {
+    const component = shallow(<DataSourceErrorMenu application={applicationMock} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should toggle popover when icon button is clicked', () => {
+    const container = render(<DataSourceErrorMenu application={applicationMock} />);
+    const iconButton = container.getByTestId('dataSourceErrorMenuHeaderLink');
+    iconButton.click();
+    expect(container.getByTestId('dataSourceErrorPopover')).toBeVisible();
+  });
+});

--- a/src/plugins/data_source_management/public/components/data_source_item/data_source_item.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_item/data_source_item.test.tsx
@@ -43,4 +43,21 @@ describe('Test on ShowDataSourceOption', () => {
     expect(component.find(EuiFlexItem)).toHaveLength(2);
     expect(component.find(EuiBadge)).toHaveLength(1);
   });
+
+  it('should render the component with a default data source', () => {
+    const item: DataSourceOption = {
+      id: 'default data source',
+      label: 'DataSource 1',
+      visible: true,
+    };
+    const defaultDataSource = 'default data source';
+    const wrapper = shallow(
+      <DataSourceItem className="test" option={item} defaultDataSource={defaultDataSource} />
+    );
+
+    expect(wrapper.find(EuiFlexGroup).exists()).toBe(true);
+    expect(wrapper.find(EuiFlexItem).exists()).toBe(true);
+    expect(wrapper.find(EuiBadge).exists()).toBe(true);
+    expect(wrapper.find(EuiBadge).prop('children')).toBe('Default');
+  });
 });


### PR DESCRIPTION

### Description

Add test for data_source_error_menu, data_source_item, data_source_multi_selectable
### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6748
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6749
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6750

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

```

 PASS  src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.test.tsx (5.229 s)
  DataSourceMultiSelectable
    ✓ should render normally with local cluster not hidden (9 ms)
    ✓ should render normally with local cluster hidden (1 ms)
    ✓ should show toasts when exception happens (2 ms)
    ✓ should callback when onChange happens (227 ms)
    ✓ should return correct state when ui Settings provided (2 ms)
    ✓ should return correct state when ui Settings provided and hide cluster is false (1 ms)
    ✓ should handle no available data source error when selected option is empty and hide localcluster (20 ms)
    ✓ should not handle no available data source error when selected option is empty and not hide localcluster (5 ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   2 passed, 2 total

 PASS  src/plugins/data_source_management/public/components/data_source_item/data_source_item.test.tsx
  Test on ShowDataSourceOption
    ✓ should render the component with label (28 ms)
    ✓ should render the component with label and default badge (11 ms)
    ✓ should render the component with a default data source (15 ms)

 PASS  src/plugins/data_source_management/public/components/data_source_item/data_source_item.test.tsx
  Test on ShowDataSourceOption
    ✓ should render the component with label (31 ms)
    ✓ should render the component with label and default badge (11 ms)
    ✓ should render the component with a default data source (15 ms)

```

## Changelog
- fix: Add test for data_source_error_menu, data_source_item, data_source_multi_selectable

<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
