### PR TITLE
Bump browserslist from `4.22.1` to `4.23.2` to resolve integration test error

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5310,14 +5310,14 @@ browserify-zlib@^0.2.0:
     pako "~1.0.5"
 
 browserslist@*, browserslist@^4.21.10, browserslist@^4.21.5, browserslist@^4.21.9, browserslist@^4.22.1:
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.1.tgz#ba91958d1a59b87dab6fed8dfbcb3da5e2e9c619"
-  integrity sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==
+  version "4.23.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.2.tgz#244fe803641f1c19c28c48c4b6ec9736eb3d32ed"
+  integrity sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==
   dependencies:
-    caniuse-lite "^1.0.30001541"
-    electron-to-chromium "^1.4.535"
-    node-releases "^2.0.13"
-    update-browserslist-db "^1.0.13"
+    caniuse-lite "^1.0.30001640"
+    electron-to-chromium "^1.4.820"
+    node-releases "^2.0.14"
+    update-browserslist-db "^1.1.0"
 
 bser@2.1.1:
   version "2.1.1"
@@ -5526,10 +5526,15 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
-caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001541:
+caniuse-lite@^1.0.30001464:
   version "1.0.30001587"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001587.tgz"
   integrity sha512-HMFNotUmLXn71BQxg8cijvqxnIAofforZOwGsxyXJ0qugTdspUF4sPSJ2vhgprHCB996tIDzEq1ubumPDV8ULA==
+
+caniuse-lite@^1.0.30001640:
+  version "1.0.30001643"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz#9c004caef315de9452ab970c3da71085f8241dbd"
+  integrity sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -7415,10 +7420,10 @@ elasticsearch@^16.4.0, elasticsearch@^16.7.0:
     chalk "^1.0.0"
     lodash "^4.17.10"
 
-electron-to-chromium@^1.4.535:
-  version "1.4.573"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.573.tgz#aa6e5edf86448bb9398f529357abcc6a17b6341d"
-  integrity sha512-tzxxvKDTO3V5vzN2F+3v9jrK9gEbCdf1YYJUx/zVq1cyzyh+x1ddeYNNWh0ZS2ETNCVK3+Pns1LHIBq4w20X2Q==
+electron-to-chromium@^1.4.820:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.0.tgz#0d3123a9f09189b9c7ab4b5d6848d71b3c1fd0e8"
+  integrity sha512-Vb3xHHYnLseK8vlMJQKJYXJ++t4u1/qJ3vykuVrVjvdiOEhYyT1AuP4x03G8EnPmYvYOhe9T+dADTmthjRQMkA==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -7786,6 +7791,11 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escalade@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.2.tgz#54076e9ab29ea5bf3d8f1ed62acffbb88272df27"
+  integrity sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==
 
 escape-latex@^1.2.0:
   version "1.2.0"
@@ -12861,10 +12871,10 @@ node-preload@^0.2.1:
   dependencies:
     process-on-spawn "^1.0.0"
 
-node-releases@^2.0.13:
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.13.tgz#d5ed1627c23e3461e819b02e57b75e4899b1c81d"
-  integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
+node-releases@^2.0.14:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
+  integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
 
 node-stream-zip@^1.15.0:
   version "1.15.0"
@@ -13622,6 +13632,11 @@ picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
+picocolors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
+  integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.0, picomatch@^2.3.1:
   version "2.3.1"
@@ -17315,13 +17330,13 @@ untildify@^4.0.0:
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
   integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
-update-browserslist-db@^1.0.13:
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz#3c5e4f5c083661bd38ef64b6328c26ed6c8248c4"
-  integrity sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==
+update-browserslist-db@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz#7ca61c0d8650766090728046e416a8cde682859e"
+  integrity sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==
   dependencies:
-    escalade "^3.1.1"
-    picocolors "^1.0.0"
+    escalade "^3.1.2"
+    picocolors "^1.0.1"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
### Description

Bump browserslist to fix 
```
FAIL  packages/osd-plugin-helpers/src/integration_tests/build.test.ts (19.15 s)
  ● builds a generated plugin into a viable archive

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `builds a generated plugin into a viable archive 2`

    - Snapshot  - 3
    + Received  + 9

      " info deleting the build and target directories
       info running @osd/optimizer
       │ info initialized, 0 bundles cached
       │ info starting worker [1 bundle]
    -  │ succ 1 bundles compiled successfully after <time>
    -  info copying assets from `public/assets` to build
    -  info copying server source into the build and converting with babel
    +  │ warn worker stderr Browserslist: caniuse-lite is outdated. Please run:
    +  │ warn worker stderr   npx update-browserslist-db@latest
    +  │ warn worker stderr   Why you should do it regularly: 
https://github.com/browserslist/update-db#readme
    +  │ succ 1 bundles compiled successfully after <time>
    +  info copying assets from `public/assets` to build
    +  info copying server source into the build and converting with babel
    + Browserslist: caniuse-lite is outdated. Please run:
    +   npx update-browserslist-db@latest
    +   Why you should do it regularly: 
https://github.com/browserslist/update-db#readme
       info running yarn to install dependencies
       info compressing plugin into [fooTestPlugin-1.0.0.zip]
       info cleaning up compression temporary artifacts"

       97 |   );
       98 |
    >  99 |   expect(buildProc.all).toMatchInlineSnapshot(`
          |                         ^
      100 |     " info deleting the build and target directories
      101 |      info running @osd/optimizer
      102 |      │ info initialized, 0 bundles cached

      at Object.<anonymous> (packages/osd-plugin-helpers/src/integration_tests/build.test.ts:99:25)

  ● builds a non-semver generated plugin into a viable archive

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `builds a non-semver generated plugin into a viable archive 2`

    - Snapshot  - 3
    + Received  + 9

      " info deleting the build and target directories
       info running @osd/optimizer
       │ info initialized, 0 bundles cached
       │ info starting worker [1 bundle]
    -  │ succ 1 bundles compiled successfully after <time>
    -  info copying assets from `public/assets` to build
    -  info copying server source into the build and converting with babel
    +  │ warn worker stderr Browserslist: caniuse-lite is outdated. Please run:
    +  │ warn worker stderr   npx update-browserslist-db@latest
    +  │ warn worker stderr   Why you should do it regularly: 
https://github.com/browserslist/update-db#readme
    +  │ succ 1 bundles compiled successfully after <time>
    +  info copying assets from `public/assets` to build
    +  info copying server source into the build and converting with babel
    + Browserslist: caniuse-lite is outdated. Please run:
    +   npx update-browserslist-db@latest
    +   Why you should do it regularly: 
https://github.com/browserslist/update-db#readme
       info running yarn to install dependencies
       info compressing plugin into [fooTestPlugin-1.0.0.x.zip]
       info cleaning up compression temporary artifacts"

      185 |   );
      186 |
    > 187 |   expect(buildProc.all).toMatchInlineSnapshot(`
          |                         ^
      188 |     " info deleting the build and target directories
      189 |      info running @osd/optimizer
      190 |      │ info initialized, 0 bundles cached

      at Object.<anonymous> (packages/osd-plugin-helpers/src/integration_tests/build.test.ts:187:25)
```

### Issues Resolved

NA



## Changelog

- skip



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
