### PR TITLE
[Look&Feel] Refactor to use semantic headers for page, modal & flyout

### DIFF
--- a/changelogs/fragments/7192.yml
+++ b/changelogs/fragments/7192.yml
@@ -1,0 +1,2 @@
+refactor:
+- [Look&Feel]  Refactor to use semantic headers for page, modal & flyout ([#7192](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7192))

--- a/src/plugins/dashboard/public/application/components/dashboard_listing/__snapshots__/dashboard_listing.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing/__snapshots__/dashboard_listing.test.tsx.snap
@@ -1097,15 +1097,19 @@ exports[`dashboard listing hideWriteControls 1`] = `
               <EuiEmptyPrompt
                 iconType="dashboardApp"
                 title={
-                  <h1
-                    id="dashboardListingHeading"
+                  <EuiText
+                    size="s"
                   >
-                    <FormattedMessage
-                      defaultMessage="Looks like you don't have any dashboards."
-                      id="dashboard.listing.noItemsMessage"
-                      values={Object {}}
-                    />
-                  </h1>
+                    <h1
+                      id="dashboardListingHeading"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Looks like you don't have any dashboards."
+                        id="dashboard.listing.noItemsMessage"
+                        values={Object {}}
+                      />
+                    </h1>
+                  </EuiText>
                 }
               />
             }
@@ -2338,15 +2342,19 @@ exports[`dashboard listing render table listing with initial filters from URL 1`
                 }
                 iconType="dashboardApp"
                 title={
-                  <h1
-                    id="dashboardListingHeading"
+                  <EuiText
+                    size="s"
                   >
-                    <FormattedMessage
-                      defaultMessage="Create your first dashboard"
-                      id="dashboard.listing.createNewDashboard.title"
-                      values={Object {}}
-                    />
-                  </h1>
+                    <h1
+                      id="dashboardListingHeading"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create your first dashboard"
+                        id="dashboard.listing.createNewDashboard.title"
+                        values={Object {}}
+                      />
+                    </h1>
+                  </EuiText>
                 }
               />
             }
@@ -3579,15 +3587,19 @@ exports[`dashboard listing renders call to action when no dashboards exist 1`] =
                 }
                 iconType="dashboardApp"
                 title={
-                  <h1
-                    id="dashboardListingHeading"
+                  <EuiText
+                    size="s"
                   >
-                    <FormattedMessage
-                      defaultMessage="Create your first dashboard"
-                      id="dashboard.listing.createNewDashboard.title"
-                      values={Object {}}
-                    />
-                  </h1>
+                    <h1
+                      id="dashboardListingHeading"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create your first dashboard"
+                        id="dashboard.listing.createNewDashboard.title"
+                        values={Object {}}
+                      />
+                    </h1>
+                  </EuiText>
                 }
               />
             }
@@ -4820,15 +4832,19 @@ exports[`dashboard listing renders table rows 1`] = `
                 }
                 iconType="dashboardApp"
                 title={
-                  <h1
-                    id="dashboardListingHeading"
+                  <EuiText
+                    size="s"
                   >
-                    <FormattedMessage
-                      defaultMessage="Create your first dashboard"
-                      id="dashboard.listing.createNewDashboard.title"
-                      values={Object {}}
-                    />
-                  </h1>
+                    <h1
+                      id="dashboardListingHeading"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create your first dashboard"
+                        id="dashboard.listing.createNewDashboard.title"
+                        values={Object {}}
+                      />
+                    </h1>
+                  </EuiText>
                 }
               />
             }
@@ -6061,15 +6077,19 @@ exports[`dashboard listing renders warning when listingLimit is exceeded 1`] = `
                 }
                 iconType="dashboardApp"
                 title={
-                  <h1
-                    id="dashboardListingHeading"
+                  <EuiText
+                    size="s"
                   >
-                    <FormattedMessage
-                      defaultMessage="Create your first dashboard"
-                      id="dashboard.listing.createNewDashboard.title"
-                      values={Object {}}
-                    />
-                  </h1>
+                    <h1
+                      id="dashboardListingHeading"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create your first dashboard"
+                        id="dashboard.listing.createNewDashboard.title"
+                        values={Object {}}
+                      />
+                    </h1>
+                  </EuiText>
                 }
               />
             }

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/__snapshots__/clone_modal.test.js.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/__snapshots__/clone_modal.test.js.snap
@@ -8,11 +8,17 @@ exports[`renders DashboardCloneModal 1`] = `
 >
   <EuiModalHeader>
     <EuiModalHeaderTitle>
