### PR TITLE
[2.16 MDS]Fix access control tab fetching for remote cluster

### DIFF
--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/connection_detail/access_control_tab.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/connection_detail/access_control_tab.tsx
@@ -25,6 +25,7 @@ interface AccessControlTabProps {
   connector: string;
   properties: unknown;
   allowedRoles: string[];
+  dataSourceMDSId: string;
 }
 
 export const AccessControlTab = (props: AccessControlTabProps) => {
@@ -34,17 +35,17 @@ export const AccessControlTab = (props: AccessControlTabProps) => {
   const { http } = useOpenSearchDashboards<DataSourceManagementContext>().services;
 
   useEffect(() => {
-    http!
-      .get(SECURITY_ROLES)
-      .then((data) =>
+    http
+      .get(SECURITY_ROLES, { query: { dataSourceId: props.dataSourceMDSId } })
+      .then((data) => {
         setRoles(
           Object.keys(data.data).map((key) => {
             return { label: key };
           })
-        )
-      )
+        );
+      })
       .catch((err) => setHasSecurityAccess(false));
-  }, [http]);
+  }, [http, props.dataSourceMDSId]);
 
   const [selectedQueryPermissionRoles, setSelectedQueryPermissionRoles] = useState<Role[]>(
     props.allowedRoles.map((role) => {

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/connection_detail/direct_query_connection_detail.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/connection_detail/direct_query_connection_detail.tsx
@@ -365,6 +365,7 @@ export const DirectQueryDataConnectionDetail: React.FC<DirectQueryDataConnection
           properties={datasourceDetails.properties}
           allowedRoles={datasourceDetails.allowedRoles}
           key={JSON.stringify(datasourceDetails.allowedRoles)}
+          dataSourceMDSId={featureFlagStatus ? dataSourceMDSId ?? '' : ''}
         />
       ),
     },


### PR DESCRIPTION
### Description
This PR will be forward port into both main and 2.x
Fix access control tab fetching for remote cluster

<!-- Describe what this change achieves-->

### Issues Resolved

- correct the behavior of fetching remote cluster roles instead of local for direct query datasource 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
