### PR TITLE
[Multi Datasource] Unify getDefaultDataSourceId and export

### DIFF
--- a/changelogs/fragments/6843.yml
+++ b/changelogs/fragments/6843.yml
@@ -1,0 +1,2 @@
+refactor:
+- Unify getDefaultDataSourceId and export ([#6843](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6843))

--- a/src/plugins/data_source_management/public/components/constants.tsx
+++ b/src/plugins/data_source_management/public/components/constants.tsx
@@ -17,3 +17,5 @@ export const NO_DATASOURCES_CONNECTED_MESSAGE = 'No data sources connected yet.'
 export const CONNECT_DATASOURCES_MESSAGE = 'Connect your data sources to get started.';
 export const NO_COMPATIBLE_DATASOURCES_MESSAGE = 'No compatible data sources are available.';
 export const ADD_COMPATIBLE_DATASOURCES_MESSAGE = 'Add a compatible data source.';
+
+export const DEFAULT_DATA_SOURCE_UI_SETTINGS_ID = 'defaultDataSource';

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
@@ -18,6 +18,7 @@ import {
   handleNoAvailableDataSourceError,
   generateComponentId,
   getDataSourceSelection,
+  getDefaultDataSourceId,
 } from '../utils';
 import { SavedObject } from '../../../../../core/public';
 import { DataSourceAttributes } from '../../types';
@@ -132,7 +133,7 @@ export class DataSourceAggregatedView extends React.Component<
         this.setState({
           ...this.state,
           allDataSourcesIdToTitleMap,
-          defaultDataSource: this.props.uiSettings?.get('defaultDataSource', null) ?? null,
+          defaultDataSource: getDefaultDataSourceId(this.props.uiSettings) ?? null,
           showEmptyState: allDataSourcesIdToTitleMap.size === 0,
         });
       })

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
@@ -18,6 +18,7 @@ import {
   handleNoAvailableDataSourceError,
   generateComponentId,
   getDataSourceSelection,
+  getDefaultDataSourceId,
 } from '../utils';
 import { DataSourceBaseState } from '../data_source_menu/types';
 import { DataSourceErrorMenu } from '../data_source_error_menu';
