### PR TITLE
[Multiple Datasource][Version Decoupling] Support Version Decoupling in Index Patterns Dashboards Plugin

### DIFF
--- a/changelogs/fragments/7100.yml
+++ b/changelogs/fragments/7100.yml
@@ -1,0 +1,2 @@
+fix:
+- [MDS][Version Decoupling] Add support of Version Decoupling in Index Patterns Dashboards Plugin ([#7100](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7100))

--- a/src/core/server/plugins/discovery/plugin_manifest_parser.test.ts
+++ b/src/core/server/plugins/discovery/plugin_manifest_parser.test.ts
@@ -416,6 +416,7 @@ test('set defaults for all missing optional fields', async () => {
     requiredBundles: [],
     server: true,
     ui: false,
+    supportedOSDataSourceVersions: undefined,
   });
 });
 
@@ -434,6 +435,7 @@ test('return all set optional fields as they are in manifest', async () => {
           'test-opensearch-plugin-2': '>=1.0.0',
         },
         ui: true,
+        supportedOSDataSourceVersions: '>=1.0.0',
       })
     )
   );
@@ -452,6 +454,7 @@ test('return all set optional fields as they are in manifest', async () => {
     },
     server: false,
     ui: true,
+    supportedOSDataSourceVersions: '>=1.0.0',
   });
 });
 

--- a/src/core/server/plugins/discovery/plugin_manifest_parser.ts
+++ b/src/core/server/plugins/discovery/plugin_manifest_parser.ts
@@ -68,6 +68,7 @@ const KNOWN_MANIFEST_FIELDS = (() => {
     server: true,
     extraPublicDirs: true,
     requiredBundles: true,
+    supportedOSDataSourceVersions: true,
   };
 
   return new Set(Object.keys(manifestFields));
@@ -245,6 +246,7 @@ export async function parseManifest(
     ui: includesUiPlugin,
     server: includesServerPlugin,
     extraPublicDirs: manifest.extraPublicDirs,
+    supportedOSDataSourceVersions: manifest.supportedOSDataSourceVersions,
   };
 }
 

--- a/src/core/server/plugins/plugin.test.ts
+++ b/src/core/server/plugins/plugin.test.ts
@@ -77,6 +77,7 @@ function createPluginManifest(manifestProps: Partial<PluginManifest> = {}): Plug
     requiredBundles: [],
     server: true,
     ui: true,
+    supportedOSDataSourceVersions: '>=1.0.0',
     ...manifestProps,
   };
 }
