### PR TITLE
Add OpenAPI specification for update, delete and migrate saved object API

### DIFF
--- a/changelogs/fragments/6864.yml
+++ b/changelogs/fragments/6864.yml
@@ -1,0 +1,2 @@
+doc:
+- Add OpenAPI specification for update, delete and migrate saved object API ([#6864](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6864))

--- a/docs/openapi/saved_objects/saved_objects.yml
+++ b/docs/openapi/saved_objects/saved_objects.yml
@@ -137,6 +137,95 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_bad_request'
+    put:
+      tags:
+        - saved objects
+      summary: Update existing saved object
+      parameters:
+        - $ref: '#components/parameters/type'
+        - $ref: '#components/parameters/id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - attributes
+              properties:
+                attributes:
+                  type: object
+                  description: The metadata of the saved object to be updated, and the object is not validated.
+                version:
+                  type: string
+                references:
+                  description: List of objects that describe other saved objects the created object references. 
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        type: string
+      responses:
+        '200': 
+          description: The update request is successful.
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: The saved object does not exist.
+          content:
+            application/json:
+              schema:
+                type: object
+    delete:
+      tags:
+        - saved objects
+      summary: Delete a saved object
+      parameters:
+        - $ref: '#components/parameters/type'
+        - $ref: '#components/parameters/id'
+        - in: query
+          name: force
+          description: If set to true, will force deletion of an object that exists in multiple namespaces.
+          schema: 
+            type: boolean
+      responses:
+        '200': 
+          description: The deletion request is successful.
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: The saved object does not exist.
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400_bad_request'
+  /api/saved_objects/_migrate:
+    post:
+      tags:
+        - saved objects
+      summary: Migrate existing saved objects
+      responses:
+        '200':
+          description: The migration is executed.
+          content:
+            application/json:
+              schema:
+                type: object
   /api/saved_objects/_find:
     get:
       tags:


### PR DESCRIPTION
### Description

This change adds OpenAPI specification for update, delete and migrate saved object API.

### Issues Resolved

Related to https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719

## Screenshot

update
![Screenshot 2024-05-30 at 11 10 39 AM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/f1d315e6-7ce3-4fc1-bf08-ca12fbf0b86b)

delete
![Screenshot 2024-05-30 at 11 10 30 AM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/5be3d540-73a6-44ab-bdb1-8e2e2a7baea8)


migrate
![Screenshot 2024-05-30 at 11 10 53 AM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/c531fc11-ff00-4fea-9ad8-b0b56e68334f)


## Testing the changes
run npx serve and see the specification being used in swagger

## Changelog
- doc: Add OpenAPI specification for update, delete and migrate saved object API

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
