### PR TITLE
[OE] skip running tests if CODEOWNERS was change

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -11,6 +11,7 @@ on:
       - '**/*.md'
       - 'docs/**'
       - '.lycheeignore'
+      - 'CODEOWNERS'
       - 'changelogs/fragments/**'
   pull_request:
     branches: ['**']
@@ -18,6 +19,7 @@ on:
       - '**/*.md'
       - 'docs/**'
       - '.lycheeignore'
+      - 'CODEOWNERS'
       - 'changelogs/fragments/**'
 
 env:

--- a/changelogs/fragments/7197.yml
+++ b/changelogs/fragments/7197.yml
@@ -1,0 +1,2 @@
+chore:
+- Skip running tests for updates in CODEOWNERS ([#7197](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7197))


### PR DESCRIPTION
### Description

Noticed here:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7196

That we are running the full suite of tests even though CODEOWNERS was just changed.

### Issues Resolved

n/a

## Changelog

- chore: Skip running tests for updates in CODEOWNERS

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
