### PR TITLE
[Bug][Workspace] Add permission validation at workspace detail page

### DIFF
--- a/changelogs/fragments/7435.yml
+++ b/changelogs/fragments/7435.yml
@@ -1,0 +1,2 @@
+fix:
+- [Bug][Workspace] Add permission validation at workspace detail page ([#7435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7435))

--- a/src/plugins/workspace/public/components/workspace_detail/workspace_updater.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/workspace_updater.tsx
@@ -65,6 +65,7 @@ export const WorkspaceUpdater = (props: WorkspaceUpdaterProps) => {
     dataSourceManagement?: DataSourceManagementPluginSetup;
   }>();
 
+  const isPermissionEnabled = application?.capabilities.workspaces.permissionEnabled;
   const currentWorkspace = useObservable(workspaces ? workspaces.currentWorkspace$ : of(null));
   const availableUseCases = useObservable(props.registeredUseCases$, []);
   const [currentWorkspaceFormData, setCurrentWorkspaceFormData] = useState<FormDataFromWorkspace>();
@@ -160,6 +161,7 @@ export const WorkspaceUpdater = (props: WorkspaceUpdaterProps) => {
               onSubmit={handleWorkspaceFormSubmit}
               operationType={WorkspaceOperationType.Update}
               savedObjects={savedObjects}
+              permissionEnabled={isPermissionEnabled}
               detailTab={props.detailTab}
               dataSourceManagement={dataSourceManagement}
               availableUseCases={availableUseCases}


### PR DESCRIPTION
### Description

Add permission validation at workspace detail page

If `permissionEnabled` is not added to the props of the `WorkspaceDetailForm`, input data (such as duplicate IDs) will not be validated by `useWorkspaceForm` when the user adds the same user ID to 'Manage Access and Permissions'

<img width="2489" alt="image" src="https://github.com/user-attachments/assets/1f2a02b3-ed15-4952-b222-aa685dcb6458">

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<img width="1453" alt="image" src="https://github.com/user-attachments/assets/76409ff4-c267-49a7-b57e-7604f7ecf048">

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: [Bug][Workspace] Add permission validation at workspace detail page
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
