### PR TITLE
Disable input in edit data source when data_source.manageableBy is none

### DIFF
--- a/changelogs/fragments/7307.yml
+++ b/changelogs/fragments/7307.yml
@@ -1,0 +1,2 @@
+feat:
+- Disable inputs in edit data source screen when data_source.manageableBy is none ([#7307](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7307))

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -933,9 +933,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             onBlur={this.validateAccessKey}
             spellCheck={false}
             disabled={
-              this.props.existingDataSource.auth.type === AuthType.SigV4 ||
-              !this.props.canManageDataSource
-            }
+              this.props.existingDataSource.auth.type === AuthType.SigV4}
             data-test-subj="editDataSourceFormAccessKeyField"
             name="dataSourceAccessKey"
           />
@@ -964,10 +962,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             onChange={this.onChangeSecretKey}
             onBlur={this.validateSecretKey}
             spellCheck={false}
-            disabled={
-              this.props.existingDataSource.auth.type === AuthType.SigV4 ||
-              !this.props.canManageDataSource
-            }
+            disabled={this.props.existingDataSource.auth.type === AuthType.SigV4}
             data-test-subj="editDataSourceFormSecretKeyField"
             name="dataSourceSecretKey"
           />

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -586,6 +586,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
       <>
         <EuiButton
           onClick={this.onClickUpdatePassword}
+          disabled={!this.props.canManageDataSource}
           data-test-subj="editDatasourceUpdatePasswordBtn"
         >
           {
@@ -601,6 +602,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             username={this.state.auth?.credentials?.username || ''}
             handleUpdatePassword={this.updatePassword}
             closeUpdatePasswordModal={this.closePasswordModal}
+            canManageDataSource={this.props.canManageDataSource}
           />
         ) : null}
       </>
@@ -613,6 +615,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
         <EuiButton
           onClick={this.onClickUpdateAwsCredential}
           data-test-subj="editDatasourceUpdateAwsCredentialBtn"
+          disabled={!this.props.canManageDataSource}
         >
           {
             <FormattedMessage
@@ -628,6 +631,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             service={this.state.auth.credentials!.service}
             handleUpdateAwsCredential={this.updateAwsCredential}
             closeUpdateAwsCredentialModal={this.closeAwsCredentialModal}
+            canManageDataSource={this.props.canManageDataSource}
           />
         ) : null}
       </>
@@ -725,6 +729,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
               isInvalid={!!this.state.formErrorsByField.title.length}
               onChange={this.onChangeTitle}
               onBlur={this.validateTitle}
+              disabled={!this.props.canManageDataSource}
             />
           </EuiFormRow>
           {/* Description */}
@@ -745,6 +750,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
                 }
               )}
               onChange={this.onChangeDescription}
+              disabled={!this.props.canManageDataSource}
             />
           </EuiFormRow>
         </EuiDescribedFormGroup>
@@ -837,7 +843,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             options={this.authOptions}
             valueOfSelected={this.state.auth.type}
             onChange={(value) => this.onChangeAuthType(value)}
-            disabled={this.authOptions.length <= 1}
+            disabled={this.authOptions.length <= 1 || !this.props.canManageDataSource}
             name="Credential"
             data-test-subj="editDataSourceSelectAuthType"
           />
@@ -883,6 +889,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             value={this.state.auth.credentials?.region || ''}
             onChange={this.onChangeRegion}
             onBlur={this.validateRegion}
+            disabled={!this.props.canManageDataSource}
             data-test-subj="editDataSourceFormRegionField"
             name="dataSourceRegion"
           />
@@ -895,6 +902,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
           <EuiSuperSelect
             options={sigV4ServiceOptions}
             valueOfSelected={this.state.auth.credentials?.service}
+            disabled={!this.props.canManageDataSource}
             onChange={(value) => this.onChangeSigV4ServiceName(value)}
             name="ServiceName"
             data-test-subj="editDataSourceFormSigV4ServiceTypeSelect"
