### PR TITLE
[CVE-2024-33883] Bump ejs from `3.1.7` to `3.1.10`

### DIFF
--- a/changelogs/fragments/6770.yml
+++ b/changelogs/fragments/6770.yml
@@ -1,2 +1,2 @@
 security:
-- [CVE-2024-33883] Bump ejs from `3.1.7` to `3.1.101` ([#6770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6770))
+- [CVE-2024-33883] Bump ejs from `3.1.7` to `3.1.10` ([#6770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6770))

--- a/changelogs/fragments/6770.yml
+++ b/changelogs/fragments/6770.yml
@@ -1,2 +1,2 @@
 security:
-- [CVE-2024-33883] Bump ejs from `3.1.7` to `3.1.101 ([#6770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6770))
+- [CVE-2024-33883] Bump ejs from `3.1.7` to `3.1.101` ([#6770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6770))

--- a/changelogs/fragments/6770.yml
+++ b/changelogs/fragments/6770.yml
@@ -1,2 +1,2 @@
 security:
-- [CVE-2024-33883] Bump ejs from `3.1.7` to `3.1.101` ([#6770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6770))
+- [CVE-2024-33883] Bump ejs from `3.1.7` to `3.1.101 ([#6770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6770))

--- a/changelogs/fragments/6770.yml
+++ b/changelogs/fragments/6770.yml
@@ -1,0 +1,2 @@
+security:
+- [CVE-2024-33883] Bump ejs from `3.1.7` to `3.1.101 ([#6770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6770))

--- a/packages/osd-plugin-generator/package.json
+++ b/packages/osd-plugin-generator/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@osd/cross-platform": "1.0.0",
     "@osd/dev-utils": "1.0.0",
-    "ejs": "^3.1.7",
+    "ejs": "^3.1.10",
     "execa": "^4.0.2",
     "inquirer": "^7.3.3",
     "normalize-path": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7788,10 +7788,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-ejs@^3.1.7:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.7.tgz#c544d9c7f715783dd92f0bddcf73a59e6962d006"
-  integrity sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==
+ejs@^3.1.10:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
+  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
   dependencies:
     jake "^10.8.5"
 


### PR DESCRIPTION
### Issue Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6769


## Changelog

- security: [CVE-2024-33883] Bump ejs from `3.1.7` to `3.1.10`


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
