### PR TITLE
[Manual Backport][2.x][Data Source] Restrict to manage data source on the DSM UI

### DIFF
--- a/changelogs/fragments/7214.yml
+++ b/changelogs/fragments/7214.yml
@@ -1,0 +1,2 @@
+feat:
+- [DataSource] Restrict to edit data source on the DSM UI. ([#7214](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7214))

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -321,6 +321,12 @@
 #   AWSSigV4:
 #     enabled: true
 
+# Optional setting that controls the permissions of data source to create, update and delete.
+# "none": The data source is readonly for all users.
+# "dashboard_admin": The data source can only be managed by dashboard admin.
+# "all": The data source can be managed by all users. Default to "all".
+# data_source.manageableBy: "all"
+
 # Set the value of this setting to false to hide the help menu link to the OpenSearch Dashboards user survey
 # opensearchDashboards.survey.url: "https://survey.opensearch.org"
 

--- a/src/plugins/data_source/common/data_sources/types.ts
+++ b/src/plugins/data_source/common/data_sources/types.ts
@@ -60,3 +60,9 @@ export enum DataSourceEngineType {
   Elasticsearch = 'Elasticsearch',
   NA = 'No Engine Type Available',
 }
+
+export enum ManageableBy {
+  All = 'all',
+  DashboardAdmin = 'dashboard_admin',
+  None = 'none',
+}

--- a/src/plugins/data_source/config.ts
+++ b/src/plugins/data_source/config.ts
@@ -59,6 +59,10 @@ export const configSchema = schema.object({
       enabled: schema.boolean({ defaultValue: true }),
     }),
   }),
+  manageableBy: schema.oneOf(
+    [schema.literal('all'), schema.literal('dashboard_admin'), schema.literal('none')],
+    { defaultValue: 'all' }
+  ),
 });
 
 export type DataSourcePluginConfigType = TypeOf<typeof configSchema>;

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -33,6 +33,8 @@ import { registerTestConnectionRoute } from './routes/test_connection';
 import { registerFetchDataSourceMetaDataRoute } from './routes/fetch_data_source_metadata';
 import { AuthenticationMethodRegistry, IAuthenticationMethodRegistry } from './auth_registry';
 import { CustomApiSchemaRegistry } from './schema_registry';
+import { ManageableBy } from '../common/data_sources';
+import { getWorkspaceState } from '../../../../src/core/server/utils';
 
 export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourcePluginStart> {
   private readonly logger: Logger;
@@ -80,6 +82,25 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
       DATA_SOURCE_SAVED_OBJECT_TYPE,
       dataSourceSavedObjectsClientWrapper.wrapperFactory
     );
