### PR TITLE
Add OpenAPI specification for bulk create and bulk update saved object APIs

### DIFF
--- a/changelogs/fragments/6859.yml
+++ b/changelogs/fragments/6859.yml
@@ -1,0 +1,2 @@
+doc:
+- Add OpenAPI specification for bulk create and bulk update saved object APIs ([#6859](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6859))

--- a/docs/openapi/saved_objects/saved_objects.yml
+++ b/docs/openapi/saved_objects/saved_objects.yml
@@ -250,6 +250,155 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_bad_request'
+  /api/saved_objects/_bulk_create:
+    post:
+      tags:
+        - saved objects
+      summary: Bulk create saved objects
+      parameters:
+      - name: overwrite
+        in: query
+        schema:
+          type: boolean
+          description: If set to true, will overwrite the existing saved object with same type and id.
+      - name: workspaces
+        in: query
+        schema: 
+          type: array
+          items:
+            type: string
+          description: Workspaces that the saved objects exist in.
+      requestBody:
+        required: true
+        description: Array of saved objects to create
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Unique id of the saved object.
+                  type:
+                    type: string
+                    required: true
+                    description: The type of saved object.
+                  attributes:
+                    type: object
+                    required: true
+                    description: The metadata of the saved object to be created, and the object is not validated.
+                  version:
+                    type: string
+                  migrationVersion:
+                    type: object
+                    description: The information about the migrations that have been applied to this saved object to be created.
+                  references:
+                    description: List of objects that describe other saved objects the created object references. 
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                        name:
+                          type: string
+                  initialNamespaces:
+                    description: Namespaces that this saved object exists in. This attribute is only used for multi-namespace saved object types.
+                    type: array
+                    items:
+                      type: string
+              example:
+                - id: 67a9021c-c97e-4499-8150-9722ab44edd4
+                  type: visualization
+                  attributes:
+                    title: 'vega-visualization'
+                    fieldFormatMap: '{"hour_of_day":{}}'
+                    fields: '[{"name":"@timestamp","type":"date","esTypes":["date"],"count":0,"scripted":false,"searchable":true,"aggregatable":true,"readFromDocValues":true}]'
+                  version: '1'
+                  migrationVersion: {}
+                  references:
+                    - id: ef71d6c1-8e6b-418d-9f7c-e5d9bbde9cf7
+                      type: data-source
+                      name: dataSource
+                  initialNamespaces: 
+                    - default
+      responses:
+        '200':
+          description: The bulk creation request is successful.
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/saved_objects/_bulk_update:
+    post:
+      tags:
+        - saved objects
+      summary: Bulk update saved objects
+      requestBody:
+        required: true
+        description: Array of saved objects to update
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Unique id of the saved object.
+                  type:
+                    type: string
+                    required: true
+                    description: The type of saved object.
+                  attributes:
+                    type: object
+                    required: true
+                    description: The metadata of the saved object to be created, and the object is not validated.
+                  version:
+                    type: string
+                  references:
+                    description: List of objects that describe other saved objects the created object references. 
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                        name:
+                          type: string
+                  namespaces:
+                    description: Namespaces that this saved object exists in. This attribute is only used for multi-namespace saved object types.
+                    type: array
+                    items:
+                      type: string
+              example:
+                - id: 67a9021c-c97e-4499-8150-9722ab44edd4
+                  type: visualization
+                  attributes:
+                    title: vega-visualization
+                    fieldFormatMap: '{"hour_of_day":{}}'
+                    fields: '[{"name":"@timestamp","type":"date","esTypes":["date"],"count":0,"scripted":false,"searchable":true,"aggregatable":true,"readFromDocValues":true}]'
+                  version: '1'
+                  migrationVersion: {}
+                  references:
+                    - id: ef71d6c1-8e6b-418d-9f7c-e5d9bbde9cf7
+                      type: data-source
+                      name: dataSource
+                  namespace: default
+      responses:
+        '200':
+          description: The bulk update request is successful.
+          content:
+            application/json:
+              schema:
+                type: object
 components:
   parameters:
     type:


### PR DESCRIPTION
### Description

This change adds OpenAPI specification for bulk create and bulk update saved object APIs.

### Issues Resolved
Related to https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719

## Screenshot

bulk create
<img width="1460" alt="Screenshot 2024-05-29 at 8 12 34 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/87ddcc4b-8d3f-4e18-99af-0d347840fbb6">

bulk update
<img width="1463" alt="Screenshot 2024-05-29 at 8 12 45 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/88058c58-9354-4b0f-b6c3-30637a7fe57d">


## Testing the changes
run npx serve and verify the api via swagger UI

## Changelog
- doc: Add OpenAPI specification for bulk create and bulk update saved object APIs

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

