### PR TITLE
Optimize scrolling behavior of Discover table

### DIFF
--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -181,11 +181,9 @@ const DefaultDiscoverTableUI = ({
       // Load the first batch of rows and adjust the columns to the contents
       tableElement.style.tableLayout = 'auto';
       // To prevent influencing the auto-sizing, unset the widths from a previous render
-      tableElement
-        .querySelectorAll('thead > tr > th:not(:first-child):not(:last-child)')
-        .forEach((th) => {
-          (th as HTMLTableCellElement).style.width = 'unset';
-        });
+      tableElement.querySelectorAll('thead > tr > th:not(:first-child)').forEach((th) => {
+        (th as HTMLTableCellElement).style.width = 'unset';
+      });
 
       tableLayoutRequestFrameRef.current = requestAnimationFrame(() => {
         if (tableElement) {

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -180,6 +180,12 @@ const DefaultDiscoverTableUI = ({
     if (tableElement) {
       // Load the first batch of rows and adjust the columns to the contents
       tableElement.style.tableLayout = 'auto';
+      // To prevent influencing the auto-sizing, unset the widths from a previous render
+      tableElement
+        .querySelectorAll('thead > tr > th:not(:first-child):not(:last-child)')
+        .forEach((th) => {
+          (th as HTMLTableCellElement).style.width = 'unset';
+        });
 
       tableLayoutRequestFrameRef.current = requestAnimationFrame(() => {
         if (tableElement) {


### PR DESCRIPTION
This is an improvement to #6683

To prevent influencing the auto-sizing, this change unset the column widths from a previous render. It results in a much better auto-sizing outcome.


## Testing the changes

1. Open discover in legacy tables.
2. Add columns manually.
3. Expect columns sizing to be acceptable.

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
