### PR TITLE
[MDS] Fix the hide local cluster config

### DIFF
--- a/changelogs/fragments/7497.yml
+++ b/changelogs/fragments/7497.yml
@@ -1,0 +1,2 @@
+fix:
+- [MDS] Fix the hide local cluster config ([#7497](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7497))

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/manage_direct_query_data_connections_table.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/manage_direct_query_data_connections_table.tsx
@@ -41,7 +41,7 @@ import { DATACONNECTIONS_BASE, observabilityMetricsID } from '../../../constants
 import { getRenderCreateAccelerationFlyout } from '../../../plugin';
 import { InstallIntegrationFlyout } from '../integrations/installed_integrations_table';
 import { redirectToExplorerS3 } from '../associated_object_management/utils/associated_objects_tab_utils';
-import { isPluginInstalled } from '../../utils';
+import { isPluginInstalled, getHideLocalCluster } from '../../utils';
 
 interface DataConnection {
   connectionType: DirectQueryDatasourceType;
@@ -306,6 +306,7 @@ export const ManageDirectQueryDataConnectionsTable: React.FC<ManageDirectQueryDa
             uiSettings={uiSettings}
             disabled={false}
             compressed={true}
+            hideLocalCluster={getHideLocalCluster().enabled}
           />
         </EuiFlexItem>
       )}


### PR DESCRIPTION
### Description
The datasource picker in zero etl datasource panel should repect the configuration of `data_source.hideLocalCluster: true`

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

https://github.com/user-attachments/assets/0ee0369c-7fcc-410e-b749-a80cced256e0


<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: [MDS] Fix the hide local cluster config

<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
