### PR TITLE
[BUG][Discover] Check if the timestamp is already included to remove duplicate col

### DIFF
--- a/changelogs/fragments/6983.yml
+++ b/changelogs/fragments/6983.yml
@@ -1,0 +1,2 @@
+fix:
+- [Discover] Check if the timestamp is already included to remove duplicate col ([#6983](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6983))

--- a/src/plugins/discover/public/application/components/default_discover_table/helper.test.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/helper.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLegacyDisplayedColumns } from './helper';
+import { IndexPattern } from '../../../opensearch_dashboards_services';
+
+const mockGetFieldByName = jest.fn();
+
+describe('getLegacyDisplayedColumns', () => {
+  let indexPattern: IndexPattern;
+
+  beforeEach(() => {
+    indexPattern = ({
+      getFieldByName: mockGetFieldByName,
+      timeFieldName: 'timestamp',
+    } as unknown) as IndexPattern;
+    mockGetFieldByName.mockReset();
+  });
+
+  it('should return correct column properties without time column', () => {
+    mockGetFieldByName.mockReturnValue({ sortable: true });
+    const result = getLegacyDisplayedColumns(['column1'], indexPattern, true, false);
+    expect(result).toEqual([
+      {
+        name: 'column1',
+        displayName: 'column1',
+        isSortable: true,
+        isRemoveable: true,
+        colLeftIdx: -1,
+        colRightIdx: -1,
+      },
+    ]);
+  });
+
+  it('should prepend time column if not hidden, indexPattern has timeFieldName, and columns do not include timeFieldName', () => {
+    mockGetFieldByName.mockReturnValue({ sortable: true });
+    const result = getLegacyDisplayedColumns(['column1'], indexPattern, false, false);
+    expect(result).toEqual([
+      {
+        name: 'timestamp',
+        displayName: 'Time',
+        isSortable: true,
+        isRemoveable: false,
+        colLeftIdx: -1,
+        colRightIdx: -1,
+      },
+      {
+        name: 'column1',
+        displayName: 'column1',
+        isSortable: true,
+        isRemoveable: true,
+        colLeftIdx: -1,
+        colRightIdx: -1,
+      },
+    ]);
+  });
+
+  it('should not prepend time column if hideTimeField is true', () => {
+    mockGetFieldByName.mockReturnValue({ sortable: true });
+    const result = getLegacyDisplayedColumns(['column1'], indexPattern, true, false);
+    expect(result).toEqual([
+      {
+        name: 'column1',
+        displayName: 'column1',
+        isSortable: true,
+        isRemoveable: true,
+        colLeftIdx: -1,
+        colRightIdx: -1,
+      },
+    ]);
+  });
+
+  it('should not prepend time column if timeFieldName is included in columns', () => {
+    mockGetFieldByName.mockReturnValue({ sortable: true });
+    const result = getLegacyDisplayedColumns(['column1', 'timestamp'], indexPattern, false, false);
+    expect(result).toEqual([
+      {
+        name: 'column1',
+        displayName: 'column1',
+        isSortable: true,
+        isRemoveable: true,
+        colLeftIdx: -1,
+        colRightIdx: 1,
+      },
+      {
+        name: 'timestamp',
+        displayName: 'timestamp',
+        isSortable: true,
+        isRemoveable: true,
+        colLeftIdx: 0,
+        colRightIdx: -1,
+      },
+    ]);
+  });
+
+  it('should shorten dotted string in displayName if isShortDots is true', () => {
+    mockGetFieldByName.mockReturnValue({ sortable: true });
+    const result = getLegacyDisplayedColumns(['column.with.dots'], indexPattern, false, true);
+    expect(result).toEqual([
+      {
+        name: 'timestamp',
+        displayName: 'Time',
+        isSortable: true,
+        isRemoveable: false,
+        colLeftIdx: -1,
+        colRightIdx: -1,
+      },
+      {
+        name: 'column.with.dots',
+        displayName: 'c.w.dots',
+        isSortable: true,
+        isRemoveable: true,
+        colLeftIdx: -1,
+        colRightIdx: -1,
+      },
+    ]);
+  });
+});

--- a/src/plugins/discover/public/application/components/default_discover_table/helper.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/helper.tsx
@@ -94,7 +94,9 @@ export function getLegacyDisplayedColumns(
       colRightIdx: idx + 1 >= columns.length ? -1 : idx + 1,
     };
   });
-  return !hideTimeField && indexPattern.timeFieldName
+  return !hideTimeField &&
+    indexPattern.timeFieldName &&
+    !columns.includes(indexPattern.timeFieldName)
     ? [getTimeColumn(indexPattern.timeFieldName), ...columnProps]
     : columnProps;
 }

--- a/src/plugins/discover/public/application/components/default_discover_table/helper.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/helper.tsx
@@ -94,9 +94,13 @@ export function getLegacyDisplayedColumns(
       colRightIdx: idx + 1 >= columns.length ? -1 : idx + 1,
     };
   });
-  return !hideTimeField &&
-    indexPattern.timeFieldName &&
-    !columns.includes(indexPattern.timeFieldName)
-    ? [getTimeColumn(indexPattern.timeFieldName), ...columnProps]
+
+  const shouldIncludeTimeField =
+    !hideTimeField &&
+    typeof indexPattern.timeFieldName === 'string' &&
+    !columns.includes(indexPattern.timeFieldName);
+
+  return shouldIncludeTimeField
+    ? [getTimeColumn(indexPattern.timeFieldName as string), ...columnProps]
     : columnProps;
 }

--- a/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_render_tab.tsx
+++ b/src/plugins/discover/public/application/components/doc_viewer/doc_viewer_render_tab.tsx
@@ -29,7 +29,7 @@
  */
 
 import React, { useRef, useEffect } from 'react';
-import { DocViewRenderFn, DocViewRenderProps } from '../../../doc_views/doc_views_types';
+import { DocViewRenderFn, DocViewRenderProps } from '../../doc_views/doc_views_types';
 
 interface Props {
   render: DocViewRenderFn;


### PR DESCRIPTION
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6982

## Screenshot



## Changelog
- fix: [Discover] Check if the timestamp is already included to remove duplicate col


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
