### PR TITLE
[Workspace]Restrict non dashboard admin access unassigned data source

### DIFF
--- a/changelogs/fragments/7180.yml
+++ b/changelogs/fragments/7180.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace] Restrict non dashboard admin access global data source ([#7180](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7180))

--- a/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts
@@ -18,6 +18,7 @@ import {
 import { httpServerMock } from '../../../../../../src/core/server/mocks';
 import * as utilsExports from '../../utils';
 import { updateWorkspaceState } from '../../../../../core/server/utils';
+import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../../../data_source/common';
 
 const repositoryKit = (() => {
   const savedObjects: Array<{ type: string; id: string }> = [];
@@ -77,6 +78,9 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
             permission: {
               enabled: true,
             },
+          },
+          data_source: {
+            enabled: true,
           },
           migrations: { skip: false },
         },
@@ -892,6 +896,70 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
         ACLError = e;
       }
       expect(SavedObjectsErrorHelpers.isNotFoundError(ACLError)).toBe(true);
+    });
+  });
+
+  describe('data source', () => {
+    beforeAll(async () => {
+      await repositoryKit.create(
+        internalSavedObjectsRepository,
+        DATA_SOURCE_SAVED_OBJECT_TYPE,
+        {
+          title: 'Global data source',
+        },
+        {
+          id: 'global-data-source',
+        }
+      );
+      await repositoryKit.create(
+        internalSavedObjectsRepository,
+        DATA_SOURCE_SAVED_OBJECT_TYPE,
+        {
+          title: 'Data source in workspace 1',
+        },
+        {
+          id: 'data-source-in-workspace-1',
+          workspaces: ['workspace-1'],
+        }
+      );
+    });
+
+    it('should throw permission error when get global data source with non dashboard admin', async () => {
+      let error;
+      try {
+        await permittedSavedObjectedClient.get(DATA_SOURCE_SAVED_OBJECT_TYPE, 'global-data-source');
+      } catch (e) {
+        error = e;
+      }
+      expect(SavedObjectsErrorHelpers.isForbiddenError(error)).toBe(true);
+    });
+
+    it('should return requested data source normally for non dashboard admin', async () => {
+      const dataSource = await permittedSavedObjectedClient.get(
+        DATA_SOURCE_SAVED_OBJECT_TYPE,
+        'data-source-in-workspace-1'
+      );
+      expect(dataSource).toEqual(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            title: 'Data source in workspace 1',
+          }),
+        })
+      );
+    });
+
+    it('should return requested global data source for dashboard admin', async () => {
+      const dataSource = await dashboardAdminSavedObjectedClient.get(
+        DATA_SOURCE_SAVED_OBJECT_TYPE,
+        'global-data-source'
+      );
+      expect(dataSource).toEqual(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            title: 'Global data source',
+          }),
+        })
+      );
     });
   });
 });

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -33,6 +33,7 @@ import {
   WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
   WorkspacePermissionMode,
 } from '../../common/constants';
+import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../../data_source/common';
 
 // Can't throw unauthorized for now, the page will be refreshed if unauthorized
 const generateWorkspacePermissionError = () =>
@@ -158,6 +159,17 @@ export class WorkspaceSavedObjectsClientWrapper {
     objectPermissionModes: WorkspacePermissionMode[],
     validateAllWorkspaces = true
   ) {
+    /**
+     * A data source saved object without workspaces attributes will be treated as a global data source.
+     * This kind of data source is not allowed for non dashboard admin. The dashboard admin will bypass this
+     * client wrapper, so denied all access to the global data source saved object here.
+     */
+    if (
+      savedObject.type === DATA_SOURCE_SAVED_OBJECT_TYPE &&
+      (!savedObject.workspaces || savedObject.workspaces.length === 0)
+    ) {
+      return false;
+    }
     /**
      *
      * Checks if the provided saved object lacks both workspaces and permissions.


### PR DESCRIPTION
### Description

For non dashboard admin user, the unassigned data source should not be accessed by non dashboard admin user. Add the specific logic to the workspace permission saved object client wrapper to  restrict non dashboard admin access these data sources when workspace enabled.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
#7181

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
No UI changes

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
Can refer the integration test file: src/plugins/workspace/server/saved_objects/integration_tests/workspace_saved_objects_client_wrapper.test.ts

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace] Restrict non dashboard admin access global data source

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
