### PR TITLE
[Multiple Datasource][Version Decoupling] Add data source version and installed plugins in data source viewer returns

### DIFF
--- a/changelogs/fragments/7420.yml
+++ b/changelogs/fragments/7420.yml
@@ -1,0 +1,2 @@
+fix:
+- [Version Decoupling] Add data source version and installed plugins in data source viewer returns ([#7420](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7420))

--- a/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
@@ -82,8 +82,7 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
       return;
     }
 
-    if (
-      optionId === '' && this.props.hideLocalCluster) {
+    if (optionId === '' && this.props.hideLocalCluster) {
       this.setState({
         selectedOption: [],
       });
@@ -97,13 +96,16 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
           optionId,
           this.props.savedObjectsClient!
         );
-        if (this.props.dataSourceFilter && [selectedDataSource].filter(this.props.dataSourceFilter).length === 0) {
+        if (
+          this.props.dataSourceFilter &&
+          [selectedDataSource].filter(this.props.dataSourceFilter).length === 0
+        ) {
           this.setState({
             selectedOption: [],
           });
           this.onSelectedDataSources([]);
         }
-        console.log("selected", selectedDataSource)
+
         if (!this._isMounted) return;
         this.setState({
           selectedOption: [{ id: optionId, label: selectedDataSource.title }],

--- a/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
@@ -104,6 +104,7 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
             selectedOption: [],
           });
           this.onSelectedDataSources([]);
+          return;
         }
 
         if (!this._isMounted) return;

--- a/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx
@@ -83,10 +83,7 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
     }
 
     if (
-      (optionId === '' && this.props.hideLocalCluster) ||
-      (this.props.dataSourceFilter &&
-        this.props.selectedOption.filter(this.props.dataSourceFilter).length === 0)
-    ) {
+      optionId === '' && this.props.hideLocalCluster) {
       this.setState({
         selectedOption: [],
       });
@@ -100,6 +97,13 @@ export class DataSourceView extends React.Component<DataSourceViewProps, DataSou
           optionId,
           this.props.savedObjectsClient!
         );
+        if (this.props.dataSourceFilter && [selectedDataSource].filter(this.props.dataSourceFilter).length === 0) {
+          this.setState({
+            selectedOption: [],
+          });
+          this.onSelectedDataSources([]);
+        }
+        console.log("selected", selectedDataSource)
         if (!this._isMounted) return;
         this.setState({
           selectedOption: [{ id: optionId, label: selectedDataSource.title }],

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -205,6 +205,8 @@ export async function getDataSourceById(
     endpoint: attributes.endpoint,
     description: attributes.description || '',
     auth: attributes.auth,
+    datasourceversion: attributes.dataSourceVersion,
+    installedplugins: attributes.installedPlugins,
   };
 }
 


### PR DESCRIPTION
### Description

* This one adds new returned fields `datasourceversion` and `installedplugins` in `DataSourceView`
* This also fix the current filter logic to ensure filter is applied as expected

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7099


## Changelog

- fix: [Version Decoupling] Add data source version and installed plugins in data source viewer returns

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
