### PR TITLE
[Workspace][Data Source] Support data source assignment in workspace

### DIFF
--- a/changelogs/fragments/7101.yml
+++ b/changelogs/fragments/7101.yml
@@ -1,0 +1,2 @@
+feat:
+- Support data source assignment in workspace. ([#7101](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7101))

--- a/src/core/server/saved_objects/service/lib/repository.test.js
+++ b/src/core/server/saved_objects/service/lib/repository.test.js
@@ -1308,6 +1308,8 @@ describe('SavedObjectsRepository', () => {
       },
     };
 
+    const workspaces = ['workspace1', 'workspace2'];
+
     const getMockBulkUpdateResponse = (objects, options, includeOriginId) => ({
       items: objects.map(({ type, id }) => ({
         update: {
@@ -1581,6 +1583,20 @@ describe('SavedObjectsRepository', () => {
         );
         client.bulk.mockClear();
       });
+    });
+
+    it(`accepts workspaces property when providing workspaces info`, async () => {
+      const objects = [obj1, obj2].map((obj) => ({ ...obj, workspaces }));
+      await bulkUpdateSuccess(objects);
+      const doc = {
+        doc: expect.objectContaining({ workspaces }),
+      };
+      const body = [expect.any(Object), doc, expect.any(Object), doc];
+      expect(client.bulk).toHaveBeenCalledWith(
+        expect.objectContaining({ body }),
+        expect.anything()
+      );
+      client.bulk.mockClear();
     });
 
     describe('errors', () => {
@@ -3950,6 +3966,8 @@ describe('SavedObjectsRepository', () => {
       },
     };
 
+    const workspaces = ['workspace1', 'workspace2'];
+
     const updateSuccess = async (type, id, attributes, options, includeOriginId) => {
       if (registry.isMultiNamespace(type)) {
         const mockGetResponse = getMockGetResponse({ type, id }, options?.namespace);
@@ -4129,6 +4147,18 @@ describe('SavedObjectsRepository', () => {
       it(`accepts permissions when providing permissions info`, async () => {
         await updateSuccess(type, id, attributes, { permissions });
         const expected = expect.objectContaining({ permissions });
+        const body = {
+          doc: expected,
+        };
+        expect(client.update).toHaveBeenCalledWith(
+          expect.objectContaining({ body }),
+          expect.anything()
+        );
+      });
+
+      it(`accepts workspaces when providing permissions info`, async () => {
+        await updateSuccess(type, id, attributes, { workspaces });
+        const expected = expect.objectContaining({ workspaces });
         const body = {
           doc: expected,
         };

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -1089,7 +1089,13 @@ export class SavedObjectsRepository {
       throw SavedObjectsErrorHelpers.createGenericNotFoundError(type, id);
     }
 
-    const { version, references, refresh = DEFAULT_REFRESH_SETTING, permissions } = options;
+    const {
+      version,
+      references,
+      refresh = DEFAULT_REFRESH_SETTING,
+      permissions,
+      workspaces,
+    } = options;
     const namespace = normalizeNamespace(options.namespace);
 
     let preflightResult: SavedObjectsRawDoc | undefined;
@@ -1104,6 +1110,7 @@ export class SavedObjectsRepository {
       updated_at: time,
       ...(Array.isArray(references) && { references }),
       ...(permissions && { permissions }),
+      ...(workspaces && { workspaces }),
     };
 
     const { body, statusCode } = await this.client.update<SavedObjectsRawDocSource>(
@@ -1142,6 +1149,7 @@ export class SavedObjectsRepository {
       namespaces,
       ...(originId && { originId }),
       ...(permissions && { permissions }),
+      ...(workspaces && { workspaces }),
       references,
       attributes,
     };
@@ -1342,7 +1350,14 @@ export class SavedObjectsRepository {
         };
       }
 
-      const { attributes, references, version, namespace: objectNamespace, permissions } = object;
+      const {
+        attributes,
+        references,
+        version,
+        namespace: objectNamespace,
+        permissions,
+        workspaces,
+      } = object;
 
       if (objectNamespace === ALL_NAMESPACES_STRING) {
         return {
@@ -1364,6 +1379,7 @@ export class SavedObjectsRepository {
         updated_at: time,
         ...(Array.isArray(references) && { references }),
         ...(permissions && { permissions }),
+        ...(workspaces && { workspaces }),
       };
 
       const requiresNamespacesCheck = this._registry.isMultiNamespace(object.type);
@@ -1516,7 +1532,13 @@ export class SavedObjectsRepository {
         )[0] as any;
 
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const { [type]: attributes, references, updated_at, permissions } = documentToSave;
+        const {
+          [type]: attributes,
+          references,
+          updated_at,
+          permissions,
+          workspaces,
+        } = documentToSave;
         if (error) {
           return {
             id,
@@ -1536,6 +1558,7 @@ export class SavedObjectsRepository {
           attributes,
           references,
           ...(permissions && { permissions }),
+          ...(workspaces && { workspaces }),
         };
       }),
     };

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -1531,11 +1531,10 @@ export class SavedObjectsRepository {
           response
         )[0] as any;
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const {
           [type]: attributes,
           references,
-          updated_at,
+          updated_at: updatedAt,
           permissions,
           workspaces,
         } = documentToSave;
@@ -1553,7 +1552,7 @@ export class SavedObjectsRepository {
           type,
           ...(namespaces && { namespaces }),
           ...(originId && { originId }),
-          updated_at,
+          updated_at: updatedAt,
           version: encodeVersion(seqNo, primaryTerm),
           attributes,
           references,

--- a/src/core/server/saved_objects/service/saved_objects_client.mock.ts
+++ b/src/core/server/saved_objects/service/saved_objects_client.mock.ts
@@ -45,6 +45,8 @@ const create = () =>
     update: jest.fn(),
     addToNamespaces: jest.fn(),
     deleteFromNamespaces: jest.fn(),
+    addToWorkspaces: jest.fn(),
+    deleteFromWorkspaces: jest.fn(),
   } as unknown) as jest.Mocked<SavedObjectsClientContract>);
 
 export const savedObjectsClientMock = { create };

--- a/src/core/server/saved_objects/service/saved_objects_client.test.js
+++ b/src/core/server/saved_objects/service/saved_objects_client.test.js
@@ -222,3 +222,44 @@ test(`#deleteByWorkspace`, async () => {
   expect(mockRepository.deleteByWorkspace).toHaveBeenCalledWith(workspace, options);
   expect(result).toBe(returnValue);
 });
+
+test(`#deleteFromWorkspaces`, async () => {
+  const returnValue = Symbol();
+  const mockRepository = {
+    get: jest.fn().mockResolvedValue(returnValue),
+    update: jest.fn().mockResolvedValue(returnValue),
+  };
+  const client = new SavedObjectsClient(mockRepository);
+
+  const type = Symbol();
+  const id = Symbol();
+  const workspaces = Symbol();
+  const result = await client.deleteFromWorkspaces(type, id, workspaces);
+
+  expect(mockRepository.get).toHaveBeenCalledWith(type, id, {});
+  expect(mockRepository.update).toHaveBeenCalledWith(type, id, undefined, {
+    workspaces: undefined,
+  });
+  expect(result).toBe(returnValue);
+});
+
+test(`#addToWorkspaces`, async () => {
+  const returnValue = Symbol();
+  const mockRepository = {
+    get: jest.fn().mockResolvedValue(returnValue),
+    update: jest.fn().mockResolvedValue(returnValue),
+  };
+  const client = new SavedObjectsClient(mockRepository);
+
+  const type = Symbol();
+  const id = Symbol();
+  const workspaces = Symbol();
+  const result = await client.addToWorkspaces(type, id, workspaces);
+
+  expect(mockRepository.get).toHaveBeenCalledWith(type, id, {});
+  expect(mockRepository.update).toHaveBeenCalledWith(type, id, undefined, {
+    workspaces: [workspaces],
+  });
+
+  expect(result).toBe(returnValue);
+});

--- a/src/core/server/saved_objects/service/saved_objects_client.test.js
+++ b/src/core/server/saved_objects/service/saved_objects_client.test.js
@@ -243,6 +243,15 @@ test(`#deleteFromWorkspaces`, async () => {
   expect(result).toBe(returnValue);
 });
 
+test(`#deleteFromWorkspaces should throw error if no workspaces passed`, () => {
+  const mockRepository = {};
+  const client = new SavedObjectsClient(mockRepository);
+  const type = Symbol();
+  const id = Symbol();
+  const workspaces = [];
+  expect(() => client.deleteFromWorkspaces(type, id, workspaces)).rejects.toThrowError();
+});
+
 test(`#addToWorkspaces`, async () => {
   const returnValue = Symbol();
   const mockRepository = {
@@ -262,4 +271,13 @@ test(`#addToWorkspaces`, async () => {
   });
 
   expect(result).toBe(returnValue);
+});
+
+test(`#addToWorkspaces should throw error if no workspaces passed`, () => {
+  const mockRepository = {};
+  const client = new SavedObjectsClient(mockRepository);
+  const type = Symbol();
+  const id = Symbol();
+  const workspaces = [];
+  expect(() => client.addToWorkspaces(type, id, workspaces)).rejects.toThrowError();
 });

--- a/src/core/server/saved_objects/service/saved_objects_client.ts
+++ b/src/core/server/saved_objects/service/saved_objects_client.ts
@@ -472,7 +472,7 @@ export class SavedObjectsClient {
    */
   deleteFromWorkspaces = async <T = unknown>(type: string, id: string, workspaces: string[]) => {
     if (!workspaces || workspaces.length === 0) {
-      throw new TypeError(`Workspace is required.`);
+      throw new TypeError(`Workspaces is required.`);
     }
     const object = await this.get<T>(type, id);
     const existingWorkspaces = object.workspaces;
@@ -481,6 +481,7 @@ export class SavedObjectsClient {
     });
     return await this.update<T>(type, id, object.attributes, {
       workspaces: newWorkspaces,
+      version: object.version,
     });
   };
 
@@ -496,7 +497,7 @@ export class SavedObjectsClient {
     workspaces: string[]
   ): Promise<any> => {
     if (!workspaces || workspaces.length === 0) {
-      throw new TypeError(`Workspace is required.`);
+      throw new TypeError(`Workspaces is required.`);
     }
     const object = await this.get<T>(type, id);
     const existingWorkspaces = object.workspaces ?? [];
@@ -505,6 +506,7 @@ export class SavedObjectsClient {
 
     return await this.update<T>(type, id, object.attributes, {
       workspaces: nonDuplicatedWorkspaces,
+      version: object.version,
     });
   };
 

--- a/src/plugins/workspace/common/types.ts
+++ b/src/plugins/workspace/common/types.ts
@@ -6,6 +6,6 @@
 import { DataSourceAttributes } from 'src/plugins/data_source/common/data_sources';
 
 export type DataSource = Pick<DataSourceAttributes, 'title'> & {
-  // SavedObjectAttribute could be single or array
+  // Id defined in SavedObjectAttribute could be single or array, here only should be single string.
   id: string;
 };

--- a/src/plugins/workspace/common/types.ts
+++ b/src/plugins/workspace/common/types.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DataSourceAttributes } from 'src/plugins/data_source/common/data_sources';
+
+export type DataSource = Pick<DataSourceAttributes, 'title'> & {
+  // SavedObjectAttribute could be single or array
+  id: string;
+};

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { PublicAppInfo } from 'opensearch-dashboards/public';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor, act } from '@testing-library/react';
 import { BehaviorSubject } from 'rxjs';
 import { WorkspaceCreator as WorkspaceCreatorComponent } from './workspace_creator';
 import { coreMock } from '../../../../../core/public/mocks';
@@ -22,6 +22,24 @@ const PublicAPPInfoMap = new Map([
   ['data-explorer', { id: 'data-explorer', title: 'Data Explorer' }],
   ['dashboards', { id: 'dashboards', title: 'Dashboards' }],
 ]);
+
+const dataSourcesList = [
+  {
+    id: '1',
+    title: 'ds1',
+    // This is used for mocking saved object function
+    get: () => {
+      return 'ds1';
+    },
+  },
+  {
+    id: '2',
+    title: 'ds2',
+    get: () => {
+      return 'ds2';
+    },
+  },
+];
 
 const mockCoreStart = coreMock.createStart();
 
@@ -52,6 +70,15 @@ const WorkspaceCreator = (props: any) => {
       workspaceClient: {
         ...mockCoreStart.workspaces,
         create: workspaceClientCreate,
+      },
+      savedObjects: {
+        ...mockCoreStart.savedObjects,
+        client: {
+          ...mockCoreStart.savedObjects.client,
+          find: jest.fn().mockResolvedValue({
+            savedObjects: dataSourcesList,
+          }),
+        },
       },
     },
   });
@@ -170,7 +197,7 @@ describe('WorkspaceCreator', () => {
         description: 'test workspace description',
         features: expect.arrayContaining(['use-case-observability']),
       }),
-      undefined
+      { dataSources: [], permissions: undefined }
     );
     await waitFor(() => {
       expect(notificationToastsAddSuccess).toHaveBeenCalled();
@@ -244,12 +271,54 @@ describe('WorkspaceCreator', () => {
         name: 'test workspace name',
       }),
       {
-        read: {
-          users: ['test user id'],
+        dataSources: [],
+        permissions: {
+          read: {
+            users: ['test user id'],
+          },
+          library_read: {
+            users: ['test user id'],
+          },
         },
-        library_read: {
-          users: ['test user id'],
-        },
+      }
+    );
+    await waitFor(() => {
+      expect(notificationToastsAddSuccess).toHaveBeenCalled();
+    });
+    expect(notificationToastsAddDanger).not.toHaveBeenCalled();
+  });
+
+  it('create workspace with customized selected dataSources', async () => {
+    const { getByTestId, getByTitle, getByText } = render(
+      <WorkspaceCreator
+        workspaceConfigurableApps$={new BehaviorSubject([...PublicAPPInfoMap.values()])}
+      />
+    );
+    const nameInput = getByTestId('workspaceForm-workspaceDetails-nameInputText');
+    fireEvent.input(nameInput, {
+      target: { value: 'test workspace name' },
+    });
+    fireEvent.click(getByTestId('workspaceUseCase-observability'));
+    fireEvent.click(getByTestId('workspaceForm-select-dataSource-addNew'));
+    fireEvent.click(getByTestId('workspaceForm-select-dataSource-comboBox'));
+    await act(() => {
+      fireEvent.click(getByText('Select'));
+    });
+    fireEvent.click(getByTitle(dataSourcesList[0].title));
+
+    fireEvent.click(getByTestId('workspaceForm-bottomBar-createButton'));
+    expect(workspaceClientCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'test workspace name',
+      }),
+      {
+        dataSources: [
+          {
+            id: '1',
+            title: 'ds1',
+          },
+        ],
+        permissions: undefined,
       }
     );
     await waitFor(() => {

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
@@ -25,7 +25,7 @@ const PublicAPPInfoMap = new Map([
 
 const dataSourcesList = [
   {
-    id: '1',
+    id: 'id1',
     title: 'ds1',
     // This is used for mocking saved object function
     get: () => {
@@ -312,12 +312,7 @@ describe('WorkspaceCreator', () => {
         name: 'test workspace name',
       }),
       {
-        dataSources: [
-          {
-            id: '1',
-            title: 'ds1',
-          },
-        ],
+        dataSources: ['id1'],
         permissions: undefined,
       }
     );

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -16,6 +16,7 @@ import { WORKSPACE_OVERVIEW_APP_ID } from '../../../common/constants';
 import { formatUrlWithWorkspaceId } from '../../../../../core/public/utils';
 import { WorkspaceClient } from '../../workspace_client';
 import { convertPermissionSettingsToPermissions } from '../workspace_form';
+import { DataSource } from '../../../common/types';
 
 export interface WorkspaceCreatorProps {
   workspaceConfigurableApps$?: BehaviorSubject<PublicAppInfo[]>;
@@ -35,8 +36,11 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
       let result;
       try {
         const { permissionSettings, selectedDataSources, ...attributes } = data;
+        const selectedDataSourceIds = (selectedDataSources ?? []).map((ds: DataSource) => {
+          return ds.id;
+        });
         result = await workspaceClient.create(attributes, {
-          dataSources: selectedDataSources,
+          dataSources: selectedDataSourceIds,
           permissions: convertPermissionSettingsToPermissions(permissionSettings),
         });
         if (result?.success) {

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -23,7 +23,7 @@ export interface WorkspaceCreatorProps {
 
 export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
   const {
-    services: { application, notifications, http, workspaceClient },
+    services: { application, notifications, http, workspaceClient, savedObjects },
   } = useOpenSearchDashboards<{ workspaceClient: WorkspaceClient }>();
   const workspaceConfigurableApps = useObservable(
     props.workspaceConfigurableApps$ ?? of(undefined)
@@ -34,11 +34,11 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
     async (data: WorkspaceFormSubmitData) => {
       let result;
       try {
-        const { permissionSettings, ...attributes } = data;
-        result = await workspaceClient.create(
-          attributes,
-          convertPermissionSettingsToPermissions(permissionSettings)
-        );
+        const { permissionSettings, selectedDataSources, ...attributes } = data;
+        result = await workspaceClient.create(attributes, {
+          dataSources: selectedDataSources,
+          permissions: convertPermissionSettingsToPermissions(permissionSettings),
+        });
         if (result?.success) {
           notifications?.toasts.addSuccess({
             title: i18n.translate('workspace.create.success', {
@@ -92,9 +92,10 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
            **/
           style={{ width: '100%', maxWidth: 1000 }}
         >
-          {application && (
+          {application && savedObjects && (
             <WorkspaceForm
               application={application}
+              savedObjects={savedObjects}
               onSubmit={handleWorkspaceFormSubmit}
               operationType={WorkspaceOperationType.Create}
               workspaceConfigurableApps={workspaceConfigurableApps}

--- a/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, act } from '@testing-library/react';
+import { SelectDataSourcePanel, SelectDataSourcePanelProps } from './select_data_source_panel';
+import { coreMock } from '../../../../../core/public/mocks';
+
+const dataSources = [
+  {
+    id: 'id1',
+    title: 'title1',
+  },
+  { id: 'id2', title: 'title2' },
+];
+
+jest.mock('../../utils', () => ({
+  getDataSourcesList: jest.fn().mockResolvedValue(dataSources),
+}));
+
+const mockCoreStart = coreMock.createStart();
+
+const setup = ({
+  savedObjects = mockCoreStart.savedObjects,
+  selectedDataSources = [],
+  onChange = jest.fn(),
+  errors = undefined,
+}: Partial<SelectDataSourcePanelProps>) => {
+  return render(
+    <SelectDataSourcePanel
+      onChange={onChange}
+      savedObjects={savedObjects}
+      selectedDataSources={selectedDataSources}
+      errors={errors}
+    />
+  );
+};
+
+describe('SelectDataSourcePanel', () => {
+  it('should render consistent data sources when selected data sources passed', () => {
+    const { getByText } = setup({ selectedDataSources: dataSources });
+
+    expect(getByText(dataSources[0].title)).toBeInTheDocument();
+    expect(getByText(dataSources[1].title)).toBeInTheDocument();
+  });
+
+  it('should call onChange when clicking add new data source button', () => {
+    const onChangeMock = jest.fn();
+    const { getByTestId } = setup({ onChange: onChangeMock });
+
+    expect(onChangeMock).not.toHaveBeenCalled();
+    fireEvent.click(getByTestId('workspaceForm-select-dataSource-addNew'));
+    expect(onChangeMock).toHaveBeenCalledWith([
+      {
+        id: '',
+        title: '',
+      },
+    ]);
+  });
+
+  it('should call onChange when updating selected data sources in combo box', async () => {
+    const onChangeMock = jest.fn();
+    const { getByTitle, getByText } = setup({
+      onChange: onChangeMock,
+      selectedDataSources: [{ id: '', title: '' }],
+    });
+    expect(onChangeMock).not.toHaveBeenCalled();
+    await act(() => {
+      fireEvent.click(getByText('Select'));
+    });
+    fireEvent.click(getByTitle(dataSources[0].title));
+    expect(onChangeMock).toHaveBeenCalledWith([{ id: 'id1', title: 'title1' }]);
+  });
+
+  it('should call onChange when deleting selected data source', async () => {
+    const onChangeMock = jest.fn();
+    const { getByLabelText } = setup({
+      onChange: onChangeMock,
+      selectedDataSources: [{ id: '', title: '' }],
+    });
+    expect(onChangeMock).not.toHaveBeenCalled();
+    await act(() => {
+      fireEvent.click(getByLabelText('Delete data source'));
+    });
+    expect(onChangeMock).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  EuiButton,
+  EuiFormRow,
+  EuiText,
+  EuiSpacer,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonIcon,
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { SavedObjectsStart } from '../../../../../core/public';
+import { getDataSourcesList } from '../../utils';
+import { DataSource } from '../../../common/types';
+
+export interface SelectDataSourcePanelProps {
+  errors?: { [key: number]: string };
+  savedObjects: SavedObjectsStart;
+  selectedDataSources: DataSource[];
+  onChange: (value: DataSource[]) => void;
+}
+
+export const SelectDataSourcePanel = ({
+  errors,
+  onChange,
+  selectedDataSources,
+  savedObjects,
+}: SelectDataSourcePanelProps) => {
+  const [dataSourcesOptions, setDataSourcesOptions] = useState<EuiComboBoxOptionOption[]>([]);
+  useEffect(() => {
+    if (!savedObjects) return;
+    getDataSourcesList(savedObjects.client, ['*']).then((result) => {
+      const options = result.map(({ title, id }) => ({
+        label: title,
+        value: id,
+      }));
+      setDataSourcesOptions(options);
+    });
+  }, [savedObjects, setDataSourcesOptions]);
+  const handleAddNewOne = useCallback(() => {
+    onChange?.([
+      ...selectedDataSources,
+      {
+        title: '',
+        id: '',
+      },
+    ]);
+  }, [onChange, selectedDataSources]);
+
+  const handleSelect = useCallback(
+    (selectedOptions, index) => {
+      const newOption = selectedOptions[0]
+        ? // Select new data source
+          {
+            title: selectedOptions[0].label,
+            id: selectedOptions[0].value,
+          }
+        : // Click reset button
+          {
+            title: '',
+            id: '',
+          };
+      const newSelectedOptions = [...selectedDataSources];
+      newSelectedOptions.splice(index, 1, newOption);
+
+      onChange(newSelectedOptions);
+    },
+    [onChange, selectedDataSources]
+  );
+
+  const handleDelete = useCallback(
+    (index) => {
+      const newSelectedOptions = [...selectedDataSources];
+      newSelectedOptions.splice(index, 1);
+
+      onChange(newSelectedOptions);
+    },
+    [onChange, selectedDataSources]
+  );
+
+  return (
+    <div>
+      <EuiText>
+        <strong>
+          {i18n.translate('workspace.form.selectDataSource.subTitle', {
+            defaultMessage: 'Data source',
+          })}
+        </strong>
+      </EuiText>
+      <EuiSpacer size="s" />
+      {selectedDataSources.map(({ id, title }, index) => (
+        <EuiFormRow key={index} isInvalid={!!errors?.[index]} error={errors?.[index]}>
+          <EuiFlexGroup gutterSize="l">
+            <EuiFlexItem grow={false}>
+              <EuiComboBox
+                data-test-subj="workspaceForm-select-dataSource-comboBox"
+                singleSelection
+                options={dataSourcesOptions}
+                selectedOptions={
+                  id
+                    ? [
+                        {
+                          label: title,
+                          value: id,
+                        },
+                      ]
+                    : []
+                }
+                onChange={(selectedOptions) => handleSelect(selectedOptions, index)}
+                placeholder="Select"
+                style={{ width: 200 }}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonIcon
+                color="danger"
+                aria-label="Delete data source"
+                iconType="trash"
+                display="empty"
+                size="m"
+                onClick={() => handleDelete(index)}
+                isDisabled={false}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFormRow>
+      ))}
+
+      <EuiButton
+        fill
+        fullWidth={false}
+        onClick={handleAddNewOne}
+        data-test-subj={`workspaceForm-select-dataSource-addNew`}
+      >
+        {i18n.translate('workspace.form.selectDataSourcePanel.addNew', {
+          defaultMessage: 'Add New',
+        })}
+      </EuiButton>
+    </div>
+  );
+};

--- a/src/plugins/workspace/public/components/workspace_form/types.ts
+++ b/src/plugins/workspace/public/components/workspace_form/types.ts
@@ -3,9 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ApplicationStart, PublicAppInfo } from '../../../../../core/public';
+import type {
+  ApplicationStart,
+  PublicAppInfo,
+  SavedObjectsStart,
+} from '../../../../../core/public';
 import type { WorkspacePermissionMode } from '../../../common/constants';
 import type { WorkspaceOperationType, WorkspacePermissionItemType } from './constants';
+import { DataSource } from '../../../common/types';
 
 export type WorkspacePermissionSetting =
   | {
@@ -27,6 +32,7 @@ export interface WorkspaceFormSubmitData {
   features?: string[];
   color?: string;
   permissionSettings?: WorkspacePermissionSetting[];
+  selectedDataSources?: DataSource[];
 }
 
 export interface WorkspaceFormData extends WorkspaceFormSubmitData {
@@ -35,13 +41,15 @@ export interface WorkspaceFormData extends WorkspaceFormSubmitData {
 }
 
 export type WorkspaceFormErrors = {
-  [key in keyof Omit<WorkspaceFormData, 'permissionSettings'>]?: string;
+  [key in keyof Omit<WorkspaceFormData, 'permissionSettings' | 'selectedDataSources'>]?: string;
 } & {
   permissionSettings?: { [key: number]: string };
+  selectedDataSources?: { [key: number]: string };
 };
 
 export interface WorkspaceFormProps {
   application: ApplicationStart;
+  savedObjects: SavedObjectsStart;
   onSubmit?: (formData: WorkspaceFormSubmitData) => void;
   defaultValues?: WorkspaceFormData;
   operationType?: WorkspaceOperationType;

--- a/src/plugins/workspace/public/components/workspace_form/use_workspace_form.ts
+++ b/src/plugins/workspace/public/components/workspace_form/use_workspace_form.ts
@@ -17,7 +17,7 @@ import {
   getUseCaseFromFeatureConfig,
   isUseCaseFeatureConfig,
 } from '../../utils';
-
+import { DataSource } from '../../../common/types';
 import { WorkspaceFormProps, WorkspaceFormErrors, WorkspacePermissionSetting } from './types';
 import { appendDefaultFeatureIds, getNumberOfErrors, validateWorkspaceForm } from './utils';
 
@@ -46,6 +46,12 @@ export const useWorkspaceForm = ({ application, defaultValues, onSubmit }: Works
       : []
   );
 
+  const [selectedDataSources, setSelectedDataSources] = useState<DataSource[]>(
+    defaultValues?.selectedDataSources && defaultValues.selectedDataSources.length > 0
+      ? defaultValues.selectedDataSources
+      : []
+  );
+
   const [formErrors, setFormErrors] = useState<WorkspaceFormErrors>({});
   const numberOfErrors = useMemo(() => getNumberOfErrors(formErrors), [formErrors]);
   const formIdRef = useRef<string>();
@@ -56,6 +62,7 @@ export const useWorkspaceForm = ({ application, defaultValues, onSubmit }: Works
     useCases: selectedUseCases,
     color,
     permissionSettings,
+    selectedDataSources,
   });
   const getFormDataRef = useRef(getFormData);
   getFormDataRef.current = getFormData;
@@ -94,6 +101,7 @@ export const useWorkspaceForm = ({ application, defaultValues, onSubmit }: Works
         features: formData.features,
         color: formData.color,
         permissionSettings: formData.permissionSettings as WorkspacePermissionSetting[],
+        selectedDataSources: formData.selectedDataSources,
       });
     },
     [onSubmit]
@@ -122,6 +130,7 @@ export const useWorkspaceForm = ({ application, defaultValues, onSubmit }: Works
     handleUseCasesChange,
     handleNameInputChange,
     setPermissionSettings,
+    setSelectedDataSources,
     handleDescriptionChange,
   };
 };

--- a/src/plugins/workspace/public/components/workspace_form/utils.test.ts
+++ b/src/plugins/workspace/public/components/workspace_form/utils.test.ts
@@ -296,7 +296,7 @@ describe('validateWorkspaceForm', () => {
           },
         ],
       }).selectedDataSources
-    ).toEqual({ 0: 'Duplicate data sources', '1': 'Duplicate data sources' });
+    ).toEqual({ '1': 'Duplicate data sources' });
   });
 });
 

--- a/src/plugins/workspace/public/components/workspace_form/utils.test.ts
+++ b/src/plugins/workspace/public/components/workspace_form/utils.test.ts
@@ -7,6 +7,7 @@ import {
   validateWorkspaceForm,
   convertPermissionSettingsToPermissions,
   convertPermissionsToPermissionSettings,
+  getNumberOfErrors,
 } from './utils';
 import { WorkspacePermissionMode } from '../../../common/constants';
 import { WorkspacePermissionItemType } from './constants';
@@ -264,5 +265,50 @@ describe('validateWorkspaceForm', () => {
         features: ['use-case-observability'],
       })
     ).toEqual({});
+  });
+
+  it('should return error if selected data source id is null', () => {
+    expect(
+      validateWorkspaceForm({
+        name: 'test',
+        selectedDataSources: [
+          {
+            id: '',
+            title: 'title',
+          },
+        ],
+      }).selectedDataSources
+    ).toEqual({ 0: 'Invalid data source' });
+  });
+
+  it('should return error if selected data source id is duplicated', () => {
+    expect(
+      validateWorkspaceForm({
+        name: 'test',
+        selectedDataSources: [
+          {
+            id: 'id',
+            title: 'title1',
+          },
+          {
+            id: 'id',
+            title: 'title2',
+          },
+        ],
+      }).selectedDataSources
+    ).toEqual({ 0: 'Duplicate data sources', '1': 'Duplicate data sources' });
+  });
+});
+
+describe('getNumberOfErrors', () => {
+  it('should calculate the error number of data sources form', () => {
+    expect(
+      getNumberOfErrors({
+        selectedDataSources: {
+          '0': 'Invalid data source',
+        },
+      })
+    ).toEqual(1);
+    expect(getNumberOfErrors({})).toEqual(0);
   });
 });

--- a/src/plugins/workspace/public/components/workspace_form/utils.ts
+++ b/src/plugins/workspace/public/components/workspace_form/utils.ts
@@ -273,7 +273,7 @@ export const validateWorkspaceForm = (
         });
       } else if (isSelectedDataSourcesDuplicated(selectedDataSources.slice(0, i), row)) {
         dataSourcesErrors[i] = i18n.translate('workspace.form.permission.invalidate.group', {
-          defaultMessage: 'Duplicate permission setting',
+          defaultMessage: 'Duplicate data sources',
         });
       }
     }

--- a/src/plugins/workspace/public/components/workspace_form/utils.ts
+++ b/src/plugins/workspace/public/components/workspace_form/utils.ts
@@ -15,6 +15,7 @@ import {
 } from './constants';
 
 import { WorkspaceFormErrors, WorkspaceFormSubmitData, WorkspacePermissionSetting } from './types';
+import { DataSource } from '../../../common/types';
 
 export const appendDefaultFeatureIds = (ids: string[]) => {
   // concat default checked ids and unique the result
@@ -40,6 +41,9 @@ export const getNumberOfErrors = (formErrors: WorkspaceFormErrors) => {
   }
   if (formErrors.permissionSettings) {
     numberOfErrors += Object.keys(formErrors.permissionSettings).length;
+  }
+  if (formErrors.selectedDataSources) {
+    numberOfErrors += Object.keys(formErrors.selectedDataSources).length;
   }
   if (formErrors.features) {
     numberOfErrors += 1;
@@ -179,6 +183,11 @@ export const convertPermissionsToPermissionSettings = (permissions: SavedObjectP
   return finalPermissionSettings;
 };
 
+export const isSelectedDataSourcesDuplicated = (
+  selectedDataSources: DataSource[],
+  row: DataSource
+) => selectedDataSources.some((ds) => ds.id === row.id);
+
 export const validateWorkspaceForm = (
   formData: Omit<Partial<WorkspaceFormSubmitData>, 'permissionSettings'> & {
     permissionSettings?: Array<
@@ -187,7 +196,7 @@ export const validateWorkspaceForm = (
   }
 ) => {
   const formErrors: WorkspaceFormErrors = {};
-  const { name, permissionSettings, features } = formData;
+  const { name, permissionSettings, features, selectedDataSources } = formData;
   if (name) {
     if (!isValidFormTextInput(name)) {
       formErrors.name = i18n.translate('workspace.form.detail.name.invalid', {
@@ -252,6 +261,24 @@ export const validateWorkspaceForm = (
     }
     if (Object.keys(permissionSettingsErrors).length > 0) {
       formErrors.permissionSettings = permissionSettingsErrors;
+    }
+  }
+  if (selectedDataSources) {
+    const dataSourcesErrors: { [key: number]: string } = {};
+    for (let i = 0; i < selectedDataSources.length; i++) {
+      const row = selectedDataSources[i];
+      if (!row.id) {
+        dataSourcesErrors[i] = i18n.translate('workspace.form.dataSource.invalid', {
+          defaultMessage: 'Invalid data source',
+        });
+      } else if (isSelectedDataSourcesDuplicated(selectedDataSources.slice(0, i), row)) {
+        dataSourcesErrors[i] = i18n.translate('workspace.form.permission.invalidate.group', {
+          defaultMessage: 'Duplicate permission setting',
+        });
+      }
+    }
+    if (Object.keys(dataSourcesErrors).length > 0) {
+      formErrors.selectedDataSources = dataSourcesErrors;
     }
   }
   return formErrors;

--- a/src/plugins/workspace/public/components/workspace_form/workspace_form.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_form.tsx
@@ -22,10 +22,12 @@ import { WorkspaceFormProps } from './types';
 import { useWorkspaceForm } from './use_workspace_form';
 import { WorkspacePermissionSettingPanel } from './workspace_permission_setting_panel';
 import { WorkspaceUseCase } from './workspace_use_case';
+import { SelectDataSourcePanel } from './select_data_source_panel';
 
 export const WorkspaceForm = (props: WorkspaceFormProps) => {
   const {
     application,
+    savedObjects,
     defaultValues,
     operationType,
     permissionEnabled,
@@ -42,6 +44,7 @@ export const WorkspaceForm = (props: WorkspaceFormProps) => {
     handleUseCasesChange,
     handleNameInputChange,
     setPermissionSettings,
+    setSelectedDataSources,
     handleDescriptionChange,
   } = useWorkspaceForm(props);
   const workspaceDetailsTitle = i18n.translate('workspace.form.workspaceDetails.title', {
@@ -172,6 +175,23 @@ export const WorkspaceForm = (props: WorkspaceFormProps) => {
           />
         </EuiPanel>
       )}
+      <EuiSpacer />
+      <EuiPanel>
+        <EuiTitle size="s">
+          <h2>
+            {i18n.translate('workspace.form.selectDataSource.title', {
+              defaultMessage: 'Select Data Sources',
+            })}
+          </h2>
+        </EuiTitle>
+        <SelectDataSourcePanel
+          errors={formErrors.selectedDataSources}
+          onChange={setSelectedDataSources}
+          savedObjects={savedObjects}
+          selectedDataSources={formData.selectedDataSources}
+          data-test-subj={`workspaceForm-dataSourcePanel`}
+        />
+      </EuiPanel>
       <EuiSpacer />
       <WorkspaceBottomBar
         operationType={operationType}

--- a/src/plugins/workspace/public/components/workspace_overview/workspace_overview.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_overview/workspace_overview.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { coreMock } from '../../../../../core/public/mocks';
 import { createOpenSearchDashboardsReactContext } from '../../../../opensearch_dashboards_react/public';
@@ -53,6 +53,15 @@ const WorkspaceOverviewPage = (props: any) => {
         applications$: new BehaviorSubject<Map<string, PublicAppInfo>>(PublicAPPInfoMap as any),
       },
       workspaces: workspacesService,
+      savedObjects: {
+        ...mockCoreStart.savedObjects,
+        client: {
+          ...mockCoreStart.savedObjects.client,
+          find: jest.fn().mockResolvedValue({
+            savedObjects: [],
+          }),
+        },
+      },
     },
   });
 
@@ -207,9 +216,11 @@ describe('WorkspaceOverview', () => {
     const workspaceService = createWorkspacesSetupContractMockWithValue(workspaceObject);
     const { getByText } = render(WorkspaceOverviewPage({ workspacesService: workspaceService }));
     fireEvent.click(getByText('Settings'));
-    expect(screen.queryByText('Enter Details')).not.toBeNull();
-    // title is hidden
-    expect(screen.queryByText('Update Workspace')).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByText('Enter Details')).not.toBeNull();
+      // title is hidden
+      expect(screen.queryByText('Update Workspace')).toBeNull();
+    });
   });
 
   it('default selected tab is overview', async () => {

--- a/src/plugins/workspace/public/components/workspace_updater/workspace_updater.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_updater/workspace_updater.test.tsx
@@ -44,14 +44,14 @@ const createWorkspacesSetupContractMockWithValue = () => {
 
 const dataSourcesList = [
   {
-    id: '1',
+    id: 'id1',
     title: 'ds1', // This is used for mocking saved object function
     get: () => {
       return 'ds1';
     },
   },
   {
-    id: '2',
+    id: 'id2',
     title: 'ds2',
     get: () => {
       return 'ds2';
@@ -238,12 +238,7 @@ describe('WorkspaceUpdater', () => {
             users: ['test user id'],
           },
         },
-        dataSources: [
-          {
-            id: '2',
-            title: 'ds2',
-          },
-        ],
+        dataSources: ['id2'],
       }
     );
     await waitFor(() => {

--- a/src/plugins/workspace/public/components/workspace_updater/workspace_updater.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_updater/workspace_updater.test.tsx
@@ -42,6 +42,11 @@ const createWorkspacesSetupContractMockWithValue = () => {
   };
 };
 
+const dataSourcesList = [
+  { id: '1', title: 'ds1' },
+  { id: '2', title: 'ds2' },
+];
+
 const mockCoreStart = coreMock.createStart();
 
 const WorkspaceUpdater = (props: any) => {
@@ -73,6 +78,13 @@ const WorkspaceUpdater = (props: any) => {
       workspaceClient: {
         ...mockCoreStart.workspaces,
         update: workspaceClientUpdate,
+      },
+      savedObjects: {
+        ...mockCoreStart.savedObjects,
+        client: {
+          ...mockCoreStart.savedObjects.client,
+          find: jest.fn().mockResolvedValue(dataSourcesList),
+        },
       },
     },
   });
@@ -148,7 +160,7 @@ describe('WorkspaceUpdater', () => {
   });
 
   it('update workspace successfully', async () => {
-    const { getByTestId, getByText, getAllByText } = render(
+    const { getByTestId, getAllByText } = render(
       <WorkspaceUpdater
         workspaceConfigurableApps$={new BehaviorSubject([...PublicAPPInfoMap.values()])}
       />

--- a/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
+++ b/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
@@ -45,7 +45,7 @@ function getFormDataFromWorkspace(
 }
 
 type FormDataFromWorkspace = ReturnType<typeof getFormDataFromWorkspace> & {
-  selectedDataSources?: DataSource[];
+  selectedDataSources: DataSource[];
 };
 
 export const WorkspaceUpdater = (props: WorkspaceUpdaterProps) => {
@@ -116,7 +116,7 @@ export const WorkspaceUpdater = (props: WorkspaceUpdaterProps) => {
   useEffect(() => {
     const rawFormData = getFormDataFromWorkspace(currentWorkspace);
 
-    if (savedObjects && currentWorkspace) {
+    if (rawFormData && savedObjects && currentWorkspace) {
       getDataSourcesList(savedObjects.client, [currentWorkspace.id]).then((selectedDataSources) => {
         setCurrentWorkspaceFormData({
           ...rawFormData,

--- a/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
+++ b/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
@@ -74,8 +74,11 @@ export const WorkspaceUpdater = (props: WorkspaceUpdaterProps) => {
 
       try {
         const { permissionSettings, selectedDataSources, ...attributes } = data;
+        const selectedDataSourceIds = (selectedDataSources ?? []).map((ds: DataSource) => {
+          return ds.id;
+        });
         result = await workspaceClient.update(currentWorkspace.id, attributes, {
-          dataSources: selectedDataSources,
+          dataSources: selectedDataSourceIds,
           permissions: convertPermissionSettingsToPermissions(permissionSettings),
         });
         if (result?.success) {

--- a/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
+++ b/src/plugins/workspace/public/components/workspace_updater/workspace_updater.tsx
@@ -114,20 +114,16 @@ export const WorkspaceUpdater = (props: WorkspaceUpdaterProps) => {
   );
 
   useEffect(() => {
-    const initSelectedDataSources = async () => {
-      const rawFormData = getFormDataFromWorkspace(currentWorkspace);
-      if (savedObjects && currentWorkspace) {
-        getDataSourcesList(savedObjects.client, [currentWorkspace.id]).then(
-          (selectedDataSources) => {
-            setCurrentWorkspaceFormData({
-              ...rawFormData,
-              selectedDataSources,
-            });
-          }
-        );
-      }
-    };
-    initSelectedDataSources();
+    const rawFormData = getFormDataFromWorkspace(currentWorkspace);
+
+    if (savedObjects && currentWorkspace) {
+      getDataSourcesList(savedObjects.client, [currentWorkspace.id]).then((selectedDataSources) => {
+        setCurrentWorkspaceFormData({
+          ...rawFormData,
+          selectedDataSources,
+        });
+      });
+    }
   }, [currentWorkspace, savedObjects]);
 
   if (!currentWorkspaceFormData) {

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -10,8 +10,12 @@ import {
   isAppAccessibleInWorkspace,
   isFeatureIdInsideUseCase,
   isNavGroupInFeatureConfigs,
+  getDataSourcesList,
 } from './utils';
 import { WorkspaceAvailability } from '../../../core/public';
+import { coreMock } from '../../../core/public/mocks';
+
+const startMock = coreMock.createStart();
 
 describe('workspace utils: featureMatchesConfig', () => {
   it('feature configured with `*` should match any features', () => {
@@ -291,5 +295,33 @@ describe('workspace utils: isNavGroupInFeatureConfigs', () => {
     expect(
       isNavGroupInFeatureConfigs('observability', ['use-case-observability', 'use-case-search'])
     ).toBe(true);
+  });
+});
+
+describe('workspace utils: getDataSourcesList', () => {
+  const mockedSavedObjectClient = startMock.savedObjects.client;
+
+  it('should return result when passed saved object client', async () => {
+    mockedSavedObjectClient.find = jest.fn().mockResolvedValue({
+      savedObjects: [
+        {
+          id: 'id1',
+          get: () => {
+            return 'title1';
+          },
+        },
+      ],
+    });
+    expect(await getDataSourcesList(mockedSavedObjectClient, [])).toStrictEqual([
+      {
+        id: 'id1',
+        title: 'title1',
+      },
+    ]);
+  });
+
+  it('should return empty array if no saved objects responded', async () => {
+    mockedSavedObjectClient.find = jest.fn().mockResolvedValue({});
+    expect(await getDataSourcesList(mockedSavedObjectClient, [])).toStrictEqual([]);
   });
 });

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { SavedObjectsStart } from '../../../core/public';
 import {
   App,
   AppCategory,
@@ -175,4 +176,29 @@ export const filterWorkspaceConfigurableApps = (applications: PublicAppInfo[]) =
   );
 
   return visibleApplications;
+};
+
+export const getDataSourcesList = (client: SavedObjectsStart['client'], workspaces: string[]) => {
+  return client
+    .find({
+      type: 'data-source',
+      fields: ['id', 'title'],
+      perPage: 10000,
+      workspaces,
+    })
+    .then((response) => {
+      const objects = response?.savedObjects;
+      if (objects) {
+        return objects.map((source) => {
+          const id = source.id;
+          const title = source.get('title');
+          return {
+            id,
+            title,
+          };
+        });
+      } else {
+        return [];
+      }
+    });
 };

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -187,7 +187,7 @@ export class WorkspaceClient {
   public async create(
     attributes: Omit<WorkspaceAttribute, 'id'>,
     settings: {
-      dataSources?: DataSource[];
+      dataSources?: Array<Omit<DataSource, 'title'>>;
       permissions?: SavedObjectPermissions;
     }
   ): Promise<IResponse<Pick<WorkspaceAttributeWithPermission, 'id'>>> {
@@ -277,7 +277,7 @@ export class WorkspaceClient {
     id: string,
     attributes: Partial<WorkspaceAttribute>,
     settings: {
-      dataSources?: DataSource[];
+      dataSources?: Array<Omit<DataSource, 'title'>>;
       permissions?: SavedObjectPermissions;
     }
   ): Promise<IResponse<boolean>> {

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -12,7 +12,6 @@ import {
   WorkspacesSetup,
 } from '../../../core/public';
 import { SavedObjectPermissions, WorkspaceAttributeWithPermission } from '../../../core/types';
-import { DataSource } from '../common/types';
 
 const WORKSPACES_API_BASE_URL = '/api/workspaces';
 
@@ -187,7 +186,7 @@ export class WorkspaceClient {
   public async create(
     attributes: Omit<WorkspaceAttribute, 'id'>,
     settings: {
-      dataSources?: Array<Omit<DataSource, 'title'>>;
+      dataSources?: string[];
       permissions?: SavedObjectPermissions;
     }
   ): Promise<IResponse<Pick<WorkspaceAttributeWithPermission, 'id'>>> {
@@ -277,7 +276,7 @@ export class WorkspaceClient {
     id: string,
     attributes: Partial<WorkspaceAttribute>,
     settings: {
-      dataSources?: Array<Omit<DataSource, 'title'>>;
+      dataSources?: string[];
       permissions?: SavedObjectPermissions;
     }
   ): Promise<IResponse<boolean>> {

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -12,6 +12,7 @@ import {
   WorkspacesSetup,
 } from '../../../core/public';
 import { SavedObjectPermissions, WorkspaceAttributeWithPermission } from '../../../core/types';
+import { DataSource } from '../common/types';
 
 const WORKSPACES_API_BASE_URL = '/api/workspaces';
 
@@ -185,7 +186,10 @@ export class WorkspaceClient {
    */
   public async create(
     attributes: Omit<WorkspaceAttribute, 'id'>,
-    permissions?: SavedObjectPermissions
+    settings: {
+      dataSources?: DataSource[];
+      permissions?: SavedObjectPermissions;
+    }
   ): Promise<IResponse<Pick<WorkspaceAttributeWithPermission, 'id'>>> {
     const path = this.getPath();
 
@@ -193,7 +197,7 @@ export class WorkspaceClient {
       method: 'POST',
       body: JSON.stringify({
         attributes,
-        permissions,
+        settings,
       }),
     });
 
@@ -272,12 +276,15 @@ export class WorkspaceClient {
   public async update(
     id: string,
     attributes: Partial<WorkspaceAttribute>,
-    permissions?: SavedObjectPermissions
+    settings: {
+      dataSources?: DataSource[];
+      permissions?: SavedObjectPermissions;
+    }
   ): Promise<IResponse<boolean>> {
     const path = this.getPath(id);
     const body = {
       attributes,
-      permissions,
+      settings,
     };
 
     const result = await this.safeFetch(path, {

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -577,7 +577,10 @@ describe('workspace service api integration test when savedObjects.permission.en
         .post(root, `/api/workspaces`)
         .send({
           attributes: omitId(testWorkspace),
-          permissions: { invalid_type: { users: ['foo'] } },
+          settings: {
+            permissions: { invalid_type: { users: ['foo'] } },
+            dataSources: [],
+          },
         })
         .expect(400);
 
@@ -613,7 +616,10 @@ describe('workspace service api integration test when savedObjects.permission.en
           attributes: {
             ...omitId(testWorkspace),
           },
-          permissions: { write: { users: ['foo'] } },
+          settings: {
+            permissions: { write: { users: ['foo'] } },
+            dataSources: [],
+          },
         })
         .expect(200);
       expect(updateResult.body.result).toBe(true);

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -588,7 +588,10 @@ describe('workspace service api integration test when savedObjects.permission.en
         .post(root, `/api/workspaces`)
         .send({
           attributes: omitId(testWorkspace),
-          permissions: { read: { users: ['foo'] } },
+          settings: {
+            permissions: { read: { users: ['foo'] } },
+            dataSources: [],
+          },
         })
         .expect(200);
 

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -9,7 +9,6 @@ import { WorkspacePermissionMode } from '../../common/constants';
 import { IWorkspaceClientImpl, WorkspaceAttributeWithPermission } from '../types';
 import { SavedObjectsPermissionControlContract } from '../permission_control/client';
 import { registerDuplicateRoute } from './duplicate';
-import { DataSource } from '../../common/types';
 
 export const WORKSPACES_API_BASE_URL = '/api/workspaces';
 
@@ -30,16 +29,11 @@ const workspacePermissions = schema.recordOf(
   schema.recordOf(principalType, schema.arrayOf(schema.string()), {})
 );
 
-const dataSources = schema.arrayOf(
-  schema.object({
-    id: schema.string(),
-    title: schema.maybe(schema.string()),
-  })
-);
+const dataSourceIds = schema.arrayOf(schema.string());
 
 const settingsSchema = schema.object({
   permissions: schema.maybe(workspacePermissions),
-  dataSources: schema.maybe(dataSources),
+  dataSources: schema.maybe(dataSourceIds),
 });
 
 const workspaceOptionalAttributesSchema = {
@@ -148,7 +142,7 @@ export function registerRoutes({
       const { attributes, settings } = req.body;
       const principals = permissionControlClient?.getPrincipalsFromRequest(req);
       const createPayload: Omit<WorkspaceAttributeWithPermission, 'id'> & {
-        dataSources?: Array<Omit<DataSource, 'title'>>;
+        dataSources?: string[];
       } = attributes;
 
       if (isPermissionControlEnabled) {

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -33,6 +33,7 @@ const workspacePermissions = schema.recordOf(
 const dataSources = schema.arrayOf(
   schema.object({
     id: schema.string(),
+    title: schema.maybe(schema.string()),
   })
 );
 

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -32,7 +32,6 @@ const workspacePermissions = schema.recordOf(
 
 const dataSources = schema.arrayOf(
   schema.object({
-    title: schema.string(),
     id: schema.string(),
   })
 );
@@ -148,7 +147,7 @@ export function registerRoutes({
       const { attributes, settings } = req.body;
       const principals = permissionControlClient?.getPrincipalsFromRequest(req);
       const createPayload: Omit<WorkspaceAttributeWithPermission, 'id'> & {
-        dataSources?: DataSource[];
+        dataSources?: Array<Omit<DataSource, 'title'>>;
       } = attributes;
 
       if (isPermissionControlEnabled) {

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.test.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.test.ts
@@ -499,20 +499,4 @@ describe('WorkspaceConflictSavedObjectsClientWrapper', () => {
       );
     });
   });
-
-  describe('find', () => {
-    beforeEach(() => {
-      mockedClient.find.mockClear();
-    });
-
-    it(`workspaces parameters should be removed when finding data sources`, async () => {
-      await wrapperClient.find({
-        type: DATA_SOURCE_SAVED_OBJECT_TYPE,
-        workspaces: ['foo'],
-      });
-      expect(mockedClient.find).toBeCalledWith({
-        type: DATA_SOURCE_SAVED_OBJECT_TYPE,
-      });
-    });
-  });
 });

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
@@ -50,11 +50,6 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
   private isConfigType(type: SavedObject['type']): boolean {
     return type === UI_SETTINGS_SAVED_OBJECTS_TYPE;
   }
-  private formatFindParams(options: SavedObjectsFindOptions): SavedObjectsFindOptions {
-    const isListingDataSource = this.isDataSourceType(options.type);
-    const { workspaces, ...otherOptions } = options;
-    return isListingDataSource ? otherOptions : options;
-  }
 
   /**
    * Workspace is a concept to manage saved objects and the `workspaces` field of each object indicates workspaces the object belongs to.
@@ -412,10 +407,7 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
       bulkCreate: bulkCreateWithWorkspaceConflictCheck,
       checkConflicts: checkConflictWithWorkspaceConflictCheck,
       delete: wrapperOptions.client.delete,
-      find: (options: SavedObjectsFindOptions) =>
-        // TODO: The `formatFindParams` is a workaround for 2.14 to always list global data sources,
-        //       should remove this workaround in the upcoming release once readonly share is available.
-        wrapperOptions.client.find(this.formatFindParams(options)),
+      find: wrapperOptions.client.find,
       bulkGet: wrapperOptions.client.bulkGet,
       get: wrapperOptions.client.get,
       update: wrapperOptions.client.update,

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
@@ -29,7 +29,8 @@ export class WorkspaceIdConsumerWrapper {
     const workspaceIdsInUserOptions = options?.workspaces;
     let finalWorkspaces: string[] = [];
     if (options?.hasOwnProperty('workspaces')) {
-      finalWorkspaces = workspaceIdsInUserOptions || [];
+      // In order to get all data sources in workspace, use * to skip appending workspace id automatically
+      finalWorkspaces = (workspaceIdsInUserOptions || []).filter((id) => id !== '*');
     } else if (workspaceIdParsedFromRequest) {
       finalWorkspaces = [workspaceIdParsedFromRequest];
     }

--- a/src/plugins/workspace/server/types.ts
+++ b/src/plugins/workspace/server/types.ts
@@ -13,6 +13,7 @@ import {
   SavedObjectsServiceStart,
   Permissions,
 } from '../../../core/server';
+import { DataSource } from '../common/types';
 
 export interface WorkspaceAttributeWithPermission extends WorkspaceAttribute {
   permissions?: Permissions;
@@ -51,13 +52,14 @@ export interface IWorkspaceClientImpl {
   /**
    * Create a workspace
    * @param requestDetail {@link IRequestDetail}
-   * @param payload {@link WorkspaceAttribute}
-   * @returns a Promise with a new-created id for the workspace
+   * @param payload - An object of type {@link WorkspaceAttributeWithPermission} excluding the 'id' property, and also containing an optional array of data sources of type {@link DataSource} excluding the 'title' property.
    * @public
    */
   create(
     requestDetail: IRequestDetail,
-    payload: Omit<WorkspaceAttributeWithPermission, 'id'>
+    payload: Omit<WorkspaceAttributeWithPermission, 'id'> & {
+      dataSources?: Array<Omit<DataSource, 'title'>>;
+    }
   ): Promise<IResponse<{ id: WorkspaceAttribute['id'] }>>;
   /**
    * List workspaces
@@ -88,14 +90,16 @@ export interface IWorkspaceClientImpl {
    * Update the detail of a given workspace
    * @param requestDetail {@link IRequestDetail}
    * @param id workspace id
-   * @param payload {@link WorkspaceAttribute}
+   * @param payload - An object of type {@link WorkspaceAttributeWithPermission} excluding the 'id' property, and also containing an optional array of data sources of type {@link DataSource} excluding the 'title' property.
    * @returns a Promise with a boolean result indicating if the update operation successed.
    * @public
    */
   update(
     requestDetail: IRequestDetail,
     id: string,
-    payload: Partial<Omit<WorkspaceAttributeWithPermission, 'id'>>
+    payload: Partial<Omit<WorkspaceAttributeWithPermission, 'id'>> & {
+      dataSources?: Array<Omit<DataSource, 'title'>>;
+    }
   ): Promise<IResponse<boolean>>;
   /**
    * Delete a given workspace

--- a/src/plugins/workspace/server/types.ts
+++ b/src/plugins/workspace/server/types.ts
@@ -13,7 +13,6 @@ import {
   SavedObjectsServiceStart,
   Permissions,
 } from '../../../core/server';
-import { DataSource } from '../common/types';
 
 export interface WorkspaceAttributeWithPermission extends WorkspaceAttribute {
   permissions?: Permissions;
@@ -52,13 +51,13 @@ export interface IWorkspaceClientImpl {
   /**
    * Create a workspace
    * @param requestDetail {@link IRequestDetail}
-   * @param payload - An object of type {@link WorkspaceAttributeWithPermission} excluding the 'id' property, and also containing an optional array of data sources of type {@link DataSource} excluding the 'title' property.
+   * @param payload - An object of type {@link WorkspaceAttributeWithPermission} excluding the 'id' property, and also containing an optional array of string.
    * @public
    */
   create(
     requestDetail: IRequestDetail,
     payload: Omit<WorkspaceAttributeWithPermission, 'id'> & {
-      dataSources?: Array<Omit<DataSource, 'title'>>;
+      dataSources?: string[];
     }
   ): Promise<IResponse<{ id: WorkspaceAttribute['id'] }>>;
   /**
@@ -90,7 +89,7 @@ export interface IWorkspaceClientImpl {
    * Update the detail of a given workspace
    * @param requestDetail {@link IRequestDetail}
    * @param id workspace id
-   * @param payload - An object of type {@link WorkspaceAttributeWithPermission} excluding the 'id' property, and also containing an optional array of data sources of type {@link DataSource} excluding the 'title' property.
+   * @param payload - An object of type {@link WorkspaceAttributeWithPermission} excluding the 'id' property, and also containing an optional array of string.
    * @returns a Promise with a boolean result indicating if the update operation successed.
    * @public
    */
@@ -98,7 +97,7 @@ export interface IWorkspaceClientImpl {
     requestDetail: IRequestDetail,
     id: string,
     payload: Partial<Omit<WorkspaceAttributeWithPermission, 'id'>> & {
-      dataSources?: Array<Omit<DataSource, 'title'>>;
+      dataSources?: string[];
     }
   ): Promise<IResponse<boolean>>;
   /**

--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -4,12 +4,17 @@
  */
 
 import { AuthStatus } from '../../../core/server';
-import { httpServerMock, httpServiceMock } from '../../../core/server/mocks';
+import {
+  httpServerMock,
+  httpServiceMock,
+  savedObjectsClientMock,
+} from '../../../core/server/mocks';
 import {
   generateRandomId,
   getOSDAdminConfigFromYMLConfig,
   getPrincipalsFromRequest,
   updateDashboardAdminStateForRequest,
+  getDataSourcesList,
 } from './utils';
 import { getWorkspaceState } from '../../../core/server/utils';
 import { Observable, of } from 'rxjs';
@@ -150,5 +155,26 @@ describe('workspace utils', () => {
     const [groups, users] = await getOSDAdminConfigFromYMLConfig(globalConfig$);
     expect(groups).toEqual([]);
     expect(users).toEqual([]);
+  });
+
+  it('should return dataSources list when passed savedObject client', async () => {
+    const savedObjectsClient = savedObjectsClientMock.create();
+    const dataSources = [
+      {
+        id: 'ds-1',
+      },
+    ];
+    savedObjectsClient.find = jest.fn().mockResolvedValue({
+      saved_objects: dataSources,
+    });
+    const result = await getDataSourcesList(savedObjectsClient, []);
+    expect(result).toEqual(dataSources);
+  });
+
+  it('should return empty array when finding no saved objects', async () => {
+    const savedObjectsClient = savedObjectsClientMock.create();
+    savedObjectsClient.find = jest.fn().mockResolvedValue({});
+    const result = await getDataSourcesList(savedObjectsClient, []);
+    expect(result).toEqual([]);
   });
 });

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -13,6 +13,7 @@ import {
   Principals,
   PrincipalType,
   SharedGlobalConfig,
+  SavedObjectsClientContract,
 } from '../../../core/server';
 import { AuthInfo } from './types';
 import { updateWorkspaceState } from '../../../core/server/utils';
@@ -88,4 +89,27 @@ export const getOSDAdminConfigFromYMLConfig = async (
   const usersResult = (globalConfig.opensearchDashboards?.dashboardAdmin?.users || []) as string[];
 
   return [groupsResult, usersResult];
+};
+
+export const getDataSourcesList = (client: SavedObjectsClientContract, workspaces: string[]) => {
+  return client
+    .find({
+      type: 'data-source',
+      fields: ['id', 'title'],
+      perPage: 10000,
+      workspaces,
+    })
+    .then((response) => {
+      const objects = response?.saved_objects;
+      if (objects) {
+        return objects.map((source) => {
+          const id = source.id;
+          return {
+            id,
+          };
+        });
+      } else {
+        return [];
+      }
+    });
 };

--- a/src/plugins/workspace/server/workspace_client.test.ts
+++ b/src/plugins/workspace/server/workspace_client.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WorkspaceClient } from './workspace_client';
+
+import { coreMock, httpServerMock } from '../../../core/server/mocks';
+import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../data_source/common';
+import { SavedObjectsServiceStart } from '../../../core/server';
+import { IRequestDetail } from './types';
+
+const coreSetup = coreMock.createSetup();
+
+const mockWorkspaceId = 'workspace_id';
+const mockWorkspaceName = 'workspace_name';
+
+jest.mock('./utils', () => ({
+  generateRandomId: () => mockWorkspaceId,
+  getDataSourcesList: jest.fn().mockResolvedValue([
+    {
+      id: 'id1',
+    },
+    {
+      id: 'id2',
+    },
+  ]),
+}));
+
+describe('#WorkspaceClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const find = jest.fn();
+  const addToWorkspaces = jest.fn();
+  const deleteFromWorkspaces = jest.fn();
+  const savedObjects = ({
+    ...coreSetup.savedObjects,
+    getScopedClient: () => ({
+      find,
+      addToWorkspaces,
+      deleteFromWorkspaces,
+      get: jest.fn().mockResolvedValue({
+        attributes: {
+          name: mockWorkspaceName,
+        },
+      }),
+    }),
+  } as unknown) as SavedObjectsServiceStart;
+
+  const mockRequestDetail = ({
+    request: httpServerMock.createOpenSearchDashboardsRequest(),
+    context: coreMock.createRequestHandlerContext(),
+    logger: {},
+  } as unknown) as IRequestDetail;
+
+  it('create# should not call addToWorkspaces if no data sources passed', async () => {
+    const client = new WorkspaceClient(coreSetup);
+    await client.setup(coreSetup);
+    client?.setSavedObjects(savedObjects);
+
+    await client.create(mockRequestDetail, {
+      permissions: {},
+      dataSources: [],
+      name: mockWorkspaceName,
+    });
+    expect(addToWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it('create# should call addToWorkspaces with passed data sources normally', async () => {
+    const client = new WorkspaceClient(coreSetup);
+    await client.setup(coreSetup);
+    client?.setSavedObjects(savedObjects);
+
+    await client.create(mockRequestDetail, {
+      name: mockWorkspaceName,
+      permissions: {},
+      dataSources: [
+        {
+          title: 'title1',
+          id: 'id1',
+        },
+      ],
+    });
+
+    expect(addToWorkspaces).toHaveBeenCalledWith(DATA_SOURCE_SAVED_OBJECT_TYPE, 'id1', [
+      mockWorkspaceId,
+    ]);
+  });
+
+  it('update# should not call addToWorkspaces if no new data sources added', async () => {
+    const client = new WorkspaceClient(coreSetup);
+    await client.setup(coreSetup);
+    client?.setSavedObjects(savedObjects);
+
+    await client.update(mockRequestDetail, mockWorkspaceId, {
+      permissions: {},
+      name: mockWorkspaceName,
+      dataSources: [
+        {
+          title: 'title1',
+          id: 'id1',
+        },
+        {
+          title: 'title2',
+          id: 'id2',
+        },
+      ],
+    });
+
+    expect(addToWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it('update# should call deleteFromWorkspaces if there is data source to be removed', async () => {
+    const client = new WorkspaceClient(coreSetup);
+    await client.setup(coreSetup);
+    client?.setSavedObjects(savedObjects);
+
+    await client.update(mockRequestDetail, mockWorkspaceId, {
+      permissions: {},
+      name: 'workspace_name',
+      dataSources: [
+        {
+          title: 'title3',
+          id: 'id3',
+        },
+        {
+          title: 'title4',
+          id: 'id4',
+        },
+      ],
+    });
+    expect(deleteFromWorkspaces).toHaveBeenCalledWith(DATA_SOURCE_SAVED_OBJECT_TYPE, 'id1', [
+      mockWorkspaceId,
+    ]);
+
+    expect(deleteFromWorkspaces).toHaveBeenCalledWith(DATA_SOURCE_SAVED_OBJECT_TYPE, 'id2', [
+      mockWorkspaceId,
+    ]);
+  });
+  it('update# should calculate data sources to be added and to be removed', async () => {
+    const client = new WorkspaceClient(coreSetup);
+    await client.setup(coreSetup);
+    client?.setSavedObjects(savedObjects);
+
+    await client.update(mockRequestDetail, mockWorkspaceId, {
+      permissions: {},
+      name: mockWorkspaceName,
+      dataSources: [
+        {
+          title: 'title1',
+          id: 'id1',
+        },
+        {
+          title: 'title3',
+          id: 'id3',
+        },
+      ],
+    });
+    expect(addToWorkspaces).toHaveBeenCalledWith(DATA_SOURCE_SAVED_OBJECT_TYPE, 'id3', [
+      mockWorkspaceId,
+    ]);
+
+    expect(deleteFromWorkspaces).toHaveBeenCalledWith(DATA_SOURCE_SAVED_OBJECT_TYPE, 'id2', [
+      mockWorkspaceId,
+    ]);
+  });
+});

--- a/src/plugins/workspace/server/workspace_client.test.ts
+++ b/src/plugins/workspace/server/workspace_client.test.ts
@@ -76,12 +76,7 @@ describe('#WorkspaceClient', () => {
     await client.create(mockRequestDetail, {
       name: mockWorkspaceName,
       permissions: {},
-      dataSources: [
-        {
-          title: 'title1',
-          id: 'id1',
-        },
-      ],
+      dataSources: ['id1'],
     });
 
     expect(addToWorkspaces).toHaveBeenCalledWith(DATA_SOURCE_SAVED_OBJECT_TYPE, 'id1', [
@@ -97,16 +92,7 @@ describe('#WorkspaceClient', () => {
     await client.update(mockRequestDetail, mockWorkspaceId, {
       permissions: {},
       name: mockWorkspaceName,
-      dataSources: [
-        {
-          title: 'title1',
-          id: 'id1',
-        },
-        {
-          title: 'title2',
-          id: 'id2',
-        },
-      ],
+      dataSources: ['id1', 'id2'],
     });
 
     expect(addToWorkspaces).not.toHaveBeenCalled();
@@ -120,16 +106,7 @@ describe('#WorkspaceClient', () => {
     await client.update(mockRequestDetail, mockWorkspaceId, {
       permissions: {},
       name: 'workspace_name',
-      dataSources: [
-        {
-          title: 'title3',
-          id: 'id3',
-        },
-        {
-          title: 'title4',
-          id: 'id4',
-        },
-      ],
+      dataSources: ['id3', 'id4'],
     });
     expect(deleteFromWorkspaces).toHaveBeenCalledWith(DATA_SOURCE_SAVED_OBJECT_TYPE, 'id1', [
       mockWorkspaceId,
@@ -147,16 +124,7 @@ describe('#WorkspaceClient', () => {
     await client.update(mockRequestDetail, mockWorkspaceId, {
       permissions: {},
       name: mockWorkspaceName,
-      dataSources: [
-        {
-          title: 'title1',
-          id: 'id1',
-        },
-        {
-          title: 'title3',
-          id: 'id3',
-        },
-      ],
+      dataSources: ['id1', 'id3'],
     });
     expect(addToWorkspaces).toHaveBeenCalledWith(DATA_SOURCE_SAVED_OBJECT_TYPE, 'id3', [
       mockWorkspaceId,

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -20,14 +20,13 @@ import {
   WorkspaceAttributeWithPermission,
 } from './types';
 import { workspace } from './saved_objects';
-import { generateRandomId } from './utils';
+import { generateRandomId, getDataSourcesList } from './utils';
 import {
   WORKSPACE_ID_CONSUMER_WRAPPER_ID,
   WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
 } from '../common/constants';
 import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../data_source/common';
 import { DataSource } from '../common/types';
-import { getDataSourcesList } from './utils';
 
 const WORKSPACE_ID_SIZE = 6;
 
@@ -107,6 +106,13 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
       if (existingWorkspaceRes && existingWorkspaceRes.total > 0) {
         throw new Error(DUPLICATE_WORKSPACE_NAME_ERROR);
       }
+
+      if (dataSources) {
+        for (const ds of dataSources) {
+          await client.addToWorkspaces(DATA_SOURCE_SAVED_OBJECT_TYPE, ds.id, [id]);
+        }
+      }
+
       const result = await client.create<Omit<WorkspaceAttribute, 'id'>>(
         WORKSPACE_TYPE,
         attributes,
@@ -115,11 +121,6 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
           permissions,
         }
       );
-      if (dataSources) {
-        for (const ds of dataSources) {
-          await client.addToWorkspaces(DATA_SOURCE_SAVED_OBJECT_TYPE, ds.id, [id]);
-        }
-      }
 
       return {
         success: true,


### PR DESCRIPTION
### Description

1. Add data source assignment in workspace create/update page.
2. Add addToWorkspaces and deleteFromWorkspaces method in savedObject client.
3. Update savedObject update/bulkUpdate in savedObject client and repository to support update workspace field.

## Screenshot

https://github.com/opensearch-project/OpenSearch-Dashboards/assets/42465692/7e2a7b89-4d01-42d7-b6a3-dcac5e4adf18


![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/42465692/d41aa499-2b16-4a69-a8f9-ec8f72ff2544)

## Testing the changes
1. Use find API to find any data sources and what workspaces they belong to. `http://localhost:6601/w/${OSD_ID}/api/saved_objects/_find?fields=id&fields=title&fields=workspaces&per_page=10000&type=data-source&workspaces=*`

2. Enter workspace create/update page to create workspaces and assign data sources or update and assign data sources.

4. Enter workspace update page or use find API to find that data source have been assigned to specific workspace.
`http://localhost:6601/w/${OSD_ID}/api/saved_objects/_find?fields=id&fields=title&fields=workspaces&per_page=10000&type=data-source&workspaces=${WORKSPACE_ID}`

## Changelog

- feat: Support data source assignment in workspace.


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
