### PR TITLE
[MDS] Fix sample data to use datasources for TSVB visualizations

### DIFF
--- a/changelogs/fragments/6940.yml
+++ b/changelogs/fragments/6940.yml
@@ -1,0 +1,2 @@
+fix:
+- Add TSVB Support for adding sample data ([#6940](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6940))

--- a/src/plugins/home/server/services/sample_data/data_sets/util.test.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/util.test.ts
@@ -13,6 +13,19 @@ describe('getSavedObjectsWithDataSource()', () => {
     return visualizationObjects.saved_objects;
   };
 
+  const TSVBVisualizationSavedObject = {
+    type: 'visualization',
+    id: 'some-id',
+    attributes: {
+      title: 'some-title',
+      visState: JSON.stringify({
+        type: 'metrics',
+        params: {},
+      }),
+    },
+    references: [],
+  };
+
   test('when processing Vega Visualization saved objects, it should attach data_source_name to each OpenSearch query', () => {
     const dataSourceId = 'some-datasource-id';
     const dataSourceName = 'Data Source Name';
@@ -126,6 +139,35 @@ describe('getSavedObjectsWithDataSource()', () => {
         ],
       },
     ]);
+  });
+
+  test('when processing TSVB Visualization saved objects, it should attach data_source_id to the visState and add datasource reference', () => {
+    const dataSourceId = 'some-datasource-id';
+    const dataSourceTitle = 'Data Source Name';
+    const expectedTSVBVisualizationSavedObject = {
+      ...TSVBVisualizationSavedObject,
+      id: `${dataSourceId}_some-id`,
+      attributes: {
+        title: `some-title_${dataSourceTitle}`,
+        visState: JSON.stringify({
+          type: 'metrics',
+          params: {
+            data_source_id: dataSourceId,
+          },
+        }),
+      },
+      references: [
+        {
+          id: dataSourceId,
+          type: 'data-source',
+          name: 'dataSource',
+        },
+      ],
+    };
+
+    expect(
+      getSavedObjectsWithDataSource([TSVBVisualizationSavedObject], dataSourceId, dataSourceTitle)
+    ).toMatchObject([expectedTSVBVisualizationSavedObject]);
   });
 });
 

--- a/src/plugins/home/server/services/sample_data/data_sets/util.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/util.ts
@@ -96,6 +96,11 @@ export const getSavedObjectsWithDataSource = (
         if (saveObject.type === 'visualization') {
           const vegaSpec = extractVegaSpecFromSavedObject(saveObject);
 
+          const visualizationSavedObject = saveObject as SavedObject & {
+            attributes: { visState: string };
+          };
+          const visStateObject = JSON.parse(visualizationSavedObject.attributes.visState);
+
           if (!!vegaSpec) {
             const updatedVegaSpec = updateDataSourceNameInVegaSpec({
               spec: vegaSpec,
@@ -104,8 +109,6 @@ export const getSavedObjectsWithDataSource = (
               spacing: 1,
             });
 
-            // @ts-expect-error
-            const visStateObject = JSON.parse(saveObject.attributes?.visState);
             visStateObject.params.spec = updatedVegaSpec;
 
             // @ts-expect-error
@@ -130,6 +133,17 @@ export const getSavedObjectsWithDataSource = (
             timelineStateObject.params.expression = modifiedExpression;
             // @ts-expect-error
             saveObject.attributes.visState = JSON.stringify(timelineStateObject);
+          }
+
+          if (visStateObject.type === 'metrics') {
+            visStateObject.params.data_source_id = dataSourceId;
+
+            visualizationSavedObject.attributes.visState = JSON.stringify(visStateObject);
+            visualizationSavedObject.references.push({
+              id: `${dataSourceId}`,
+              type: 'data-source',
+              name: 'dataSource',
+            });
           }
         }
       }


### PR DESCRIPTION
### Description

This PR adds TSVB support for "Add Sample Data" when MDS is enabled 

### Issues Resolved

Closes #6936 

## Screenshot

### Navigating when MDS is disabled

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/8d6e5006-63e3-46e0-bbfe-2d0d0dd115d8

### Navigating when MDS is enabled

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/73027756/2e0a0346-4a49-41af-b990-fdc0869e6f06

## Testing the changes

```bash
$ yarn test:jest src/plugins/home/server/services/sample_data/data_sets/util.test.ts
yarn run v1.22.22
$ scripts/use_node scripts/jest src/plugins/home/server/services/sample_data/data_sets/util.test.ts
ciGroups []
jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/plugins/vis_type_vega/public/expressions/__mocks__/index.ts
    * <rootDir>/src/core/server/saved_objects/import/__mocks__/index.ts

 PASS  src/plugins/home/server/services/sample_data/data_sets/util.test.ts
  getSavedObjectsWithDataSource()
    ✓ when processing Vega Visualization saved objects, it should attach data_source_name to each OpenSearch query (8 ms)
    ✓ should processing timeline saved object and add datasource name in the end (1 ms)
    ✓ should update index-pattern id and references with given data source
    ✓ when processing TSVB Visualization saved objects, it should attach data_source_id to the visState and add datasource reference (1 ms)
  getFinalSavedObjects()
    ✓ should return consistent saved object id and title when workspace id and data source provided (1 ms)
    ✓ should return consistent saved object id when workspace id
    ✓ should return consistent saved object id and title when data source id and title (1 ms)
    ✓ should return original saved objects when no workspace and data source provided

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        3.287 s
```

### When MDS is disabled
- [x] `DataSourceSelector` component should not be visible
- [x] TSVB should render data both in the visualization edit view and dashboard view

### When MDS is enabled
- [x] `DataSourceSelector` component should be visible
- [x] TSVB should render data from the correct data source both in the visualization edit view and dashboard view
- [x] The `DataSourceSelector` should have the correct datasource option selected on initial render 

## Changelog
- fix: Add TSVB Support for adding sample data

### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
