### PR TITLE
[OSD-7141] Upgrade uuid dependency to latest version (^10.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "tinygradient": "^1.1.5",
     "tslib": "^2.0.0",
     "type-detect": "^4.0.8",
-    "uuid": "3.3.2",
+    "uuid": "^10.0.0",
     "whatwg-fetch": "^3.0.0",
     "yauzl": "^2.10.0",
     "@opensearch-dashboards-test/opensearch-dashboards-test-library": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.6.tar.gz"
@@ -356,7 +356,7 @@
     "@types/testing-library__jest-dom": "^5.14.2",
     "@types/tough-cookie": "^4.0.1",
     "@types/type-detect": "^4.0.1",
-    "@types/uuid": "^3.4.4",
+    "@types/uuid": "^10.0.0",
     "@types/vinyl": "^2.0.4",
     "@types/vinyl-fs": "^2.4.11",
     "@types/webpack": "^4.41.31",


### PR DESCRIPTION
### Description

This change upgrades the uuid dependency from version 3.3.2   to ^10.0.0. This addresses using a deprecated version, improves security, and ensures the project uses a supported version of the uuid package.

### Issues Resolved

closes #7141 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
-skip: Upgrade uuid dependency from 3.3.2 to ^10.0.0 and @types/uuid from 3.4.4 to ^10.0.0

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
