### PR TITLE
add @zhyuanqi as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT @xinruiba
+*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT @xinruiba @zhyuanqi

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,6 +24,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Yulong Ruan               | [ruanyl](https://github.com/ruanyl)                 | Amazon      |
 | Lu Yu                     | [BionIT](https://github.com/BionIT)                 | Amazon      |
 | Xinrui Bai                | [xinruiba](https://github.com/xinruiba)             | Amazon      |
+| Ella Zhu                  | [zhyuanqi](https://github.com/zhyuanqi)             | Amazon      |
 
 ## Emeritus
 

--- a/changelogs/fragments/6788.yml
+++ b/changelogs/fragments/6788.yml
@@ -1,0 +1,2 @@
+doc:
+- Add zhyuanqi as maintainer ([#6788](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6788))


### PR DESCRIPTION
### Description
Updates MAINTAINERS.md and .github/CODEOWNERS.

Here are zhyuanqi's current merge contributions, total contributions, and issues:
PR： https://github.com/opensearch-project/OpenSearch-Dashboards/pulls?q=is%3Apr+author%3Azhyuanqi+is%3Amerged
Review: https://github.com/opensearch-project/OpenSearch-Dashboards/pulls?q=is%3Apr+reviewed-by%3Azhyuanqi
Issues: https://github.com/opensearch-project/OpenSearch-Dashboards/issues?q=is%3Aissue+author%3Azhyuanqi


## Changelog
- doc: Add zhyuanqi as maintainer

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
