### PR TITLE
[MD] Fix server sider endpoint validation by passing in request when creating datasource client

### DIFF
--- a/changelogs/fragments/6822.yml
+++ b/changelogs/fragments/6822.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix endpoint validation by passing in request when creating datasource client ([#6822](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6822))


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

- Fix endpoint validation by passing in request when creating datasource client. Even tho request is an optional param, but there might be data source auth types registered that from external plugin, that will depend on the request. So we still need to pass it in when creating the client. Note that for existing MDS auth types, noauth, basic auth, sigV4, they don't depend on "request".
- added test
### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: fix endpoint validation by passing in request when creating datasource client
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
