### PR TITLE
Fix UI and detection of external data source in query assist

### DIFF
--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -138,6 +138,7 @@ export default class QueryEditorUI extends Component<Props, State> {
     return (
       <QueryEditorExtensions
         language={this.props.queryLanguage}
+        onSelectLanguage={this.onSelectLanguage}
         configMap={this.extensionMap}
         componentContainer={this.headerRef.current}
         bannerContainer={this.bannerRef.current}

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -123,6 +123,10 @@ export default class QueryEditorUI extends Component<Props, State> {
     return toUser(this.props.query.query);
   };
 
+  private setIsCollapsed = (isCollapsed: boolean) => {
+    this.setState({ isCollapsed });
+  };
+
   private renderQueryEditorExtensions() {
     if (
       !(
@@ -139,6 +143,8 @@ export default class QueryEditorUI extends Component<Props, State> {
       <QueryEditorExtensions
         language={this.props.queryLanguage}
         onSelectLanguage={this.onSelectLanguage}
+        isCollapsed={this.state.isCollapsed}
+        setIsCollapsed={this.setIsCollapsed}
         configMap={this.extensionMap}
         componentContainer={this.headerRef.current}
         bannerContainer={this.bannerRef.current}

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -39,7 +39,6 @@ monaco.languages.register({ id: LANGUAGE_ID_KUERY });
 
 export interface QueryEditorProps {
   indexPatterns: Array<IIndexPattern | string>;
-  dataSource?: DataSource;
   query: Query;
   dataSetContainerRef?: React.RefCallback<HTMLDivElement>;
   settings: Settings;
@@ -142,8 +141,6 @@ export default class QueryEditorUI extends Component<Props, State> {
         configMap={this.extensionMap}
         componentContainer={this.headerRef.current}
         bannerContainer={this.bannerRef.current}
-        indexPatterns={this.props.indexPatterns}
-        dataSource={this.props.dataSource}
       />
     );
   }
@@ -375,11 +372,11 @@ export default class QueryEditorUI extends Component<Props, State> {
       // eslint-disable-next-line no-unsanitized/property
       style.innerHTML = `
       .${containerId} .monaco-editor .view-lines {
-        padding-left: 15px; 
+        padding-left: 15px;
       }
       .${containerId} .monaco-editor .cursor {
         height: ${customCursorHeight}px !important;
-        margin-top: ${(38 - customCursorHeight) / 2}px !important; 
+        margin-top: ${(38 - customCursorHeight) / 2}px !important;
       }
     `;
 

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.test.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.test.tsx
@@ -31,6 +31,8 @@ describe('QueryEditorExtension', () => {
     dependencies: {
       language: 'Test',
       onSelectLanguage: jest.fn(),
+      isCollapsed: false,
+      setIsCollapsed: jest.fn(),
     },
     componentContainer: document.createElement('div'),
     bannerContainer: document.createElement('div'),

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.test.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.test.tsx
@@ -30,6 +30,7 @@ describe('QueryEditorExtension', () => {
     },
     dependencies: {
       language: 'Test',
+      onSelectLanguage: jest.fn(),
     },
     componentContainer: document.createElement('div'),
     bannerContainer: document.createElement('div'),

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.test.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.test.tsx
@@ -6,7 +6,6 @@
 import { render, waitFor } from '@testing-library/react';
 import React, { ComponentProps } from 'react';
 import { of } from 'rxjs';
-import { IIndexPattern } from '../../../../common';
 import { QueryEditorExtension } from './query_editor_extension';
 
 jest.mock('react-dom', () => ({
@@ -15,21 +14,6 @@ jest.mock('react-dom', () => ({
 }));
 
 type QueryEditorExtensionProps = ComponentProps<typeof QueryEditorExtension>;
-
-const mockIndexPattern = {
-  id: '1234',
-  title: 'logstash-*',
-  fields: [
-    {
-      name: 'response',
-      type: 'number',
-      esTypes: ['integer'],
-      aggregatable: true,
-      filterable: true,
-      searchable: true,
-    },
-  ],
-} as IIndexPattern;
 
 describe('QueryEditorExtension', () => {
   const getComponentMock = jest.fn();
@@ -45,7 +29,6 @@ describe('QueryEditorExtension', () => {
       getBanner: getBannerMock,
     },
     dependencies: {
-      indexPatterns: [mockIndexPattern],
       language: 'Test',
     },
     componentContainer: document.createElement('div'),

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.tsx
@@ -7,8 +7,6 @@ import { EuiErrorBoundary } from '@elastic/eui';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Observable } from 'rxjs';
-import { IIndexPattern } from '../../../../common';
-import { DataSource } from '../../../data_sources/datasource';
 
 interface QueryEditorExtensionProps {
   config: QueryEditorExtensionConfig;
@@ -18,14 +16,6 @@ interface QueryEditorExtensionProps {
 }
 
 export interface QueryEditorExtensionDependencies {
-  /**
-   * Currently selected index patterns.
-   */
-  indexPatterns?: Array<IIndexPattern | string>;
-  /**
-   * Currently selected data source.
-   */
-  dataSource?: DataSource;
   /**
    * Currently selected query language.
    */

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.tsx
@@ -24,6 +24,14 @@ export interface QueryEditorExtensionDependencies {
    * Change the selected query language.
    */
   onSelectLanguage: (language: string) => void;
+  /**
+   * Whether the query editor is collapsed.
+   */
+  isCollapsed: boolean;
+  /**
+   * Set whether the query editor is collapsed.
+   */
+  setIsCollapsed: (isCollapsed: boolean) => void;
 }
 
 export interface QueryEditorExtensionConfig {

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.tsx
@@ -20,6 +20,10 @@ export interface QueryEditorExtensionDependencies {
    * Currently selected query language.
    */
   language: string;
+  /**
+   * Change the selected query language.
+   */
+  onSelectLanguage: (language: string) => void;
 }
 
 export interface QueryEditorExtensionConfig {

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.test.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.test.tsx
@@ -14,33 +14,16 @@ type QueryEditorExtensionsProps = ComponentProps<typeof QueryEditorExtensions>;
 jest.mock('./query_editor_extension', () => ({
   QueryEditorExtension: jest.fn(({ config, dependencies }: QueryEditorExtensionProps) => (
     <div>
-      Mocked QueryEditorExtension {config.id} with{' '}
-      {dependencies.indexPatterns?.map((i) => (typeof i === 'string' ? i : i.title)).join(', ')}
+      Mocked QueryEditorExtension {config.id} with {dependencies.language}
     </div>
   )),
 }));
 
 describe('QueryEditorExtensions', () => {
   const defaultProps: QueryEditorExtensionsProps = {
-    indexPatterns: [
-      {
-        id: '1234',
-        title: 'logstash-*',
-        fields: [
-          {
-            name: 'response',
-            type: 'number',
-            esTypes: ['integer'],
-            aggregatable: true,
-            filterable: true,
-            searchable: true,
-          },
-        ],
-      },
-    ],
     componentContainer: document.createElement('div'),
     bannerContainer: document.createElement('div'),
-    language: 'Test',
+    language: 'Test-lang',
   };
 
   beforeEach(() => {
@@ -59,8 +42,8 @@ describe('QueryEditorExtensions', () => {
 
   it('correctly orders configurations based on order property', () => {
     const configMap = {
-      '1': { id: '1', order: 2, isEnabled: jest.fn(), getComponent: jest.fn() },
-      '2': { id: '2', order: 1, isEnabled: jest.fn(), getComponent: jest.fn() },
+      '1': { id: '1', order: 2, isEnabled$: jest.fn(), getComponent: jest.fn() },
+      '2': { id: '2', order: 1, isEnabled$: jest.fn(), getComponent: jest.fn() },
     };
 
     const { getAllByText } = render(
@@ -75,18 +58,18 @@ describe('QueryEditorExtensions', () => {
 
   it('passes dependencies correctly to QueryEditorExtension', async () => {
     const configMap = {
-      '1': { id: '1', order: 1, isEnabled: jest.fn(), getComponent: jest.fn() },
+      '1': { id: '1', order: 1, isEnabled$: jest.fn(), getComponent: jest.fn() },
     };
 
     const { getByText } = render(<QueryEditorExtensions {...defaultProps} configMap={configMap} />);
 
     await waitFor(() => {
-      expect(getByText(/logstash-\*/)).toBeInTheDocument();
+      expect(getByText(/Test-lang/)).toBeInTheDocument();
     });
 
     expect(QueryEditorExtension).toHaveBeenCalledWith(
       expect.objectContaining({
-        dependencies: { indexPatterns: defaultProps.indexPatterns, language: 'Test' },
+        dependencies: { language: 'Test-lang' },
       }),
       expect.anything()
     );

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.test.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.test.tsx
@@ -25,6 +25,8 @@ describe('QueryEditorExtensions', () => {
     bannerContainer: document.createElement('div'),
     language: 'Test-lang',
     onSelectLanguage: jest.fn(),
+    isCollapsed: false,
+    setIsCollapsed: jest.fn(),
   };
 
   beforeEach(() => {
@@ -70,7 +72,12 @@ describe('QueryEditorExtensions', () => {
 
     expect(QueryEditorExtension).toHaveBeenCalledWith(
       expect.objectContaining({
-        dependencies: { language: 'Test-lang', onSelectLanguage: expect.any(Function) },
+        dependencies: {
+          language: 'Test-lang',
+          onSelectLanguage: expect.any(Function),
+          isCollapsed: false,
+          setIsCollapsed: expect.any(Function),
+        },
       }),
       expect.anything()
     );

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.test.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.test.tsx
@@ -24,6 +24,7 @@ describe('QueryEditorExtensions', () => {
     componentContainer: document.createElement('div'),
     bannerContainer: document.createElement('div'),
     language: 'Test-lang',
+    onSelectLanguage: jest.fn(),
   };
 
   beforeEach(() => {
@@ -69,7 +70,7 @@ describe('QueryEditorExtensions', () => {
 
     expect(QueryEditorExtension).toHaveBeenCalledWith(
       expect.objectContaining({
-        dependencies: { language: 'Test-lang' },
+        dependencies: { language: 'Test-lang', onSelectLanguage: expect.any(Function) },
       }),
       expect.anything()
     );

--- a/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
@@ -48,7 +48,6 @@ export interface QueryEditorTopRowProps {
   disableAutoFocus?: boolean;
   screenTitle?: string;
   indexPatterns?: Array<IIndexPattern | string>;
-  dataSource?: DataSource;
   isLoading?: boolean;
   prepend?: React.ComponentProps<typeof EuiCompressedFieldText>['prepend'];
   showQueryEditor?: boolean;
@@ -220,7 +219,6 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
         <QueryEditor
           disableAutoFocus={props.disableAutoFocus}
           indexPatterns={props.indexPatterns!}
-          dataSource={props.dataSource}
           prepend={props.prepend}
           query={parsedQuery}
           dataSetContainerRef={props.dataSetContainerRef}

--- a/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
@@ -210,7 +210,6 @@ export function createSearchBar({
           showSaveQuery={props.showSaveQuery}
           screenTitle={props.screenTitle}
           indexPatterns={props.indexPatterns}
-          dataSource={props.dataSource}
           indicateNoData={props.indicateNoData}
           timeHistory={data.query.timefilter.history}
           dateRangeFrom={timeRange.from}

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -60,7 +60,6 @@ interface SearchBarInjectedDeps {
 
 export interface SearchBarOwnProps {
   indexPatterns?: IIndexPattern[];
-  dataSource?: DataSource;
   isLoading?: boolean;
   customSubmitButton?: React.ReactNode;
   screenTitle?: string;
@@ -498,7 +497,6 @@ class SearchBarUI extends Component<SearchBarProps, State> {
           screenTitle={this.props.screenTitle}
           onSubmit={this.onQueryBarSubmit}
           indexPatterns={this.props.indexPatterns}
-          dataSource={this.props.dataSource}
           isLoading={this.props.isLoading}
           prepend={this.props.showFilterBar ? savedQueryManagement : undefined}
           showDatePicker={this.props.showDatePicker}

--- a/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
@@ -126,10 +126,6 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
         useDefaultBehaviors
         setMenuMountPoint={opts.setHeaderActionMenu}
         indexPatterns={indexPattern ? [indexPattern] : indexPatterns}
-        // TODO after
-        // https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6833
-        // is ported to main, pass dataSource to TopNavMenu by picking
-        // commit 328e08e688c again.
         onQuerySubmit={opts.onQuerySubmit}
         savedQueryId={state.savedQuery}
         onSavedQueryIdChange={updateSavedQueryId}

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.test.tsx
@@ -24,6 +24,10 @@ const renderQueryAssistBanner = (overrideProps: Partial<QueryAssistBannerProps> 
   >(
     {
       languages: ['test-lang1', 'test-lang2'],
+      dependencies: {
+        language: 'default',
+        onSelectLanguage: jest.fn(),
+      },
     },
     overrideProps
   );
@@ -46,5 +50,12 @@ describe('<QueryAssistBanner /> spec', () => {
     expect(
       component.queryByText('Natural Language Query Generation for test-lang1, test-lang2')
     ).toBeNull();
+  });
+
+  it('should change language', async () => {
+    const { props, component } = renderQueryAssistBanner();
+
+    fireEvent.click(component.getByTestId('queryAssist-banner-changeLanguage'));
+    expect(props.dependencies.onSelectLanguage).toBeCalledWith('test-lang1');
   });
 });

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.test.tsx
@@ -27,6 +27,8 @@ const renderQueryAssistBanner = (overrideProps: Partial<QueryAssistBannerProps> 
       dependencies: {
         language: 'default',
         onSelectLanguage: jest.fn(),
+        isCollapsed: true,
+        setIsCollapsed: jest.fn(),
       },
     },
     overrideProps
@@ -57,5 +59,6 @@ describe('<QueryAssistBanner /> spec', () => {
 
     fireEvent.click(component.getByTestId('queryAssist-banner-changeLanguage'));
     expect(props.dependencies.onSelectLanguage).toBeCalledWith('test-lang1');
+    expect(props.dependencies.setIsCollapsed).toBeCalledWith(false);
   });
 });

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
@@ -59,7 +59,10 @@ export const QueryAssistBanner: React.FC<QueryAssistBannerProps> = (props) => {
               />
               <EuiLink
                 data-test-subj="queryAssist-banner-changeLanguage"
-                onClick={() => props.dependencies.onSelectLanguage(props.languages[0])}
+                onClick={() => {
+                  props.dependencies.onSelectLanguage(props.languages[0]);
+                  if (props.dependencies.isCollapsed) props.dependencies.setIsCollapsed(false);
+                }}
               >
                 <FormattedMessage
                   id="queryAssist.banner.title.suffix"

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
@@ -14,12 +14,14 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import React, { useState } from 'react';
+import { QueryEditorExtensionDependencies } from '../../../../data/public';
 import assistantMark from '../../assets/query_assist_mark.svg';
 import { getStorage } from '../../services';
 
 const BANNER_STORAGE_KEY = 'queryAssist:banner:show';
 
 interface QueryAssistBannerProps {
+  dependencies: QueryEditorExtensionDependencies;
   languages: string[];
 }
 
@@ -33,7 +35,8 @@ export const QueryAssistBanner: React.FC<QueryAssistBannerProps> = (props) => {
     _setShowCallOut(show);
   };
 
-  if (!showCallOut || storage.get(BANNER_STORAGE_KEY) === false) return null;
+  if (!showCallOut || storage.get(BANNER_STORAGE_KEY) === false || props.languages.length === 0)
+    return null;
 
   return (
     <EuiCallOut
@@ -54,7 +57,10 @@ export const QueryAssistBanner: React.FC<QueryAssistBannerProps> = (props) => {
                 id="queryAssist.banner.title.prefix"
                 defaultMessage="Use natural language to explore your data with "
               />
-              <EuiLink>
+              <EuiLink
+                data-test-subj="queryAssist-banner-changeLanguage"
+                onClick={() => props.dependencies.onSelectLanguage(props.languages[0])}
+              >
                 <FormattedMessage
                   id="queryAssist.banner.title.suffix"
                   defaultMessage="Natural Language Query Generation for {languages}"

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
@@ -82,6 +82,8 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
     }
   };
 
+  if (props.dependencies.isCollapsed) return null;
+
   return (
     <EuiForm component="form" onSubmit={onSubmit}>
       <EuiFormRow fullWidth>

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.test.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { of } from 'rxjs';
 import { coreMock } from '../../../../../core/public/mocks';
 import { SimpleDataSet } from '../../../../data/common';
-import { IIndexPattern } from '../../../../data/public';
 import { dataPluginMock } from '../../../../data/public/mocks';
 import { DataSetContract } from '../../../../data/public/query';
 import { ConfigSchema } from '../../../common/config';
@@ -53,7 +52,9 @@ describe('CreateExtension', () => {
   it('should be enabled if at least one language is configured', async () => {
     httpMock.get.mockResolvedValueOnce({ configuredLanguages: ['PPL'] });
     const extension = createQueryAssistExtension(httpMock, dataMock, config);
-    const isEnabled = await firstValueFrom(extension.isEnabled$({ language: 'PPL' }));
+    const isEnabled = await firstValueFrom(
+      extension.isEnabled$({ language: 'PPL', onSelectLanguage: jest.fn() })
+    );
     expect(isEnabled).toBeTruthy();
     expect(httpMock.get).toBeCalledWith('/api/enhancements/assist/languages', {
       query: { dataSourceId: 'mock-data-source-id' },
@@ -63,7 +64,9 @@ describe('CreateExtension', () => {
   it('should be disabled for unsupported language', async () => {
     httpMock.get.mockRejectedValueOnce(new Error('network failure'));
     const extension = createQueryAssistExtension(httpMock, dataMock, config);
-    const isEnabled = await firstValueFrom(extension.isEnabled$({ language: 'PPL' }));
+    const isEnabled = await firstValueFrom(
+      extension.isEnabled$({ language: 'PPL', onSelectLanguage: jest.fn() })
+    );
     expect(isEnabled).toBeFalsy();
     expect(httpMock.get).toBeCalledWith('/api/enhancements/assist/languages', {
       query: { dataSourceId: 'mock-data-source-id' },
@@ -75,7 +78,7 @@ describe('CreateExtension', () => {
     const extension = createQueryAssistExtension(httpMock, dataMock, config);
     const component = extension.getComponent?.({
       language: 'PPL',
-      indexPatterns: [{ id: 'test-pattern' }] as IIndexPattern[],
+      onSelectLanguage: jest.fn(),
     });
 
     if (!component) throw new Error('QueryEditorExtensions Component is undefined');
@@ -92,7 +95,7 @@ describe('CreateExtension', () => {
     const extension = createQueryAssistExtension(httpMock, dataMock, config);
     const banner = extension.getBanner?.({
       language: 'DQL',
-      indexPatterns: [{ id: 'test-pattern' }] as IIndexPattern[],
+      onSelectLanguage: jest.fn(),
     });
 
     if (!banner) throw new Error('QueryEditorExtensions Banner is undefined');

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -83,7 +83,10 @@ export const createQueryAssistExtension = (
           data={data}
           invert
         >
-          <QueryAssistBanner languages={config.supportedLanguages.map((conf) => conf.language)} />
+          <QueryAssistBanner
+            dependencies={dependencies}
+            languages={config.supportedLanguages.map((conf) => conf.language)}
+          />
         </QueryAssistWrapper>
       );
     },


### PR DESCRIPTION
### Description

- fix(queryEditorExtensions): use dataset manager to determine external datasource
   - previously it used the dataSource passed in from search bar, it is no longer accurate
   - also Remove datasource and indexpattern in query editor extension dependencies
- fix(queryAssist): enable click to change language in banner
- fix(queryAssist): hide query assist bar if editor is collapsed

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
