### PR TITLE
fix for quickrange to use datemath to parse datetime strings

### DIFF
--- a/changelogs/fragments/6782.yml
+++ b/changelogs/fragments/6782.yml
@@ -1,0 +1,2 @@
+fix:
+- Quickrange selection fix ([#6782](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6782))

--- a/src/plugins/data/common/data_frames/data_frame_utils.test.ts
+++ b/src/plugins/data/common/data_frames/data_frame_utils.test.ts
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { TimeRange } from '../types';
+import { formatTimePickerDate } from './utils';
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+describe('Data Frame Utils', () => {
+  describe('formatTimePickerDate function', () => {
+    Date.now = jest.fn(() => new Date('2024-05-04T12:30:00.000Z'));
+
+    test('should return a correctly formatted date', () => {
+      const range = { from: 'now-15m', to: 'now' } as TimeRange;
+      const formattedDate = formatTimePickerDate(range, 'YYYY-MM-DD HH:mm:ss.SSS');
+      expect(formattedDate).toStrictEqual({
+        fromDate: '2024-05-04 12:15:00.000',
+        toDate: '2024-05-04 12:30:00.000',
+      });
+    });
+  });
+});

--- a/src/plugins/data/common/data_frames/data_frame_utils.test.ts
+++ b/src/plugins/data/common/data_frames/data_frame_utils.test.ts
@@ -43,5 +43,14 @@ describe('Data Frame Utils', () => {
         toDate: '2024-05-04 12:30:00.000',
       });
     });
+
+    test('should indicate invalid when given bad dates', () => {
+      const range = { from: 'fake', to: 'date' } as TimeRange;
+      const formattedDate = formatTimePickerDate(range, 'YYYY-MM-DD HH:mm:ss.SSS');
+      expect(formattedDate).toStrictEqual({
+        fromDate: 'Invalid date',
+        toDate: 'Invalid date',
+      });
+    });
   });
 });

--- a/src/plugins/data/common/data_frames/data_frame_utils.test.ts
+++ b/src/plugins/data/common/data_frames/data_frame_utils.test.ts
@@ -1,35 +1,10 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import { TimeRange } from '../types';
 import { formatTimePickerDate } from './utils';
-
-/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 
 describe('Data Frame Utils', () => {
   describe('formatTimePickerDate function', () => {

--- a/src/plugins/data/common/data_frames/utils.ts
+++ b/src/plugins/data/common/data_frames/utils.ts
@@ -17,7 +17,7 @@ import {
 import { IFieldType } from './fields';
 import { IndexPatternFieldMap, IndexPatternSpec } from '../index_patterns';
 import { IOpenSearchDashboardsSearchRequest } from '../search';
-import { GetAggTypeFn, GetDataFrameAggQsFn } from '../types';
+import { GetAggTypeFn, GetDataFrameAggQsFn, TimeRange } from '../types';
 
 /**
  * Returns the raw data frame from the search request.
@@ -288,6 +288,26 @@ export const getTimeField = (
   return aggConfig && aggConfig.date_histogram && aggConfig.date_histogram.field
     ? fields.find((field) => field.name === aggConfig?.date_histogram?.field)
     : fields.find((field) => field.type === 'date');
+};
+
+/**
+ * Parses timepicker datetimes using datemath package. Will attempt to parse strings such as
+ * "now - 15m"
+ *
+ * @param dateRange - of type TimeRange
+ * @returns object with fromDate and toDate, both of which will be in utc time and formatted to
+ * 'YYYY-MM-DD HH:mm:ss.SSS'
+ */
+export const formatTimePickerDate = (dateRange: TimeRange) => {
+  const dateMathParse = (date: string) => {
+    const parsedDate = datemath.parse(date);
+    return parsedDate ? parsedDate.utc().format('YYYY-MM-DD HH:mm:ss.SSS') : '';
+  };
+
+  const fromDate = dateMathParse(dateRange.from);
+  const toDate = dateMathParse(dateRange.to);
+
+  return { fromDate, toDate };
 };
 
 /**

--- a/src/plugins/data/common/data_frames/utils.ts
+++ b/src/plugins/data/common/data_frames/utils.ts
@@ -295,13 +295,14 @@ export const getTimeField = (
  * "now - 15m"
  *
  * @param dateRange - of type TimeRange
- * @returns object with fromDate and toDate, both of which will be in utc time and formatted to
- * 'YYYY-MM-DD HH:mm:ss.SSS'
+ * @param dateFormat - formatting string (should work with Moment)
+ * @returns object with `fromDate` and `toDate` strings, both of which will be in utc time and formatted to
+ * the `dateFormat` parameter
  */
-export const formatTimePickerDate = (dateRange: TimeRange) => {
+export const formatTimePickerDate = (dateRange: TimeRange, dateFormat: string) => {
   const dateMathParse = (date: string) => {
     const parsedDate = datemath.parse(date);
-    return parsedDate ? parsedDate.utc().format('YYYY-MM-DD HH:mm:ss.SSS') : '';
+    return parsedDate ? parsedDate.utc().format(dateFormat) : '';
   };
 
   const fromDate = dateMathParse(dateRange.from);


### PR DESCRIPTION
### Description

provides a formatting util function meant to convert quick range time (such as 'now-15m') to datetimes that can be understood. 
related to: https://github.com/kavilla/qlDashboards/pull/4 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Quickrange selection fix

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