+
+    const { manageableBy } = config;
+    core.capabilities.registerProvider(() => ({
+      dataSource: {
+        canManage: false,
+      },
+    }));
+
+    core.capabilities.registerSwitcher((request) => {
+      const { requestWorkspaceId, isDashboardAdmin } = getWorkspaceState(request);
+      // User can not manage data source in the workspace.
+      const canManage =
+        (manageableBy === ManageableBy.All && !requestWorkspaceId) ||
+        (manageableBy === ManageableBy.DashboardAdmin &&
+          isDashboardAdmin !== false &&
+          !requestWorkspaceId);
+
+      return { dataSource: { canManage } };
+    });
 
     core.logging.configure(
       this.config$.pipe<LoggerContextConfigInput>(

--- a/src/plugins/data_source_management/public/components/data_source_table/__snapshots__/data_source_table.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_table/__snapshots__/data_source_table.test.tsx.snap
@@ -2532,3 +2532,1105 @@ exports[`DataSourceTable should get datasources successful should render normall
   </DataSourceTable>
 </IntlProvider>
 `;
+
+exports[`DataSourceTable should not manage datasources when canManageDataSource is false should render empty table 1`] = `
+<IntlProvider
+  locale="en"
+>
+  <DataSourceTable
+    history={
+      Object {
+        "action": "PUSH",
+        "block": [MockFunction],
+        "createHref": [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "alpha-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "beta-test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test",
+              },
+            ],
+            Array [
+              Object {
+                "pathname": "test2",
+              },
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
+        "createSubHistory": [MockFunction],
+        "go": [MockFunction],
+        "goBack": [MockFunction],
+        "goForward": [MockFunction],
+        "length": 1,
+        "listen": [MockFunction],
+        "location": Object {
+          "hash": "",
+          "key": undefined,
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [MockFunction],
+        "replace": [MockFunction],
+      }
+    }
+    location={Object {}}
+    match={Object {}}
+  >
+    <EuiSpacer
+      size="l"
+    >
+      <div
+        className="euiSpacer euiSpacer--l"
+      />
+    </EuiSpacer>
+    <EuiPanel
+      data-test-subj="datasourceTableEmptyState"
+      hasBorder={false}
+      hasShadow={false}
+      style={
+        Object {
+          "textAlign": "center",
+        }
+      }
+    >
+      <div
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPanel--noBorder"
+        data-test-subj="datasourceTableEmptyState"
+        style={
+          Object {
+            "textAlign": "center",
+          }
+        }
+      >
+        <EuiText>
+          <div
+            className="euiText euiText--medium"
+          >
+            <FormattedMessage
+              defaultMessage="No Data Source Connections have been created yet."
+              id="dataSourcesManagement.dataSourcesTable.noData"
+              values={Object {}}
+            >
+              <span>
+                No Data Source Connections have been created yet.
+              </span>
+            </FormattedMessage>
+          </div>
+        </EuiText>
+        <EuiSpacer>
+          <div
+            className="euiSpacer euiSpacer--l"
+          />
+        </EuiSpacer>
+      </div>
+    </EuiPanel>
+    <EuiSpacer
+      size="l"
+    >
+      <div
+        className="euiSpacer euiSpacer--l"
+      />
+    </EuiSpacer>
+  </DataSourceTable>
+</IntlProvider>
+`;

--- a/src/plugins/data_source_management/public/components/data_source_table/__snapshots__/data_source_table.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_table/__snapshots__/data_source_table.test.tsx.snap
@@ -3576,61 +3576,1246 @@ exports[`DataSourceTable should not manage datasources when canManageDataSource 
     location={Object {}}
     match={Object {}}
   >
-    <EuiSpacer
-      size="l"
+    <EuiPageContent
+      aria-label="Data Sources"
+      data-test-subj="dataSourceTable"
+      role="region"
     >
-      <div
-        className="euiSpacer euiSpacer--l"
-      />
-    </EuiSpacer>
-    <EuiPanel
-      data-test-subj="datasourceTableEmptyState"
-      hasBorder={false}
-      hasShadow={false}
-      style={
-        Object {
-          "textAlign": "center",
-        }
-      }
-    >
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPanel--noBorder"
-        data-test-subj="datasourceTableEmptyState"
-        style={
-          Object {
-            "textAlign": "center",
-          }
-        }
+      <EuiPanel
+        aria-label="Data Sources"
+        className="euiPageContent"
+        data-test-subj="dataSourceTable"
+        paddingSize="l"
+        role="region"
       >
-        <EuiText>
-          <div
-            className="euiText euiText--medium"
+        <div
+          aria-label="Data Sources"
+          className="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent"
+          data-test-subj="dataSourceTable"
+          role="region"
+        >
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
           >
-            <FormattedMessage
-              defaultMessage="No Data Source Connections have been created yet."
-              id="dataSourcesManagement.dataSourcesTable.noData"
-              values={Object {}}
+            <div
+              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <span>
-                No Data Source Connections have been created yet.
-              </span>
-            </FormattedMessage>
-          </div>
-        </EuiText>
-        <EuiSpacer>
-          <div
-            className="euiSpacer euiSpacer--l"
-          />
-        </EuiSpacer>
-      </div>
-    </EuiPanel>
-    <EuiSpacer
-      size="l"
-    >
-      <div
-        className="euiSpacer euiSpacer--l"
-      />
-    </EuiSpacer>
+              <EuiFlexItem
+                grow={false}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <EuiTitle>
+                    <h2
+                      className="euiTitle euiTitle--medium"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Data Sources"
+                        id="dataSourcesManagement.dataSourcesTable.title"
+                        values={Object {}}
+                      >
+                        <span>
+                          Data Sources
+                        </span>
+                      </FormattedMessage>
+                    </h2>
+                  </EuiTitle>
+                  <EuiSpacer
+                    size="s"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--s"
+                    />
+                  </EuiSpacer>
+                  <EuiText>
+                    <div
+                      className="euiText euiText--medium"
+                    >
+                      <p>
+                        <FormattedMessage
+                          defaultMessage="Create and manage data source connections to help you retrieve data from multiple OpenSearch compatible sources."
+                          id="dataSourcesManagement.dataSourcesTable.description"
+                          values={Object {}}
+                        >
+                          <span>
+                            Create and manage data source connections to help you retrieve data from multiple OpenSearch compatible sources.
+                          </span>
+                        </FormattedMessage>
+                      </p>
+                    </div>
+                  </EuiText>
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem
+                grow={false}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <CreateButton
+                    dataTestSubj="createDataSourceButton"
+                    history={
+                      Object {
+                        "action": "PUSH",
+                        "block": [MockFunction],
+                        "createHref": [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "alpha-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "beta-test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test",
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "pathname": "test2",
+                              },
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        },
+                        "createSubHistory": [MockFunction],
+                        "go": [MockFunction],
+                        "goBack": [MockFunction],
+                        "goForward": [MockFunction],
+                        "length": 1,
+                        "listen": [MockFunction],
+                        "location": Object {
+                          "hash": "",
+                          "key": undefined,
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [MockFunction],
+                        "replace": [MockFunction],
+                      }
+                    }
+                  >
+                    <EuiButton
+                      data-test-subj="createDataSourceButton"
+                      fill={true}
+                      onClick={[Function]}
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButton"
+                        data-test-subj="createDataSourceButton"
+                        disabled={false}
+                        element="button"
+                        fill={true}
+                        isDisabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <button
+                          className="euiButton euiButton--primary euiButton--fill"
+                          data-test-subj="createDataSourceButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
+                          type="button"
+                        >
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text"
+                              >
+                                <FormattedMessage
+                                  defaultMessage="Create data source connection"
+                                  id="dataSourcesManagement.dataSourceListing.createButton"
+                                  values={Object {}}
+                                >
+                                  <span>
+                                    Create data source connection
+                                  </span>
+                                </FormattedMessage>
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonDisplay>
+                    </EuiButton>
+                  </CreateButton>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer>
+            <div
+              className="euiSpacer euiSpacer--l"
+            />
+          </EuiSpacer>
+          <EuiSpacer
+            size="l"
+          >
+            <div
+              className="euiSpacer euiSpacer--l"
+            />
+          </EuiSpacer>
+          <EuiPanel
+            data-test-subj="datasourceTableEmptyState"
+            hasBorder={false}
+            hasShadow={false}
+            style={
+              Object {
+                "textAlign": "center",
+              }
+            }
+          >
+            <div
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPanel--noBorder"
+              data-test-subj="datasourceTableEmptyState"
+              style={
+                Object {
+                  "textAlign": "center",
+                }
+              }
+            >
+              <EuiText>
+                <div
+                  className="euiText euiText--medium"
+                >
+                  <FormattedMessage
+                    defaultMessage="No Data Source Connections have been created yet."
+                    id="dataSourcesManagement.dataSourcesTable.noData"
+                    values={Object {}}
+                  >
+                    <span>
+                      No Data Source Connections have been created yet.
+                    </span>
+                  </FormattedMessage>
+                </div>
+              </EuiText>
+              <EuiSpacer>
+                <div
+                  className="euiSpacer euiSpacer--l"
+                />
+              </EuiSpacer>
+            </div>
+          </EuiPanel>
+          <EuiSpacer
+            size="l"
+          >
+            <div
+              className="euiSpacer euiSpacer--l"
+            />
+          </EuiSpacer>
+        </div>
+      </EuiPanel>
+    </EuiPageContent>
   </DataSourceTable>
 </IntlProvider>
 `;

--- a/src/plugins/data_source_management/public/components/data_source_table/data_source_table.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_table/data_source_table.test.tsx
@@ -24,7 +24,10 @@ const tableColumnHeaderButtonIdentifier = 'EuiTableHeaderCell .euiTableHeaderBut
 const emptyStateIdentifier = '[data-test-subj="datasourceTableEmptyState"]';
 
 describe('DataSourceTable', () => {
-  const mockedContext = mockManagementPlugin.createDataSourceManagementContext();
+  const mockedContext = {
+    ...mockManagementPlugin.createDataSourceManagementContext(),
+    application: { capabilities: { dataSource: { canManage: true } } },
+  };
   const uiSettings = mockedContext.uiSettings;
   let component: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
   const history = (scopedHistoryMock.create() as unknown) as ScopedHistory;
@@ -167,6 +170,38 @@ describe('DataSourceTable', () => {
       expect(utils.setFirstDataSourceAsDefault).not.toHaveBeenCalled();
       // @ts-ignore
       expect(component.find(confirmModalIdentifier).exists()).toBe(false);
+    });
+  });
+
+  describe('should not manage datasources when canManageDataSource is false', () => {
+    const mockedContextWithFalseManage = {
+      ...mockManagementPlugin.createDataSourceManagementContext(),
+      application: { capabilities: { dataSource: { canManage: false } } },
+    };
+    beforeEach(async () => {
+      spyOn(utils, 'getDataSources').and.returnValue(Promise.reject());
+      await act(async () => {
+        component = await mount(
+          wrapWithIntl(
+            <DataSourceTable
+              history={history}
+              location={({} as unknown) as RouteComponentProps['location']}
+              match={({} as unknown) as RouteComponentProps['match']}
+            />
+          ),
+          {
+            wrappingComponent: OpenSearchDashboardsContextProvider,
+            wrappingComponentProps: {
+              services: mockedContextWithFalseManage,
+            },
+          }
+        );
+      });
+      component.update();
+    });
+    test('should render empty table', () => {
+      expect(component).toMatchSnapshot();
+      expect(component.find(emptyStateIdentifier).exists()).toBe(true);
     });
   });
 });

--- a/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
@@ -57,6 +57,7 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
     savedObjects,
     notifications: { toasts },
     uiSettings,
+    application,
   } = useOpenSearchDashboards<DataSourceManagementContext>().services;
 
   /* Component state variables */
@@ -65,6 +66,7 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [isDeleting, setIsDeleting] = React.useState<boolean>(false);
   const [confirmDeleteVisible, setConfirmDeleteVisible] = React.useState(false);
+  const canManageDataSource = !!application.capabilities?.dataSource?.canManage;
 
   /* useEffectOnce hook to avoid these methods called multiple times when state is updated. */
   useEffectOnce(() => {
@@ -118,11 +120,11 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
   };
 
   const renderToolsRight = () => {
-    return (
+    return canManageDataSource ? (
       <EuiFlexItem key="delete" grow={false}>
         {renderDeleteButton()}
       </EuiFlexItem>
-    );
+    ) : null;
   };
 
   const search = {
@@ -372,7 +374,7 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
             }
           </EuiText>
           <EuiSpacer />
-          {createButtonEmptyState}
+          {canManageDataSource ? createButtonEmptyState : null}
         </EuiPanel>
         <EuiSpacer size="l" />
       </>

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.test.tsx
@@ -90,6 +90,7 @@ describe('Datasource Management: Edit Datasource Form', () => {
             onSetDefaultDataSource={mockFn}
             handleTestConnection={mockFn}
             displayToastMessage={mockFn}
+            canManageDataSource={true}
           />
         ),
         {
@@ -261,6 +262,7 @@ describe('Datasource Management: Edit Datasource Form', () => {
             handleSubmit={mockFn}
             handleTestConnection={mockFn}
             displayToastMessage={mockFn}
+            canManageDataSource={true}
           />
         ),
         {
@@ -373,6 +375,7 @@ describe('Datasource Management: Edit Datasource Form', () => {
             onSetDefaultDataSource={mockFn}
             handleTestConnection={mockFn}
             displayToastMessage={mockFn}
+            canManageDataSource={true}
           />
         ),
         {
@@ -593,6 +596,7 @@ describe('With Registered Authentication', () => {
           onSetDefaultDataSource={jest.fn()}
           handleTestConnection={jest.fn()}
           displayToastMessage={jest.fn()}
+          canManageDataSource={true}
         />
       ),
       {
@@ -634,6 +638,7 @@ describe('With Registered Authentication', () => {
           onSetDefaultDataSource={jest.fn()}
           handleTestConnection={jest.fn()}
           displayToastMessage={jest.fn()}
+          canManageDataSource={true}
         />
       ),
       {

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -56,6 +56,7 @@ export interface EditDataSourceProps {
   onDeleteDataSource?: () => Promise<void>;
   onSetDefaultDataSource: () => Promise<void>;
   displayToastMessage: (info: ToastMessageItem) => void;
+  canManageDataSource: boolean;
 }
 export interface EditDataSourceState {
   formErrorsByField: CreateEditDataSourceValidation;
@@ -644,6 +645,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
         onClickTestConnection={this.onClickTestConnection}
         onClickSetDefault={this.setDefaultDataSource}
         isDefault={this.props.isDefault}
+        canManageDataSource={this.props.canManageDataSource}
       />
     );
   };
@@ -1119,24 +1121,26 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
               />
             </EuiButtonEmpty>
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButton
-              className="mgtAdvancedSettingsForm__button"
-              disabled={!this.isFormValid()}
-              color="secondary"
-              fill
-              size="s"
-              iconType="check"
-              isLoading={this.state.isLoading}
-              onClick={this.onClickUpdateDataSource}
-              data-test-subj="datasource-edit-saveButton"
-            >
-              <FormattedMessage
-                id="dataSourcesManagement.editDataSource.saveButtonLabel"
-                defaultMessage="Save changes"
-              />
-            </EuiButton>
-          </EuiFlexItem>
+          {this.props.canManageDataSource ? (
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                className="mgtAdvancedSettingsForm__button"
+                disabled={!this.isFormValid()}
+                color="secondary"
+                fill
+                size="s"
+                iconType="check"
+                isLoading={this.state.isLoading}
+                onClick={this.onClickUpdateDataSource}
+                data-test-subj="datasource-edit-saveButton"
+              >
+                <FormattedMessage
+                  id="dataSourcesManagement.editDataSource.saveButtonLabel"
+                  defaultMessage="Save changes"
+                />
+              </EuiButton>
+            </EuiFlexItem>
+          ) : null}
         </EuiFlexGroup>
       </EuiBottomBar>
     );

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.test.tsx
@@ -34,6 +34,7 @@ describe('Datasource Management: Edit Datasource Header', () => {
             dataSourceName={dataSourceName}
             onClickSetDefault={mockFn}
             isDefault={false}
+            canManageDataSource={true}
           />
         ),
         {
@@ -87,6 +88,7 @@ describe('Datasource Management: Edit Datasource Header', () => {
             dataSourceName={dataSourceName}
             onClickSetDefault={mockFn}
             isDefault={false}
+            canManageDataSource={true}
           />
         ),
         {
@@ -116,6 +118,7 @@ describe('Datasource Management: Edit Datasource Header', () => {
             dataSourceName={dataSourceName}
             onClickSetDefault={onClickSetDefault}
             isDefault={isDefaultDataSourceState}
+            canManageDataSource={true}
           />
         ),
         {
@@ -152,6 +155,7 @@ describe('Datasource Management: Edit Datasource Header', () => {
             dataSourceName={dataSourceName}
             onClickSetDefault={onClickSetDefault}
             isDefault={isDefaultDataSourceState}
+            canManageDataSource={true}
           />
         ),
         {
@@ -172,6 +176,37 @@ describe('Datasource Management: Edit Datasource Header', () => {
       expect(component.find(setDefaultButtonIdentifier).first().prop('iconType')).toBe(
         'starFilled'
       );
+    });
+  });
+  describe('should not manage data source', () => {
+    beforeEach(() => {
+      component = mount(
+        wrapWithIntl(
+          <Header
+            isFormValid={true}
+            showDeleteIcon={true}
+            onClickDeleteIcon={mockFn}
+            onClickTestConnection={mockFn}
+            dataSourceName={dataSourceName}
+            onClickSetDefault={mockFn}
+            isDefault={false}
+            canManageDataSource={false}
+          />
+        ),
+        {
+          wrappingComponent: OpenSearchDashboardsContextProvider,
+          wrappingComponentProps: {
+            services: mockedContext,
+          },
+        }
+      );
+    });
+    test('should not show delete', () => {
+      expect(component.find(headerTitleIdentifier).last().text()).toBe(dataSourceName);
+      expect(component.find(deleteIconIdentifier).exists()).toBe(false);
+    });
+    test('should not show default icon', () => {
+      expect(component.find(setDefaultButtonIdentifier).exists()).toBe(false);
     });
   });
 });

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.tsx
@@ -29,6 +29,7 @@ export const Header = ({
   onClickSetDefault,
   dataSourceName,
   isDefault,
+  canManageDataSource,
 }: {
   showDeleteIcon: boolean;
   isFormValid: boolean;
@@ -37,6 +38,7 @@ export const Header = ({
   onClickSetDefault: () => void;
   dataSourceName: string;
   isDefault: boolean;
+  canManageDataSource: boolean;
 }) => {
   /* State Variables */
   const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
@@ -175,11 +177,15 @@ export const Header = ({
       <EuiFlexItem grow={false}>
         <EuiFlexGroup alignItems="baseline" gutterSize="m" responsive={false}>
           {/* Test default button */}
-          <EuiFlexItem grow={false}>{renderDefaultIcon()}</EuiFlexItem>
+          {canManageDataSource ? (
+            <EuiFlexItem grow={false}>{renderDefaultIcon()}</EuiFlexItem>
+          ) : null}
           {/* Test connection button */}
           <EuiFlexItem grow={false}>{renderTestConnectionButton()}</EuiFlexItem>
           {/* Delete icon button */}
-          <EuiFlexItem grow={false}>{showDeleteIcon ? renderDeleteButton() : null}</EuiFlexItem>
+          {canManageDataSource ? (
+            <EuiFlexItem grow={false}>{showDeleteIcon ? renderDeleteButton() : null}</EuiFlexItem>
+          ) : null}
         </EuiFlexGroup>
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.test.tsx
@@ -28,7 +28,10 @@ const formIdentifier = 'EditDataSourceForm';
 const notFoundIdentifier = '[data-test-subj="dataSourceNotFound"]';
 
 describe('Datasource Management: Edit Datasource Wizard', () => {
-  const mockedContext = mockManagementPlugin.createDataSourceManagementContext();
+  const mockedContext = {
+    ...mockManagementPlugin.createDataSourceManagementContext(),
+    application: { capabilities: { dataSource: { canManage: true } } },
+  };
   const uiSettings = mockedContext.uiSettings;
   mockedContext.authenticationMethodRegistry.registerAuthenticationMethod(
     noAuthCredentialAuthMethod

--- a/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.tsx
@@ -46,6 +46,7 @@ export const EditDataSource: React.FunctionComponent<RouteComponentProps<{ id: s
     setBreadcrumbs,
     http,
     notifications: { toasts },
+    application,
   } = useOpenSearchDashboards<DataSourceManagementContext>().services;
   const dataSourceID: string = props.match.params.id;
 
@@ -162,6 +163,7 @@ export const EditDataSource: React.FunctionComponent<RouteComponentProps<{ id: s
             handleSubmit={handleSubmit}
             displayToastMessage={handleDisplayToastMessage}
             handleTestConnection={handleTestConnection}
+            canManageDataSource={!!application.capabilities?.dataSource?.canManage}
           />
         ) : null}
         {isLoading || !dataSource?.endpoint ? <LoadingMask /> : null}

--- a/src/plugins/saved_objects_management/public/management_section/mount_section.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/mount_section.tsx
@@ -69,6 +69,11 @@ export const mountManagementSection = async ({
   if (allowedObjectTypes === undefined) {
     allowedObjectTypes = await getAllowedTypes(coreStart.http);
   }
+  // Restrict user to manage data source in the saved object management page according the manageableBy flag.
+  const showDataSource = !!coreStart.application.capabilities?.dataSource?.canManage;
+  allowedObjectTypes = showDataSource
+    ? allowedObjectTypes
+    : allowedObjectTypes.filter((type) => type !== 'data-source');
 
   coreStart.chrome.docTitle.change(title);
 


### PR DESCRIPTION
### Description

Manual backport https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7214

delete conflict file:
 - src/plugins/data_source_management/public/components/data_source_home_panel/data_source_home_panel.tsx
 - src/plugins/data_source_management/public/components/data_source_home_panel/data_source_home_panel.test.tsx

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
