### PR TITLE
[Multi DataSource] Add removedComponentIds for data source selection service

### DIFF
--- a/changelogs/fragments/6920.yml
+++ b/changelogs/fragments/6920.yml
@@ -1,0 +1,2 @@
+feat:
+- [Multi DataSource] Add removedComponentIds for data source selection service ([#6920](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6920))

--- a/src/plugins/data_source_management/public/service/data_source_selection_service.test.ts
+++ b/src/plugins/data_source_management/public/service/data_source_selection_service.test.ts
@@ -45,4 +45,16 @@ describe('DataSourceSelectionService service', () => {
       done();
     });
   });
+
+  it('should not store same id selection after calling remove', () => {
+    const dataSourceSelection = new DataSourceSelectionService();
+    const id = generateComponentId();
+    const dataSource = { id: 'id', label: 'label' };
+    dataSourceSelection.selectDataSource(id, [dataSource]);
+    expect(dataSourceSelection.getSelectionValue().get(id)).toStrictEqual([dataSource]);
+    dataSourceSelection.remove(id);
+    expect(dataSourceSelection.getSelectionValue().get(id)).toStrictEqual(undefined);
+    dataSourceSelection.selectDataSource(id, [dataSource]);
+    expect(dataSourceSelection.getSelectionValue().get(id)).toStrictEqual(undefined);
+  });
 });

--- a/src/plugins/data_source_management/public/service/data_source_selection_service.ts
+++ b/src/plugins/data_source_management/public/service/data_source_selection_service.ts
@@ -8,14 +8,21 @@ import { DataSourceOption } from '../components/data_source_menu/types';
 
 export class DataSourceSelectionService {
   private selectedDataSource$ = new BehaviorSubject(new Map<string, DataSourceOption[]>());
+  // Some components may call onSelect function in promise then, which could be executed later than componentWillUnmount.
+  // Use this array to record unmounted component ID to fallback.
+  private removedComponentIds: string[] = [];
 
   public selectDataSource = (componentId: string, dataSource: DataSourceOption[]) => {
+    if (this.removedComponentIds.indexOf(componentId) > -1) {
+      return;
+    }
     const newMap = new Map(this.selectedDataSource$.value);
     newMap.set(componentId, dataSource);
     this.selectedDataSource$.next(newMap);
   };
 
   public remove = (componentId: string) => {
+    this.removedComponentIds.push(componentId);
     const newMap = new Map(this.selectedDataSource$.value);
     newMap.delete(componentId);
     this.selectedDataSource$.next(newMap);

--- a/src/plugins/data_source_management/public/service/data_source_selection_service.ts
+++ b/src/plugins/data_source_management/public/service/data_source_selection_service.ts
@@ -8,8 +8,8 @@ import { DataSourceOption } from '../components/data_source_menu/types';
 
 export class DataSourceSelectionService {
   private selectedDataSource$ = new BehaviorSubject(new Map<string, DataSourceOption[]>());
-  // Some components may call onSelect function in promise then, which could be executed later than componentWillUnmount.
-  // Use this array to record unmounted component ID to fallback.
+  // Some components may call onSelect function in promise.then, which could be executed later than componentWillUnmount.
+  // Use this array to record unmounted component IDs to fallback.
   private removedComponentIds: string[] = [];
 
   public selectDataSource = (componentId: string, dataSource: DataSourceOption[]) => {

--- a/src/plugins/navigation/public/top_nav_menu/__snapshots__/top_nav_menu.test.tsx.snap
+++ b/src/plugins/navigation/public/top_nav_menu/__snapshots__/top_nav_menu.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`TopNavMenu mounts the data source menu as well as top nav menu 1`] = `
           "getSelection$": [Function],
           "getSelectionValue": [Function],
           "remove": [Function],
+          "removedComponentIds": Array [],
           "selectDataSource": [Function],
           "selectedDataSource$": BehaviorSubject {
             "_isScalar": false,
@@ -93,6 +94,7 @@ exports[`TopNavMenu mounts the data source menu if showDataSourceMenu is true 1`
           "getSelection$": [Function],
           "getSelectionValue": [Function],
           "remove": [Function],
+          "removedComponentIds": Array [],
           "selectDataSource": [Function],
           "selectedDataSource$": BehaviorSubject {
             "_isScalar": false,


### PR DESCRIPTION
### Description

Add removedComponentIds for data source selection service. 

In the implementation of some selector components,  it may call onSelect function in promise.then or after await, which could be executed later than componentWillUnmount. 
If some components do not use memorize and frequently unmount and mount, it is possible that the set function is triggered   and selected data source stored after the componentWillUnmount emit. The security analytics page is currently known which may cause this problem.


## Screenshot

No UI updates

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- feat: [Multi DataSource] Add removedComponentIds for data source selection service


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
