### PR TITLE
[Navigation] Update dev tools tab css for new left navigation

### DIFF
--- a/changelogs/fragments/7328.yml
+++ b/changelogs/fragments/7328.yml
@@ -1,0 +1,2 @@
+fix:
+- [Navigation] Update dev tools tab css for new left navigation ([#7328](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7328))

--- a/src/plugins/dev_tools/public/index.scss
+++ b/src/plugins/dev_tools/public/index.scss
@@ -26,9 +26,3 @@
   margin: 7px 8px 0 0;
   min-width: 400px;
 }
-
-.devAppTabs {
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: space-between;
-}


### PR DESCRIPTION
### Description

As part of new left navigation Workbench would be moved to dev tools. To make this happen we have registered workbench based on the new nav condition. The css in devtools is making the tabs justify apart `justify-content: space-between;`. Removing this css is fixing the UI and keeping it as expected. This PR removes the unnecessary css on dev tools Tab.

### Issues Resolved

Related Workbench PR: https://github.com/opensearch-project/dashboards-query-workbench/pull/349 


## Screenshot



Before:
<img width="1792" alt="Screenshot 2024-07-19 at 3 14 04 PM" src="https://github.com/user-attachments/assets/639fe06b-e95e-4695-9d8e-197731de23ca">





After:
<img width="1792" alt="Screenshot 2024-07-19 at 3 15 11 PM" src="https://github.com/user-attachments/assets/c6d38c6f-ee5d-429b-952f-d4239fbd2c41">
<img width="1791" alt="Screenshot 2024-07-19 at 3 15 21 PM" src="https://github.com/user-attachments/assets/1f342850-627c-449d-9067-4cb8e74b2b15">


## Testing the changes

1. Load dashboards core in local setup
2. Add workbench plugin from main/2.x branch
3. Add the feature flag for new nav. 
4. Move to dev tools and looks at the tabs spacing. 

## Changelog 
- fix: [Navigation] Update dev tools tab css for new left navigation
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
