### PR TITLE
[Workspace] Unassign data source before deleteByWorkspace

### DIFF
--- a/src/plugins/workspace/server/workspace_client.test.ts
+++ b/src/plugins/workspace/server/workspace_client.test.ts
@@ -180,4 +180,20 @@ describe('#WorkspaceClient', () => {
 
     expect(mockCheckAndSetDefaultDataSource).toHaveBeenCalledWith(uiSettingsClient, ['id1'], true);
   });
+
+  it('delete# should unassign data source before deleting related saved objects', async () => {
+    const client = new WorkspaceClient(coreSetup, logger);
+    await client.setup(coreSetup);
+    client?.setSavedObjects(savedObjects);
+    client?.setUiSettings(uiSettings);
+
+    await client.delete(mockRequestDetail, mockWorkspaceId);
+
+    expect(deleteFromWorkspaces).toHaveBeenCalledWith(DATA_SOURCE_SAVED_OBJECT_TYPE, 'id1', [
+      mockWorkspaceId,
+    ]);
+    expect(deleteFromWorkspaces).toHaveBeenCalledWith(DATA_SOURCE_SAVED_OBJECT_TYPE, 'id2', [
+      mockWorkspaceId,
+    ]);
+  });
 });

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -306,6 +306,21 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
           }),
         };
       }
+
+      // When workspace is to be deleted, unassign all assigned data source before deleting saved object by workspace.
+      const selectedDataSources = await getDataSourcesList(savedObjectClient, [id]);
+      if (selectedDataSources.length > 0) {
+        const promises = [];
+        for (const dataSource of selectedDataSources) {
+          promises.push(
+            savedObjectClient.deleteFromWorkspaces(DATA_SOURCE_SAVED_OBJECT_TYPE, dataSource.id, [
+              id,
+            ])
+          );
+        }
+        await Promise.all(promises);
+      }
+
       await savedObjectClient.deleteByWorkspace(id);
       // delete workspace itself at last, deleteByWorkspace depends on the workspace to do permission check
       await savedObjectClient.delete(WORKSPACE_TYPE, id);


### PR DESCRIPTION
### Description

In current implementation, we call `deleteByWorkspace` to delete related saved objects when deleting a workspace. This will cause selected data source deleted when it is only assigned to this workspace. So we will unassign this data source before calling `deleteByWorkspace`.


## Testing the changes

1. Use find API to find any data sources and what workspaces they belong to. http://localhost:6601/w/${OSD_ID}/api/saved_objects/_find?fields=id&fields=title&fields=workspaces&per_page=10000&type=data-source&workspaces=*
2. Enter workspace list page to delete some workspace.
3. Use find API then you could see that the data source is unassigned and still existed.

## Changelog

- fix: Unassign data source before deleteByWorkspace

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
