### PR TITLE
Fix Discover not respecting searchOnPageLoad Advanced Setting

### DIFF
--- a/src/plugins/discover/public/application/view_components/context/index.tsx
+++ b/src/plugins/discover/public/application/view_components/context/index.tsx
@@ -10,7 +10,7 @@ import {
   useOpenSearchDashboards,
 } from '../../../../../opensearch_dashboards_react/public';
 import { getServices } from '../../../opensearch_dashboards_services';
-import { useSearch, SearchContextValue, ResultStatus } from '../utils/use_search';
+import { useSearch, SearchContextValue } from '../utils/use_search';
 
 const SearchContext = React.createContext<SearchContextValue>({} as SearchContextValue);
 
@@ -21,9 +21,6 @@ export default function DiscoverContext({ children }: React.PropsWithChildren<Vi
   const searchParams = useSearch({
     ...deServices,
     ...services,
-  });
-  searchParams.data$.next({
-    status: ResultStatus.LOADING,
   });
 
   return (


### PR DESCRIPTION
### Description

When we set the searchOnPageLoad Advanced Setting as false , Upon navigating to Discover home page, we can see the page being stuck in a loading state. Refer the image below for reference. 

![image](https://github.com/user-attachments/assets/b19e1ecb-1c0b-4f21-b3d8-775da198e907)

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

- Set the searchOnPageLoad Advanced Setting to False
- Navigate to Discover
- You should See a Page which provides user a option to refresh manually
Adding a sample image for reference 
![image](https://github.com/user-attachments/assets/85bb1071-ca72-41d1-8206-1b3a4a12aef2)


## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
