### PR TITLE
Update sidecar z-index style

### DIFF
--- a/changelogs/fragments/6964.yml
+++ b/changelogs/fragments/6964.yml
@@ -1,0 +1,2 @@
+fix:
+- Update z-index of sidecar container to make it more than mask, from 1000 to 1001. ([#6964](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6964))

--- a/src/core/public/overlays/sidecar/components/sidecar.scss
+++ b/src/core/public/overlays/sidecar/components/sidecar.scss
@@ -6,7 +6,9 @@
 .osdSidecarFlyout {
   box-shadow: initial;
   position: fixed;
-  z-index: 1000;
+
+  // Sidecar z-index should more than mask. Actually will be 1001.
+  z-index: $euiZMaskBelowHeader + 1;
   background: lightOrDarkTheme($euiColorGhost, $euiColorInk);
   display: flex;
 


### PR DESCRIPTION
### Description

Update sidecar z-index from 1000 to 1001.
The mask in UI component will cover the entire screen, even if their child element flyout has left or right, they will still cover the entire screen. As a container independent of OSD, sidecar should not be blocked by redundant masks.

## Screenshot

![image](https://github.com/opensearch-project/dashboards-assistant/assets/42465692/402673ce-dc00-4516-bf6a-931749c120c8)
![image](https://github.com/opensearch-project/dashboards-assistant/assets/42465692/925a22cd-386d-4ab0-b31d-014d8a6fd6a8)
Before

![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/42465692/432d1c5a-00b6-4174-9c5b-b8bfe35e388c)
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/42465692/c85d11ae-5988-4020-b7f3-4c9974227214)

After
## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- fix: Update z-index of sidecar container to make it more than mask, from 1000 to 1001.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
