### PR TITLE
[Workspace]Register workspace settings under setup and settings

### DIFF
--- a/changelogs/fragments/7242.yml
+++ b/changelogs/fragments/7242.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace] Register workspace settings under setup and settings ([#7242](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7242))

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -8,6 +8,7 @@ import { waitFor } from '@testing-library/dom';
 import { ChromeBreadcrumb } from 'opensearch-dashboards/public';
 import { workspaceClientMock, WorkspaceClientMock } from './workspace_client.mock';
 import { applicationServiceMock, chromeServiceMock, coreMock } from '../../../core/public/mocks';
+import { DEFAULT_NAV_GROUPS, AppNavLinkStatus } from '../../../core/public';
 import { WorkspacePlugin } from './plugin';
 import { WORKSPACE_FATAL_ERROR_APP_ID, WORKSPACE_OVERVIEW_APP_ID } from '../common/constants';
 import { savedObjectsManagementPluginMock } from '../../saved_objects_management/public/mocks';
@@ -148,6 +149,29 @@ describe('Workspace plugin', () => {
       management: managementPluginMock.createSetupContract(),
     });
     expect(setupMock.chrome.registerCollapsibleNavHeader).toBeCalledTimes(1);
+  });
+
+  it('#setup should register workspace list with a visible application and register to settingsAndSetup nav group', async () => {
+    const setupMock = coreMock.createSetup();
+    setupMock.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    const workspacePlugin = new WorkspacePlugin();
+    await workspacePlugin.setup(setupMock, {});
+
+    expect(setupMock.application.register).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'workspace_list',
+        navLinkStatus: AppNavLinkStatus.visible,
+      })
+    );
+    expect(setupMock.chrome.navGroup.addNavLinksToGroup).toHaveBeenCalledWith(
+      DEFAULT_NAV_GROUPS.settingsAndSetup,
+      expect.arrayContaining([
+        {
+          id: 'workspace_list',
+          title: 'workspace settings',
+        },
+      ])
+    );
   });
 
   it('#start add workspace overview page to breadcrumbs when start', async () => {

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -20,6 +20,7 @@ import {
   WorkspaceAvailability,
   ChromeNavGroupUpdater,
   NavGroupStatus,
+  DEFAULT_NAV_GROUPS,
 } from '../../../core/public';
 import {
   WORKSPACE_FATAL_ERROR_APP_ID,
@@ -318,13 +319,25 @@ export class WorkspacePlugin implements Plugin<{}, {}, WorkspacePluginSetupDeps>
     core.application.register({
       id: WORKSPACE_LIST_APP_ID,
       title: '',
-      navLinkStatus: AppNavLinkStatus.hidden,
+      // nav link should be visible when nav group enabled
+      navLinkStatus: core.chrome.navGroup.getNavGroupEnabled()
+        ? AppNavLinkStatus.visible
+        : AppNavLinkStatus.hidden,
       async mount(params: AppMountParameters) {
         const { renderListApp } = await import('./application');
         return mountWorkspaceApp(params, renderListApp);
       },
       workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
     });
+
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.settingsAndSetup, [
+      {
+        id: WORKSPACE_LIST_APP_ID,
+        title: i18n.translate('workspace.settingsAndSetup.workspaceSettings', {
+          defaultMessage: 'workspace settings',
+        }),
+      },
+    ]);
 
     /**
      * register workspace column into saved objects table

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -319,7 +319,11 @@ export class WorkspacePlugin implements Plugin<{}, {}, WorkspacePluginSetupDeps>
     core.application.register({
       id: WORKSPACE_LIST_APP_ID,
       title: '',
-      // nav link should be visible when nav group enabled
+      /**
+       * Nav link status should be visible when nav group enabled.
+       * The page should be refreshed and all applications need to register again
+       * after nav group enabled changed.
+       */
       navLinkStatus: core.chrome.navGroup.getNavGroupEnabled()
         ? AppNavLinkStatus.visible
         : AppNavLinkStatus.hidden,


### PR DESCRIPTION
### Description

This PR is for registering workspace settings under setup and settings. The workspace settings will link to the workspace list page. To support display link in the left navigation, need to update link status to visible when nav group enabled.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
#7244

## Screenshot

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a7ad2435-b106-4177-838b-918d9bd1672d">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
All changes working fine in the [feature/navigation-next](https://github.com/opensearch-project/OpenSearch-Dashboards/tree/feature/navigation-next) branch. Need to checkout the code and rebase `feature/navigation-next` branch.
Another way is to refer the `src/plugins/workspace/public/plugin.test.ts` unit test file. All changes have been covered in it.

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- feat: [Workspace] Register workspace settings under setup and settings

### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
