### PR TITLE
fix(discover): break new lines in table cell

### DIFF
--- a/changelogs/fragments/7207.yml
+++ b/changelogs/fragments/7207.yml
@@ -1,0 +1,2 @@
+fix:
+- Break new lines in table cell in legacy discover ([#7207](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7207))

--- a/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
+++ b/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
@@ -95,3 +95,7 @@
     font-size: inherit !important;
   }
 }
+
+.osdDocTableCell__dataField {
+  white-space: pre-wrap;
+}

--- a/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
@@ -34,8 +34,11 @@ const TableCellUI = ({
 }: TableCellProps) => {
   const content = (
     <>
-      {/* eslint-disable-next-line react/no-danger */}
-      <span dangerouslySetInnerHTML={{ __html: sanitizedCellValue }} />
+      <span
+        className="osdDocTableCell__dataField"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: sanitizedCellValue }}
+      />
       <span className="osdDocTableCell__filter">
         <EuiToolTip
           content={i18n.translate('discover.filterForValue', {


### PR DESCRIPTION
### Description

add `white-space: pre-wrap;` back to table cell to fix regression in #7177

### Issues Resolved

fixes #7177

## Screenshot

<img width="1506" alt="image" src="https://github.com/opensearch-project/OpenSearch-Dashboards/assets/28062824/049c22da-f27c-43cd-9cff-62490626510d">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: break new lines in table cell in legacy discover

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
