### PR TITLE
Add OpenAPI specification for API for retrieving fields of index pattern

### DIFF
--- a/changelogs/fragments/7270.yml
+++ b/changelogs/fragments/7270.yml
@@ -1,0 +1,2 @@
+doc:
+- Add OpenAPI specification for API for retrieving fields of index patterns ([#7270](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7270))

--- a/docs/openapi/index_patterns/index.html
+++ b/docs/openapi/index_patterns/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3/swagger-ui.css">
+
+  <title>Index Patterns API</title>
+
+<body>
+
+  <div id="api-docs" />
+
+  <script src="//unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+  <script>
+
+    window.onload = function() {
+      const ui = SwaggerUIBundle({
+        url: "index_patterns.yml",
+        dom_id: "#api-docs",
+        deepLinking: true,
+      })
+
+    }
+
+  </script>
+
+</body>
+</html>

--- a/docs/openapi/index_patterns/index_patterns.yml
+++ b/docs/openapi/index_patterns/index_patterns.yml
@@ -1,0 +1,83 @@
+openapi: 3.0.3
+info:
+  version: v1
+  title: OpenSearch Dashboards Index Patterns API
+  contact:
+    name: OpenSearch Dashboards Team
+  description: |-
+    OpenAPI schema for OpenSearch Dashboards Index Patterns API
+tags:
+  - name: index patterns
+paths:
+  /api/index_patterns/_fields_for_wildcard:
+    get:
+      tags:
+        - index patterns
+      summary: 
+      parameters:
+        - in: query
+          name: pattern
+          description: The index pattern used to retrieve fields.
+          required: true
+          schema:
+            type: string
+          example: my-index*
+        - in: query
+          name: meta_fields
+          description: The list of metadata fields which will be included in the response, it usually contains "_source", "_id", "_type", "_index" and "_score".
+          schema:
+            oneOf:
+              - type: string
+              - type: array
+            default: []
+          example: _source
+        - in: query
+          name: data_source
+          description: The data source of index patterns and indices.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Fetching fields for index pattern is successful.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  fields: 
+                    type: array
+                    description: Retrieved fields based on wildcard pattern.
+                    items:
+                      type: object 
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400_bad_request'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    400_bad_request:
+      title: Bad request
+      type: object
+      required:
+        - error
+        - message
+        - statusCode
+      properties:
+        error:
+          type: string
+          enum:
+            - Bad Request
+        message:
+          type: string
+        statusCode:
+          type: integer
+          enum:
+            - 400


### PR DESCRIPTION
### Description

Add OpenAPI specification for API for retrieving fields of index pattern

### Issues Resolved

N/A

## Screenshot
<img width="1134" alt="Screenshot 2024-07-16 at 3 19 59 PM" src="https://github.com/user-attachments/assets/4c885b1c-4f04-4e01-a56b-df47e56993e0">
<img width="1117" alt="Screenshot 2024-07-16 at 3 20 09 PM" src="https://github.com/user-attachments/assets/6eefe247-86af-44e8-8e25-6f227e5c5e7f">


## Testing the changes
Go to the docs/openapi/index_patterns directory, and run `npx serve`, check webpage rendered on http://localhost:3000    

## Changelog
- doc: Add OpenAPI specification for API for retrieving fields of index patterns

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