@@ -924,7 +932,10 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             onChange={this.onChangeAccessKey}
             onBlur={this.validateAccessKey}
             spellCheck={false}
-            disabled={this.props.existingDataSource.auth.type === AuthType.SigV4}
+            disabled={
+              this.props.existingDataSource.auth.type === AuthType.SigV4 ||
+              !this.props.canManageDataSource
+            }
             data-test-subj="editDataSourceFormAccessKeyField"
             name="dataSourceAccessKey"
           />
@@ -953,7 +964,10 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             onChange={this.onChangeSecretKey}
             onBlur={this.validateSecretKey}
             spellCheck={false}
-            disabled={this.props.existingDataSource.auth.type === AuthType.SigV4}
+            disabled={
+              this.props.existingDataSource.auth.type === AuthType.SigV4 ||
+              !this.props.canManageDataSource
+            }
             data-test-subj="editDataSourceFormSecretKeyField"
             name="dataSourceSecretKey"
           />
@@ -989,6 +1003,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             isInvalid={!!this.state.formErrorsByField.createCredential?.username?.length}
             onChange={this.onChangeUsername}
             onBlur={this.validateUsername}
+            disabled={!this.props.canManageDataSource}
           />
         </EuiFormRow>
 
@@ -1018,7 +1033,10 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
                 spellCheck={false}
                 onChange={this.onChangePassword}
                 onBlur={this.validatePassword}
-                disabled={this.props.existingDataSource.auth.type === AuthType.UsernamePasswordType}
+                disabled={
+                  this.props.existingDataSource.auth.type === AuthType.UsernamePasswordType ||
+                  !this.props.canManageDataSource
+                }
                 data-test-subj="updateDataSourceFormPasswordField"
               />
             </EuiFlexItem>

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -932,8 +932,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
             onChange={this.onChangeAccessKey}
             onBlur={this.validateAccessKey}
             spellCheck={false}
