### PR TITLE
[Multiple Datasource][Version Decoupling] Add data source version and installed plugins in MDS data source viewer returns

### DIFF
--- a/changelogs/fragments/7172.yml
+++ b/changelogs/fragments/7172.yml
@@ -1,0 +1,2 @@
+fix:
+- [MDS][Version Decoupling] Add dataSourceVersion' and  'installedPlugins in viewer returns ([#7172](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7172))

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.test.tsx
@@ -127,7 +127,7 @@ describe('DataSourceAggregatedView: read all view (displayAllCompatibleDataSourc
       // Renders normally
       expect(component).toMatchSnapshot();
       expect(client.find).toBeCalledWith({
-        fields: ['id', 'title', 'auth.type'],
+        fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
         perPage: 10000,
         type: 'data-source',
       });
@@ -247,7 +247,7 @@ describe('DataSourceAggregatedView: read active view (displayAllCompatibleDataSo
       // Should render normally
       expect(component).toMatchSnapshot();
       expect(client.find).toBeCalledWith({
-        fields: ['id', 'title', 'auth.type'],
+        fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
         perPage: 10000,
         type: 'data-source',
       });

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
@@ -97,7 +97,13 @@ export class DataSourceAggregatedView extends React.Component<
 
   async componentDidMount() {
     this._isMounted = true;
-    getDataSourcesWithFields(this.props.savedObjectsClient, ['id', 'title', 'auth.type'])
+    getDataSourcesWithFields(this.props.savedObjectsClient, [
+      'id',
+      'title',
+      'auth.type',
+      'dataSourceVersion',
+      'installedPlugins',
+    ])
       .then((fetchedDataSources) => {
         const allDataSourcesIdToTitleMap = new Map();
 

--- a/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/create_data_source_menu.test.tsx
@@ -56,7 +56,7 @@ describe('create data source menu', () => {
     const component = render(<TestComponent {...props} />);
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
+      fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
       perPage: 10000,
       type: 'data-source',
     });
@@ -86,7 +86,7 @@ describe('create data source menu', () => {
 
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
+      fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
       perPage: 10000,
       type: 'data-source',
     });
@@ -158,7 +158,7 @@ describe('when setMenuMountPoint is provided', () => {
     await refresh();
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
+      fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
       perPage: 10000,
       type: 'data-source',
     });

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.test.tsx
@@ -49,7 +49,7 @@ describe('DataSourceMultiSelectable', () => {
     );
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
+      fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
       perPage: 10000,
       type: 'data-source',
     });
@@ -68,7 +68,7 @@ describe('DataSourceMultiSelectable', () => {
     );
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
+      fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
       perPage: 10000,
       type: 'data-source',
     });

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
@@ -83,6 +83,8 @@ export class DataSourceMultiSelectable extends React.Component<
         'id',
         'title',
         'auth.type',
+        'dataSourceVersion',
+        'installedPlugins',
       ]);
 
       if (fetchedDataSources?.length) {

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
@@ -56,7 +56,7 @@ describe('DataSourceSelectable', () => {
     );
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
+      fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
       perPage: 10000,
       type: 'data-source',
     });
@@ -76,7 +76,7 @@ describe('DataSourceSelectable', () => {
     );
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
+      fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
       perPage: 10000,
       type: 'data-source',
     });

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -184,6 +184,8 @@ export class DataSourceSelectable extends React.Component<
         'id',
         'title',
         'auth.type',
+        'dataSourceVersion',
+        'installedPlugins',
       ]);
 
       const dataSourceOptions: DataSourceOption[] = getFilteredDataSources(

--- a/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.test.tsx
@@ -45,7 +45,7 @@ describe('create data source selector', () => {
     const component = render(<TestComponent {...props} />);
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
+      fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
       perPage: 10000,
       type: 'data-source',
     });

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.test.tsx
@@ -46,7 +46,7 @@ describe('DataSourceSelector', () => {
     );
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
+      fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
       perPage: 10000,
       type: 'data-source',
     });
@@ -67,7 +67,7 @@ describe('DataSourceSelector', () => {
     );
     expect(component).toMatchSnapshot();
     expect(client.find).toBeCalledWith({
-      fields: ['id', 'title', 'auth.type'],
+      fields: ['id', 'title', 'auth.type', 'dataSourceVersion', 'installedPlugins'],
       perPage: 10000,
       type: 'data-source',
     });

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
@@ -145,6 +145,8 @@ export class DataSourceSelector extends React.Component<
         'id',
         'title',
         'auth.type',
+        'dataSourceVersion',
+        'installedPlugins',
       ]);
 
       // 2. Process

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -43,7 +43,7 @@ export async function getDataSources(savedObjectsClient: SavedObjectsClientContr
   return savedObjectsClient
     .find({
       type: 'data-source',
-      fields: ['id', 'description', 'title'],
+      fields: ['id', 'description', 'title', 'dataSourceVersion', 'installedPlugins'],
       perPage: 10000,
     })
     .then(
@@ -52,12 +52,16 @@ export async function getDataSources(savedObjectsClient: SavedObjectsClientContr
           const id = source.id;
           const title = source.get('title');
           const description = source.get('description');
+          const datasourceversion = source.get('dataSourceVersion');
+          const installedplugins = source.get('installedPlugins');
 
           return {
             id,
             title,
             description,
             sort: `${title}`,
+            datasourceversion,
+            installedplugins,
           };
         }) || []
     );


### PR DESCRIPTION
### Description

* This one is to add fields `dataSourceVersion` and `installedPlugins` in all data source viewers.
* These two metadata would be consumed by plugins to perform data source filtering and decoupling check

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7099

## Screenshot
<img width="1740" alt="Screenshot 2024-07-03 at 4 33 19 PM" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/99905560/989ea2ef-bb32-40a1-9409-a3820e3e81f5">


## Changelog

- fix: [MDS][Version Decoupling] Add dataSourceVersion' and  'installedPlugins in viewer returns

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
