### PR TITLE
[Workspace] Fix workspace name duplication check

### DIFF
--- a/changelogs/fragments/6776.yml
+++ b/changelogs/fragments/6776.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix workspace name duplication check ([#6776](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6776))

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -95,7 +95,7 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
       const existingWorkspaceRes = await this.getScopedClientWithoutPermission(requestDetail)?.find(
         {
           type: WORKSPACE_TYPE,
-          search: attributes.name,
+          search: `"${attributes.name}"`,
           searchFields: ['name'],
         }
       );
@@ -184,7 +184,7 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
           requestDetail
         )?.find({
           type: WORKSPACE_TYPE,
-          search: attributes.name,
+          search: `"${attributes.name}"`,
           searchFields: ['name'],
           fields: ['_id'],
         });


### PR DESCRIPTION
### Description

enclose workspace name with double quotes when doing duplication check, so that it will not interpret by simply query syntax and do match it with exact match (workspace.name field type is `keyword`)


```
GET .kibana/_search
{
  "profile": "true", 
  "query": {
    "simple_query_string": {
      "query": "\"demo workspace\"",
      "fields": ["workspace.name"]
    }
  }
}
```
It will convert to `TermQuery` that's exact match.

```json
  "profile": {
    "shards": [
      {
        "id": "[qYfwnwnoTiqalgsnAT9rjA][.kibana_12][0]",
        "inbound_network_time_in_millis": 0,
        "outbound_network_time_in_millis": 0,
        "searches": [
          {
            "query": [
              {
                "type": "TermQuery",
                "description": "workspace.name:demo workspace",
                "time_in_nanos": 9585,
                "breakdown": {
                  ...
                }
              }
            ]
           ...
          }
        ],
        "aggregations": []
      }
    ]
  }

```


### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6480

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: fix workspace name duplication check

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
~~- [ ] New functionality has been documented.~~
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
