### PR TITLE
[Discover-next] dataframes respects datasources

### DIFF
--- a/changelogs/fragments/7092.yml
+++ b/changelogs/fragments/7092.yml
@@ -1,0 +1,2 @@
+feat:
+- Onboard dataframes to MDS ([#7092](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7092))

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "start": "scripts/use_node scripts/opensearch_dashboards --dev",
     "start:docker": "scripts/use_node scripts/opensearch_dashboards --dev --opensearch.hosts=$OPENSEARCH_HOSTS --opensearch.ignoreVersionMismatch=true --server.host=$SERVER_HOST",
     "start:security": "scripts/use_node scripts/opensearch_dashboards --dev --security",
-    "start:enhancements": "scripts/use_node scripts/opensearch_dashboards --dev --data.enhancements.enabled=true --uiSettings.overrides['query:enhancements:enabled']=true --uiSettings.overrides['query:dataSource:readOnly']=false",
+    "start:enhancements": "scripts/use_node scripts/opensearch_dashboards --dev --data.enhancements.enabled=true --data_source.enabled=true --uiSettings.overrides['query:enhancements:enabled']=true --uiSettings.overrides['query:dataSource:readOnly']=false",
     "debug": "scripts/use_node --nolazy --inspect scripts/opensearch_dashboards --dev",
     "debug-break": "scripts/use_node --nolazy --inspect-brk scripts/opensearch_dashboards --dev",
     "lint": "yarn run lint:es && yarn run lint:style",

--- a/src/plugins/data/common/data_frames/utils.ts
+++ b/src/plugins/data/common/data_frames/utils.ts
@@ -46,6 +46,26 @@ export const getRawQueryString = (
 };
 
 /**
+ * Parses a raw query string and extracts the query string and data source.
+ * @param rawQueryString - The raw query string to parse.
+ * @returns An object containing the parsed query string and data source (if found).
+ */
+export const parseRawQueryString = (rawQueryString: string) => {
+  const rawDataSource = rawQueryString.match(/::(.*?)::/);
+  return {
+    qs: rawQueryString.replace(/::.*?::/, ''),
+    formattedQs(key: string = '.'): string {
+      const parts = rawQueryString.split('::');
+      if (parts.length > 1) {
+        return parts.slice(0, 1).join('') + parts.slice(1).join(key);
+      }
+      return rawQueryString;
+    },
+    ...(rawDataSource && { dataSource: rawDataSource[1] }),
+  };
+};
+
+/**
  * Returns the raw aggregations from the search request.
  *
  * @param searchRequest - search request object
@@ -379,6 +399,7 @@ export const updateDataFrameMeta = ({
   getAggQsFn: GetDataFrameAggQsFn;
 }) => {
   dataFrame.meta = {
+    ...dataFrame.meta,
     aggs: aggConfig,
     aggsQs: {
       [aggConfig.id]: getAggQsFn({

--- a/src/plugins/data/common/data_frames/utils.ts
+++ b/src/plugins/data/common/data_frames/utils.ts
@@ -57,7 +57,10 @@ export const parseRawQueryString = (rawQueryString: string) => {
     formattedQs(key: string = '.'): string {
       const parts = rawQueryString.split('::');
       if (parts.length > 1) {
-        return parts.slice(0, 1).join('') + parts.slice(1).join(key);
+        return (parts.slice(0, 1).join('') + parts.slice(1).join(key)).replace(
+          new RegExp(key + '$'),
+          ''
+        );
       }
       return rawQueryString;
     },

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
@@ -142,6 +142,25 @@ export class IndexPatternsService {
   };
 
   /**
+   * Finds a data source by its title.
+   *
+   * @param title - The title of the data source to find.
+   * @param size - The number of results to return. Defaults to 10.
+   * @returns The first matching data source or undefined if not found.
+   */
+  findDataSourceByTitle = async (title: string, size: number = 10) => {
+    const savedObjectsResponse = await this.savedObjectsClient.find<DataSourceAttributes>({
+      type: 'data-source',
+      fields: ['title'],
+      search: title,
+      searchFields: ['title'],
+      perPage: size,
+    });
+
+    return savedObjectsResponse[0] || undefined;
+  };
+
+  /**
    * Get list of index pattern ids
    * @param refresh Force refresh of index pattern list
    */

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -87,7 +87,15 @@ import { normalizeSortRequest } from './normalize_sort_request';
 import { filterDocvalueFields } from './filter_docvalue_fields';
 import { fieldWildcardFilter } from '../../../../opensearch_dashboards_utils/common';
 import { IIndexPattern } from '../../index_patterns';
-import { DATA_FRAME_TYPES, IDataFrame, IDataFrameResponse, convertResult } from '../../data_frames';
+import {
+  DATA_FRAME_TYPES,
+  IDataFrame,
+  IDataFrameResponse,
+  convertResult,
+  createDataFrame,
+  getRawQueryString,
+  parseRawQueryString,
+} from '../../data_frames';
 import { IOpenSearchSearchRequest, IOpenSearchSearchResponse, ISearchOptions } from '../..';
 import { IOpenSearchDashboardsSearchRequest, IOpenSearchDashboardsSearchResponse } from '../types';
 import { ISearchSource, SearchSourceOptions, SearchSourceFields } from './types';
@@ -306,6 +314,23 @@ export class SearchSource {
   }
 
   /**
+   * Create and set the data frame of this SearchSource
+   *
+   * @async
+   * @return {undefined|IDataFrame}
+   */
+  async createDataFrame(searchRequest: SearchRequest) {
+    const rawQueryString = this.getRawQueryStringFromRequest(searchRequest);
+    const dataFrame = createDataFrame({
+      name: searchRequest.index.title || searchRequest.index,
+      fields: [],
+      ...(rawQueryString && { meta: { queryConfig: parseRawQueryString(rawQueryString) } }),
+    });
+    await this.setDataFrame(dataFrame);
+    return this.getDataFrame();
+  }
+
+  /**
    * Clear the data frame of this SearchSource
    */
   destroyDataFrame() {
@@ -401,6 +426,10 @@ export class SearchSource {
   private async fetchExternalSearch(searchRequest: SearchRequest, options: ISearchOptions) {
     const { search, getConfig, onResponse } = this.dependencies;
 
+    if (!this.getDataFrame()) {
+      await this.createDataFrame(searchRequest);
+    }
+
     const params = getExternalSearchParamsFromRequest(searchRequest, {
       getConfig,
       getDataFrame: this.getDataFrame.bind(this),
@@ -442,6 +471,10 @@ export class SearchSource {
 
   private isUnsupportedRequest(request: SearchRequest): boolean {
     return request.body!.query.hasOwnProperty('type') && request.body!.query.type === 'unsupported';
+  }
+
+  private getRawQueryStringFromRequest(request: SearchRequest): string | undefined {
+    return getRawQueryString({ params: request });
   }
 
   /**

--- a/src/plugins/data/public/search/search_service.ts
+++ b/src/plugins/data/public/search/search_service.ts
@@ -145,6 +145,16 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
         if (this.dfCache.get() && this.dfCache.get()?.name !== dataFrame.name) {
           indexPatterns.clearCache(this.dfCache.get()!.name, false);
         }
+        if (
+          dataFrame.meta &&
+          dataFrame.meta.queryConfig &&
+          'dataSource' in dataFrame.meta.queryConfig
+        ) {
+          const dataSource = await indexPatterns.findDataSourceByTitle(
+            dataFrame.meta.queryConfig.dataSource
+          );
+          dataFrame.meta.queryConfig.dataSourceId = dataSource?.id;
+        }
         this.dfCache.set(dataFrame);
         const existingIndexPattern = indexPatterns.getByTitle(dataFrame.name!, true);
         const dataSet = await indexPatterns.create(

--- a/src/plugins/data/server/search/search_service.ts
+++ b/src/plugins/data/server/search/search_service.ts
@@ -218,6 +218,16 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
               if (this.dfCache.get() && this.dfCache.get()?.name !== dataFrame.name) {
                 scopedIndexPatterns.clearCache(this.dfCache.get()!.name, false);
               }
+              if (
+                dataFrame.meta &&
+                dataFrame.meta.queryConfig &&
+                'dataSource' in dataFrame.meta.queryConfig
+              ) {
+                const dataSource = await scopedIndexPatterns.findDataSourceByTitle(
+                  dataFrame.meta.queryConfig.dataSource
+                );
+                dataFrame.meta.queryConfig.dataSourceId = dataSource?.id;
+              }
               this.dfCache.set(dataFrame);
               const existingIndexPattern = scopedIndexPatterns.getByTitle(dataFrame.name!, true);
               const dataSet = await scopedIndexPatterns.create(


### PR DESCRIPTION
### Description

Parses user string between `::datasource::` to get the data source Then appends the dataSourceId in the meta.

Also creates the data frame before the interceptor to keep the meta info passed around.

If this gets accepted follow ups need to happen:
* should be ensuring the virtual index pattern includes the data source name with the index pattern name to avoid conflicts and a weird state.
* some reason dataframe is being always wiped out the first call in the search source. need to fix so that the schema is persisted
* weird initial load state. likely just too many things at once so we should make sure the usual and fresh experience is respected
* better indicator on the datasource, or just autocomplete that displays all the datasource connections when user types initial `::`.

### Issues Related

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6957

## Screenshot

<img width="446" alt="Screenshot 2024-06-24 at 1 42 56 AM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/12060704/7e6d512c-3dd0-421f-add7-ba5e05f7ee70">

## Testing the changes

run `yarn opensearch snapshot --sql`
run `yarn start:enhancements`

add a new data source connection

## Changelog

- feat: onboard dataframes to MDS

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
