### PR TITLE
Modify the adding sample data part for timeline

### DIFF
--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -328,6 +328,8 @@ export {
   SavedObjectsDeleteByWorkspaceOptions,
   updateDataSourceNameInVegaSpec,
   extractVegaSpecFromSavedObject,
+  extractTimelineExpression,
+  updateDataSourceNameInTimeline,
 } from './saved_objects';
 
 export {

--- a/src/core/server/saved_objects/import/index.ts
+++ b/src/core/server/saved_objects/import/index.ts
@@ -43,4 +43,9 @@ export {
   SavedObjectsResolveImportErrorsOptions,
   SavedObjectsImportRetry,
 } from './types';
-export { updateDataSourceNameInVegaSpec, extractVegaSpecFromSavedObject } from './utils';
+export {
+  updateDataSourceNameInVegaSpec,
+  extractVegaSpecFromSavedObject,
+  extractTimelineExpression,
+  updateDataSourceNameInTimeline,
+} from './utils';

--- a/src/plugins/home/server/services/sample_data/data_sets/util.test.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/util.test.ts
@@ -63,6 +63,38 @@ describe('getSavedObjectsWithDataSource()', () => {
     expect(updatedVegaVisualizationsFields).toEqual(expect.arrayContaining(expectedUpdatedFields));
   });
 
+  it('should processing timeline saved object and add datasource name in the end', () => {
+    const dataSourceId = 'some-datasource-id';
+    const dataSourceName = 'dataSourceName';
+    const savedObjects = [
+      {
+        id: 'saved-object-1',
+        type: 'visualization',
+        title: 'example',
+        attributes: {
+          title: 'example',
+          visState:
+            '{"title":"(Timeline) Avg bytes over time","type":"timelion","aggs":[],"params":{"expression":".opensearch(opensearch_dashboards_sample_data_logs, metric=avg:bytes, timefield=@timestamp).lines(show=true).points(show=true).yaxis(label=\\"Average bytes\\")","interval":"auto"}}',
+        },
+        references: [],
+      },
+    ];
+
+    expect(getSavedObjectsWithDataSource(savedObjects, dataSourceId, dataSourceName)).toEqual([
+      {
+        id: 'some-datasource-id_saved-object-1',
+        type: 'visualization',
+        title: 'example',
+        attributes: {
+          title: 'example_dataSourceName',
+          visState:
+            '{"title":"(Timeline) Avg bytes over time","type":"timelion","aggs":[],"params":{"expression":".opensearch(opensearch_dashboards_sample_data_logs, metric=avg:bytes, timefield=@timestamp, data_source_name=\\"dataSourceName\\").lines(show=true).points(show=true).yaxis(label=\\"Average bytes\\")","interval":"auto"}}',
+        },
+        references: [],
+      },
+    ]);
+  });
+
   it('should update index-pattern id and references with given data source', () => {
     const dataSourceId = 'some-datasource-id';
     const dataSourceName = 'Data Source Name';

--- a/src/plugins/home/server/services/sample_data/data_sets/util.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/util.ts
@@ -6,7 +6,9 @@
 import { SavedObject } from 'opensearch-dashboards/server';
 import {
   extractVegaSpecFromSavedObject,
+  extractTimelineExpression,
   updateDataSourceNameInVegaSpec,
+  updateDataSourceNameInTimeline,
 } from '../../../../../../core/server';
 import { SampleDatasetSchema } from '../lib/sample_dataset_registry_types';
 
@@ -113,6 +115,21 @@ export const getSavedObjectsWithDataSource = (
               type: 'data-source',
               name: 'dataSource',
             });
+          }
+
+          const timelineExpression = extractTimelineExpression(saveObject);
+          if (!!timelineExpression) {
+            // Get the timeline expression with the updated data source name
+            const modifiedExpression = updateDataSourceNameInTimeline(
+              timelineExpression,
+              dataSourceTitle
+            );
+
+            // @ts-expect-error
+            const timelineStateObject = JSON.parse(saveObject.attributes?.visState);
+            timelineStateObject.params.expression = modifiedExpression;
+            // @ts-expect-error
+            saveObject.attributes.visState = JSON.stringify(timelineStateObject);
           }
         }
       }


### PR DESCRIPTION
### Description

Modify the adding sample data part for timeline to add data source name if customer has enabled MDS

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6123

## Screenshot


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/5866ecc2-d5bf-4ef9-bb61-026fb7649ef9



## Testing the changes
Please see screenshot

## Changelog

- fix: Modify the adding sample data part for timeline


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
