### PR TITLE
Add example in create API for create index pattern, vega visualizatinn, dashboards for docs

### DIFF
--- a/changelogs/fragments/6855.yml
+++ b/changelogs/fragments/6855.yml
@@ -1,0 +1,2 @@
+doc:
+- Add example for saved object creation part for openapi doc. ([#6855](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6855))

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -10,6 +10,7 @@
     - [Client_management_design](multi-datasource/client_management_design.md)
     - [High_level_design](multi-datasource/high_level_design.md)
     - [User_stories](multi-datasource/user_stories.md)
+  - [Openapi](openapi/README.md)
   - Plugins
     - [Data_persistence](plugins/data_persistence.md)
   - Saved_objects
@@ -159,6 +160,7 @@
     - [Opensearch dashboards.release notes 2.11.1](../release-notes/opensearch-dashboards.release-notes-2.11.1.md)
     - [Opensearch dashboards.release notes 2.12.0](../release-notes/opensearch-dashboards.release-notes-2.12.0.md)
     - [Opensearch dashboards.release notes 2.13.0](../release-notes/opensearch-dashboards.release-notes-2.13.0.md)
+    - [Opensearch dashboards.release notes 2.14.0](../release-notes/opensearch-dashboards.release-notes-2.14.0.md)
     - [Opensearch dashboards.release notes 2.2.0](../release-notes/opensearch-dashboards.release-notes-2.2.0.md)
     - [Opensearch dashboards.release notes 2.2.1](../release-notes/opensearch-dashboards.release-notes-2.2.1.md)
     - [Opensearch dashboards.release notes 2.3.0](../release-notes/opensearch-dashboards.release-notes-2.3.0.md)
@@ -172,6 +174,7 @@
   - scripts
     - [README](../scripts/README.md)
   - [DOCS_README](DOCS_README.md)
+  - [Theme](theme.md)
   - [CHANGELOG](../CHANGELOG.md)
   - [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md)
   - [COMMUNICATIONS](../COMMUNICATIONS.md)

--- a/docs/openapi/saved_objects/saved_objects.yml
+++ b/docs/openapi/saved_objects/saved_objects.yml
@@ -80,6 +80,50 @@ paths:
                   items:
                     type: string
                   description: Workspaces that this saved object exists in.
+            examples:
+              indexPattern:
+                summary: Example of creating an index pattern saved object
+                value:
+                  attributes:
+                    title: 'my-index-pattern'
+                    fields: '[{"count":"1","name":"@timestamp","searchable":"true"}]'
+                  references:
+                    - id: '51339560-1d7c-11ef-b757-55fac6c80d9a'
+                      name: 'dataSource'
+                      type: 'data-source'
+              vegaVisualization:
+                summary: Example of creating a Vega visualization saved object
+                value:
+                  attributes:
+                    title: 'my-vega-visualization'
+                    visState: '{"title":"vegaVisualization","type":"vega","aggs":[]}}'
+                    uiStateJSON: '{}'
+                    description: ''
+                    version: 1
+                    kibanaSavedObjectMeta: {
+                      searchSourceJSON: '{"query":{"language":"kuery","query":""},"filter":[]}'
+                    }
+                  references:
+                    - id: '51339560-1d7c-11ef-b757-55fac6c80d9a'
+                      name: 'dataSource'
+                      type: 'data-source'
+              dashboards:
+                summary: Example of creating a dashboard saved object
+                value:
+                  attributes:
+                    title: 'Revenue Dashboard'
+                    description: 'Revenue dashboard'
+                    panelsJSON: '[{"version":"2.9.0","gridData":{"x":0,"y":0,"w":24,"h":15,"i":"5db1d75d-f680-4869-a0e8-0f2b8b05b99c"},"panelIndex":"5db1d75d-f680-4869-a0e8-0f2b8b05b99c","embeddableConfig":{},"panelRefName":"panel_0"}]'
+                    optionsJSON: '{"hidePanelTitles":false,"useMargins":true}'
+                    version: 1
+                    timeRestore: true
+                    kibanaSavedObjectMeta: {
+                      searchSourceJSON: '{"query":{"language":"kuery","query":""},"filter":[]}'
+                    }
+                  references:
+                    - id: '37cc8650-b882-11e8-a6d9-e546fe2bba5f'
+                      name: 'panel_0'
+                      type: 'visualization'  
       responses:
         '200':
           description: The creation request is successful


### PR DESCRIPTION
### Description

Add example in create API for create index pattern, vega visualizatinn, dashboards for docs

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719

## Screenshot

<img width="1343" alt="Screenshot 2024-05-29 at 11 08 40 AM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/c83415ee-ac0f-477a-adb7-20913256ab52">
<img width="1351" alt="Screenshot 2024-05-29 at 11 08 46 AM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/7d54bfde-deac-4f43-b240-6177b7a4a1ae">
<img width="1307" alt="Screenshot 2024-05-29 at 11 08 52 AM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/6a6a9f2a-3b02-417f-930f-7831da03d136">

## Changelog
- doc: Add example for saved object creation part for openapi doc.

