### PR TITLE
Fix object empty check and minor perf issue in query editor extensions

### DIFF
--- a/changelogs/fragments/7077.yml
+++ b/changelogs/fragments/7077.yml
@@ -1,2 +1,0 @@
-fix:
-- Fix object empty check and minor perf issue in query editor extensions ([#7077](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7077))

--- a/changelogs/fragments/7077.yml
+++ b/changelogs/fragments/7077.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix object empty check and minor perf issue in query editor extensions ([#7077](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7077))

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import { isEqual } from 'lodash';
 import React, { Component, createRef, RefObject } from 'react';
 import { Settings } from '..';
-import { IDataPluginServices, IIndexPattern, Query, TimeRange } from '../..';
+import { DataSource, IDataPluginServices, IIndexPattern, Query, TimeRange } from '../..';
 import {
   CodeEditor,
   OpenSearchDashboardsReactContextValue,
@@ -19,9 +19,11 @@ import { SuggestionsListSize } from '../typeahead/suggestions_component';
 import { DataSettings, QueryEnhancement } from '../types';
 import { fetchIndexPatterns } from './fetch_index_patterns';
 import { QueryLanguageSelector } from './language_selector';
+import { QueryEditorExtensions } from './query_editor_extensions';
 
 export interface QueryEditorProps {
   indexPatterns: Array<IIndexPattern | string>;
+  dataSource?: DataSource;
   query: Query;
   containerRef?: React.RefCallback<HTMLDivElement>;
   settings: Settings;
@@ -41,10 +43,9 @@ export interface QueryEditorProps {
   size?: SuggestionsListSize;
   className?: string;
   isInvalid?: boolean;
-  queryEditorHeaderRef: React.RefObject<HTMLDivElement>;
-  queryEditorHeaderClassName?: string;
-  queryEditorBannerRef: React.RefObject<HTMLDivElement>;
-  queryEditorBannerClassName?: string;
+  queryLanguage?: string;
+  headerClassName?: string;
+  bannerClassName?: string;
 }
 
 interface Props extends QueryEditorProps {
@@ -92,6 +93,9 @@ export default class QueryEditorUI extends Component<Props, State> {
   private services = this.props.opensearchDashboards.services;
   private componentIsUnmounting = false;
   private queryEditorDivRefInstance: RefObject<HTMLDivElement> = createRef();
+  private headerRef: RefObject<HTMLDivElement> = createRef();
+  private bannerRef: RefObject<HTMLDivElement> = createRef();
+  private extensionMap = this.props.settings?.getQueryEditorExtensionMap();
 
   private getQueryString = () => {
     if (!this.props.query.query) {
@@ -119,6 +123,30 @@ export default class QueryEditorUI extends Component<Props, State> {
       indexPatterns: [...objectPatterns, ...objectPatternsFromStrings],
     });
   };
+
+  private renderQueryEditorExtensions() {
+    if (
+      !(
+        this.headerRef.current &&
+        this.bannerRef.current &&
+        this.props.queryLanguage &&
+        this.extensionMap &&
+        Object.keys(this.extensionMap).length > 0
+      )
+    ) {
+      return null;
+    }
+    return (
+      <QueryEditorExtensions
+        language={this.props.queryLanguage}
+        configMap={this.extensionMap}
+        componentContainer={this.headerRef.current}
+        bannerContainer={this.bannerRef.current}
+        indexPatterns={this.props.indexPatterns}
+        dataSource={this.props.dataSource}
+      />
+    );
+  }
 
   private onSubmit = (query: Query, dateRange?: TimeRange) => {
     if (this.props.onSubmit) {
@@ -249,20 +277,12 @@ export default class QueryEditorUI extends Component<Props, State> {
 
   public render() {
     const className = classNames(this.props.className);
-
-    const queryEditorHeaderClassName = classNames(
-      'osdQueryEditorHeader',
-      this.props.queryEditorHeaderClassName
-    );
-
-    const queryEditorBannerClassName = classNames(
-      'osdQueryEditorBanner',
-      this.props.queryEditorBannerClassName
-    );
+    const headerClassName = classNames('osdQueryEditorHeader', this.props.headerClassName);
+    const bannerClassName = classNames('osdQueryEditorBanner', this.props.bannerClassName);
 
     return (
       <div className={className}>
-        <div ref={this.props.queryEditorBannerRef} className={queryEditorBannerClassName} />
+        <div ref={this.bannerRef} className={bannerClassName} />
         <EuiFlexGroup gutterSize="xs" direction="column">
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="xs">
@@ -285,7 +305,7 @@ export default class QueryEditorUI extends Component<Props, State> {
             </EuiFlexGroup>
           </EuiFlexItem>
           <EuiFlexItem onClick={this.onClickInput} grow={true}>
-            <div ref={this.props.queryEditorHeaderRef} className={queryEditorHeaderClassName} />
+            <div ref={this.headerRef} className={headerClassName} />
             <CodeEditor
               height={70}
               languageId="opensearchql"
@@ -306,6 +326,7 @@ export default class QueryEditorUI extends Component<Props, State> {
             />
           </EuiFlexItem>
         </EuiFlexGroup>
+        {this.renderQueryEditorExtensions()}
       </div>
     );
   }

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -58,7 +58,6 @@ interface State {
   index: number | null;
   suggestions: QuerySuggestion[];
   indexPatterns: IIndexPattern[];
-  queryEditorRect: DOMRect | undefined;
 }
 
 const KEY_CODES = {
@@ -83,7 +82,6 @@ export default class QueryEditorUI extends Component<Props, State> {
     index: null,
     suggestions: [],
     indexPatterns: [],
-    queryEditorRect: undefined,
   };
 
   public inputRef: HTMLElement | null = null;
@@ -92,7 +90,6 @@ export default class QueryEditorUI extends Component<Props, State> {
   private abortController?: AbortController;
   private services = this.props.opensearchDashboards.services;
   private componentIsUnmounting = false;
-  private queryEditorDivRefInstance: RefObject<HTMLDivElement> = createRef();
   private headerRef: RefObject<HTMLDivElement> = createRef();
   private bannerRef: RefObject<HTMLDivElement> = createRef();
   private extensionMap = this.props.settings?.getQueryEditorExtensionMap();
@@ -249,12 +246,6 @@ export default class QueryEditorUI extends Component<Props, State> {
     this.initPersistedLog();
     // this.fetchIndexPatterns().then(this.updateSuggestions);
     this.initDataSourcesVisibility();
-    this.handleListUpdate();
-
-    window.addEventListener('scroll', this.handleListUpdate, {
-      passive: true, // for better performance as we won't call preventDefault
-      capture: true, // scroll events don't bubble, they must be captured instead
-    });
   }
 
   public componentDidUpdate(prevProps: Props) {
@@ -269,16 +260,7 @@ export default class QueryEditorUI extends Component<Props, State> {
   public componentWillUnmount() {
     if (this.abortController) this.abortController.abort();
     this.componentIsUnmounting = true;
-    window.removeEventListener('scroll', this.handleListUpdate, { capture: true });
   }
-
-  handleListUpdate = () => {
-    if (this.componentIsUnmounting) return;
-
-    return this.setState({
-      queryEditorRect: this.queryEditorDivRefInstance.current?.getBoundingClientRect(),
-    });
-  };
 
   handleOnFocus = () => {
     if (this.props.onChangeQueryEditorFocus) {

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -58,7 +58,6 @@ interface State {
   index: number | null;
   suggestions: QuerySuggestion[];
   indexPatterns: IIndexPattern[];
-  queryEditorRect: DOMRect | undefined;
 }
 
 const KEY_CODES = {
@@ -83,7 +82,6 @@ export default class QueryEditorUI extends Component<Props, State> {
     index: null,
     suggestions: [],
     indexPatterns: [],
-    queryEditorRect: undefined,
   };
 
   public inputRef: HTMLTextAreaElement | null = null;
@@ -91,8 +89,6 @@ export default class QueryEditorUI extends Component<Props, State> {
   private persistedLog: PersistedLog | undefined;
   private abortController?: AbortController;
   private services = this.props.opensearchDashboards.services;
-  private componentIsUnmounting = false;
-  private queryEditorDivRefInstance: RefObject<HTMLDivElement> = createRef();
   private headerRef: RefObject<HTMLDivElement> = createRef();
   private bannerRef: RefObject<HTMLDivElement> = createRef();
   private extensionMap = this.props.settings?.getQueryEditorExtensionMap();
@@ -238,12 +234,6 @@ export default class QueryEditorUI extends Component<Props, State> {
 
     this.initPersistedLog();
     // this.fetchIndexPatterns().then(this.updateSuggestions);
-    this.handleListUpdate();
-
-    window.addEventListener('scroll', this.handleListUpdate, {
-      passive: true, // for better performance as we won't call preventDefault
-      capture: true, // scroll events don't bubble, they must be captured instead
-    });
   }
 
   public componentDidUpdate(prevProps: Props) {
@@ -257,17 +247,7 @@ export default class QueryEditorUI extends Component<Props, State> {
 
   public componentWillUnmount() {
     if (this.abortController) this.abortController.abort();
-    this.componentIsUnmounting = true;
-    window.removeEventListener('scroll', this.handleListUpdate, { capture: true });
   }
-
-  handleListUpdate = () => {
-    if (this.componentIsUnmounting) return;
-
-    return this.setState({
-      queryEditorRect: this.queryEditorDivRefInstance.current?.getBoundingClientRect(),
-    });
-  };
 
   handleOnFocus = () => {
     if (this.props.onChangeQueryEditorFocus) {

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.tsx
@@ -20,7 +20,7 @@ const QueryEditorExtensions: React.FC<QueryEditorExtensionsProps> = React.memo((
   const { configMap, componentContainer, bannerContainer, ...dependencies } = props;
 
   const sortedConfigs = useMemo(() => {
-    if (!configMap || !Object.keys(configMap)) return [];
+    if (!configMap || Object.keys(configMap).length === 0) return [];
     return Object.values(configMap).sort((a, b) => a.order - b.order);
   }, [configMap]);
 

--- a/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
@@ -29,10 +29,10 @@ import {
 } from '../../../../opensearch_dashboards_react/public';
 import { UI_SETTINGS } from '../../../common';
 import { fromUser, getQueryLog, PersistedLog } from '../../query';
-import { QueryEditorExtensions } from './query_editor_extensions';
 import { Settings } from '../types';
 import { NoDataPopover } from './no_data_popover';
 import QueryEditorUI from './query_editor';
+import { QueryEditorExtensions } from './query_editor_extensions';
 
 const QueryEditor = withOpenSearchDashboards(QueryEditorUI);
 
@@ -255,10 +255,12 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
 
   function renderQueryEditorExtensions() {
     if (
-      !shouldRenderQueryEditorExtensions() ||
-      !queryEditorHeaderRef.current ||
-      !queryEditorBannerRef.current ||
-      !queryLanguage
+      !(
+        queryEditorHeaderRef.current &&
+        queryEditorBannerRef.current &&
+        queryLanguage &&
+        shouldRenderQueryEditorExtensions()
+      )
     )
       return;
     return (
@@ -305,7 +307,7 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
   }
 
   function shouldRenderQueryEditorExtensions(): boolean {
-    return Boolean(queryEditorExtensionMap && Object.keys(queryEditorExtensionMap).length);
+    return Boolean(queryEditorExtensionMap && Object.keys(queryEditorExtensionMap).length > 0);
   }
 
   function renderUpdateButton() {

--- a/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
@@ -32,7 +32,6 @@ import { fromUser, getQueryLog, PersistedLog } from '../../query';
 import { Settings } from '../types';
 import { NoDataPopover } from './no_data_popover';
 import QueryEditorUI from './query_editor';
-import { QueryEditorExtensions } from './query_editor_extensions';
 
 const QueryEditor = withOpenSearchDashboards(QueryEditorUI);
 
@@ -71,8 +70,6 @@ export interface QueryEditorTopRowProps {
 export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
   const [isDateRangeInvalid, setIsDateRangeInvalid] = useState(false);
   const [isQueryEditorFocused, setIsQueryEditorFocused] = useState(false);
-  const queryEditorHeaderRef = useRef<HTMLDivElement | null>(null);
-  const queryEditorBannerRef = useRef<HTMLDivElement | null>(null);
 
   const opensearchDashboards = useOpenSearchDashboards<IDataPluginServices>();
   const { uiSettings, storage, appName } = opensearchDashboards.services;
@@ -85,7 +82,6 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
       props.settings &&
       props.settings.getQueryEnhancements(queryLanguage)?.searchBar) ||
     null;
-  const queryEditorExtensionMap = props.settings?.getQueryEditorExtensionMap();
   const parsedQuery =
     !queryUiEnhancement || isValidQuery(props.query)
       ? props.query!
@@ -235,6 +231,7 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
         <QueryEditor
           disableAutoFocus={props.disableAutoFocus}
           indexPatterns={props.indexPatterns!}
+          dataSource={props.dataSource}
           prepend={props.prepend}
           query={parsedQuery}
           containerRef={props.containerRef}
@@ -246,32 +243,9 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
           getQueryStringInitialValue={getQueryStringInitialValue}
           persistedLog={persistedLog}
           dataTestSubj={props.dataTestSubj}
-          queryEditorHeaderRef={queryEditorHeaderRef}
-          queryEditorBannerRef={queryEditorBannerRef}
+          queryLanguage={queryLanguage}
         />
       </EuiFlexItem>
-    );
-  }
-
-  function renderQueryEditorExtensions() {
-    if (
-      !(
-        queryEditorHeaderRef.current &&
-        queryEditorBannerRef.current &&
-        queryLanguage &&
-        shouldRenderQueryEditorExtensions()
-      )
-    )
-      return;
-    return (
-      <QueryEditorExtensions
-        language={queryLanguage}
-        configMap={queryEditorExtensionMap}
-        componentContainer={queryEditorHeaderRef.current}
-        bannerContainer={queryEditorBannerRef.current}
-        indexPatterns={props.indexPatterns}
-        dataSource={props.dataSource}
-      />
     );
   }
 
@@ -304,10 +278,6 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
     return Boolean(
       props.showQueryEditor && props.settings && props.indexPatterns && props.query && storage
     );
-  }
-
-  function shouldRenderQueryEditorExtensions(): boolean {
-    return Boolean(queryEditorExtensionMap && Object.keys(queryEditorExtensionMap).length > 0);
   }
 
   function renderUpdateButton() {
@@ -402,7 +372,6 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
       direction="column"
       justifyContent="flexEnd"
     >
-      {renderQueryEditorExtensions()}
       {renderQueryEditor()}
       <EuiFlexItem>
         <EuiFlexGroup responsive={false} gutterSize="none">


### PR DESCRIPTION
### Description

Follow up for #7034, this PR
- addresses https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7034#discussion_r1646749538
- addresses https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7034#discussion_r1646750783
- fixes render order
   - QueryEditorExtensions requires the container divs to be mounted first,
but in the previous implementation, extensions will be mounted first and
it relied on rerendering of queryEditorTopRow. Moving them into query
editor fixes the render order and ensures refs are set.

@AMoo-Miki I didn't use the object check `'[object Object]' !== Object.prototype.toString.call(configMap)`. I don't know what access user has, but if an attacker can arbitrarily alter `configMap`, the code will still break with something like
```tsx
        configMap={
          new Proxy(
            {},
            {
              ownKeys(target) {
                throw new Error('Accessing keys is not allowed.');
              },
            }
          )
        }
```

Given that our code creates the config map here, I think relying on static type check is enough, but feel free to comment if otherwise.
https://github.com/opensearch-project/OpenSearch-Dashboards/blob/7f0e39eb9809c95b98069cc971611edc2cbbc62b/src/plugins/data/public/ui/ui_service.ts#L31

No test changes because this PR does not change code behavior.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Fix object empty check and minor perf issue in query editor extensions

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
