### PR TITLE
Make Field Name Search Filter Case Insensitive

### DIFF
--- a/changelogs/fragments/6759.yml
+++ b/changelogs/fragments/6759.yml
@@ -1,0 +1,2 @@
+feat:
+- Make Field Name Search Filter Case Insensitive ([#6759](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6759))

--- a/src/plugins/discover/public/application/components/sidebar/lib/field_filter.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/field_filter.ts
@@ -83,7 +83,8 @@ export function isFieldFiltered(
     field.type === '_source' ||
     field.scripted ||
     fieldCounts[field.name] > 0;
-  const matchName = !filterState.name || field.name.indexOf(filterState.name) !== -1;
+  const matchName =
+    !filterState.name || field.name.toLowerCase().indexOf(filterState.name.toLowerCase()) !== -1; // case insensitive matching name
 
   return matchFilter && isAggregatable && isSearchable && scriptedOrMissing && matchName;
 }


### PR DESCRIPTION
### Description

This change is aimed at making the  **Search Field Name Filter** in Discover Case Insensitive. 

## Testing the changes

- Navigate to Discover Page
- Type a Field Name in the Search a Field Name search bar
- Validate the field shown in the left navigation pane contains the Field name (irrespective of the case)

## Changelog
- feat: Make Field Name Search Filter Case Insensitive

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
