### PR TITLE
add dataSourceId to dataSet

### DIFF
--- a/src/plugins/data/public/data_sources/datasource/types.ts
+++ b/src/plugins/data/public/data_sources/datasource/types.ts
@@ -12,6 +12,7 @@ import { DataSource } from './datasource';
 export interface IndexPatternOption {
   title: string;
   id: string;
+  dataSourceId?: string;
 }
 
 export interface IDataSourceGroup {

--- a/src/plugins/data/public/data_sources/default_datasource/default_datasource.test.ts
+++ b/src/plugins/data/public/data_sources/default_datasource/default_datasource.test.ts
@@ -48,8 +48,8 @@ describe('DefaultDslDataSource', () => {
 
   it('should return a populated dataset if getCache returns non-empty array', async () => {
     const mockSavedObjects = [
-      { id: '1', attributes: { title: 'Index1' } },
-      { id: '2', attributes: { title: 'Index2' } },
+      { id: '1', attributes: { title: 'Index1' }, references: [] },
+      { id: '2', attributes: { title: 'Index2' }, references: [] },
     ];
     indexPatternsMock.getCache.mockResolvedValue(mockSavedObjects);
     const dataSource = new DefaultDslDataSource({

--- a/src/plugins/data/public/data_sources/default_datasource/default_datasource.ts
+++ b/src/plugins/data/public/data_sources/default_datasource/default_datasource.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getDataSourceReference } from '../../../common/index_patterns/utils';
 import { SavedObject } from '../../../../../core/public';
 import {
   IndexPatternSavedObjectAttrs,
@@ -54,6 +55,7 @@ export class DefaultDslDataSource extends DataSource<
         return {
           id: savedObject.id,
           title: savedObject.attributes.title,
+          dataSourceId: getDataSourceReference(savedObject.references)?.id,
         };
       }),
     };


### PR DESCRIPTION
### Description
In `DataSourceSelectable` component, for current selected data source of type `DataSourceOption`, calling `await selectedSource?.ds.getDataSet()` returned all data sets with only `id` and `title`, now added corresponding `dataSourceId` to data set so that by selecting from the dropdown, I can tell what's the current select data set's data source id.

With dataSourceAdded, `await selectedSource?.ds.getDataSet()` should return:
<img width="1325" alt="image" src="https://github.com/user-attachments/assets/903b486f-b635-4cd8-ac43-4d3f20b8fcfb">


<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- feat: expose data source id in data set of DataSourceSelectable component

Descriptions following the prefixes must be 100 characters long or less
-->

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
