### PR TITLE
Modify the import for timeline visualization to includes data source name in MDS scenario

### DIFF
--- a/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
+++ b/src/core/server/saved_objects/import/check_conflict_for_data_source.test.ts
@@ -318,6 +318,120 @@ describe('#checkConflictsForDataSource', () => {
     );
   });
 
+  /*
+   * Timeline test cases
+   */
+  it('will not change timeline expression when importing from datasource to different datasource', async () => {
+    const timelineSavedObject = createObject('visualization', 'old-datasource-id_some-object-id');
+    // @ts-expect-error
+    timelineSavedObject.attributes.visState =
+      '{"title":"(Timeline) Avg bytes over time","type":"timelion","aggs":[],"params":{"expression":".opensearch(opensearch_dashboards_sample_data_logs, metric=avg:bytes, timefield=@timestamp, data_source_name=newDataSource).lines(show=true).points(show=true).yaxis(label=\\"Average bytes\\")","interval":"auto"}}';
+    const params = setupParams({
+      objects: [timelineSavedObject],
+      ignoreRegularConflicts: true,
+      dataSourceId: 'some-datasource-id',
+      savedObjectsClient: getSavedObjectClient(),
+    });
+    const checkConflictsForDataSourceResult = await checkConflictsForDataSource(params);
+
+    expect(checkConflictsForDataSourceResult).toEqual(
+      expect.objectContaining({
+        filteredObjects: [
+          {
+            ...timelineSavedObject,
+            attributes: {
+              title: 'some-title',
+              visState:
+                '{"title":"(Timeline) Avg bytes over time","type":"timelion","aggs":[],"params":{"expression":".opensearch(opensearch_dashboards_sample_data_logs, metric=avg:bytes, timefield=@timestamp, data_source_name=newDataSource).lines(show=true).points(show=true).yaxis(label=\\"Average bytes\\")","interval":"auto"}}',
+            },
+            id: 'some-datasource-id_some-object-id',
+          },
+        ],
+        errors: [],
+        importIdMap: new Map([
+          [
+            `visualization:old-datasource-id_some-object-id`,
+            { id: 'some-datasource-id_some-object-id', omitOriginId: true },
+          ],
+        ]),
+      })
+    );
+  });
+
+  it('will change timeline expression when importing expression does not have a datasource name', async () => {
+    const timelineSavedObject = createObject('visualization', 'old-datasource-id_some-object-id');
+    // @ts-expect-error
+    timelineSavedObject.attributes.visState =
+      '{"title":"(Timeline) Avg bytes over time","type":"timelion","aggs":[],"params":{"expression":".opensearch(opensearch_dashboards_sample_data_logs, metric=avg:bytes, timefield=@timestamp).lines(show=true).points(show=true).yaxis(label=\\"Average bytes\\")","interval":"auto"}}';
+    const params = setupParams({
+      objects: [timelineSavedObject],
+      ignoreRegularConflicts: true,
+      dataSourceId: 'some-datasource-id',
+      savedObjectsClient: getSavedObjectClient(),
+    });
+    const checkConflictsForDataSourceResult = await checkConflictsForDataSource(params);
+
+    expect(checkConflictsForDataSourceResult).toEqual(
+      expect.objectContaining({
+        filteredObjects: [
+          {
+            ...timelineSavedObject,
+            attributes: {
+              title: 'some-title',
+              visState:
+                '{"title":"(Timeline) Avg bytes over time","type":"timelion","aggs":[],"params":{"expression":".opensearch(opensearch_dashboards_sample_data_logs, metric=avg:bytes, timefield=@timestamp, data_source_name=\\"some-datasource-title\\").lines(show=true).points(show=true).yaxis(label=\\"Average bytes\\")","interval":"auto"}}',
+            },
+            id: 'some-datasource-id_some-object-id',
+          },
+        ],
+        errors: [],
+        importIdMap: new Map([
+          [
+            `visualization:old-datasource-id_some-object-id`,
+            { id: 'some-datasource-id_some-object-id', omitOriginId: true },
+          ],
+        ]),
+      })
+    );
+  });
+
+  it('When there are multiple opensearch queries in the expression, it would go through each query and add data source name if it does not have any.', async () => {
+    const timelineSavedObject = createObject('visualization', 'old-datasource-id_some-object-id');
+    // @ts-expect-error
+    timelineSavedObject.attributes.visState =
+      '{"title":"some-other-title","type":"timelion","params":{"expression":".es(index=old-datasource-title, timefield=@timestamp, data_source_name=\\"aos 211\\"), .elasticsearch(index=old-datasource-title, timefield=@timestamp)"},"aggs":[]}';
+    const params = setupParams({
+      objects: [timelineSavedObject],
+      ignoreRegularConflicts: true,
+      dataSourceId: 'some-datasource-id',
+      savedObjectsClient: getSavedObjectClient(),
+    });
+    const checkConflictsForDataSourceResult = await checkConflictsForDataSource(params);
+
+    expect(checkConflictsForDataSourceResult).toEqual(
+      expect.objectContaining({
+        filteredObjects: [
+          {
+            ...timelineSavedObject,
+            attributes: {
+              title: 'some-title',
+              visState:
+                '{"title":"some-other-title","type":"timelion","params":{"expression":".es(index=old-datasource-title, timefield=@timestamp, data_source_name=\\"aos 211\\"), .elasticsearch(index=old-datasource-title, timefield=@timestamp, data_source_name=\\"some-datasource-title\\")"},"aggs":[]}',
+            },
+            id: 'some-datasource-id_some-object-id',
+          },
+        ],
+        errors: [],
+        importIdMap: new Map([
+          [
+            `visualization:old-datasource-id_some-object-id`,
+            { id: 'some-datasource-id_some-object-id', omitOriginId: true },
+          ],
+        ]),
+      })
+    );
+  });
+
   /**
    * TSVB test cases
    */

