### PR TITLE
Add datasource readonly feature flag and disable certain routes

### DIFF
--- a/changelogs/fragments/7256.yml
+++ b/changelogs/fragments/7256.yml
@@ -1,0 +1,2 @@
+feat:
+- Add datasource readonly feature flag and disable certain routes ([#7256](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7256))

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -269,6 +269,7 @@
 
 # Set the value of this setting to true to enable multiple data source feature.
 #data_source.enabled: false
+#data_source.readOnly: false
 # Set the value of this setting to true to hide local cluster in data source feature.
 #data_source.hideLocalCluster: false
 # Set the value of these settings to customize crypto materials to encryption saved credentials

--- a/src/plugins/data_source/config.ts
+++ b/src/plugins/data_source/config.ts
@@ -13,6 +13,7 @@ const WRAPPING_KEY_SIZE: number = 32;
 
 export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: false }),
+  readOnly: schema.boolean({ defaultValue: false }),
   hideLocalCluster: schema.boolean({ defaultValue: false }),
   encryption: schema.object({
     wrappingKeyName: schema.string({

--- a/src/plugins/data_source/public/plugin.ts
+++ b/src/plugins/data_source/public/plugin.ts
@@ -21,6 +21,7 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
     const config = this.initializerContext.config.get();
     return {
       dataSourceEnabled: config.enabled,
+      dataSourceReadOnly: config.readOnly,
       hideLocalCluster: config.hideLocalCluster,
       noAuthenticationTypeEnabled: config.authTypes.NoAuthentication.enabled,
       usernamePasswordAuthEnabled: config.authTypes.UsernamePassword.enabled,
@@ -32,6 +33,7 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
     const config = this.initializerContext.config.get();
     return {
       dataSourceEnabled: config.enabled,
+      dataSourceReadOnly: config.readOnly,
       hideLocalCluster: config.hideLocalCluster,
       noAuthenticationTypeEnabled: config.authTypes.NoAuthentication.enabled,
       usernamePasswordAuthEnabled: config.authTypes.UsernamePassword.enabled,

--- a/src/plugins/data_source/public/types.ts
+++ b/src/plugins/data_source/public/types.ts
@@ -5,6 +5,7 @@
 
 export interface DataSourcePluginSetup {
   dataSourceEnabled: boolean;
+  dataSourceReadOnly: boolean;
   hideLocalCluster: boolean;
   noAuthenticationTypeEnabled: boolean;
   usernamePasswordAuthEnabled: boolean;
@@ -13,6 +14,7 @@ export interface DataSourcePluginSetup {
 
 export interface DataSourcePluginStart {
   dataSourceEnabled: boolean;
+  dataSourceReadOnly: boolean;
   hideLocalCluster: boolean;
   noAuthenticationTypeEnabled: boolean;
   usernamePasswordAuthEnabled: boolean;

--- a/src/plugins/data_source/server/index.ts
+++ b/src/plugins/data_source/server/index.ts
@@ -12,6 +12,7 @@ export const config: PluginConfigDescriptor<DataSourcePluginConfigType> = {
     enabled: true,
     hideLocalCluster: true,
     authTypes: true,
+    readOnly: true,
   },
   schema: configSchema,
 };

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -363,9 +363,17 @@ export interface HideLocalCluster {
   enabled: boolean;
 }
 
+export interface DataSourceReadOnly {
+  readOnly: boolean;
+}
+
 export const [getHideLocalCluster, setHideLocalCluster] = createGetterSetter<HideLocalCluster>(
   'HideLocalCluster'
 );
+
+export const [getDataSourceReadOnly, setDataSourceReadOnly] = createGetterSetter<
+  DataSourceReadOnly
+>('DataSourceReadOnly');
 
 // This will maintain an unified data source selection instance among components and export it to other plugin.
 const [getDataSourceSelectionInstance, setDataSourceSelection] = createGetterSetter<

--- a/src/plugins/data_source_management/public/management_app/mount_management_section.test.tsx
+++ b/src/plugins/data_source_management/public/management_app/mount_management_section.test.tsx
@@ -67,7 +67,13 @@ const mockAuthMethodsRegistry: AuthenticationMethodRegistry = {} as Authenticati
 
 describe('mountManagementSection', () => {
   it('renders routes correctly with feature flag enabled', async () => {
-    await mountManagementSection(mockStartServices, mockParams, mockAuthMethodsRegistry, true);
+    await mountManagementSection(
+      mockStartServices,
+      mockParams,
+      mockAuthMethodsRegistry,
+      true,
+      false
+    );
     const wrapper = shallow(
       <OpenSearchDashboardsContextProvider services={{}}>
         <I18nProvider>
@@ -96,7 +102,13 @@ describe('mountManagementSection', () => {
   });
 
   it('renders routes correctly with feature flag disabled', async () => {
-    await mountManagementSection(mockStartServices, mockParams, mockAuthMethodsRegistry, false);
+    await mountManagementSection(
+      mockStartServices,
+      mockParams,
+      mockAuthMethodsRegistry,
+      false,
+      false
+    );
     const wrapper = shallow(
       <OpenSearchDashboardsContextProvider services={{}}>
         <I18nProvider>
@@ -118,5 +130,35 @@ describe('mountManagementSection', () => {
     wrapper.find(Route).forEach((route) => {
       expect(route.prop('path')).not.toEqual(['/:id']);
     });
+  });
+
+  it('renders routes correctly with feature flag enabled and readonly enabled', async () => {
+    await mountManagementSection(
+      mockStartServices,
+      mockParams,
+      mockAuthMethodsRegistry,
+      true,
+      true
+    );
+    const wrapper = shallow(
+      <OpenSearchDashboardsContextProvider services={{}}>
+        <I18nProvider>
+          <Router history={mockParams.history}>
+            <Switch>
+              <Route path={['/create']} />
+              <Route path={['/configure/OpenSearch']} />
+              <Route
+                path={['/configure/:type']}
+                component={ConfigureDirectQueryDataSourceWithRouter}
+              />
+              <Route path={['/:id']} component={EditDataSourceWithRouter} />
+              <Route path={['/']} component={DataSourceHomePanel} />
+            </Switch>
+          </Router>
+        </I18nProvider>
+      </OpenSearchDashboardsContextProvider>
+    );
+
+    expect(wrapper.find(Route)).toHaveLength(5);
   });
 });

--- a/src/plugins/data_source_management/public/management_app/mount_management_section.tsx
+++ b/src/plugins/data_source_management/public/management_app/mount_management_section.tsx
@@ -29,7 +29,8 @@ export async function mountManagementSection(
   getStartServices: StartServicesAccessor<DataSourceManagementStartDependencies>,
   params: ManagementAppMountParams,
   authMethodsRegistry: AuthenticationMethodRegistry,
-  featureFlagStatus: boolean
+  featureFlagStatus: boolean,
+  dataSourceReadOnly: boolean
 ) {
   const [
     { chrome, application, savedObjects, uiSettings, notifications, overlays, http, docLinks },
@@ -54,11 +55,13 @@ export async function mountManagementSection(
         <Router history={params.history}>
           <Switch>
             <Route path={['/create']}>
-              <CreateDataSourcePanel {...params} featureFlagStatus={featureFlagStatus} />
+              {dataSourceReadOnly ? null : (
+                <CreateDataSourcePanel {...params} featureFlagStatus={featureFlagStatus} />
+              )}
             </Route>
             {featureFlagStatus && (
               <Route path={['/configure/OpenSearch']}>
-                <CreateDataSourceWizardWithRouter />
+                {dataSourceReadOnly ? null : <CreateDataSourceWizardWithRouter />}
               </Route>
             )}
             <Route path={['/configure/:type']}>

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -392,6 +392,7 @@ export const testDataSourceManagementPlugin = (
     indexPatternManagement: indexPatternManagementPluginMock.createSetupContract(),
     dataSource: {
       dataSourceEnabled: true,
+      dataSourceReadOnly: true,
       hideLocalCluster: true,
       noAuthenticationTypeEnabled: true,
       usernamePasswordAuthEnabled: true,
@@ -418,6 +419,7 @@ export const createAuthenticationMethod = (
 
 export const mockDataSourcePluginSetupWithShowLocalCluster: DataSourcePluginSetup = {
   dataSourceEnabled: true,
+  dataSourceReadOnly: false,
   hideLocalCluster: false,
   noAuthenticationTypeEnabled: true,
   usernamePasswordAuthEnabled: true,

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -26,8 +26,10 @@ import {
   setHideLocalCluster,
   setUiSettings,
   setDataSourceSelection,
+  setDataSourceReadOnly,
   getDefaultDataSourceId,
   getDefaultDataSourceId$,
+  getDataSourceReadOnly,
 } from './components/utils';
 import { DataSourceSelectionService } from './service/data_source_selection_service';
 
@@ -85,6 +87,9 @@ export class DataSourceManagementPlugin
     indexPatternManagement.columns.register(column);
 
     const featureFlagStatus = !!dataSource;
+    setDataSourceReadOnly({
+      readOnly: featureFlagStatus ? dataSource.dataSourceReadOnly : false,
+    });
 
     opensearchDashboardsSection.registerApp({
       id: DSM_APP_ID,
@@ -97,7 +102,8 @@ export class DataSourceManagementPlugin
           core.getStartServices,
           params,
           this.authMethodsRegistry,
-          featureFlagStatus
+          featureFlagStatus,
+          getDataSourceReadOnly().readOnly
         );
       },
     });


### PR DESCRIPTION
### Description

Add datasource readonly feature flag and disable certain routes 
* /create
* configure/opensearch



## Screenshot
### When datasource is enabled and readonly is false, customer should be able to create and configure opensearch.
```
data_source.enabled: true
data_source.readonly: false
```


https://github.com/user-attachments/assets/4969e10b-1cac-4b94-afe3-ecc79e13bdf6




### When datasource is enabled and readonly is true, customer should not be able to create and configure openSearch.
```
data_source.enabled: true
data_source.readOnly: true
```

https://github.com/user-attachments/assets/fb4050f5-1ece-4ab5-8dec-b8bf5a8e46aa


### When datasource is diabled and readonly is disable, datasource section should be hidden
```
data_source.enabled: false
data_source.readOnly: false
```
![Screenshot 2024-07-15 at 11 18 55 PM](https://github.com/user-attachments/assets/f96e3d17-317f-4432-bba6-319cac7aefb6)
![Screenshot 2024-07-15 at 11 19 04 PM](https://github.com/user-attachments/assets/18d19bab-605c-4f10-b3d6-657cc9ef901d)

### When datasource is diabled and readonly is  true , datasource section should still be hidden
```
data_source.enabled: false
data_source.readOnly: true
```

![Screenshot 2024-07-15 at 11 20 07 PM](https://github.com/user-attachments/assets/0a7cb41a-372e-4105-857e-d260aeb4a17c)
![Screenshot 2024-07-15 at 11 20 16 PM](https://github.com/user-attachments/assets/64510d95-d038-4010-b601-fdd2cda42572)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- feat: Add datasource readonly feature flag and disable certain routes


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