-      <FormattedMessage
-        defaultMessage="Clone dashboard"
-        id="dashboard.topNav.cloneModal.cloneDashboardModalHeaderTitle"
-        values={Object {}}
-      />
+      <EuiText
+        size="s"
+      >
+        <h2>
+          <FormattedMessage
+            defaultMessage="Clone dashboard"
+            id="dashboard.topNav.cloneModal.cloneDashboardModalHeaderTitle"
+            values={Object {}}
+          />
+        </h2>
+      </EuiText>
     </EuiModalHeaderTitle>
   </EuiModalHeader>
   <EuiModalBody>

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/clone_modal.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/clone_modal.tsx
@@ -168,10 +168,14 @@ export class DashboardCloneModal extends React.Component<Props, State> {
       >
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <FormattedMessage
-              id="dashboard.topNav.cloneModal.cloneDashboardModalHeaderTitle"
-              defaultMessage="Clone dashboard"
-            />
+            <EuiText size="s">
+              <h2>
+                <FormattedMessage
+                  id="dashboard.topNav.cloneModal.cloneDashboardModalHeaderTitle"
+                  defaultMessage="Clone dashboard"
+                />
+              </h2>
+            </EuiText>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 

--- a/src/plugins/dashboard/public/application/utils/get_no_items_message.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_no_items_message.tsx
@@ -5,7 +5,7 @@
 
 import React, { Fragment } from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
-import { EuiButton, EuiEmptyPrompt, EuiLink } from '@elastic/eui';
+import { EuiButton, EuiEmptyPrompt, EuiLink, EuiText } from '@elastic/eui';
 import { ApplicationStart } from 'opensearch-dashboards/public';
 
 export const getNoItemsMessage = (
@@ -18,12 +18,14 @@ export const getNoItemsMessage = (
       <EuiEmptyPrompt
         iconType="dashboardApp"
         title={
-          <h1 id="dashboardListingHeading">
-            <FormattedMessage
-              id="dashboard.listing.noItemsMessage"
-              defaultMessage="Looks like you don't have any dashboards."
-            />
-          </h1>
+          <EuiText size="s">
+            <h1 id="dashboardListingHeading">
+              <FormattedMessage
+                id="dashboard.listing.noItemsMessage"
+                defaultMessage="Looks like you don't have any dashboards."
+              />
+            </h1>
+          </EuiText>
         }
       />
     );
@@ -33,12 +35,14 @@ export const getNoItemsMessage = (
     <EuiEmptyPrompt
       iconType="dashboardApp"
       title={
-        <h1 id="dashboardListingHeading">
-          <FormattedMessage
-            id="dashboard.listing.createNewDashboard.title"
-            defaultMessage="Create your first dashboard"
-          />
-        </h1>
+        <EuiText size="s">
+          <h1 id="dashboardListingHeading">
+            <FormattedMessage
+              id="dashboard.listing.createNewDashboard.title"
+              defaultMessage="Create your first dashboard"
+            />
+          </h1>
+        </EuiText>
       }
       body={
         <Fragment>

--- a/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
+++ b/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
@@ -234,9 +234,13 @@ export function SaveQueryForm({
     <EuiModal onClose={onClose} initialFocus="[name=title]">
       <EuiModalHeader>
         <EuiModalHeaderTitle>
-          {i18n.translate('data.search.searchBar.savedQueryFormTitle', {
-            defaultMessage: 'Save query',
-          })}
+          <EuiText size="s">
+            <h2>
+              {i18n.translate('data.search.searchBar.savedQueryFormTitle', {
+                defaultMessage: 'Save query',
+              })}
+            </h2>
+          </EuiText>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
 

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_flyout.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_flyout.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlyoutBody,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiTitle,
+  EuiText,
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { DocViewer } from '../doc_viewer/doc_viewer';
@@ -43,11 +43,11 @@ export function DataGridFlyout({
   return (
     <EuiFlyout onClose={onClose} size="m" data-test-subj="documentDetailFlyOut" ownFocus={false}>
       <EuiFlyoutHeader>
-        <EuiTitle>
+        <EuiText size="s">
           <h2>
             <FormattedMessage id="discover.docView.flyoutTitle" defaultMessage="Document Details" />
           </h2>
-        </EuiTitle>
+        </EuiText>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <EuiFlexGroup direction="column">

--- a/src/plugins/discover/public/application/components/top_nav/__snapshots__/open_search_panel.test.tsx.snap
+++ b/src/plugins/discover/public/application/components/top_nav/__snapshots__/open_search_panel.test.tsx.snap
@@ -9,8 +9,8 @@ exports[`render 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
-      size="m"
+    <EuiText
+      size="s"
     >
       <h2>
         <FormattedMessage
@@ -19,7 +19,7 @@ exports[`render 1`] = `
           values={Object {}}
         />
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <SavedObjectFinderUi

--- a/src/plugins/discover/public/application/components/top_nav/open_search_panel.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/open_search_panel.tsx
@@ -40,7 +40,7 @@ import {
   EuiFlyoutHeader,
   EuiFlyoutFooter,
   EuiFlyoutBody,
-  EuiTitle,
+  EuiText,
 } from '@elastic/eui';
 import { SavedObjectFinderUi } from '../../../../../saved_objects/public';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
@@ -63,14 +63,14 @@ export function OpenSearchPanel({ onClose, makeUrl }: Props) {
   return (
     <EuiFlyout ownFocus onClose={onClose} data-test-subj="loadSearchForm">
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="m">
+        <EuiText size="s">
           <h2>
             <FormattedMessage
               id="discover.topNav.openSearchPanel.openSearchTitle"
               defaultMessage="OpenSearch"
             />
           </h2>
-        </EuiTitle>
+        </EuiText>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <SavedObjectFinderUi

--- a/src/plugins/inspector/public/ui/__snapshots__/inspector_panel.test.tsx.snap
+++ b/src/plugins/inspector/public/ui/__snapshots__/inspector_panel.test.tsx.snap
@@ -154,15 +154,17 @@ exports[`InspectorPanel should render as expected 1`] = `
             <div
               className="euiFlexItem"
             >
-              <EuiTitle
+              <EuiText
                 size="s"
               >
-                <h1
-                  className="euiTitle euiTitle--small"
+                <div
+                  className="euiText euiText--small"
                 >
-                  Inspector
-                </h1>
-              </EuiTitle>
+                  <h2>
+                    Inspector
+                  </h2>
+                </div>
+              </EuiText>
             </div>
           </EuiFlexItem>
           <EuiFlexItem

--- a/src/plugins/inspector/public/ui/inspector_panel.tsx
+++ b/src/plugins/inspector/public/ui/inspector_panel.tsx
@@ -32,7 +32,7 @@ import './inspector_panel.scss';
 import { i18n } from '@osd/i18n';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { EuiFlexGroup, EuiFlexItem, EuiFlyoutHeader, EuiTitle, EuiFlyoutBody } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiFlyoutHeader, EuiFlyoutBody, EuiText } from '@elastic/eui';
 import { InspectorViewDescription } from '../types';
 import { Adapters } from '../../common';
 import { InspectorViewChooser } from './inspector_view_chooser';
@@ -122,9 +122,9 @@ export class InspectorPanel extends Component<InspectorPanelProps, InspectorPane
         <EuiFlyoutHeader hasBorder>
           <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
             <EuiFlexItem grow={true}>
-              <EuiTitle size="s">
-                <h1>{title}</h1>
-              </EuiTitle>
+              <EuiText size="s">
+                <h2>{title}</h2>
+              </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <InspectorViewChooser

--- a/src/plugins/management/public/components/landing/landing.tsx
+++ b/src/plugins/management/public/components/landing/landing.tsx
@@ -31,14 +31,7 @@
 import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
 
-import {
-  EuiHorizontalRule,
-  EuiIcon,
-  EuiPageContent,
-  EuiSpacer,
-  EuiText,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiHorizontalRule, EuiIcon, EuiPageContent, EuiSpacer, EuiText } from '@elastic/eui';
 import { useMount } from 'react-use';
 
 interface ManagementLandingPageProps {
@@ -57,14 +50,14 @@ export const ManagementLandingPage = ({ setBreadcrumbs }: ManagementLandingPageP
         <div className="eui-textCenter">
           <EuiIcon type="managementApp" size="xxl" />
           <EuiSpacer />
-          <EuiTitle>
+          <EuiText size="s">
             <h1>
               <FormattedMessage
                 id="management.landing.header"
                 defaultMessage="Welcome to Dashboards Management"
               />
             </h1>
-          </EuiTitle>
+          </EuiText>
           <EuiText size="s">
             <FormattedMessage
               id="management.landing.subhead"

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/__snapshots__/overview_page_header.test.tsx.snap
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/__snapshots__/overview_page_header.test.tsx.snap
@@ -14,15 +14,15 @@ exports[`OverviewPageHeader  renders with the toolbar by default 1`] = `
           responsive={false}
         >
           <EuiFlexItem>
-            <EuiTitle
-              size="m"
+            <EuiText
+              size="s"
             >
               <h1
                 id="osdOverviewPageHeader__title"
               >
                 Page Title
               </h1>
-            </EuiTitle>
+            </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
@@ -34,7 +34,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
-  EuiTitle,
+  EuiText,
   IconType,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
@@ -101,9 +101,9 @@ export const OverviewPageHeader: FC<Props> = ({
               )}
 
               <EuiFlexItem>
-                <EuiTitle size="m">
+                <EuiText size="s">
                   <h1 id="osdOverviewPageHeader__title">{title}</h1>
-                </EuiTitle>
+                </EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>

--- a/src/plugins/saved_objects/public/save_modal/__snapshots__/saved_object_save_modal.test.tsx.snap
+++ b/src/plugins/saved_objects/public/save_modal/__snapshots__/saved_object_save_modal.test.tsx.snap
@@ -8,15 +8,21 @@ exports[`SavedObjectSaveModal should render matching snapshot 1`] = `
 >
   <EuiModalHeader>
     <EuiModalHeaderTitle>
-      <FormattedMessage
-        defaultMessage="Save {objectType}"
-        id="savedObjects.saveModal.saveTitle"
-        values={
-          Object {
-            "objectType": "visualization",
-          }
-        }
-      />
+      <EuiText
+        size="s"
+      >
+        <h2>
+          <FormattedMessage
+            defaultMessage="Save {objectType}"
+            id="savedObjects.saveModal.saveTitle"
+            values={
+              Object {
+                "objectType": "visualization",
+              }
+            }
+          />
+        </h2>
+      </EuiText>
     </EuiModalHeaderTitle>
   </EuiModalHeader>
   <EuiModalBody>

--- a/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
+++ b/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
@@ -106,11 +106,15 @@ export class SavedObjectSaveModal extends React.Component<Props, SaveModalState>
       >
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <FormattedMessage
-              id="savedObjects.saveModal.saveTitle"
-              defaultMessage="Save {objectType}"
-              values={{ objectType: this.props.objectType }}
-            />
+            <EuiText size="s">
+              <h2>
+                <FormattedMessage
+                  id="savedObjects.saveModal.saveTitle"
+                  defaultMessage="Save {objectType}"
+                  values={{ objectType: this.props.objectType }}
+                />
+              </h2>
+            </EuiText>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/__snapshots__/header.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/__snapshots__/header.test.tsx.snap
@@ -17,23 +17,27 @@ exports[`Intro component renders correctly 1`] = `
         <div
           className="euiPageContentHeaderSection"
         >
-          <EuiTitle>
-            <h1
-              className="euiTitle euiTitle--medium"
+          <EuiText
+            size="s"
+          >
+            <div
+              className="euiText euiText--small"
             >
-              <FormattedMessage
-                defaultMessage="Edit {title}"
-                id="savedObjectsManagement.view.editItemTitle"
-                values={
-                  Object {
-                    "title": "search",
+              <h1>
+                <FormattedMessage
+                  defaultMessage="Edit {title}"
+                  id="savedObjectsManagement.view.editItemTitle"
+                  values={
+                    Object {
+                      "title": "search",
+                    }
                   }
-                }
-              >
-                Edit search
-              </FormattedMessage>
-            </h1>
-          </EuiTitle>
+                >
+                  Edit search
+                </FormattedMessage>
+              </h1>
+            </div>
+          </EuiText>
         </div>
       </EuiPageContentHeaderSection>
       <EuiPageContentHeaderSection>

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/header.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/header.tsx
@@ -32,10 +32,10 @@ import React from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiTitle,
   EuiButton,
   EuiPageContentHeader,
   EuiPageContentHeaderSection,
+  EuiText,
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 
@@ -59,7 +59,7 @@ export const Header = ({
   return (
     <EuiPageContentHeader>
       <EuiPageContentHeaderSection>
-        <EuiTitle>
+        <EuiText size="s">
           {canEdit ? (
             <h1>
               <FormattedMessage
@@ -77,7 +77,7 @@ export const Header = ({
               />
             </h1>
           )}
-        </EuiTitle>
+        </EuiText>
       </EuiPageContentHeaderSection>
       <EuiPageContentHeaderSection>
         <EuiFlexGroup responsive={false}>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/header.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/header.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`Header should render normally 1`] = `
     <EuiFlexItem
       grow={false}
     >
-      <EuiTitle>
+      <EuiText
+        size="s"
+      >
         <h1>
           <FormattedMessage
             defaultMessage="Saved Objects"
@@ -17,7 +19,7 @@ exports[`Header should render normally 1`] = `
             values={Object {}}
           />
         </h1>
-      </EuiTitle>
+      </EuiText>
     </EuiFlexItem>
     <EuiFlexItem
       grow={false}

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
@@ -31,7 +31,6 @@
 import React, { Fragment } from 'react';
 import {
   EuiSpacer,
-  EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
@@ -54,14 +53,14 @@ export const Header = ({
   <Fragment>
     <EuiFlexGroup justifyContent="spaceBetween" alignItems="baseline">
       <EuiFlexItem grow={false}>
-        <EuiTitle>
+        <EuiText size="s">
           <h1>
             <FormattedMessage
               id="savedObjectsManagement.objectsTable.header.savedObjectsTitle"
               defaultMessage="Saved Objects"
             />
           </h1>
-        </EuiTitle>
+        </EuiText>
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>

--- a/src/plugins/visualize/public/application/utils/get_table_columns.tsx
+++ b/src/plugins/visualize/public/application/utils/get_table_columns.tsx
@@ -175,12 +175,14 @@ export const getNoItemsMessage = (createItem: () => void) => (
   <EuiEmptyPrompt
     iconType="visualizeApp"
     title={
-      <h1 id="visualizeListingHeading">
-        <FormattedMessage
-          id="visualize.listing.createNew.title"
-          defaultMessage="Create your first visualization"
-        />
-      </h1>
+      <EuiText size="s">
+        <h1 id="visualizeListingHeading">
+          <FormattedMessage
+            id="visualize.listing.createNew.title"
+            defaultMessage="Create your first visualization"
+          />
+        </h1>
+      </EuiText>
     }
     body={
       <EuiText size="s">


### PR DESCRIPTION
### Description
 Refactor to use semantic headers for page, modal & flyout

<!-- Describe what this change achieves-->
![image](https://github.com/opensearch-project/OpenSearch-Dashboards/assets/32652829/840aea11-c555-4ab2-8e0e-9b5c5250fcdd)



### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- refactor: [Look&Feel]  Refactor to use semantic headers for page, modal & flyout

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
