### PR TITLE
[Workspace]Fix breadcrumbs not set properly when out a workspace

### DIFF
--- a/src/plugins/workspace/public/components/workspace_detail_app.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail_app.tsx
@@ -5,6 +5,7 @@
 
 import React, { useEffect } from 'react';
 import { I18nProvider } from '@osd/i18n/react';
+import { i18n } from '@osd/i18n';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { useObservable } from 'react-use';
 import { EuiBreadcrumb } from '@elastic/eui';
@@ -33,6 +34,9 @@ export const WorkspaceDetailApp = (props: WorkspaceDetailProps) => {
     if (currentWorkspace) {
       breadcrumbs.push({
         text: currentWorkspace.name,
+      });
+      breadcrumbs.push({
+        text: i18n.translate('workspace.detail.breadcrumb', { defaultMessage: 'Workspace Detail' }),
       });
     }
     chrome?.setBreadcrumbs(breadcrumbs);

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -515,7 +515,7 @@ describe('workspace utils: prependWorkspaceToBreadcrumbs', () => {
   it('should not enrich breadcrumbs when out a workspace', async () => {
     const coreStart = coreMock.createStart();
     prependWorkspaceToBreadcrumbs(coreStart, null, 'app1', undefined, {});
-    expect(coreStart.chrome.setBreadcrumbsEnricher).toHaveBeenCalledWith(undefined);
+    expect(coreStart.chrome.setBreadcrumbsEnricher).not.toHaveBeenCalled();
   });
 
   it('should enrich breadcrumbs when in a workspace and use workspace use case as current nav group', async () => {

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -295,6 +295,16 @@ export function prependWorkspaceToBreadcrumbs(
     core.chrome.setBreadcrumbsEnricher(undefined);
     return;
   }
+
+  /**
+   * There has 3 cases
+   * nav group is enable + workspace enable + in a workspace -> workspace enricher
+   * nav group is enable + workspace enable + out a workspace -> nav group enricher
+   * nav group is enable + workspace disabled -> nav group enricher
+   *
+   * switch workspace will cause page refresh, breadcrumbs enricher will reset automatically
+   * so we don't need to have reset logic for workspace
+   */
   if (currentWorkspace) {
     const useCase = getFirstUseCaseOfFeatureConfigs(currentWorkspace?.features || []);
     // get workspace the only use case
@@ -336,7 +346,5 @@ export function prependWorkspaceToBreadcrumbs(
         return [homeBreadcrumb, navGroupBreadcrumb, ...breadcrumbs];
       }
     });
-  } else {
-    core.chrome.setBreadcrumbsEnricher(undefined);
   }
 }


### PR DESCRIPTION
### Description

Remove the breadcrumbs enricher reset when out a workspace, the enricher will set by nav group service if we are in data administration or settings and setup pages

There has 3 cases
1. nav group is enable + workspace enable + in a workspace -> workspace enricher 
2. nav group is enable + workspace enable + out a workspace -> nav group enricher
3. nav group is enable  + workspace disabled -> nav group enricher



### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
#7359 bug in #7360

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
