### PR TITLE
fix vega visualization error message not been formatted

### DIFF
--- a/changelogs/fragments/6777.yml
+++ b/changelogs/fragments/6777.yml
@@ -1,0 +1,2 @@
+fix:
+- Error message is not formatted in vis_type_vega url parser. ([#6777](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6777))

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
@@ -674,7 +674,7 @@ The URL is an identifier only. OpenSearch Dashboards and your browser will never
           i18n.translate('visTypeVega.vegaParser.notSupportedUrlTypeErrorMessage', {
             defaultMessage: '{urlObject} is not supported',
             values: {
-              urlObject: 'url: {"%type%": "${type}"}',
+              urlObject: `url: {"%type%": "${type}"}`,
             },
           })
         );


### PR DESCRIPTION
### Description
With unsupported type `ppl`
The error message before:
`url: {"%type%": "${type}"} is not supported`
It should be:
`url: {"%type%": "ppl"} is not supported`

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- fix: error message is not formatted in vis_type_vega url parser.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
