### PR TITLE
Update json5 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 🛠 Maintenance
 
+- Update json5 dependency ([#6937](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6937))
+
 ### 🪛 Refactoring
 
 - Remove unused Sass in `tile_map` plugin ([#4110](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4110))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### 🛠 Maintenance
 
-- Update json5 dependency ([#6937](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6937))
-
 ### 🪛 Refactoring
 
 - Remove unused Sass in `tile_map` plugin ([#4110](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4110))

--- a/package.json
+++ b/package.json
@@ -421,7 +421,7 @@
     "jimp": "^0.14.0",
     "jquery": "^3.5.0",
     "json-stringify-pretty-compact": "1.2.0",
-    "json5": "^1.0.1",
+    "json5": "^2.2.3",
     "leaflet": "1.5.1",
     "leaflet-draw": "0.4.14",
     "leaflet-responsive-popup": "0.6.4",


### PR DESCRIPTION
### Description

Coming from downstream where we recently added json5 for a feature, our distribution build is failing due to an [outdated json5 version](https://github.com/opensearch-project/dashboards-observability/issues/1861#issuecomment-2151148902) used here. We could downgrade our dependency, but considering that the json5 changelog has [no breaking changes for the core API](https://github.com/json5/json5/blob/main/CHANGELOG.md), it seems more straightforward to update it here directly.

### Issues Resolved

Resolves build failures in https://github.com/opensearch-project/dashboards-observability/issues/1861.

## Screenshot

N/A

## Testing the changes

Trusting CI to catch any issues on this one; according to the json5 changelog this is a no-op.

## Changelog
- skip: update json5 dependency from 1.0.1 to 2.2.3

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
