### PR TITLE
[Look&Feel] Apply missing guidance for visBuilder

### DIFF
--- a/changelogs/fragments/7341.yml
+++ b/changelogs/fragments/7341.yml
@@ -1,0 +1,2 @@
+refactor:
+- [Look&Feel] Apply guidance for visBuilder ([#7341](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7341))

--- a/src/plugins/data/public/ui/apply_filters/apply_filter_popover_content.tsx
+++ b/src/plugins/data/public/ui/apply_filters/apply_filter_popover_content.tsx
@@ -38,6 +38,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiCompressedSwitch,
+  EuiText,
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import React, { Component } from 'react';
@@ -100,10 +101,14 @@ export default class ApplyFiltersPopoverContent extends Component<Props, State> 
       <React.Fragment>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <FormattedMessage
-              id="data.filter.applyFilters.popupHeader"
-              defaultMessage="Select filters to apply"
-            />
+            <EuiText size="s">
+              <h2>
+                <FormattedMessage
+                  id="data.filter.applyFilters.popupHeader"
+                  defaultMessage="Select filters to apply"
+                />
+              </h2>
+            </EuiText>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 

--- a/src/plugins/vis_builder/public/application/components/data_tab/field_bucket.test.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/field_bucket.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+// @ts-ignore
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
+import { IndexPatternField } from '../../../../../data/common';
+// @ts-ignore
+import { findTestSubject } from '@elastic/eui/lib/test';
+import { FieldBucket } from './field_bucket';
+import { Bucket } from './types';
+
+const mockUseIndexPatterns = jest.fn(() => ({ selected: 'mockIndexPattern' }));
+const mockUseOnAddFilter = jest.fn();
+jest.mock('../../utils/use', () => ({
+  useIndexPatterns: jest.fn(() => mockUseIndexPatterns),
+  useOnAddFilter: jest.fn(() => mockUseOnAddFilter),
+}));
+
+describe('visBuilder field bucket', function () {
+  function mountComponent(field: IndexPatternField, bucket: Bucket) {
+    const compProps = { field, bucket };
+    return mountWithIntl(<FieldBucket {...compProps} />);
+  }
+
+  it('should render with buttons if field is filterable', async () => {
+    const field = new IndexPatternField(
+      {
+        name: 'bytes',
+        type: 'number',
+        esTypes: ['long'],
+        count: 10,
+        scripted: false,
+        searchable: true,
+        aggregatable: true,
+        readFromDocValues: true,
+      },
+      'bytes'
+    );
+    const bucket = {
+      display: `display`,
+      value: `value`,
+      percent: 25,
+      count: 100,
+    };
+    const comp = mountComponent(field, bucket);
+    const addButton = findTestSubject(comp, 'plus-bytes-value');
+    const minusButton = findTestSubject(comp, 'minus-bytes-value');
+    expect(addButton.length).toBe(1);
+    expect(minusButton.length).toBe(1);
+
+    addButton.simulate('click');
+    minusButton.simulate('click');
+    expect(mockUseOnAddFilter).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/plugins/vis_builder/public/application/components/data_tab/field_bucket.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/field_bucket.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiProgress,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 
@@ -35,11 +36,20 @@ export function FieldBucket({ bucket, field }: FieldBucketProps) {
     // We need this to communicate to users when a top value is actually an empty string
     defaultMessage: 'Empty string',
   });
+  const addText = i18n.translate('visBuilder.fieldSelector.detailsView.filterValueButtonToolTip', {
+    defaultMessage: 'Filter for value',
+  });
   const addLabel = i18n.translate(
     'visBuilder.fieldSelector.detailsView.filterValueButtonAriaLabel',
     {
       defaultMessage: 'Filter for {fieldName}: "{value}"',
       values: { fieldName, value },
+    }
+  );
+  const removeText = i18n.translate(
+    'visBuilder.fieldSelector.detailsView.filterOutValueButtonToolTip',
+    {
+      defaultMessage: 'Filter out value',
     }
   );
   const removeLabel = i18n.translate(
@@ -84,22 +94,26 @@ export function FieldBucket({ bucket, field }: FieldBucketProps) {
         {isFilterableField && (
           <EuiFlexItem grow={false}>
             <div>
-              <EuiSmallButtonIcon
-                className="vbFieldDetails__filterButton"
-                iconSize="s"
-                iconType="plusInCircle"
-                onClick={() => onAddFilter(field, value, '+')}
-                aria-label={addLabel}
-                data-test-subj={`plus-${fieldName}-${value}`}
-              />
-              <EuiSmallButtonIcon
-                className="vbFieldDetails__filterButton"
-                iconSize="s"
-                iconType="minusInCircle"
-                onClick={() => onAddFilter(field, value, '-')}
-                aria-label={removeLabel}
-                data-test-subj={`minus-${fieldName}-${value}`}
-              />
+              <EuiToolTip content={addText} delay="long" position="bottom">
+                <EuiSmallButtonIcon
+                  className="vbFieldDetails__filterButton"
+                  iconSize="s"
+                  iconType="plusInCircle"
+                  onClick={() => onAddFilter(field, value, '+')}
+                  aria-label={addLabel}
+                  data-test-subj={`plus-${fieldName}-${value}`}
+                />
+              </EuiToolTip>
+              <EuiToolTip content={removeText} delay="long" position="bottom">
+                <EuiSmallButtonIcon
+                  className="vbFieldDetails__filterButton"
+                  iconSize="s"
+                  iconType="minusInCircle"
+                  onClick={() => onAddFilter(field, value, '-')}
+                  aria-label={removeLabel}
+                  data-test-subj={`minus-${fieldName}-${value}`}
+                />
+              </EuiToolTip>
             </div>
           </EuiFlexItem>
         )}

--- a/src/plugins/vis_builder/public/application/components/data_tab/field_details.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/field_details.tsx
@@ -53,7 +53,7 @@ export function FieldDetailsView({ field, details }: FieldDetailsProps) {
 
   return (
     <>
-      <EuiPopoverTitle>{title}</EuiPopoverTitle>
+      <EuiPopoverTitle tabIndex={0}>{title}</EuiPopoverTitle>
       <div className="vbFieldDetails" data-test-subj="fieldDetailsContainer">
         {error ? (
           <EuiText size="xs" data-test-subj="fieldDetailsError">

--- a/src/plugins/vis_default_editor/public/components/sidebar/controls.tsx
+++ b/src/plugins/vis_default_editor/public/components/sidebar/controls.tsx
@@ -109,7 +109,7 @@ function DefaultEditorControls({
                 data-test-subj="visualizeEditorRenderButton"
                 disabled={!isDirty}
                 fill
-                iconType="play"
+                iconType="refresh"
                 onClick={applyChanges}
                 size="s"
               >


### PR DESCRIPTION
### Description

Applies look and feel pattern guidance to components in visBuilder. 

## Screenshot

| Scope | Before (v7Light) | After (v7Light) | Before (v8dark) | After (v8dark) |
| ----- | ----- | ----- | ----- | ----- |
| Flyover: Update icon | <img width="323" alt="Flyover Update v7 Light Before" src="https://github.com/user-attachments/assets/073a5a8d-9fa9-42e4-bda7-ba72fb6ae0c9"> | <img width="323" alt="Flyover Update v7 Light Post" src="https://github.com/user-attachments/assets/1cfb226d-5810-4cd7-b3e4-068184e0f7f3"> | <img width="323" alt="Flyover Update v8 Dark Before" src="https://github.com/user-attachments/assets/9da2e0a0-b64b-4558-bb0d-4ca38379741a"> | <img width="323" alt="Flyover Update v8 Dark Post" src="https://github.com/user-attachments/assets/5188b652-1112-47d1-90e2-a8ae643f9c48"> |
| Modal: Semantic header | <img width="386" alt="VisBuilder Modal v7 Light Before" src="https://github.com/user-attachments/assets/d176ddaa-dd31-4c65-ae48-2e7421b1502f"> | <img width="386" alt="VisBuilder Modal v7 Light Post" src="https://github.com/user-attachments/assets/90f25c2d-3234-48e6-8894-e6e385758f17"> | <img width="386" alt="VisBuilder Modal v8 Dark Before" src="https://github.com/user-attachments/assets/f65b1366-404d-46a0-8db6-a0d19f847333"> | <img width="386" alt="VisBuilder Modal v8 Dark Post" src="https://github.com/user-attachments/assets/b930af7c-d53e-4cc5-bb1f-f16bf2e479a9"> |
| Field detail: Adding tooltip | <img width="251" alt="Tooltip v7 Light Before" src="https://github.com/user-attachments/assets/60b02937-54e5-4022-b073-b524a0afbbcf"> | <img width="251" alt="Tooltip v7 Light Post" src="https://github.com/user-attachments/assets/6e91369b-ec68-428b-a55f-3bc05ff593c2"> | <img width="251" alt="Tooltip v8 Dark Before" src="https://github.com/user-attachments/assets/30be6971-7e05-40a0-b255-9b3ddcf27729"> | <img width="251" alt="Tooltip v8 Dark Post" src="https://github.com/user-attachments/assets/dad18a3c-0978-463d-a43f-26b8afd46150"> |

## Changelog
- refactor: [Look&Feel] Apply guidance for visBuilder

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
