### PR TITLE
[Backport 2.x] Add example in create API for create index pattern, vega visualizatinn, dashboards for docs

### DIFF
--- a/changelogs/fragments/6855.yml
+++ b/changelogs/fragments/6855.yml
@@ -1,0 +1,2 @@
+doc:
+- Add example for saved object creation part for openapi doc. ([#6855](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6855))

--- a/docs/openapi/saved_objects/saved_objects.yml
+++ b/docs/openapi/saved_objects/saved_objects.yml
@@ -80,6 +80,50 @@ paths:
                   items:
                     type: string
                   description: Workspaces that this saved object exists in.
+            examples:
+              indexPattern:
+                summary: Example of creating an index pattern saved object
+                value:
+                  attributes:
+                    title: 'my-index-pattern'
+                    fields: '[{"count":"1","name":"@timestamp","searchable":"true"}]'
+                  references:
+                    - id: '51339560-1d7c-11ef-b757-55fac6c80d9a'
+                      name: 'dataSource'
+                      type: 'data-source'
+              vegaVisualization:
+                summary: Example of creating a Vega visualization saved object
+                value:
+                  attributes:
+                    title: 'my-vega-visualization'
+                    visState: '{"title":"vegaVisualization","type":"vega","aggs":[]}}'
+                    uiStateJSON: '{}'
+                    description: ''
+                    version: 1
+                    kibanaSavedObjectMeta: {
+                      searchSourceJSON: '{"query":{"language":"kuery","query":""},"filter":[]}'
+                    }
+                  references:
+                    - id: '51339560-1d7c-11ef-b757-55fac6c80d9a'
+                      name: 'dataSource'
+                      type: 'data-source'
+              dashboards:
+                summary: Example of creating a dashboard saved object
+                value:
+                  attributes:
+                    title: 'Revenue Dashboard'
+                    description: 'Revenue dashboard'
+                    panelsJSON: '[{"version":"2.9.0","gridData":{"x":0,"y":0,"w":24,"h":15,"i":"5db1d75d-f680-4869-a0e8-0f2b8b05b99c"},"panelIndex":"5db1d75d-f680-4869-a0e8-0f2b8b05b99c","embeddableConfig":{},"panelRefName":"panel_0"}]'
+                    optionsJSON: '{"hidePanelTitles":false,"useMargins":true}'
+                    version: 1
+                    timeRestore: true
+                    kibanaSavedObjectMeta: {
+                      searchSourceJSON: '{"query":{"language":"kuery","query":""},"filter":[]}'
+                    }
+                  references:
+                    - id: '37cc8650-b882-11e8-a6d9-e546fe2bba5f'
+                      name: 'panel_0'
+                      type: 'visualization'  
       responses:
         '200':
           description: The creation request is successful


### PR DESCRIPTION
### Description

Add example in create API for create index pattern, vega visualizatinn, dashboards for docs
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6855

Auto backport failed, so manually generated this file. 
Removed the docs/_sidebar.md change as the docs/_sidebar.md does not exists in branch 2.x

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
