### PR TITLE
[Manual Backport][2.x][Workspace] [Data Source] feat: support workspace level default data source

### DIFF
--- a/changelogs/fragments/7188.yml
+++ b/changelogs/fragments/7188.yml
@@ -1,0 +1,2 @@
+feat:
+- Support workspace level default data source ([#7188](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7188))

--- a/src/plugins/data_source_management/common/index.ts
+++ b/src/plugins/data_source_management/common/index.ts
@@ -5,3 +5,4 @@
 
 export const PLUGIN_ID = 'dataSourceManagement';
 export const PLUGIN_NAME = 'Data sources';
+export const DEFAULT_DATA_SOURCE_UI_SETTINGS_ID = 'defaultDataSource';

--- a/src/plugins/data_source_management/public/components/constants.tsx
+++ b/src/plugins/data_source_management/public/components/constants.tsx
@@ -18,4 +18,4 @@ export const CONNECT_DATASOURCES_MESSAGE = 'Connect your data sources to get sta
 export const NO_COMPATIBLE_DATASOURCES_MESSAGE = 'No compatible data sources are available.';
 export const ADD_COMPATIBLE_DATASOURCES_MESSAGE = 'Add a compatible data source.';
 
-export const DEFAULT_DATA_SOURCE_UI_SETTINGS_ID = 'defaultDataSource';
+export { DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from '../../common';

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -52,7 +52,6 @@ export interface DataSourceManagementPluginStart {
   getAuthenticationMethodRegistry: () => IAuthenticationMethodRegistry;
 }
 
-// src/plugins/workspace/public/plugin.ts Workspace depends on this ID and hard code to avoid adding dependency on DSM bundle.
 export const DSM_APP_ID = 'dataSources';
 
 export class DataSourceManagementPlugin

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -113,7 +113,7 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     const globalConfig = await this.globalConfig$.pipe(first()).toPromise();
     const isPermissionControlEnabled = globalConfig.savedObjects.permission.enabled === true;
 
-    this.client = new WorkspaceClient(core);
+    this.client = new WorkspaceClient(core, this.logger);
 
     await this.client.setup(core);
 
@@ -176,6 +176,7 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     this.logger.debug('Starting Workspace service');
     this.permissionControl?.setup(core.savedObjects.getScopedClient, core.http.auth);
     this.client?.setSavedObjects(core.savedObjects);
+    this.client?.setUiSettings(core.uiSettings);
     this.workspaceConflictControl?.setSerializer(core.savedObjects.createSerializer());
     this.workspaceSavedObjectsClientWrapper?.setScopedClient(core.savedObjects.getScopedClient);
     this.workspaceUiSettingsClientWrapper?.setScopedClient(core.savedObjects.getScopedClient);

--- a/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.test.ts
@@ -7,6 +7,7 @@ import { loggerMock } from '@osd/logging/target/mocks';
 import { httpServerMock, savedObjectsClientMock, coreMock } from '../../../../core/server/mocks';
 import { WorkspaceUiSettingsClientWrapper } from './workspace_ui_settings_client_wrapper';
 import { WORKSPACE_TYPE } from '../../../../core/server';
+import { DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from '../../../data_source_management/common';
 
 import * as utils from '../../../../core/server/utils';
 
@@ -28,6 +29,7 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
           type: 'config',
           attributes: {
             defaultIndex: 'default-index-global',
+            [DEFAULT_DATA_SOURCE_UI_SETTINGS_ID]: 'default-ds-global',
           },
         });
       } else if (type === WORKSPACE_TYPE) {
@@ -59,7 +61,7 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
     };
   };
 
-  it('should return workspace ui settings if in a workspace', async () => {
+  it('should return workspace ui settings and should return workspace default data source and not extend global if in a workspace', async () => {
     // Currently in a workspace
     jest.spyOn(utils, 'getWorkspaceState').mockReturnValue({ requestWorkspaceId: 'workspace-id' });
 
@@ -72,6 +74,7 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
       type: 'config',
       attributes: {
         defaultIndex: 'default-index-workspace',
+        [DEFAULT_DATA_SOURCE_UI_SETTINGS_ID]: undefined,
       },
     });
   });
