### PR TITLE
[BUG] fix default data source bug

### DIFF
--- a/changelogs/fragments/6908.yml
+++ b/changelogs/fragments/6908.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix not setting the default data source when creating data source bug ([#6908](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6908))

--- a/src/plugins/data_source_management/public/components/utils.test.ts
+++ b/src/plugins/data_source_management/public/components/utils.test.ts
@@ -369,6 +369,12 @@ describe('DataSourceManagement: Utils.ts', () => {
       await handleSetDefaultDatasource(savedObjects.client, uiSettings);
       expect(uiSettings.set).toHaveBeenCalled();
     });
+    test('should set default datasource when returned default datasource id is empty string', async () => {
+      mockUiSettingsCalls(uiSettings, 'get', '');
+      mockResponseForSavedObjectsCalls(savedObjects.client, 'find', getDataSourcesResponse);
+      await handleSetDefaultDatasource(savedObjects.client, uiSettings);
+      expect(uiSettings.set).toHaveBeenCalled();
+    });
     test('should not set default datasource when it has default datasouce', async () => {
       mockUiSettingsCalls(uiSettings, 'get', 'test');
       mockResponseForSavedObjectsCalls(savedObjects.client, 'find', getDataSourcesResponse);

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -79,7 +79,7 @@ export async function handleSetDefaultDatasource(
   savedObjectsClient: SavedObjectsClientContract,
   uiSettings: IUiSettingsClient
 ) {
-  if (getDefaultDataSourceId(uiSettings) === null) {
+  if (!getDefaultDataSourceId(uiSettings)) {
     return await setFirstDataSourceAsDefault(savedObjectsClient, uiSettings, false);
   }
 }


### PR DESCRIPTION
### Description

In https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6237/files, we introduced default data source, and expect that if default data source is not set, the get call to uisettings would return null, which is not always the case. See in the recordings that for cases that a default data source is accidentally removed from UI, the data source id is empty string from `api/opensearch-dashboards/settings` API call. Thus instead of checking if the returned value is exactly null, we need to check if it is not blank/empty. 

### Issues Resolved

fixes #6835

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/17714150/1bf891b2-2e4b-4625-b840-f876ae14dfab




## Testing the changes

In the recording, the following steps were performed:
- enable data source

before change:
- check the api/opensearch-dashboards/settings which has empty string for the default data source
- creating data source will not make it default data source

after change:
- check the api/opensearch-dashboards/settings which has empty string for the default data source
- creating data source will make it default data source

## Changelog
- fix: fix not setting the default data source when creating data source bug


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
