### PR TITLE
[Manual][Backport 2.x][Workspace]Hide create workspace button for non dashboard admin

### DIFF
--- a/changelogs/fragments/7357.yml
+++ b/changelogs/fragments/7357.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace]Hide create workspace button for non dashboard admin ([#7357](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7357))

--- a/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
@@ -81,25 +81,6 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                 </div>
               </div>
             </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <button
-                class="euiButton euiButton--primary"
-                data-test-subj="workspaceList-create-workspace"
-                type="button"
-              >
-                <span
-                  class="euiButtonContent euiButton__content"
-                >
-                  <span
-                    class="euiButton__text"
-                  >
-                    Create workspace
-                  </span>
-                </span>
-              </button>
-            </div>
           </div>
           <div
             class="euiSpacer euiSpacer--l"

--- a/src/plugins/workspace/public/components/workspace_list/index.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.test.tsx
@@ -28,9 +28,16 @@ function getWrapWorkspaceListInContext(
     { id: 'id1', name: 'name1', features: ['use-case-all'] },
     { id: 'id2', name: 'name2' },
     { id: 'id3', name: 'name3', features: ['use-case-observability'] },
-  ]
+  ],
+  isDashboardAdmin = true
 ) {
   const coreStartMock = coreMock.createStart();
+  coreStartMock.application.capabilities = {
+    ...coreStartMock.application.capabilities,
+    dashboards: {
+      isDashboardAdmin,
+    },
+  };
 
   const services = {
     ...coreStartMock,
@@ -134,5 +141,17 @@ describe('WorkspaceList', () => {
     fireEvent.click(paginationButton);
     expect(queryByText('name1')).not.toBeInTheDocument();
     expect(getByText('name6')).toBeInTheDocument();
+  });
+
+  it('should display create workspace button for dashboard admin', async () => {
+    const { getByText } = render(getWrapWorkspaceListInContext([], true));
+
+    expect(getByText('Create workspace')).toBeInTheDocument();
+  });
+
+  it('should hide create workspace button for non dashboard admin', async () => {
+    const { queryByText } = render(getWrapWorkspaceListInContext([], false));
+
+    expect(queryByText('Create workspace')).toBeNull();
   });
 });

--- a/src/plugins/workspace/public/components/workspace_list/index.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.tsx
@@ -26,7 +26,7 @@ import { WORKSPACE_CREATE_APP_ID } from '../../../common/constants';
 
 import { cleanWorkspaceId } from '../../../../../core/public';
 import { DeleteWorkspaceModal } from '../delete_workspace_modal';
-import { getFirstUseCaseOfFeatureConfigs, getUseCaseFromFeatureConfig } from '../../utils';
+import { getFirstUseCaseOfFeatureConfigs } from '../../utils';
 import { WorkspaceUseCase } from '../../types';
 
 const WORKSPACE_LIST_PAGE_DESCRIPTION = i18n.translate('workspace.list.description', {
@@ -43,6 +43,7 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
     services: { workspaces, application, http },
   } = useOpenSearchDashboards();
   const registeredUseCases = useObservable(registeredUseCases$);
+  const isDashboardAdmin = application?.capabilities?.dashboards?.isDashboardAdmin;
 
   const initialSortField = 'name';
   const initialSortDirection = 'asc';
@@ -172,13 +173,19 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
       incremental: true,
     },
     toolsRight: [
-      <EuiButton
-        href={workspaceCreateUrl}
-        key="create_workspace"
-        data-test-subj="workspaceList-create-workspace"
-      >
-        Create workspace
-      </EuiButton>,
+      ...(isDashboardAdmin
+        ? [
+            <EuiButton
+              href={workspaceCreateUrl}
+              key="create_workspace"
+              data-test-subj="workspaceList-create-workspace"
+            >
+              {i18n.translate('workspace.workspaceList.buttons.createWorkspace', {
+                defaultMessage: 'Create workspace',
+              })}
+            </EuiButton>,
+          ]
+        : []),
     ],
   };
 

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
@@ -62,7 +62,7 @@ describe('<WorkspaceMenu />', () => {
   it('should display a list of workspaces in the dropdown', () => {
     coreStartMock.workspaces.workspaceList$.next([
       { id: 'workspace-1', name: 'workspace 1', features: [] },
-      { id: 'workspace-2', name: 'workspace 2', features: [] },
+      { id: 'workspace-2', name: 'workspace 2' },
     ]);
 
     render(<WorkspaceMenuCreatorComponent />);
@@ -169,5 +169,20 @@ describe('<WorkspaceMenu />', () => {
     fireEvent.click(screen.getByTestId('workspace-select-button'));
     fireEvent.click(screen.getByText(/View all/i));
     expect(coreStartMock.application.navigateToApp).toHaveBeenCalledWith('workspace_list');
+  });
+
+  it('should hide create workspace button for non dashboard admin', () => {
+    coreStartMock.application.capabilities = {
+      ...coreStartMock.application.capabilities,
+      dashboards: {
+        ...coreStartMock.application.capabilities.dashboards,
+        isDashboardAdmin: false,
+      },
+    };
+    render(<WorkspaceMenuCreatorComponent />);
+
+    fireEvent.click(screen.getByTestId('workspace-select-button'));
+    expect(screen.getByText(/View all/i)).toBeInTheDocument();
+    expect(screen.queryByText(/create workspaces/i)).toBeNull();
   });
 });

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -72,7 +72,7 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
   const [isPopoverOpen, setPopover] = useState(false);
   const currentWorkspace = useObservable(coreStart.workspaces.currentWorkspace$, null);
   const workspaceList = useObservable(coreStart.workspaces.workspaceList$, []);
-  const isDashboardAdmin = !!coreStart.application.capabilities.dashboards;
+  const isDashboardAdmin = coreStart.application.capabilities?.dashboards?.isDashboardAdmin;
   const availableUseCases = useObservable(registeredUseCases$, []);
 
   const filteredWorkspaceList = useMemo(() => {
@@ -90,7 +90,10 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
   const currentWorkspaceName = currentWorkspace?.name ?? defaultHeaderName;
 
   const getUseCase = (workspace: WorkspaceObject) => {
-    const useCaseId = getFirstUseCaseOfFeatureConfigs(workspace?.features!);
+    if (!workspace.features) {
+      return;
+    }
+    const useCaseId = getFirstUseCaseOfFeatureConfigs(workspace.features);
     return availableUseCases.find((useCase) => useCase.id === useCaseId);
   };
 


### PR DESCRIPTION


### Description

Manual backport #7357 to 2.x, only conflict with `src/plugins/workspace/public/components/workspace_list/index.tsx` 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