@@ -76,7 +77,7 @@ export class DataSourceMultiSelectable extends React.Component<
   async componentDidMount() {
     this._isMounted = true;
     try {
-      const defaultDataSource = this.props.uiSettings?.get('defaultDataSource', null) ?? null;
+      const defaultDataSource = getDefaultDataSourceId(this.props.uiSettings) ?? null;
       let selectedOptions: SelectedDataSourceOption[] = [];
       const fetchedDataSources = await getDataSourcesWithFields(this.props.savedObjectsClient, [
         'id',

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -26,6 +26,7 @@ import {
   handleNoAvailableDataSourceError,
   generateComponentId,
   getDataSourceSelection,
+  getDefaultDataSourceId,
 } from '../utils';
 import { LocalCluster } from '../data_source_selector/data_source_selector';
 import { SavedObject } from '../../../../../core/public';
@@ -209,7 +210,7 @@ export class DataSourceSelectable extends React.Component<
         return;
       }
 
-      const defaultDataSource = this.props.uiSettings?.get('defaultDataSource', null) ?? null;
+      const defaultDataSource = getDefaultDataSourceId(this.props.uiSettings) ?? null;
 
       if (this.props.selectedOption?.length) {
         this.handleSelectedOption(dataSourceOptions, defaultDataSource);

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
@@ -14,6 +14,7 @@ import {
   getFilteredDataSources,
   generateComponentId,
   getDataSourceSelection,
+  getDefaultDataSourceId,
 } from '../utils';
 import { DataSourceAttributes } from '../../types';
 import { DataSourceItem } from '../data_source_item';
@@ -164,7 +165,7 @@ export class DataSourceSelector extends React.Component<
         return;
       }
 
-      const defaultDataSource = this.props.uiSettings?.get('defaultDataSource', null) ?? null;
+      const defaultDataSource = getDefaultDataSourceId(this.props.uiSettings) ?? null;
       // 5.1 Empty default option, [], just want to show placeholder
       if (this.props.defaultOption?.length === 0) {
         this.setState({

--- a/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
@@ -29,7 +29,12 @@ import {
 } from '../../../../opensearch_dashboards_react/public';
 import { DataSourceManagementContext, DataSourceTableItem, ToastMessageItem } from '../../types';
 import { CreateButton } from '../create_button';
-import { deleteMultipleDataSources, getDataSources, setFirstDataSourceAsDefault } from '../utils';
+import {
+  deleteMultipleDataSources,
+  getDataSources,
+  setFirstDataSourceAsDefault,
+  getDefaultDataSourceId,
+} from '../utils';
 import { LoadingMask } from '../loading_mask';
 
 /* Table config */
@@ -149,7 +154,7 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
           <EuiButtonEmpty size="xs" {...reactRouterNavigate(history, `${index.id}`)}>
             {name}
           </EuiButtonEmpty>
-          {index.id === uiSettings.get('defaultDataSource', null) ? (
+          {index.id === getDefaultDataSourceId(uiSettings) ? (
             <EuiBadge iconType="starFilled" iconSide="left">
               Default
             </EuiBadge>
@@ -251,7 +256,7 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
   const setDefaultDataSource = async () => {
     try {
       for (const dataSource of selectedDataSources) {
-        if (uiSettings.get('defaultDataSource') === dataSource.id) {
+        if (getDefaultDataSourceId(uiSettings) === dataSource.id) {
           await setFirstDataSourceAsDefault(savedObjects.client, uiSettings, true);
         }
       }

--- a/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
@@ -18,6 +18,7 @@ import {
   handleDataSourceFetchError,
   generateComponentId,
   getDataSourceSelection,
+  getDefaultDataSourceId,
 } from '../utils';
 import { DataSourceDropDownHeader } from '../drop_down_header';
 import { DataSourceItem } from '../data_source_item';
@@ -71,7 +72,7 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
     const option = selectedOption[0];
     const optionId = option.id;
 
-    const defaultDataSource = this.props.uiSettings?.get('defaultDataSource', null) ?? null;
+    const defaultDataSource = getDefaultDataSourceId(this.props.uiSettings) ?? null;
     if (optionId === '' && !this.props.hideLocalCluster) {
       this.setState({
         selectedOption: [LocalCluster],

--- a/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.tsx
@@ -18,11 +18,13 @@ import {
   testConnection,
   updateDataSourceById,
   setFirstDataSourceAsDefault,
+  getDefaultDataSourceId,
 } from '../utils';
 import { getEditBreadcrumbs } from '../breadcrumbs';
 import { EditDataSourceForm } from './components/edit_form/edit_data_source_form';
 import { LoadingMask } from '../loading_mask';
 import { AuthType, DataSourceAttributes } from '../../types';
+import { DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from '../constants';
 
 const defaultDataSource: DataSourceAttributes = {
   title: '',
@@ -86,10 +88,10 @@ export const EditDataSource: React.FunctionComponent<RouteComponentProps<{ id: s
   };
 
   const handleSetDefault = async () => {
-    await uiSettings.set('defaultDataSource', dataSourceID);
+    await uiSettings.set(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, dataSourceID);
   };
 
-  const isDefaultDataSource = uiSettings.get('defaultDataSource', null) === dataSourceID;
+  const isDefaultDataSource = getDefaultDataSourceId(uiSettings) === dataSourceID;
 
   /* Handle submit - create data source*/
   const handleSubmit = async (attributes: DataSourceAttributes) => {
@@ -126,7 +128,7 @@ export const EditDataSource: React.FunctionComponent<RouteComponentProps<{ id: s
 
   const setDefaultDataSource = async () => {
     try {
-      if (uiSettings.get('defaultDataSource') === dataSourceID) {
+      if (getDefaultDataSourceId(uiSettings) === dataSourceID) {
         await setFirstDataSourceAsDefault(savedObjects.client, uiSettings, true);
       }
     } catch (e) {

--- a/src/plugins/data_source_management/public/components/utils.test.ts
+++ b/src/plugins/data_source_management/public/components/utils.test.ts
@@ -22,6 +22,8 @@ import {
   handleNoAvailableDataSourceError,
   getDataSourceSelection,
   setDataSourceSelection,
+  getDefaultDataSourceId,
+  getDefaultDataSourceId$,
 } from './utils';
 import { coreMock, notificationServiceMock } from '../../../../core/public/mocks';
 import {
@@ -59,6 +61,7 @@ import {
   DataSourceSelectionService,
   defaultDataSourceSelection,
 } from '../service/data_source_selection_service';
+import { Observable, of } from 'rxjs';
 
 const { savedObjects } = coreMock.createStart();
 const { uiSettings } = coreMock.createStart();
@@ -656,6 +659,35 @@ describe('DataSourceManagement: Utils.ts', () => {
       setDataSourceSelection(dataSourceSelection);
       const result = getDataSourceSelection();
       expect(result).toEqual(dataSourceSelection);
+    });
+  });
+  describe('getDefaultDataSourceId', () => {
+    it('should return null if uiSettings is not passed', () => {
+      mockUiSettingsCalls(uiSettings, 'get', 'id-1');
+      const result = getDefaultDataSourceId();
+      expect(result).toEqual(null);
+    });
+
+    it('should return string value normally', () => {
+      mockUiSettingsCalls(uiSettings, 'get', 'id-1');
+      const result = getDefaultDataSourceId(uiSettings);
+      expect(result).toEqual('id-1');
+    });
+  });
+
+  describe('getDefaultDataSourceId$', () => {
+    it('should return null if uiSettings is not passed', () => {
+      mockUiSettingsCalls(uiSettings, 'get', 'id-1');
+      const result = getDefaultDataSourceId$();
+      expect(result).toEqual(null);
+    });
+
+    it('should return observable value normally', () => {
+      const id$ = of('id-1');
+      mockUiSettingsCalls(uiSettings, 'get$', id$);
+      const result$ = getDefaultDataSourceId$(uiSettings);
+      expect(result$).toBeInstanceOf(Observable);
+      expect(result$).toEqual(id$);
     });
   });
 });

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -31,6 +31,7 @@ import {
   CONNECT_DATASOURCES_MESSAGE,
   NO_COMPATIBLE_DATASOURCES_MESSAGE,
   NO_DATASOURCES_CONNECTED_MESSAGE,
+  DEFAULT_DATA_SOURCE_UI_SETTINGS_ID,
 } from './constants';
 import {
   DataSourceSelectionService,
@@ -78,7 +79,7 @@ export async function handleSetDefaultDatasource(
   savedObjectsClient: SavedObjectsClientContract,
   uiSettings: IUiSettingsClient
 ) {
-  if (uiSettings.get('defaultDataSource', null) === null) {
+  if (getDefaultDataSourceId(uiSettings) === null) {
     return await setFirstDataSourceAsDefault(savedObjectsClient, uiSettings, false);
   }
 }
@@ -89,12 +90,12 @@ export async function setFirstDataSourceAsDefault(
   exists: boolean
 ) {
   if (exists) {
-    uiSettings.remove('defaultDataSource');
+    uiSettings.remove(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID);
   }
   const listOfDataSources: DataSourceTableItem[] = await getDataSources(savedObjectsClient);
   if (Array.isArray(listOfDataSources) && listOfDataSources.length >= 1) {
     const datasourceId = listOfDataSources[0].id;
-    return await uiSettings.set('defaultDataSource', datasourceId);
+    return await uiSettings.set(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, datasourceId);
   }
 }
 
@@ -133,6 +134,16 @@ export function getFilteredDataSources(
       label: ds.attributes?.title || '',
     }))
     .sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()));
+}
+
+export function getDefaultDataSourceId(uiSettings?: IUiSettingsClient) {
+  if (!uiSettings) return null;
+  return uiSettings.get(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, null);
+}
+
+export function getDefaultDataSourceId$(uiSettings?: IUiSettingsClient) {
+  if (!uiSettings) return null;
+  return uiSettings.get$(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, null);
 }
 
 export function getDefaultDataSource(

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -138,12 +138,12 @@ export function getFilteredDataSources(
 
 export function getDefaultDataSourceId(uiSettings?: IUiSettingsClient) {
   if (!uiSettings) return null;
-  return uiSettings.get(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, null);
+  return uiSettings.get<string | null>(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, null);
 }
 
 export function getDefaultDataSourceId$(uiSettings?: IUiSettingsClient) {
   if (!uiSettings) return null;
-  return uiSettings.get$(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, null);
+  return uiSettings.get$<string | null>(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, null);
 }
 
 export function getDefaultDataSource(

--- a/src/plugins/data_source_management/public/index.ts
+++ b/src/plugins/data_source_management/public/index.ts
@@ -25,3 +25,4 @@ export {
   createDataSourceMenu,
 } from './components/data_source_menu';
 export { DataSourceSelectionService } from './service/data_source_selection_service';
+export { getDefaultDataSourceId, getDefaultDataSourceId$ } from './components/utils';

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -361,7 +361,7 @@ export const mockErrorResponseForSavedObjectsCalls = (
 
 export const mockUiSettingsCalls = (
   uiSettings: IUiSettingsClient,
-  uiSettingsMethodName: 'get' | 'set',
+  uiSettingsMethodName: 'get' | 'set' | 'get$',
   response: any
 ) => {
   (uiSettings[uiSettingsMethodName] as jest.Mock).mockReturnValue(response);

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -42,10 +42,10 @@ export interface DataSourceManagementPluginSetup {
   ui: {
     DataSourceSelector: React.ComponentType<DataSourceSelectorProps>;
     getDataSourceMenu: <T>() => React.ComponentType<DataSourceMenuProps<T>>;
-    getDefaultDataSourceId: typeof getDefaultDataSourceId;
-    getDefaultDataSourceId$: typeof getDefaultDataSourceId$;
   };
   dataSourceSelection: DataSourceSelectionService;
+  getDefaultDataSourceId: typeof getDefaultDataSourceId;
+  getDefaultDataSourceId$: typeof getDefaultDataSourceId$;
 }
 
 export interface DataSourceManagementPluginStart {

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -26,6 +26,8 @@ import {
   setHideLocalCluster,
   setUiSettings,
   setDataSourceSelection,
+  getDefaultDataSourceId,
+  getDefaultDataSourceId$,
 } from './components/utils';
 import { DataSourceSelectionService } from './service/data_source_selection_service';
 
@@ -40,6 +42,8 @@ export interface DataSourceManagementPluginSetup {
   ui: {
     DataSourceSelector: React.ComponentType<DataSourceSelectorProps>;
     getDataSourceMenu: <T>() => React.ComponentType<DataSourceMenuProps<T>>;
+    getDefaultDataSourceId: typeof getDefaultDataSourceId;
+    getDefaultDataSourceId$: typeof getDefaultDataSourceId$;
   };
   dataSourceSelection: DataSourceSelectionService;
 }
@@ -123,6 +127,8 @@ export class DataSourceManagementPlugin
         DataSourceSelector: createDataSourceSelector(uiSettings, dataSource),
         getDataSourceMenu: <T>() => createDataSourceMenu<T>(),
       },
+      getDefaultDataSourceId,
+      getDefaultDataSourceId$,
     };
   }
 


### PR DESCRIPTION
### Description

1. Add getDefaultDataSourceId and getDefaultDataSourceId$ function, unify in DSM and export in setup for other plugins to use
2. Unify default data source ui settings id

### Context
https://github.com/opensearch-project/dashboards-assistant/pull/191#discussion_r1616799996

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- refactor: Unify getDefaultDataSourceId and export

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