@@ -125,6 +126,7 @@ test('`constructor` correctly initializes plugin instance', () => {
   expect(plugin.path).toBe('some-plugin-path');
   expect(plugin.requiredPlugins).toEqual(['some-required-dep']);
   expect(plugin.optionalPlugins).toEqual(['some-optional-dep']);
+  expect(plugin.supportedOSDataSourceVersions).toEqual('>=1.0.0');
 });
 
 test('`setup` fails if `plugin` initializer is not exported', async () => {

--- a/src/core/server/plugins/plugin.ts
+++ b/src/core/server/plugins/plugin.ts
@@ -70,6 +70,7 @@ export class PluginWrapper<
   public readonly requiredBundles: PluginManifest['requiredBundles'];
   public readonly includesServerPlugin: PluginManifest['server'];
   public readonly includesUiPlugin: PluginManifest['ui'];
+  public readonly supportedOSDataSourceVersions: PluginManifest['supportedOSDataSourceVersions'];
 
   private readonly log: Logger;
   private readonly initializerContext: PluginInitializerContext;
@@ -100,6 +101,7 @@ export class PluginWrapper<
     this.requiredBundles = params.manifest.requiredBundles;
     this.includesServerPlugin = params.manifest.server;
     this.includesUiPlugin = params.manifest.ui;
+    this.supportedOSDataSourceVersions = params.manifest.supportedOSDataSourceVersions;
   }
 
   /**

--- a/src/core/server/plugins/types.ts
+++ b/src/core/server/plugins/types.ts
@@ -200,6 +200,12 @@ export interface PluginManifest {
    * @deprecated
    */
   readonly extraPublicDirs?: string[];
+
+  /**
+   * Specifies the supported version range when adding OpenSearch cluster as data sources.
+   * Value will be following semver as a range for example ">= 1.3.0"
+   */
+  readonly supportedOSDataSourceVersions?: string;
 }
 
 /**

--- a/src/plugins/data_source/common/data_sources/types.ts
+++ b/src/plugins/data_source/common/data_sources/types.ts
@@ -9,7 +9,7 @@ export interface DataSourceAttributes extends SavedObjectAttributes {
   title: string;
   description?: string;
   endpoint: string;
-  dataSourceVersion?: string;
+  dataSourceVersion: string;
   dataSourceEngineType?: DataSourceEngineType;
   installedPlugins?: string[];
   auth: {

--- a/src/plugins/index_pattern_management/opensearch_dashboards.json
+++ b/src/plugins/index_pattern_management/opensearch_dashboards.json
@@ -5,5 +5,6 @@
   "ui": true,
   "optionalPlugins": ["dataSource"],
   "requiredPlugins": ["management", "data", "urlForwarding"],
-  "requiredBundles": ["opensearchDashboardsReact", "opensearchDashboardsUtils"]
+  "requiredBundles": ["opensearchDashboardsReact", "opensearchDashboardsUtils"],
+  "supportedOSDataSourceVersions": ">=1.0.0"
 }

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_data_source/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_data_source/components/header/header.tsx
@@ -23,10 +23,12 @@ import {
   DataSourceRef,
   IndexPatternManagmentContext,
 } from 'src/plugins/index_pattern_management/public/types';
+import semver from 'semver';
 import { useOpenSearchDashboards } from '../../../../../../../../../plugins/opensearch_dashboards_react/public';
 import { getDataSources } from '../../../../../../components/utils';
 import { DataSourceTableItem, StepInfo } from '../../../../types';
 import { LoadingState } from '../../../loading_state';
+import * as pluginManifest from '../../../../../../../opensearch_dashboards.json';
 
 interface HeaderProps {
   onDataSourceSelected: (id: string, type: string, title: string) => void;
@@ -68,6 +70,12 @@ export const Header: React.FC<HeaderProps> = (props: HeaderProps) => {
       .then((fetchedDataSources: DataSourceTableItem[]) => {
         setIsLoading(false);
         if (fetchedDataSources?.length) {
+          fetchedDataSources = fetchedDataSources.filter((dataSource) =>
+            semver.satisfies(
+              dataSource.datasourceversion,
+              pluginManifest.supportedOSDataSourceVersions
+            )
+          );
           setDataSources(fetchedDataSources);
         }
       })

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/types.ts
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/types.ts
@@ -92,4 +92,5 @@ export interface DataSourceTableItem {
   sort: string;
   checked?: 'on' | 'off';
   label: string;
+  datasourceversion: string;
 }

--- a/src/plugins/index_pattern_management/public/components/utils.ts
+++ b/src/plugins/index_pattern_management/public/components/utils.ts
@@ -90,7 +90,7 @@ export async function getDataSources(savedObjectsClient: SavedObjectsClientContr
     savedObjectsClient
       .find<DataSourceAttributes>({
         type: 'data-source',
-        fields: ['title', 'type'],
+        fields: ['title', 'type', 'dataSourceVersion'],
         perPage: 10000,
       })
       .then((response) =>
@@ -99,6 +99,7 @@ export async function getDataSources(savedObjectsClient: SavedObjectsClientContr
             const id = dataSource.id;
             const type = dataSource.type;
             const title = dataSource.get('title');
+            const datasourceversion = dataSource.get('dataSourceVersion');
 
             return {
               id,
@@ -106,6 +107,7 @@ export async function getDataSources(savedObjectsClient: SavedObjectsClientContr
               type,
               label: title,
               sort: `${title}`,
+              datasourceversion,
             };
           })
           .sort((a, b) => a.sort.localeCompare(b.sort))


### PR DESCRIPTION
### Description

* This PR is to add support of `Version Decoupling` in `Index Patterns Dashboards Plugin`
* This is achieved mainly by add a new entry `supportedOSDataSourceVersions` in the plugin manifest file
*  For `Index Patterns Plugin` it would support all versions of OS clusters so the supported range would be `>=1.0.0`
* The current behavior is to filter out the incompatible data sources out of the data source list.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7099

## Screenshot


https://github.com/opensearch-project/OpenSearch-Dashboards/assets/99905560/883852c5-51a2-4b50-9226-f84d873721b0


## Changelog

- fix: [MDS][Version Decoupling] Add support of Version Decoupling in Index Patterns Dashboards Plugin

### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