@@ -89,6 +92,7 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
       type: 'config',
       attributes: {
         defaultIndex: 'default-index-global',
+        [DEFAULT_DATA_SOURCE_UI_SETTINGS_ID]: 'default-ds-global',
       },
     });
   });

--- a/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../../core/server';
 import { WORKSPACE_UI_SETTINGS_CLIENT_WRAPPER_ID } from '../../common/constants';
 import { Logger } from '../../../../core/server';
+import { DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from '../../../data_source_management/common';
 
 /**
  * This saved object client wrapper offers methods to get and update UI settings considering
@@ -73,9 +74,14 @@ export class WorkspaceUiSettingsClientWrapper {
           this.logger.error(`Unable to get workspaceObject with id: ${requestWorkspaceId}`);
         }
 
+        const workspaceLevelDefaultDS =
+          workspaceObject?.attributes?.uiSettings?.[DEFAULT_DATA_SOURCE_UI_SETTINGS_ID];
+
         configObject.attributes = {
           ...configObject.attributes,
           ...(workspaceObject ? workspaceObject.attributes.uiSettings : {}),
+          // Workspace level default data source value should not extend global UIsettings value.
+          [DEFAULT_DATA_SOURCE_UI_SETTINGS_ID]: workspaceLevelDefaultDS,
         };
 
         return configObject as SavedObject<T>;

--- a/src/plugins/workspace/server/types.ts
+++ b/src/plugins/workspace/server/types.ts
@@ -12,6 +12,7 @@ import {
   WorkspaceAttribute,
   SavedObjectsServiceStart,
   Permissions,
+  UiSettingsServiceStart,
 } from '../../../core/server';
 
 export interface WorkspaceAttributeWithPermission extends WorkspaceAttribute {
@@ -48,6 +49,13 @@ export interface IWorkspaceClientImpl {
    * @public
    */
   setSavedObjects(savedObjects: SavedObjectsServiceStart): void;
+  /**
+   * Set ui settings client that will be used inside the workspace client.
+   * @param uiSettings {@link UiSettingsServiceStart}
+   * @returns void
+   * @public
+   */
+  setUiSettings(uiSettings: UiSettingsServiceStart): void;
   /**
    * Create a workspace
    * @param requestDetail {@link IRequestDetail}

--- a/src/plugins/workspace/server/workspace_client.test.ts
+++ b/src/plugins/workspace/server/workspace_client.test.ts
@@ -5,15 +5,22 @@
 
 import { WorkspaceClient } from './workspace_client';
 
-import { coreMock, httpServerMock } from '../../../core/server/mocks';
+import {
+  coreMock,
+  httpServerMock,
+  uiSettingsServiceMock,
+  loggingSystemMock,
+} from '../../../core/server/mocks';
 import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../data_source/common';
-import { SavedObjectsServiceStart } from '../../../core/server';
+import { SavedObjectsServiceStart, SavedObjectsClientContract } from '../../../core/server';
 import { IRequestDetail } from './types';
 
 const coreSetup = coreMock.createSetup();
 
 const mockWorkspaceId = 'workspace_id';
 const mockWorkspaceName = 'workspace_name';
+const mockCheckAndSetDefaultDataSource = jest.fn();
+const logger = loggingSystemMock.create().get();
 
 jest.mock('./utils', () => ({
   generateRandomId: () => mockWorkspaceId,
@@ -25,6 +32,7 @@ jest.mock('./utils', () => ({
       id: 'id2',
     },
   ]),
+  checkAndSetDefaultDataSource: (...args) => mockCheckAndSetDefaultDataSource(...args),
 }));
 
 describe('#WorkspaceClient', () => {
@@ -35,19 +43,23 @@ describe('#WorkspaceClient', () => {
   const find = jest.fn();
   const addToWorkspaces = jest.fn();
   const deleteFromWorkspaces = jest.fn();
+  const savedObjectClient = ({
+    find,
+    addToWorkspaces,
+    deleteFromWorkspaces,
+    create: jest.fn(),
+    get: jest.fn().mockResolvedValue({
+      attributes: {
+        name: mockWorkspaceName,
+      },
+    }),
+  } as unknown) as SavedObjectsClientContract;
   const savedObjects = ({
     ...coreSetup.savedObjects,
-    getScopedClient: () => ({
-      find,
-      addToWorkspaces,
-      deleteFromWorkspaces,
-      get: jest.fn().mockResolvedValue({
-        attributes: {
-          name: mockWorkspaceName,
-        },
-      }),
-    }),
+    getScopedClient: () => savedObjectClient,
   } as unknown) as SavedObjectsServiceStart;
+
+  const uiSettings = uiSettingsServiceMock.createStartContract();
 
   const mockRequestDetail = ({
     request: httpServerMock.createOpenSearchDashboardsRequest(),
@@ -56,7 +68,7 @@ describe('#WorkspaceClient', () => {
   } as unknown) as IRequestDetail;
 
   it('create# should not call addToWorkspaces if no data sources passed', async () => {
-    const client = new WorkspaceClient(coreSetup);
+    const client = new WorkspaceClient(coreSetup, logger);
     await client.setup(coreSetup);
     client?.setSavedObjects(savedObjects);
 
@@ -69,7 +81,7 @@ describe('#WorkspaceClient', () => {
   });
 
   it('create# should call addToWorkspaces with passed data sources normally', async () => {
-    const client = new WorkspaceClient(coreSetup);
+    const client = new WorkspaceClient(coreSetup, logger);
     await client.setup(coreSetup);
     client?.setSavedObjects(savedObjects);
 
@@ -84,8 +96,25 @@ describe('#WorkspaceClient', () => {
     ]);
   });
 
+  it('create# should call set default data source after creating', async () => {
+    const client = new WorkspaceClient(coreSetup, logger);
+    await client.setup(coreSetup);
+    client?.setSavedObjects(savedObjects);
+    client?.setUiSettings(uiSettings);
+
+    await client.create(mockRequestDetail, {
+      name: mockWorkspaceName,
+      permissions: {},
+      dataSources: ['id1'],
+    });
+
+    const uiSettingsClient = uiSettings.asScopedToClient(savedObjectClient);
+
+    expect(mockCheckAndSetDefaultDataSource).toHaveBeenCalledWith(uiSettingsClient, ['id1'], false);
+  });
+
   it('update# should not call addToWorkspaces if no new data sources added', async () => {
-    const client = new WorkspaceClient(coreSetup);
+    const client = new WorkspaceClient(coreSetup, logger);
     await client.setup(coreSetup);
     client?.setSavedObjects(savedObjects);
 
@@ -99,7 +128,7 @@ describe('#WorkspaceClient', () => {
   });
 
   it('update# should call deleteFromWorkspaces if there is data source to be removed', async () => {
-    const client = new WorkspaceClient(coreSetup);
+    const client = new WorkspaceClient(coreSetup, logger);
     await client.setup(coreSetup);
     client?.setSavedObjects(savedObjects);
 
@@ -117,7 +146,7 @@ describe('#WorkspaceClient', () => {
     ]);
   });
   it('update# should calculate data sources to be added and to be removed', async () => {
-    const client = new WorkspaceClient(coreSetup);
+    const client = new WorkspaceClient(coreSetup, logger);
     await client.setup(coreSetup);
     client?.setSavedObjects(savedObjects);
 
@@ -133,5 +162,22 @@ describe('#WorkspaceClient', () => {
     expect(deleteFromWorkspaces).toHaveBeenCalledWith(DATA_SOURCE_SAVED_OBJECT_TYPE, 'id2', [
       mockWorkspaceId,
     ]);
+  });
+
+  it('update# should call set default data source with check after updating', async () => {
+    const client = new WorkspaceClient(coreSetup, logger);
+    await client.setup(coreSetup);
+    client?.setSavedObjects(savedObjects);
+    client?.setUiSettings(uiSettings);
+
+    await client.update(mockRequestDetail, mockWorkspaceId, {
+      name: mockWorkspaceName,
+      permissions: {},
+      dataSources: ['id1'],
+    });
+
+    const uiSettingsClient = uiSettings.asScopedToClient(savedObjectClient);
+
+    expect(mockCheckAndSetDefaultDataSource).toHaveBeenCalledWith(uiSettingsClient, ['id1'], true);
   });
 });


### PR DESCRIPTION
## Description

Manual backport https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7188

## Changelog

- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
