### PR TITLE
[CVE-2024-37890] Bump ws from `8.5.0` to `8.17.1` and from `7.5.7` to `7.5.10`

### DIFF
--- a/changelogs/fragments/7153.yml
+++ b/changelogs/fragments/7153.yml
@@ -1,0 +1,2 @@
+security:
+- [CVE-2024-37890] Bump ws from `8.5.0` to `8.17.1` and from `7.5.7` to `7.5.10` ([#7153](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7153))

--- a/yarn.lock
+++ b/yarn.lock
@@ -18886,14 +18886,14 @@ write@1.0.3:
     mkdirp "^0.5.1"
 
 ws@^7.4.6:
-  version "7.5.7"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
-  integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 ws@^8.0.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
-  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 x-is-string@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
### Description

https://nvd.nist.gov/vuln/detail/CVE-2024-37890 requests to bump ws from `8.5.0` to `8.17.1` and from `7.5.7` to `7.5.10`
```
The vulnerability was fixed in ws@8.17.1 (e55e510) and backported to ws@7.5.10 (22c2876), ws@6.2.3 (eeb76d3), and ws@5.2.4 (4abd8f6). 
```

## Screenshot

```
=> Found "ws@8.17.1"
info Reasons this module exists
   - "_project_#@percy#cli#@percy#cli-command#@percy#core" depends on it
   - Hoisted from "_project_#@percy#cli#@percy#cli-command#@percy#core#ws"
info Disk size without dependencies: "180KB"
info Disk size with unique dependencies: "180KB"
info Disk size with transitive dependencies: "180KB"
info Number of shared dependencies: 0
=> Found "jsdom#ws@7.5.10"
info This module exists because "_project_#jest#@jest#core#jest-config#jest-environment-jsdom#jsdom" depends on it.
info Disk size without dependencies: "168KB"
info Disk size with unique dependencies: "168KB"
info Disk size with transitive dependencies: "168KB"
info Number of shared dependencies: 0
Done in 1.28s.
```

## Changelog
- security: [CVE-2024-37890] Bump ws from `8.5.0` to `8.17.1` and from `7.5.7` to `7.5.10`

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