-            disabled={
-              this.props.existingDataSource.auth.type === AuthType.SigV4}
+            disabled={this.props.existingDataSource.auth.type === AuthType.SigV4}
             data-test-subj="editDataSourceFormAccessKeyField"
             name="dataSourceAccessKey"
           />

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/update_aws_credential_modal/update_aws_credential_modal.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/update_aws_credential_modal/update_aws_credential_modal.test.tsx
@@ -20,6 +20,7 @@ describe('UpdateAwsCredentialModal', () => {
     service: SigV4ServiceName.OpenSearch,
     handleUpdateAwsCredential: mockHandleUpdateAwsCredential,
     closeUpdateAwsCredentialModal: mockCloseUpdateAwsCredentialModal,
+    canManageDataSource: true,
   };
 
   it('updates new access key state on input change', () => {

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/update_aws_credential_modal/update_aws_credential_modal.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/update_aws_credential_modal/update_aws_credential_modal.tsx
@@ -28,6 +28,7 @@ export interface UpdateAwsCredentialModalProps {
   service: SigV4ServiceName;
   handleUpdateAwsCredential: (accessKey: string, secretKey: string) => void;
   closeUpdateAwsCredentialModal: () => void;
+  canManageDataSource: boolean;
 }
 
 export const UpdateAwsCredentialModal = ({
@@ -35,6 +36,7 @@ export const UpdateAwsCredentialModal = ({
   service,
   handleUpdateAwsCredential,
   closeUpdateAwsCredentialModal,
+  canManageDataSource,
 }: UpdateAwsCredentialModalProps) => {
   /* State Variables */
   const [newAccessKey, setNewAccessKey] = useState<string>('');
@@ -134,6 +136,7 @@ export const UpdateAwsCredentialModal = ({
                 spellCheck={false}
                 onChange={(e) => setNewAccessKey(e.target.value)}
                 onBlur={validateNewAccessKey}
+                disabled={!canManageDataSource}
               />
             </EuiFormRow>
 
@@ -159,6 +162,7 @@ export const UpdateAwsCredentialModal = ({
                 spellCheck={false}
                 onChange={(e) => setNewSecretKey(e.target.value)}
                 onBlur={validateNewSecretKey}
+                disabled={!canManageDataSource}
               />
             </EuiFormRow>
           </EuiForm>

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/update_password_modal/__snapshots__/update_password_modal.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/update_password_modal/__snapshots__/update_password_modal.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Datasource Management: Update Stored Password Modal should render norma
   locale="en"
 >
   <UpdatePasswordModal
+    canManageDataSource={true}
     closeUpdatePasswordModal={[MockFunction]}
     handleUpdatePassword={[MockFunction]}
     username="test_user"
@@ -522,6 +523,7 @@ exports[`Datasource Management: Update Stored Password Modal should render norma
                                     <EuiFieldPassword
                                       compressed={false}
                                       data-test-subj="updateStoredPasswordUpdatedPasswordField"
+                                      disabled={false}
                                       fullWidth={false}
                                       id="generated-id"
                                       isInvalid={false}
@@ -540,6 +542,7 @@ exports[`Datasource Management: Update Stored Password Modal should render norma
                                           Array [
                                             <EuiButtonIcon
                                               aria-label="Show password as plain text. Note: this will visually expose your password on the screen."
+                                              disabled={false}
                                               iconType="eye"
                                               onClick={[Function]}
                                               title="Show password as plain text. Note: this will visually expose your password on the screen."
@@ -563,6 +566,7 @@ exports[`Datasource Management: Update Stored Password Modal should render norma
                                               <input
                                                 className="euiFieldPassword euiFieldPassword--inGroup euiFieldPassword--withToggle"
                                                 data-test-subj="updateStoredPasswordUpdatedPasswordField"
+                                                disabled={false}
                                                 id="generated-id"
                                                 name="updatedPassword"
                                                 onBlur={[Function]}
@@ -610,6 +614,7 @@ exports[`Datasource Management: Update Stored Password Modal should render norma
                                           <EuiButtonIcon
                                             aria-label="Show password as plain text. Note: this will visually expose your password on the screen."
                                             className="euiFormControlLayout__append"
+                                            disabled={false}
                                             iconType="eye"
                                             key="0/.0"
                                             onClick={[Function]}
@@ -618,6 +623,7 @@ exports[`Datasource Management: Update Stored Password Modal should render norma
                                             <button
                                               aria-label="Show password as plain text. Note: this will visually expose your password on the screen."
                                               className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiFormControlLayout__append"
+                                              disabled={false}
                                               onClick={[Function]}
                                               title="Show password as plain text. Note: this will visually expose your password on the screen."
                                               type="button"
@@ -686,6 +692,7 @@ exports[`Datasource Management: Update Stored Password Modal should render norma
                                     <EuiFieldPassword
                                       compressed={false}
                                       data-test-subj="updateStoredPasswordConfirmUpdatedPasswordField"
+                                      disabled={false}
                                       fullWidth={false}
                                       id="generated-id"
                                       isInvalid={false}
@@ -704,6 +711,7 @@ exports[`Datasource Management: Update Stored Password Modal should render norma
                                           Array [
                                             <EuiButtonIcon
                                               aria-label="Show password as plain text. Note: this will visually expose your password on the screen."
+                                              disabled={false}
                                               iconType="eye"
                                               onClick={[Function]}
                                               title="Show password as plain text. Note: this will visually expose your password on the screen."
@@ -727,6 +735,7 @@ exports[`Datasource Management: Update Stored Password Modal should render norma
                                               <input
                                                 className="euiFieldPassword euiFieldPassword--inGroup euiFieldPassword--withToggle"
                                                 data-test-subj="updateStoredPasswordConfirmUpdatedPasswordField"
+                                                disabled={false}
                                                 id="generated-id"
                                                 name="confirmUpdatedPassword"
                                                 onBlur={[Function]}
@@ -774,6 +783,7 @@ exports[`Datasource Management: Update Stored Password Modal should render norma
                                           <EuiButtonIcon
                                             aria-label="Show password as plain text. Note: this will visually expose your password on the screen."
                                             className="euiFormControlLayout__append"
+                                            disabled={false}
                                             iconType="eye"
                                             key="0/.0"
                                             onClick={[Function]}
@@ -782,6 +792,7 @@ exports[`Datasource Management: Update Stored Password Modal should render norma
                                             <button
                                               aria-label="Show password as plain text. Note: this will visually expose your password on the screen."
                                               className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiFormControlLayout__append"
+                                              disabled={false}
                                               onClick={[Function]}
                                               title="Show password as plain text. Note: this will visually expose your password on the screen."
                                               type="button"

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/update_password_modal/update_password_modal.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/update_password_modal/update_password_modal.test.tsx
@@ -30,6 +30,7 @@ describe('Datasource Management: Update Stored Password Modal', () => {
           username={mockUserName}
           handleUpdatePassword={mockFn}
           closeUpdatePasswordModal={mockFn}
+          canManageDataSource={true}
         />
       ),
       {

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/update_password_modal/update_password_modal.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/update_password_modal/update_password_modal.tsx
@@ -25,12 +25,14 @@ export interface UpdatePasswordModalProps {
   username: string;
   handleUpdatePassword: (password: string) => void;
   closeUpdatePasswordModal: () => void;
+  canManageDataSource: boolean;
 }
 
 export const UpdatePasswordModal = ({
   username,
   handleUpdatePassword,
   closeUpdatePasswordModal,
+  canManageDataSource,
 }: UpdatePasswordModalProps) => {
   /* State Variables */
   const [newPassword, setNewPassword] = useState<string>('');
@@ -128,6 +130,7 @@ export const UpdatePasswordModal = ({
                 spellCheck={false}
                 onChange={(e) => setNewPassword(e.target.value)}
                 onBlur={validateNewPassword}
+                disabled={!canManageDataSource}
               />
             </EuiFormRow>
             {/* Password */}
@@ -153,6 +156,7 @@ export const UpdatePasswordModal = ({
                 spellCheck={false}
                 onChange={(e) => setConfirmNewPassword(e.target.value)}
                 onBlur={validateConfirmNewPassword}
+                disabled={!canManageDataSource}
               />
             </EuiFormRow>
           </EuiForm>


### PR DESCRIPTION
### Description

Disable the input fields on the edit data source form when data_source.manageableBy is set to none. For OpenSearch connections.

## Screenshot
No Authentication - data_source.manageableBy: "none"
![Screenshot 2024-07-18 at 10 51 13 AM](https://github.com/user-attachments/assets/44a177be-b2ab-4cf7-b4be-07a852928f8e)
No Authentication - data_source.manageableBy: "all"
![Screenshot 2024-07-18 at 11 31 48 AM](https://github.com/user-attachments/assets/11037ad5-4595-4208-90a7-7f5fad9e8808)

Username and Password Authentication - data_source.manageableBy: "none"
![Screenshot 2024-07-18 at 10 51 28 AM](https://github.com/user-attachments/assets/b2afd2c7-8aa0-4dfa-8d29-e8eb5d39eda2)

Username and Password Authentication - data_source.manageableBy: "all"
![Screenshot 2024-07-18 at 11 34 25 AM](https://github.com/user-attachments/assets/20e7a153-b9c2-4c40-8fb9-ce0665bbc86a)


AWS Authentication - data_source.manageableBy: "none"
![Screenshot 2024-07-18 at 10 51 41 AM](https://github.com/user-attachments/assets/b04339ca-f72f-4d04-98d4-75d0f2aca6e6)

AWS Authentication - data_source.manageableBy: "all"
![Screenshot 2024-07-18 at 11 34 12 AM](https://github.com/user-attachments/assets/e3dfced1-6109-4eed-a132-44f10dd45bb3)

## Testing the changes
1. data_source.enabled: true
data_source.manageableBy: "none"
2. yarn start
3. Use data source management

## Changelog

- feat: Disable inputs in edit data source screen when data_source.manageableBy is none


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
