### PR TITLE
[Look&Feel] Apply small popover padding and add Oui tooltips

### DIFF
--- a/changelogs/fragments/7449.yml
+++ b/changelogs/fragments/7449.yml
@@ -1,2 +1,2 @@
 refactor:
-- [Look&Feel] Updated Table padding size ([#7449](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7449))
+- [Look&Feel] Apply small popover padding and Oui tooltip to index management pages ([#7449](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7449))

--- a/changelogs/fragments/7449.yml
+++ b/changelogs/fragments/7449.yml
@@ -1,0 +1,2 @@
+refactor:
+- [Look&Feel] Updated Table padding size ([#7449](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7449))

--- a/src/core/public/chrome/ui/header/recent_items.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.tsx
@@ -80,6 +80,7 @@ export const RecentItems = ({
       anchorPosition="downCenter"
       repositionOnScroll
       initialFocus={false}
+      panelPaddingSize="s"
     >
       <EuiTitle size="xxs">
         <h4>Recents</h4>

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/table/__snapshots__/table.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/table/__snapshots__/table.test.tsx.snap
@@ -2,19 +2,31 @@
 
 exports[`Table editing should show a save button 1`] = `
 <div>
-  <EuiButtonIcon
-    aria-label="Edit"
-    iconType="pencil"
-    onClick={[Function]}
-    size="s"
-  />
-  <EuiButtonIcon
-    aria-label="Delete"
-    color="danger"
-    iconType="trash"
-    onClick={[Function]}
-    size="s"
-  />
+  <EuiToolTip
+    content="Edit"
+    delay="long"
+    position="top"
+  >
+    <EuiButtonIcon
+      aria-label="Edit"
+      iconType="pencil"
+      onClick={[Function]}
+      size="s"
+    />
+  </EuiToolTip>
+  <EuiToolTip
+    content="Delete"
+    delay="long"
+    position="top"
+  >
+    <EuiButtonIcon
+      aria-label="Delete"
+      color="danger"
+      iconType="trash"
+      onClick={[Function]}
+      size="s"
+    />
+  </EuiToolTip>
 </div>
 `;
 

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/table/table.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/table/table.tsx
@@ -37,6 +37,7 @@ import {
   EuiCompressedFieldText,
   EuiButtonIcon,
   RIGHT_ALIGNMENT,
+  EuiToolTip,
 } from '@elastic/eui';
 
 import { i18n } from '@osd/i18n';
@@ -224,19 +225,23 @@ export class Table extends Component<TableProps, TableState> {
 
           return (
             <>
-              <EuiButtonIcon
-                size="s"
-                onClick={() => this.startEditingFilter(filter.clientId, filter.value)}
-                iconType="pencil"
-                aria-label={editAria}
-              />
-              <EuiButtonIcon
-                size="s"
-                color="danger"
-                onClick={() => deleteFilter(filter)}
-                iconType="trash"
-                aria-label={deleteAria}
-              />
+              <EuiToolTip content={editAria} delay="long" position="top">
+                <EuiButtonIcon
+                  size="s"
+                  onClick={() => this.startEditingFilter(filter.clientId, filter.value)}
+                  iconType="pencil"
+                  aria-label={editAria}
+                />
+              </EuiToolTip>
+              <EuiToolTip content={deleteAria} delay="long" position="top">
+                <EuiButtonIcon
+                  size="s"
+                  color="danger"
+                  onClick={() => deleteFilter(filter)}
+                  iconType="trash"
+                  aria-label={deleteAria}
+                />
+              </EuiToolTip>
             </>
           );
         },

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/table.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`Table prevents saved objects from being deleted 1`] = `
           hasArrow={true}
           isOpen={false}
           ownFocus={true}
-          panelPaddingSize="m"
+          panelPaddingSize="s"
         >
           <EuiCompressedFormRow
             describedByIds={Array []}
@@ -301,7 +301,7 @@ exports[`Table should call onDuplicateSingle when show duplicate 1`] = `
           hasArrow={true}
           isOpen={false}
           ownFocus={true}
-          panelPaddingSize="m"
+          panelPaddingSize="s"
         >
           <EuiCompressedFormRow
             describedByIds={Array []}
@@ -536,7 +536,7 @@ exports[`Table should render normally 1`] = `
           hasArrow={true}
           isOpen={false}
           ownFocus={true}
-          panelPaddingSize="m"
+          panelPaddingSize="s"
         >
           <EuiCompressedFormRow
             describedByIds={Array []}

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
@@ -443,6 +443,7 @@ export class Table extends PureComponent<TableProps, TableState> {
               button={button}
               isOpen={this.state.isExportPopoverOpen}
               closePopover={this.closeExportPopover}
+              panelPaddingSize="s"
             >
               <EuiCompressedFormRow
                 label={

--- a/src/plugins/vis_augmenter/public/view_events_flyout/components/event_vis_item_icon.tsx
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/components/event_vis_item_icon.tsx
@@ -53,6 +53,7 @@ export function EventVisItemIcon(props: Props) {
             button={dangerButton}
             isOpen={isErrorPopoverOpen}
             closePopover={closeErrorPopover}
+            panelPaddingSize="s"
           >
             <div>{errorMsg}</div>
           </EuiPopover>


### PR DESCRIPTION
### Description

Applies small padding on popovers for index management page. Also adds OUI tooltip to icons to Index Pattern Source Filters table to match other tables under index management.

## Screenshot
### Small padding on popovers
Added the `smallPopoverPadding = s` attribute to the following popovers:
| Scope | Before (v7Light) | After (v7Light) | Before (v8Dark) | After (v8Dark) |
| ----- | ----- | ----- | ----- | ----- |
| Saved Objects Export | <img width="251" alt="Saved Objects Export v7 Light After" src="https://github.com/user-attachments/assets/b2318b3f-c41a-4faf-928c-4d1d3d1bc1d1"> | <img width="251" alt="Saved Objects Export v7 Light Before" src="https://github.com/user-attachments/assets/64a36cab-2efa-4b50-b882-da33b47c5263"> | <img width="251" alt="Saved Objects Export v8 Dark Before" src="https://github.com/user-attachments/assets/b5898b76-9887-4402-a753-c6ebdbcca396">  | <img width="251" alt="Saved Objects Export v8 Dark After" src="https://github.com/user-attachments/assets/ac0a405c-2c94-4746-8677-345d47c1cc86"> |
| Vis Augmenter | <img width="255" alt="Vis Augmenter v7 Light Before" src="https://github.com/user-attachments/assets/ea71d970-7e39-4f23-8842-f85e4f25db9a"> | <img width="255" alt="Vis Augmenter v7 Light Post" src="https://github.com/user-attachments/assets/f8708148-cbed-4867-8637-bdd54f7d0339"> | <img width="255" alt="Vis Augmenter v8 Dark Before" src="https://github.com/user-attachments/assets/e49bfb25-77c9-4fb1-9b4a-baf1df43541a"> | <img width="255" alt="Vis Augmenter v8 Dark Post" src="https://github.com/user-attachments/assets/4e858c00-c333-4e55-b2e7-f6dc288532f9"> |
| Recent Items | <img width="255" alt="Recent Items v7 Light Before" src="https://github.com/user-attachments/assets/14483346-dd7b-4482-8731-4f1e750082ac"> | <img width="255" alt="Recent Items v7 Light Post" src="https://github.com/user-attachments/assets/6ecf18d6-9ef1-48a3-9b52-7f0c4941fba0"> | <img width="255" alt="Recent Items v8 Dark Before" src="https://github.com/user-attachments/assets/fc17f7c8-14bf-425c-9fec-496f3d6bf59d"> | <img width="255" alt="Recent Items v8 Dark Post" src="https://github.com/user-attachments/assets/4afd73c3-776d-4608-8402-5fbec8909503"> |

### Tooltip Additions
Added EuiTooltips to edit and delete icons in the index patterns source filters listing to match other tables:
| Scope | Before (v7Light) | After (v7Light) | Before (v8Dark) | After (v8Dark) |
| ----- | ----- | ----- | ----- | ----- |
| Index Patterns: Source Filters | <img width="151" alt="Edit v7 Light Before" src="https://github.com/user-attachments/assets/f86e11a1-f6b9-4ffc-9b44-d152fc330167"> | <img width="151" alt="Edit v7 Light Post" src="https://github.com/user-attachments/assets/5a8ce117-dc3f-4b25-8ded-1603f25850c0"> | <img width="151" alt="Edit v8 Dark Before" src="https://github.com/user-attachments/assets/84a3d648-b31d-4c27-8315-5e7a4a16fbec"> | <img width="151" alt="Edit v8 Dark Post" src="https://github.com/user-attachments/assets/cdc9299f-1171-4a11-8dbb-97037c077869"> | 
| Index Patterns: Source Filters | <img width="151" alt="Delete v7 Light Before" src="https://github.com/user-attachments/assets/9a23ea3e-ebe9-424b-bc15-43643ff0fffb"> | <img width="151" alt="Delete v7 Light Post" src="https://github.com/user-attachments/assets/5b39878f-ed8a-4a9d-8f91-5e45991b4df5"> | <img width="151" alt="Delete v8 Dark Before" src="https://github.com/user-attachments/assets/03ff5b3b-77c4-4486-aefd-899578f5e167"> | <img width="151" alt="Delete v8 Dark Post" src="https://github.com/user-attachments/assets/10a65d0f-6170-46ef-bff8-644349a22dc3"> |

Other tables for reference, which have tooltips for edit and delete icons:
| Scope | Screenshot |
| ----- | ----- | 
| Dashboards Listing | <img width="799" alt="Dashboards Listing" src="https://github.com/user-attachments/assets/59a61637-da03-4dc9-a0b6-e4c799c29bbc"> |
| Visualizations Listing | <img width="799" alt="Visualizations Listing" src="https://github.com/user-attachments/assets/f9ddb4de-fbc4-4192-86c2-e07ed14b14fa"> |
| Index Patterns: Scripted Fields | <img width="983" alt="Screenshot 2024-07-29 at 11 20 08 AM" src="https://github.com/user-attachments/assets/2045c43f-ff57-46ca-8838-d4be64c391e1"> | 
| Index Patterns: Scripted Fields | <img width="983" alt="Screenshot 2024-07-29 at 11 20 14 AM" src="https://github.com/user-attachments/assets/1ea2ede8-d6a2-4cc3-8666-4fbf9512b568"> |


## Changelog
- refactor: [Look&Feel] Apply small popover padding and add Oui tooltips

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
