### PR TITLE
Add OpenAPI specification for bulk_get saved object APIs

### DIFF
--- a/changelogs/fragments/6860.yml
+++ b/changelogs/fragments/6860.yml
@@ -1,0 +1,2 @@
+doc:
+- Add OpenAPI specification for bulk_get saved object APIs ([#6860](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6860))

--- a/docs/openapi/saved_objects/saved_objects.yml
+++ b/docs/openapi/saved_objects/saved_objects.yml
@@ -406,7 +406,7 @@ paths:
       summary: Bulk get saved objects
       requestBody:
         required: true
-        description: Array of saved objects to update
+        description: Array of criteria including id, type, fields used to retrieve matching saved objects
         content: 
           application/json:
             schema:

--- a/docs/openapi/saved_objects/saved_objects.yml
+++ b/docs/openapi/saved_objects/saved_objects.yml
@@ -170,7 +170,7 @@ paths:
           example: 1
         - in: query
           name: search
-          description: The search query that filters the saved objects.
+          description: The simple_query_string query that filters the objects in the response.
           schema:
             type: string
           example: "open*"
@@ -399,6 +399,38 @@ paths:
             application/json:
               schema:
                 type: object
+  /api/saved_objects/_bulk_get:
+    get:
+      tags:
+        - saved objects
+      summary: Bulk get saved objects
+      requestBody:
+        required: true
+        description: Array of saved objects to update
+        content: 
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    required: true
+                    description: Unique id of the saved object.
+                  type:
+                    type: string
+                    required: true
+                    description: The type of saved object.
+                  fields:
+                    type: array
+                    items:
+                      type: string
+                    description: The fields to return in the attributes key of the object response.
+              example:
+                - id: 67a9021c-c97e-4499-8150-9722ab44edd4
+                  type: visualization
+                  fields: ['title', 'fieldFormatMap']
 components:
   parameters:
     type:


### PR DESCRIPTION
### Description

Add OpenAPI specification for bulk_get saved object APIs

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719

## Screenshot
<img width="1207" alt="Screenshot 2024-05-29 at 10 33 48 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/98b3d781-7626-4cda-a445-ef895a4022aa">


## Changelog

- doc: Add OpenAPI specification for bulk_get saved object APIs


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
