### PR TITLE
[Discover][Bug] Migrate global state from legacy URL

### DIFF
--- a/changelogs/fragments/6780.yml
+++ b/changelogs/fragments/6780.yml
@@ -1,0 +1,2 @@
+fix:
+- [Discover][Bug] Migrate global state from legacy URL ([#6780](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6780))

--- a/src/plugins/discover/public/migrate_state.ts
+++ b/src/plugins/discover/public/migrate_state.ts
@@ -133,7 +133,9 @@ export function migrateUrlState(oldPath: string, newPath = '/'): string {
           indexPattern: index,
         },
       };
+      const _g = getStateFromOsdUrl<any>('_g', oldPath);
 
+      path = setStateToOsdUrl('_g', _g, { useHash: false }, path);
       path = setStateToOsdUrl('_a', _a, { useHash: false }, path);
       path = setStateToOsdUrl('_q', _q, { useHash: false }, path);
 

--- a/src/plugins/discover/public/migrate_states.test.ts
+++ b/src/plugins/discover/public/migrate_states.test.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { migrateUrlState } from './migrate_state';
+import { setStateToOsdUrl, getStateFromOsdUrl } from '../../opensearch_dashboards_utils/public';
+
+jest.mock('../../opensearch_dashboards_utils/public', () => ({
+  setStateToOsdUrl: jest.fn(),
+  getStateFromOsdUrl: jest.fn(),
+}));
+
+describe('migrateUrlState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return the new path if no matching pattern', () => {
+    const result = migrateUrlState('#/unknown', '/newPath');
+    expect(result).toBe('/newPath');
+  });
+
+  it('should migrate doc view', () => {
+    const result = migrateUrlState('#/doc/indexPattern/id', '/newPath');
+    expect(result).toBe('#/doc/indexPattern/id');
+  });
+
+  it('should migrate context view', () => {
+    const result = migrateUrlState('#/context/indexPattern/id', '/newPath');
+    expect(result).toBe('#/context/indexPattern/id');
+  });
+
+  it('should migrate discover view with saved search id and with global state', () => {
+    (getStateFromOsdUrl as jest.Mock).mockImplementation((key) => {
+      if (key === '_a') {
+        return {
+          columns: ['column1'],
+          filters: [],
+          index: 'indexPattern',
+          interval: 'auto',
+          query: { language: 'kuery', query: 'test' },
+          sort: [['field', 'desc']],
+          savedQuery: 'savedQueryId',
+        };
+      }
+      if (key === '_g') {
+        return {
+          time: { from: 'now-15m', to: 'now' },
+          filters: [],
+          refreshInterval: { pause: true, value: 0 },
+        };
+      }
+      return null;
+    });
+
+    (setStateToOsdUrl as jest.Mock).mockImplementation((key, state, options, rawUrl) => {
+      const query = new URLSearchParams(rawUrl.split('?')[1] || '');
+      query.set(key, JSON.stringify(state)); // Simplified encoding
+      return `${rawUrl.split('?')[0]}?${query.toString()}`;
+    });
+
+    const result = migrateUrlState('#/view/savedSearchId', '/newPath');
+    const decodedResult = decodeURIComponent(result);
+    const expectedPath =
+      '/newPath#/view/savedSearchId?_g={"time":{"from":"now-15m","to":"now"},"filters":[],"refreshInterval":{"pause":true,"value":0}}&_a={"discover":{"columns":["column1"],"interval":"auto","sort":[["field","desc"]],"savedQuery":"savedQueryId"},"metadata":{"indexPattern":"indexPattern"}}&_q={"query":{"language":"kuery","query":"test"},"filters":[]}';
+    expect(decodedResult).toBe(expectedPath);
+  });
+
+  it('should migrate discover view without saved search id and with global state', () => {
+    (getStateFromOsdUrl as jest.Mock).mockImplementation((key) => {
+      if (key === '_a') {
+        return {
+          columns: ['column1'],
+          filters: [],
+          index: 'indexPattern',
+          interval: 'auto',
+          query: { language: 'kuery', query: 'test' },
+          sort: [['field', 'desc']],
+          savedQuery: 'savedQueryId',
+        };
+      }
+      if (key === '_g') {
+        return {
+          time: { from: 'now-15m', to: 'now' },
+          filters: [],
+          refreshInterval: { pause: true, value: 0 },
+        };
+      }
+      return null;
+    });
+
+    const result = migrateUrlState('#/', '/newPath');
+    const decodedResult = decodeURIComponent(result);
+    const expectedPath =
+      '/newPath?_g={"time":{"from":"now-15m","to":"now"},"filters":[],"refreshInterval":{"pause":true,"value":0}}&_a={"discover":{"columns":["column1"],"interval":"auto","sort":[["field","desc"]],"savedQuery":"savedQueryId"},"metadata":{"indexPattern":"indexPattern"}}&_q={"query":{"language":"kuery","query":"test"},"filters":[]}';
+    expect(decodedResult).toBe(expectedPath);
+  });
+
+  it('should migrate discover view without saved search id and without global state', () => {
+    (getStateFromOsdUrl as jest.Mock).mockImplementation((key) => {
+      if (key === '_a') {
+        return {
+          columns: ['column1'],
+          filters: [],
+          index: 'indexPattern',
+          interval: 'auto',
+          query: { language: 'kuery', query: 'test' },
+          sort: [['field', 'desc']],
+          savedQuery: 'savedQueryId',
+        };
+      }
+      return null;
+    });
+
+    (setStateToOsdUrl as jest.Mock).mockImplementation((key, state, options, rawUrl) => {
+      const query = new URLSearchParams(rawUrl.split('?')[1] || '');
+      query.set(key, JSON.stringify(state)); // Simplified encoding
+      return `${rawUrl.split('?')[0]}?${query.toString()}`;
+    });
+
+    const result = migrateUrlState('#/', '/newPath');
+    const decodedResult = decodeURIComponent(result);
+    const expectedPath =
+      '/newPath?_g=null&_a={"discover":{"columns":["column1"],"interval":"auto","sort":[["field","desc"]],"savedQuery":"savedQueryId"},"metadata":{"indexPattern":"indexPattern"}}&_q={"query":{"language":"kuery","query":"test"},"filters":[]}';
+    expect(decodedResult).toBe(expectedPath);
+  });
+
+  it('should return the new path if appState is null', () => {
+    (getStateFromOsdUrl as jest.Mock).mockImplementation((key) => {
+      if (key === '_a') {
+        return null;
+      }
+      return null;
+    });
+
+    const result = migrateUrlState('#/view/savedSearchId', '/newPath');
+    expect(result).toBe('/newPath#/view/savedSearchId');
+  });
+
+  it('should handle missing global state to null', () => {
+    (getStateFromOsdUrl as jest.Mock).mockImplementation((key) => {
+      if (key === '_a') {
+        return {
+          columns: ['column1'],
+          filters: [],
+          index: 'indexPattern',
+          interval: 'auto',
+          query: { language: 'kuery', query: 'test' },
+          sort: [['field', 'desc']],
+          savedQuery: 'savedQueryId',
+        };
+      }
+      if (key === '_g') {
+        return null;
+      }
+      return null;
+    });
+
+    const result = migrateUrlState('#/view/savedSearchId', '/newPath');
+    const decodedResult = decodeURIComponent(result);
+    const expectedPath =
+      '/newPath#/view/savedSearchId?_g=null&_a={"discover":{"columns":["column1"],"interval":"auto","sort":[["field","desc"]],"savedQuery":"savedQueryId"},"metadata":{"indexPattern":"indexPattern"}}&_q={"query":{"language":"kuery","query":"test"},"filters":[]}';
+    expect(decodedResult).toBe(expectedPath);
+  });
+
+  it('should handle present global state', () => {
+    (getStateFromOsdUrl as jest.Mock).mockImplementation((key) => {
+      if (key === '_a') {
+        return {
+          columns: ['column1'],
+          filters: [],
+          index: 'indexPattern',
+          interval: 'auto',
+          query: { language: 'kuery', query: 'test' },
+          sort: [['field', 'desc']],
+          savedQuery: 'savedQueryId',
+        };
+      }
+      if (key === '_g') {
+        return {
+          time: { from: 'now-15m', to: 'now' },
+          filters: [],
+          refreshInterval: { pause: true, value: 0 },
+        };
+      }
+      return null;
+    });
+
+    const result = migrateUrlState('#/view/savedSearchId', '/newPath');
+    const decodedResult = decodeURIComponent(result);
+    const expectedPath =
+      '/newPath#/view/savedSearchId?_g={"time":{"from":"now-15m","to":"now"},"filters":[],"refreshInterval":{"pause":true,"value":0}}&_a={"discover":{"columns":["column1"],"interval":"auto","sort":[["field","desc"]],"savedQuery":"savedQueryId"},"metadata":{"indexPattern":"indexPattern"}}&_q={"query":{"language":"kuery","query":"test"},"filters":[]}';
+    expect(decodedResult).toBe(expectedPath);
+  });
+});


### PR DESCRIPTION
### Description
Allow migrate global state. I also thought about capture all other states besides `_g`, `_a, and `_q` like customized states, but our current helper func requiring us to know the key in advance. Given customized keys might have various formats, it is easy to make new bugs. 
```
export function getStatesFromOsdUrl(
  url: string = window.location.href,
  keys?: string[]
): Record<string, unknown> {
  const query = parseUrlHash(url)?.query;

  if (!query) return {};
  const decoded: Record<string, unknown> = {};
  Object.entries(query)
    .filter(([key]) => (keys ? keys.includes(key) : true))
    .forEach(([q, value]) => {
      decoded[q] = decodeState(value as string);
    });

  return decoded;
}
```


### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6766

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/79961084/8da52c7d-58d4-4c0e-9083-8876d91f8bc0

## Changelog

- fix: [Discover][Bug] Migrate global state from legacy URL

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
