### PR TITLE
Move @BSFishy to emeritus maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @BSFishy @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT @xinruiba @zhyuanqi
+*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT @xinruiba @zhyuanqi

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,7 +17,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Manasvini B Suryanarayana | [manasvinibs](https://github.com/manasvinibs)       | Amazon      |
 | Tao Liu                   | [Flyingliuhub](https://github.com/Flyingliuhub)     | Amazon      |
 | Zilong Xia                | [ZilongX](https://github.com/ZilongX)               | Amazon      |
-| Matt Provost              | [BSFishy](https://github.com/BSFishy)               | Amazon      |
 | Sirazh Gabdullin          | [curq](https://github.com/curq)                     | External contributor |
 | Bandini Bhopi             | [bandinib-amzn](https://github.com/bandinib-amzn)   | Amazon      |
 | Su Zhou                   | [SuZhou-Joe](https://github.com/SuZhou-Joe)         | Amazon      |
@@ -35,3 +34,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Bishoy Boktor | [boktorbb](https://github.com/boktorbb)       | Amazon      |
 | Sean Neumann  | [seanneumann](https://github.com/seanneumann) | Contributor |
 | Kristen Tian  | [kristenTian](https://github.com/kristenTian) | Amazon      |
+| Matt Provost  | [BSFishy](https://github.com/BSFishy)         | Amazon      |

--- a/changelogs/fragments/6790.yml
+++ b/changelogs/fragments/6790.yml
@@ -1,0 +1,2 @@
+doc:
+- Move @BSFishy to emeritus maintainer ([#6790](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6790))


### PR DESCRIPTION
### Description
This change moves @BSFishy to emeritus maintainer.

## Changelog
- doc: Move @BSFishy to emeritus maintainer

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
