### PR TITLE
[Discover] Allow the last column of a table wider than the window to show up properly

### DIFF
--- a/changelogs/fragments/7058.yml
+++ b/changelogs/fragments/7058.yml
@@ -1,0 +1,2 @@
+fix:
+- [Discover] Allow the last column of a table wider than the window to show up properly ([#7058](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7058))

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -192,14 +192,11 @@ const DefaultDiscoverTableUI = ({
            *   1) prevent columns from changing size when more rows are added, and
            *   2) speed of rendering time of subsequently added rows.
            *
-           * First cell is skipped because it has a dimention set already, and the last cell is skipped to allow it to
-           * grow as much as the table needs.
+           * First cell is skipped because it has a fixed dimension set already.
            */
-          tableElement
-            .querySelectorAll('thead > tr > th:not(:first-child):not(:last-child)')
-            .forEach((th) => {
-              (th as HTMLTableCellElement).style.width = th.getBoundingClientRect().width + 'px';
-            });
+          tableElement.querySelectorAll('thead > tr > th:not(:first-child)').forEach((th) => {
+            (th as HTMLTableCellElement).style.width = th.getBoundingClientRect().width + 'px';
+          });
 
           tableElement.style.tableLayout = 'fixed';
         }


### PR DESCRIPTION
### Description

The last column on a table wider than the screen was crushed.

![Screenshot 2024-06-18 at 17-40-34 Discover - OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/3527403/37f36f22-155e-40de-9ca8-f8a84dbab211)


### Issues Resolved

Fixes #7056

## Changelog


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
