### PR TITLE
Remove unnecessary markdown rendering

### DIFF
--- a/src/plugins/opensearch_dashboards_utils/public/history/redirect_when_missing.tsx
+++ b/src/plugins/opensearch_dashboards_utils/public/history/redirect_when_missing.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import { History } from 'history';
 import { i18n } from '@osd/i18n';
 import { EuiLoadingSpinner } from '@elastic/eui';
@@ -37,10 +37,9 @@ import ReactDOM from 'react-dom';
 import { ApplicationStart, HttpStart, ToastsSetup } from 'opensearch-dashboards/public';
 import { SavedObjectNotFound } from '..';
 
-const ReactMarkdown = React.lazy(() => import('react-markdown'));
 const ErrorRenderer = (props: { children: string }) => (
   <React.Suspense fallback={<EuiLoadingSpinner />}>
-    <ReactMarkdown renderers={{ root: Fragment }} {...props} />
+    <span>{props.children}</span>
   </React.Suspense>
 );
 


### PR DESCRIPTION
### Description

This PR removes unnecessary markdown rendering when handling [SavedObjectNotFound](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/opensearch_dashboards_utils/common/errors/errors.ts#L51-L70) errors. The error rendering occurs [here](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/opensearch_dashboards_utils/public/history/redirect_when_missing.tsx#L96-L123) and unnecessarily renders the text as markdown when the message will always be plain text based on the error type. 

## Testing the changes

- All CI checks pass

## Changelog

- chore: Remove unnecessary markdown rendering

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
