### PR TITLE
Add Scripted Field Support in Vis Builder

### DIFF
--- a/src/plugins/vis_builder/public/application/components/data_tab/utils/get_available_fields.test.ts
+++ b/src/plugins/vis_builder/public/application/components/data_tab/utils/get_available_fields.test.ts
@@ -44,7 +44,7 @@ describe('getAvailableFields', () => {
       },
     ]);
 
-    expect(getAvailableFields(fields).length).toBe(1);
+    expect(getAvailableFields(fields).length).toBe(2);
   });
 
   test('should return all fields if filterFieldTypes was not specified', () => {
@@ -54,6 +54,21 @@ describe('getAvailableFields', () => {
       },
       {
         name: 'field 2',
+      },
+    ]);
+
+    expect(getAvailableFields(fields).length).toBe(2);
+  });
+
+  test('should return scripted fields', () => {
+    const fields = createIndexFields([
+      {
+        name: 'field 1',
+        scripted: true,
+      },
+      {
+        name: 'field 2',
+        scripted: true,
       },
     ]);
 

--- a/src/plugins/vis_builder/public/application/components/data_tab/utils/get_available_fields.ts
+++ b/src/plugins/vis_builder/public/application/components/data_tab/utils/get_available_fields.ts
@@ -17,7 +17,7 @@ export const getAvailableFields = (
   filterFieldTypes: FieldTypes = '*'
 ) => {
   const filteredFields = fields.filter((field: IndexPatternField) => {
-    if (!field.aggregatable || isNestedField(field) || field.scripted) {
+    if (!field.aggregatable || isNestedField(field)) {
       return false;
     }
 


### PR DESCRIPTION
### Description

Add Scripted Field Support in Vis Builder.    

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/38322563/332a8663-fa5c-4612-aeff-5c6c2564f633


## Testing the changes

1. Create an Index pattern with scripted fields
2. Navigate to Vis Builder and verify if the scripted field is available in the left side panel

## Changelog
- feat: Add Scripted Field Support in Vis Builder
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