--- a/src/core/server/saved_objects/import/check_conflict_for_data_source.ts
+++ b/src/core/server/saved_objects/import/check_conflict_for_data_source.ts
@@ -15,6 +15,8 @@ import {
   getDataSourceTitleFromId,
   getUpdatedTSVBVisState,
   updateDataSourceNameInVegaSpec,
+  extractTimelineExpression,
+  updateDataSourceNameInTimeline,
 } from './utils';
 
 export interface ConflictsForDataSourceParams {
@@ -118,6 +120,22 @@ export async function checkConflictsForDataSource({
                 type: 'data-source',
               });
             }
+          }
+
+          // For timeline visualizations, update the data source name in the timeline expression
+          const timelineExpression = extractTimelineExpression(object);
+          if (!!timelineExpression && !!dataSourceTitle) {
+            // Get the timeline expression with the updated data source name
+            const modifiedExpression = updateDataSourceNameInTimeline(
+              timelineExpression,
+              dataSourceTitle
+            );
+
+            // @ts-expect-error
+            const timelineStateObject = JSON.parse(object.attributes?.visState);
+            timelineStateObject.params.expression = modifiedExpression;
+            // @ts-expect-error
+            object.attributes.visState = JSON.stringify(timelineStateObject);
           }
 
           if (!!dataSourceId) {

--- a/src/core/server/saved_objects/import/create_saved_objects.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.ts
@@ -40,6 +40,8 @@ import {
   extractVegaSpecFromSavedObject,
   getUpdatedTSVBVisState,
   updateDataSourceNameInVegaSpec,
+  extractTimelineExpression,
+  updateDataSourceNameInTimeline,
 } from './utils';
 
 interface CreateSavedObjectsParams<T> {
@@ -128,6 +130,22 @@ export const createSavedObjects = async <T>({
               type: 'data-source',
               name: 'dataSource',
             });
+          }
+
+          // Some visualization types will need special modifications, like TSVB visualizations
+          const timelineExpression = extractTimelineExpression(object);
+          if (!!timelineExpression && !!dataSourceTitle) {
+            // Get the timeline expression with the updated data source name
+            const modifiedExpression = updateDataSourceNameInTimeline(
+              timelineExpression,
+              dataSourceTitle
+            );
+
+            // @ts-expect-error
+            const timelineStateObject = JSON.parse(object.attributes?.visState);
+            timelineStateObject.params.expression = modifiedExpression;
+            // @ts-expect-error
+            object.attributes.visState = JSON.stringify(timelineStateObject);
           }
 
           const visualizationObject = object as VisualizationObject;

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -72,7 +72,8 @@ export async function importSavedObjectsFromStream({
     supportedTypes,
     dataSourceId,
   });
-  // if not enable data_source, throw error early
+  // if dataSource is not enabled, but object type is data-source, or saved object id contains datasource id
+  // return unsupported type error
   if (!dataSourceEnabled) {
     const notSupportedErrors: SavedObjectsImportError[] = collectSavedObjectsResult.collectedObjects.reduce(
       (errors: SavedObjectsImportError[], obj) => {


### PR DESCRIPTION
### Description
Modify the import for timeline visualization to includes data source name in MDS scenario

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6919

## Testing the changes

### Add data source name when import non-mds timeline to mds timeline
https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/fa6df05f-d93c-4bc2-9ffc-8a84678a6bc5



### When import from MDS to MDS, the data source name stays the same in timeline
https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/d7f131e5-8cf1-44b2-a70c-2fa9bb8140a4


### Import for overwriting scenerio
https://github.com/opensearch-project/OpenSearch-Dashboards/assets/53279298/2cb59bef-5589-416e-87e7-6fad3758d5e1

## Changelog

- fix: Modify the import for timeline visualization to includes data source name in MDS scenario

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
