### PR TITLE
fix(discover): truncate height of table cell

### DIFF
--- a/changelogs/fragments/7178.yml
+++ b/changelogs/fragments/7178.yml
@@ -1,0 +1,2 @@
+fix:
+- Truncate height of table cell in legacy discover ([#7178](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7178))

--- a/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
@@ -80,7 +80,7 @@ const TableCellUI = ({
       data-test-subj="docTableField"
       className="osdDocTableCell eui-textBreakAll eui-textBreakWord"
     >
-      <div className="osdDocTable__limitedHeight">{content}</div>
+      <div className="truncate-by-height">{content}</div>
     </td>
   );
 };


### PR DESCRIPTION
### Description

see #7176. `osdDocTable__limitedHeight` class isn't associated with any style, use `truncate-by-height` to truncate. 

@AMoo-Miki  `osdDocTable__limitedHeight` was added in 1ba45a7c738e912dc7671079650445a69dd73e18, any concerns with this?

### Issues Resolved

closes #7176

## Screenshot

before
<img width="1095" alt="image" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/28062824/d75bf2e7-6f83-477d-b0a0-388403a94120">

after

<img width="1103" alt="image" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/28062824/83355404-e38e-40b6-8d70-fae58e5c8fa7">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: truncate height of table cell in legacy discover

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
