### PR TITLE
[Discover-next] add data source selector

### DIFF
--- a/changelogs/fragments/7128.yml
+++ b/changelogs/fragments/7128.yml
@@ -1,0 +1,2 @@
+feat:
+- Add datasource selector in Discover ([#7128](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7128))

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -353,6 +353,9 @@ export class SearchSource {
     if (getConfig(UI_SETTINGS.COURIER_BATCH_SEARCHES)) {
       response = await this.legacyFetch(searchRequest, options);
     } else if (this.isUnsupportedRequest(searchRequest)) {
+      const indexPattern = this.getField('index');
+      searchRequest.dataSourceId = indexPattern?.dataSourceRef?.id;
+
       response = await this.fetchExternalSearch(searchRequest, options);
     } else {
       const indexPattern = this.getField('index');

--- a/src/plugins/discover/opensearch_dashboards.json
+++ b/src/plugins/discover/opensearch_dashboards.json
@@ -15,7 +15,7 @@
     "uiActions",
     "visualizations"
   ],
-  "optionalPlugins": ["home", "share"],
+  "optionalPlugins": ["home", "share", "dataSource", "dataSourceManagement"],
   "requiredBundles": [
     "home",
     "opensearchDashboardsUtils",

--- a/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
@@ -37,10 +37,13 @@ export const TopNav = ({ opts, showSaveQuery }: TopNavProps) => {
     },
     core: {
       application: { getUrlForApp },
+      savedObjects,
     },
     data,
     chrome,
     osdUrlStateStorage,
+    notifications,
+    dataSource,
   } = services;
 
   const topNavLinks = savedSearch ? getTopNavLinks(services, inspectorAdapters, savedSearch) : [];
@@ -104,6 +107,16 @@ export const TopNav = ({ opts, showSaveQuery }: TopNavProps) => {
       onQuerySubmit={opts.onQuerySubmit}
       savedQueryId={state.savedQuery}
       onSavedQueryIdChange={updateSavedQueryId}
+      showDataSourceMenu={dataSource?.dataSourceEnabled}
+      dataSourceMenuConfig={{
+        componentType: 'DataSourceAggregatedView',
+        componentConfig: {
+          fullWidth: true,
+          savedObjects: savedObjects.client,
+          notifications,
+          displayAllCompatibleDataSources: true,
+        },
+      }}
     />
   );
 };

--- a/src/plugins/discover/public/build_services.ts
+++ b/src/plugins/discover/public/build_services.ts
@@ -51,6 +51,7 @@ import { ChartsPluginStart } from 'src/plugins/charts/public';
 import { VisualizationsStart } from 'src/plugins/visualizations/public';
 import { SavedObjectOpenSearchDashboardsServices } from 'src/plugins/saved_objects/public';
 
+import { DataSourcePluginStart } from 'src/plugins/data_source/public';
 import { DiscoverStartPlugins } from './plugin';
 import { createSavedSearchesLoader, SavedSearch } from './saved_searches';
 import { getHistory } from './opensearch_dashboards_services';
@@ -66,6 +67,7 @@ export interface DiscoverServices {
   chrome: ChromeStart;
   core: CoreStart;
   data: DataPublicPluginStart;
+  dataSource?: DataSourcePluginStart;
   docLinks: DocLinksStart;
   history: () => History;
   theme: ChartsPluginStart['theme'];
@@ -107,6 +109,7 @@ export function buildServices(
     chrome: core.chrome,
     core,
     data: plugins.data,
+    dataSource: plugins.dataSource,
     docLinks: core.docLinks,
     theme: plugins.charts.theme,
     filterManager: plugins.data.query.filterManager,

--- a/src/plugins/discover/public/plugin.ts
+++ b/src/plugins/discover/public/plugin.ts
@@ -30,6 +30,7 @@ import { Start as InspectorPublicPluginStart } from 'src/plugins/inspector/publi
 import { stringify } from 'query-string';
 import rison from 'rison-node';
 import { lazy } from 'react';
+import { DataSourcePluginStart } from 'src/plugins/data_source/public';
 import { DataPublicPluginStart, DataPublicPluginSetup, opensearchFilters } from '../../data/public';
 import { SavedObjectLoader } from '../../saved_objects/public';
 import { url } from '../../opensearch_dashboards_utils/public';
@@ -139,6 +140,7 @@ export interface DiscoverStartPlugins {
   navigation: NavigationStart;
   charts: ChartsPluginStart;
   data: DataPublicPluginStart;
+  dataSource?: DataSourcePluginStart;
   share?: SharePluginStart;
   opensearchDashboardsLegacy: OpenSearchDashboardsLegacyStart;
   urlForwarding: UrlForwardingStart;


### PR DESCRIPTION
### Description

Onboards data source selector from Discover next.

The index patterns populated are based on the current data source. If the default cluster is not the local cluster then Discover pretty much breaks because it will default assume the data source by the current context which is currently only the local cluster.

Another way to say it:
when the default data source is not the local cluster, Discover is still only displaying the index patterns in the local cluster.

### Issues Resolved

related: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7129

## Changelog
- feat: add datasource selector in Discover

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
