### PR TITLE
[Bug] Remove unused import and property

### DIFF
--- a/changelogs/fragments/6879.yml
+++ b/changelogs/fragments/6879.yml
@@ -1,0 +1,2 @@
+fix:
+- Remove unused import and property which broke compilation ([#6879](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6879))

--- a/examples/multiple_data_source_examples/public/components/data_source_view_example.tsx
+++ b/examples/multiple_data_source_examples/public/components/data_source_view_example.tsx
@@ -18,7 +18,6 @@ import { CoreStart, MountPoint } from 'opensearch-dashboards/public';
 import {
   DataSourceManagementPluginSetup,
   DataSourceViewConfig,
-  DataSourceSelectionService,
 } from 'src/plugins/data_source_management/public';
 import { ComponentProp } from './types';
 import { COLUMNS } from './constants';
@@ -89,7 +88,6 @@ export const DataSourceViewExample = ({
             setSelectedDataSources(ds);
           },
         }}
-        dataSourceSelection={new DataSourceSelectionService()}
       />
     );
   }, [setActionMenu, notifications, savedObjects]);


### PR DESCRIPTION
### Description

This change fix the bug introduced by #6827 which added new prop but then removed.

### Issues Resolved
fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6878

## Screenshot
data source view example

![Screenshot 2024-05-31 at 8 48 16 AM](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/36b7f7ae-34f5-426c-ad28-817c19478368)


## Testing the changes
After the fix, running dashboards locally and the error reported went away, data source view example renders successfully

## Changelog
- fix: remove unused import and property which broke compilation

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
