### PR TITLE
[Manual] [Backport 2.16] [Look&Feel] Revert tooltip addition for navigation menu

### DIFF
--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -3134,118 +3134,102 @@ exports[`Header handles visibility and lock changes 1`] = `
                 <div
                   className="euiHeaderSectionItem euiHeaderSectionItem--borderRight header__toggleNavButtonSection"
                 >
-                  <EuiToolTip
-                    content="Menu"
-                    delay="long"
-                    position="bottom"
+                  <EuiHeaderSectionItemButton
+                    aria-controls="mockId"
+                    aria-expanded={false}
+                    aria-label="Toggle primary navigation"
+                    aria-pressed={false}
+                    data-test-subj="toggleNavButton"
+                    onClick={[Function]}
                   >
-                    <span
-                      className="euiToolTipAnchor"
-                      onKeyUp={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                    <EuiButtonEmpty
+                      aria-controls="mockId"
+                      aria-expanded={false}
+                      aria-label="Toggle primary navigation"
+                      aria-pressed={false}
+                      buttonRef={
+                        Object {
+                          "current": <button
+                            aria-controls="mockId"
+                            aria-expanded="false"
+                            aria-label="Toggle primary navigation"
+                            aria-pressed="false"
+                            class="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
+                            data-test-subj="toggleNavButton"
+                            type="button"
+                          >
+                            <span
+                              class="euiButtonContent euiButtonEmpty__content"
+                            >
+                              <span
+                                class="euiButtonEmpty__text"
+                              >
+                                <span
+                                  class="euiHeaderSectionItemButton__content"
+                                >
+                                  <span
+                                    data-euiicon-type="menu"
+                                    title="Menu"
+                                  />
+                                </span>
+                              </span>
+                            </span>
+                          </button>,
+                        }
+                      }
+                      className="euiHeaderSectionItemButton"
+                      color="text"
+                      data-test-subj="toggleNavButton"
+                      onClick={[Function]}
                     >
-                      <EuiHeaderSectionItemButton
+                      <button
                         aria-controls="mockId"
                         aria-expanded={false}
                         aria-label="Toggle primary navigation"
                         aria-pressed={false}
+                        className="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
                         data-test-subj="toggleNavButton"
-                        onBlur={[Function]}
+                        disabled={false}
                         onClick={[Function]}
-                        onFocus={[Function]}
+                        type="button"
                       >
-                        <EuiButtonEmpty
-                          aria-controls="mockId"
-                          aria-expanded={false}
-                          aria-label="Toggle primary navigation"
-                          aria-pressed={false}
-                          buttonRef={
+                        <EuiButtonContent
+                          className="euiButtonEmpty__content"
+                          iconSide="left"
+                          iconSize="m"
+                          textProps={
                             Object {
-                              "current": <button
-                                aria-controls="mockId"
-                                aria-expanded="false"
-                                aria-label="Toggle primary navigation"
-                                aria-pressed="false"
-                                class="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
-                                data-test-subj="toggleNavButton"
-                                type="button"
-                              >
-                                <span
-                                  class="euiButtonContent euiButtonEmpty__content"
-                                >
-                                  <span
-                                    class="euiButtonEmpty__text"
-                                  >
-                                    <span
-                                      class="euiHeaderSectionItemButton__content"
-                                    >
-                                      <span
-                                        data-euiicon-type="menu"
-                                      />
-                                    </span>
-                                  </span>
-                                </span>
-                              </button>,
+                              "className": "euiButtonEmpty__text",
                             }
                           }
-                          className="euiHeaderSectionItemButton"
-                          color="text"
-                          data-test-subj="toggleNavButton"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
                         >
-                          <button
-                            aria-controls="mockId"
-                            aria-expanded={false}
-                            aria-label="Toggle primary navigation"
-                            aria-pressed={false}
-                            className="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
-                            data-test-subj="toggleNavButton"
-                            disabled={false}
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            type="button"
+                          <span
+                            className="euiButtonContent euiButtonEmpty__content"
                           >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="m"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
-                              }
+                            <span
+                              className="euiButtonEmpty__text"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiHeaderSectionItemButton__content"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
+                                <EuiIcon
+                                  size="m"
+                                  title="Menu"
+                                  type="menu"
                                 >
                                   <span
-                                    className="euiHeaderSectionItemButton__content"
-                                  >
-                                    <EuiIcon
-                                      size="m"
-                                      type="menu"
-                                    >
-                                      <span
-                                        data-euiicon-type="menu"
-                                        size="m"
-                                      />
-                                    </EuiIcon>
-                                  </span>
-                                </span>
+                                    data-euiicon-type="menu"
+                                    size="m"
+                                    title="Menu"
+                                  />
+                                </EuiIcon>
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </EuiHeaderSectionItemButton>
-                    </span>
-                  </EuiToolTip>
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonEmpty>
+                  </EuiHeaderSectionItemButton>
                 </div>
               </EuiHeaderSectionItem>
               <EuiHeaderSectionItem
@@ -9020,118 +9004,102 @@ exports[`Header renders condensed header 1`] = `
                 <div
                   className="euiHeaderSectionItem euiHeaderSectionItem--borderRight header__toggleNavButtonSection"
                 >
-                  <EuiToolTip
-                    content="Menu"
-                    delay="long"
-                    position="bottom"
+                  <EuiHeaderSectionItemButton
+                    aria-controls="mockId"
+                    aria-expanded={false}
+                    aria-label="Toggle primary navigation"
+                    aria-pressed={false}
+                    data-test-subj="toggleNavButton"
+                    onClick={[Function]}
                   >
-                    <span
-                      className="euiToolTipAnchor"
-                      onKeyUp={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                    <EuiButtonEmpty
+                      aria-controls="mockId"
+                      aria-expanded={false}
+                      aria-label="Toggle primary navigation"
+                      aria-pressed={false}
+                      buttonRef={
+                        Object {
+                          "current": <button
+                            aria-controls="mockId"
+                            aria-expanded="false"
+                            aria-label="Toggle primary navigation"
+                            aria-pressed="false"
+                            class="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
+                            data-test-subj="toggleNavButton"
+                            type="button"
+                          >
+                            <span
+                              class="euiButtonContent euiButtonEmpty__content"
+                            >
+                              <span
+                                class="euiButtonEmpty__text"
+                              >
+                                <span
+                                  class="euiHeaderSectionItemButton__content"
+                                >
+                                  <span
+                                    data-euiicon-type="menu"
+                                    title="Menu"
+                                  />
+                                </span>
+                              </span>
+                            </span>
+                          </button>,
+                        }
+                      }
+                      className="euiHeaderSectionItemButton"
+                      color="text"
+                      data-test-subj="toggleNavButton"
+                      onClick={[Function]}
                     >
-                      <EuiHeaderSectionItemButton
+                      <button
                         aria-controls="mockId"
                         aria-expanded={false}
                         aria-label="Toggle primary navigation"
                         aria-pressed={false}
+                        className="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
                         data-test-subj="toggleNavButton"
-                        onBlur={[Function]}
+                        disabled={false}
                         onClick={[Function]}
-                        onFocus={[Function]}
+                        type="button"
                       >
-                        <EuiButtonEmpty
-                          aria-controls="mockId"
-                          aria-expanded={false}
-                          aria-label="Toggle primary navigation"
-                          aria-pressed={false}
-                          buttonRef={
+                        <EuiButtonContent
+                          className="euiButtonEmpty__content"
+                          iconSide="left"
+                          iconSize="m"
+                          textProps={
                             Object {
-                              "current": <button
-                                aria-controls="mockId"
-                                aria-expanded="false"
-                                aria-label="Toggle primary navigation"
-                                aria-pressed="false"
-                                class="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
-                                data-test-subj="toggleNavButton"
-                                type="button"
-                              >
-                                <span
-                                  class="euiButtonContent euiButtonEmpty__content"
-                                >
-                                  <span
-                                    class="euiButtonEmpty__text"
-                                  >
-                                    <span
-                                      class="euiHeaderSectionItemButton__content"
-                                    >
-                                      <span
-                                        data-euiicon-type="menu"
-                                      />
-                                    </span>
-                                  </span>
-                                </span>
-                              </button>,
+                              "className": "euiButtonEmpty__text",
                             }
                           }
-                          className="euiHeaderSectionItemButton"
-                          color="text"
-                          data-test-subj="toggleNavButton"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
                         >
-                          <button
-                            aria-controls="mockId"
-                            aria-expanded={false}
-                            aria-label="Toggle primary navigation"
-                            aria-pressed={false}
-                            className="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
-                            data-test-subj="toggleNavButton"
-                            disabled={false}
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            type="button"
+                          <span
+                            className="euiButtonContent euiButtonEmpty__content"
                           >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="m"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
-                              }
+                            <span
+                              className="euiButtonEmpty__text"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiHeaderSectionItemButton__content"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
+                                <EuiIcon
+                                  size="m"
+                                  title="Menu"
+                                  type="menu"
                                 >
                                   <span
-                                    className="euiHeaderSectionItemButton__content"
-                                  >
-                                    <EuiIcon
-                                      size="m"
-                                      type="menu"
-                                    >
-                                      <span
-                                        data-euiicon-type="menu"
-                                        size="m"
-                                      />
-                                    </EuiIcon>
-                                  </span>
-                                </span>
+                                    data-euiicon-type="menu"
+                                    size="m"
+                                    title="Menu"
+                                  />
+                                </EuiIcon>
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </EuiHeaderSectionItemButton>
-                    </span>
-                  </EuiToolTip>
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonEmpty>
+                  </EuiHeaderSectionItemButton>
                 </div>
               </EuiHeaderSectionItem>
               <EuiHeaderSectionItem
@@ -12301,6 +12269,5554 @@ exports[`Header renders condensed header 1`] = `
         onClose={[Function]}
         outsideClickCloses={false}
       />
+    </CollapsibleNav>
+  </header>
+</Header>
+`;
+
+exports[`Header toggles primary navigation menu when clicked 1`] = `
+<Header
+  appTitle$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "test",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  application={
+    Object {
+      "applications$": BehaviorSubject {
+        "_isScalar": false,
+        "_value": Map {},
+        "closed": false,
+        "hasError": false,
+        "isStopped": false,
+        "observers": Array [],
+        "thrownError": null,
+      },
+      "capabilities": Object {
+        "catalogue": Object {},
+        "management": Object {},
+        "navLinks": Object {},
+        "workspaces": Object {},
+      },
+      "currentActionMenu$": BehaviorSubject {
+        "_isScalar": false,
+        "_value": undefined,
+        "closed": false,
+        "hasError": false,
+        "isStopped": false,
+        "observers": Array [
+          Subscriber {
+            "_parentOrParents": null,
+            "_subscriptions": Array [
+              SubjectSubscription {
+                "_parentOrParents": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "subject": [Circular],
+                "subscriber": [Circular],
+              },
+            ],
+            "closed": false,
+            "destination": SafeSubscriber {
+              "_complete": undefined,
+              "_context": [Circular],
+              "_error": undefined,
+              "_next": [Function],
+              "_parentOrParents": null,
+              "_parentSubscriber": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "destination": Object {
+                "closed": true,
+                "complete": [Function],
+                "error": [Function],
+                "next": [Function],
+              },
+              "isStopped": false,
+              "syncErrorThrowable": false,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+            "isStopped": false,
+            "syncErrorThrowable": true,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+        ],
+        "thrownError": null,
+      },
+      "currentAppId$": Observable {
+        "_isScalar": false,
+        "source": Subject {
+          "_isScalar": false,
+          "closed": false,
+          "hasError": false,
+          "isStopped": false,
+          "observers": Array [
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
+                  "_subscriptions": null,
+                  "closed": false,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
+                  "_subscriptions": null,
+                  "closed": false,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+          ],
+          "thrownError": null,
+        },
+      },
+      "getComponent": [MockFunction],
+      "getUrlForApp": [MockFunction],
+      "history": Object {
+        "action": "PUSH",
+        "block": [MockFunction],
+        "createHref": [MockFunction],
+        "go": [MockFunction],
+        "goBack": [MockFunction],
+        "goForward": [MockFunction],
+        "length": 1,
+        "listen": [MockFunction],
+        "location": Object {
+          "hash": "",
+          "key": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [MockFunction],
+        "replace": [MockFunction],
+      },
+      "navigateToApp": [MockFunction],
+      "navigateToUrl": [MockFunction],
+      "registerMountContext": [MockFunction],
+    }
+  }
+  badge$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  basePath={
+    BasePath {
+      "basePath": "/test",
+      "clientBasePath": "",
+      "get": [Function],
+      "getBasePath": [Function],
+      "prepend": [Function],
+      "remove": [Function],
+      "serverBasePath": "/test",
+    }
+  }
+  branding={
+    Object {
+      "useExpandedHeader": false,
+    }
+  }
+  breadcrumbs$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  breadcrumbsEnricher$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  currentNavGroup$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [],
+      "thrownError": null,
+    }
+  }
+  customNavLink$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  forceAppSwitcherNavigation$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": false,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  helpExtension$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        InnerSubscriber {
+          "_parentOrParents": CombineLatestSubscriber {
+            "_parentOrParents": Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                [Circular],
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+            "_subscriptions": Array [
+              [Circular],
+              InnerSubscriber {
+                "_parentOrParents": [Circular],
+                "_subscriptions": Array [
+                  SubjectSubscription {
+                    "_parentOrParents": [Circular],
+                    "_subscriptions": null,
+                    "closed": false,
+                    "subject": BehaviorSubject {
+                      "_isScalar": false,
+                      "_value": "",
+                      "closed": false,
+                      "hasError": false,
+                      "isStopped": false,
+                      "observers": Array [
+                        [Circular],
+                      ],
+                      "thrownError": null,
+                    },
+                    "subscriber": [Circular],
+                  },
+                ],
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "index": 1,
+                "isStopped": false,
+                "outerIndex": 1,
+                "outerValue": undefined,
+                "parent": [Circular],
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+            ],
+            "active": 2,
+            "closed": false,
+            "destination": Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                [Circular],
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+            "isStopped": true,
+            "observables": Array [
+              [Circular],
+              BehaviorSubject {
+                "_isScalar": false,
+                "_value": "",
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [
+                  InnerSubscriber {
+                    "_parentOrParents": [Circular],
+                    "_subscriptions": Array [
+                      SubjectSubscription {
+                        "_parentOrParents": [Circular],
+                        "_subscriptions": null,
+                        "closed": false,
+                        "subject": [Circular],
+                        "subscriber": [Circular],
+                      },
+                    ],
+                    "closed": false,
+                    "destination": Object {
+                      "closed": true,
+                      "complete": [Function],
+                      "error": [Function],
+                      "next": [Function],
+                    },
+                    "index": 1,
+                    "isStopped": false,
+                    "outerIndex": 1,
+                    "outerValue": undefined,
+                    "parent": [Circular],
+                    "syncErrorThrowable": false,
+                    "syncErrorThrown": false,
+                    "syncErrorValue": null,
+                  },
+                ],
+                "thrownError": null,
+              },
+            ],
+            "resultSelector": undefined,
+            "syncErrorThrowable": true,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+            "toRespond": 0,
+            "values": Array [
+              undefined,
+              "",
+            ],
+          },
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": Object {
+            "closed": true,
+            "complete": [Function],
+            "error": [Function],
+            "next": [Function],
+          },
+          "index": 1,
+          "isStopped": false,
+          "outerIndex": 0,
+          "outerValue": undefined,
+          "parent": CombineLatestSubscriber {
+            "_parentOrParents": Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                [Circular],
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+            "_subscriptions": Array [
+              [Circular],
+              InnerSubscriber {
+                "_parentOrParents": [Circular],
+                "_subscriptions": Array [
+                  SubjectSubscription {
+                    "_parentOrParents": [Circular],
+                    "_subscriptions": null,
+                    "closed": false,
+                    "subject": BehaviorSubject {
+                      "_isScalar": false,
+                      "_value": "",
+                      "closed": false,
+                      "hasError": false,
+                      "isStopped": false,
+                      "observers": Array [
+                        [Circular],
+                      ],
+                      "thrownError": null,
+                    },
+                    "subscriber": [Circular],
+                  },
+                ],
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "index": 1,
+                "isStopped": false,
+                "outerIndex": 1,
+                "outerValue": undefined,
+                "parent": [Circular],
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+            ],
+            "active": 2,
+            "closed": false,
+            "destination": Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                [Circular],
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+            "isStopped": true,
+            "observables": Array [
+              [Circular],
+              BehaviorSubject {
+                "_isScalar": false,
+                "_value": "",
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [
+                  InnerSubscriber {
+                    "_parentOrParents": [Circular],
+                    "_subscriptions": Array [
+                      SubjectSubscription {
+                        "_parentOrParents": [Circular],
+                        "_subscriptions": null,
+                        "closed": false,
+                        "subject": [Circular],
+                        "subscriber": [Circular],
+                      },
+                    ],
+                    "closed": false,
+                    "destination": Object {
+                      "closed": true,
+                      "complete": [Function],
+                      "error": [Function],
+                      "next": [Function],
+                    },
+                    "index": 1,
+                    "isStopped": false,
+                    "outerIndex": 1,
+                    "outerValue": undefined,
+                    "parent": [Circular],
+                    "syncErrorThrowable": false,
+                    "syncErrorThrown": false,
+                    "syncErrorValue": null,
+                  },
+                ],
+                "thrownError": null,
+              },
+            ],
+            "resultSelector": undefined,
+            "syncErrorThrowable": true,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+            "toRespond": 0,
+            "values": Array [
+              undefined,
+              "",
+            ],
+          },
+          "syncErrorThrowable": false,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  helpSupportUrl$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": "",
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        InnerSubscriber {
+          "_parentOrParents": CombineLatestSubscriber {
+            "_parentOrParents": Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                [Circular],
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+            "_subscriptions": Array [
+              InnerSubscriber {
+                "_parentOrParents": [Circular],
+                "_subscriptions": Array [
+                  SubjectSubscription {
+                    "_parentOrParents": [Circular],
+                    "_subscriptions": null,
+                    "closed": false,
+                    "subject": BehaviorSubject {
+                      "_isScalar": false,
+                      "_value": undefined,
+                      "closed": false,
+                      "hasError": false,
+                      "isStopped": false,
+                      "observers": Array [
+                        [Circular],
+                      ],
+                      "thrownError": null,
+                    },
+                    "subscriber": [Circular],
+                  },
+                ],
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "index": 1,
+                "isStopped": false,
+                "outerIndex": 0,
+                "outerValue": undefined,
+                "parent": [Circular],
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              [Circular],
+            ],
+            "active": 2,
+            "closed": false,
+            "destination": Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                [Circular],
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+            "isStopped": true,
+            "observables": Array [
+              BehaviorSubject {
+                "_isScalar": false,
+                "_value": undefined,
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [
+                  InnerSubscriber {
+                    "_parentOrParents": [Circular],
+                    "_subscriptions": Array [
+                      SubjectSubscription {
+                        "_parentOrParents": [Circular],
+                        "_subscriptions": null,
+                        "closed": false,
+                        "subject": [Circular],
+                        "subscriber": [Circular],
+                      },
+                    ],
+                    "closed": false,
+                    "destination": Object {
+                      "closed": true,
+                      "complete": [Function],
+                      "error": [Function],
+                      "next": [Function],
+                    },
+                    "index": 1,
+                    "isStopped": false,
+                    "outerIndex": 0,
+                    "outerValue": undefined,
+                    "parent": [Circular],
+                    "syncErrorThrowable": false,
+                    "syncErrorThrown": false,
+                    "syncErrorValue": null,
+                  },
+                ],
+                "thrownError": null,
+              },
+              [Circular],
+            ],
+            "resultSelector": undefined,
+            "syncErrorThrowable": true,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+            "toRespond": 0,
+            "values": Array [
+              undefined,
+              "",
+            ],
+          },
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": Object {
+            "closed": true,
+            "complete": [Function],
+            "error": [Function],
+            "next": [Function],
+          },
+          "index": 1,
+          "isStopped": false,
+          "outerIndex": 1,
+          "outerValue": undefined,
+          "parent": CombineLatestSubscriber {
+            "_parentOrParents": Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                [Circular],
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+            "_subscriptions": Array [
+              InnerSubscriber {
+                "_parentOrParents": [Circular],
+                "_subscriptions": Array [
+                  SubjectSubscription {
+                    "_parentOrParents": [Circular],
+                    "_subscriptions": null,
+                    "closed": false,
+                    "subject": BehaviorSubject {
+                      "_isScalar": false,
+                      "_value": undefined,
+                      "closed": false,
+                      "hasError": false,
+                      "isStopped": false,
+                      "observers": Array [
+                        [Circular],
+                      ],
+                      "thrownError": null,
+                    },
+                    "subscriber": [Circular],
+                  },
+                ],
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "index": 1,
+                "isStopped": false,
+                "outerIndex": 0,
+                "outerValue": undefined,
+                "parent": [Circular],
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              [Circular],
+            ],
+            "active": 2,
+            "closed": false,
+            "destination": Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                [Circular],
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+            "isStopped": true,
+            "observables": Array [
+              BehaviorSubject {
+                "_isScalar": false,
+                "_value": undefined,
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [
+                  InnerSubscriber {
+                    "_parentOrParents": [Circular],
+                    "_subscriptions": Array [
+                      SubjectSubscription {
+                        "_parentOrParents": [Circular],
+                        "_subscriptions": null,
+                        "closed": false,
+                        "subject": [Circular],
+                        "subscriber": [Circular],
+                      },
+                    ],
+                    "closed": false,
+                    "destination": Object {
+                      "closed": true,
+                      "complete": [Function],
+                      "error": [Function],
+                      "next": [Function],
+                    },
+                    "index": 1,
+                    "isStopped": false,
+                    "outerIndex": 0,
+                    "outerValue": undefined,
+                    "parent": [Circular],
+                    "syncErrorThrowable": false,
+                    "syncErrorThrown": false,
+                    "syncErrorValue": null,
+                  },
+                ],
+                "thrownError": null,
+              },
+              [Circular],
+            ],
+            "resultSelector": undefined,
+            "syncErrorThrowable": true,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+            "toRespond": 0,
+            "values": Array [
+              undefined,
+              "",
+            ],
+          },
+          "syncErrorThrowable": false,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  homeHref="/"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+  isLocked$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": false,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  isVisible$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": true,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  loadingCount$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": 0,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  logos={
+    Object {
+      "AnimatedMark": Object {
+        "dark": Object {
+          "type": "default",
+          "url": "/ui/logos/opensearch_spinner_on_dark.svg",
+        },
+        "light": Object {
+          "type": "default",
+          "url": "/ui/logos/opensearch_spinner_on_light.svg",
+        },
+        "type": "default",
+        "url": "/ui/logos/opensearch_spinner_on_light.svg",
+      },
+      "Application": Object {
+        "dark": Object {
+          "type": "default",
+          "url": "/ui/logos/opensearch_dashboards_on_dark.svg",
+        },
+        "light": Object {
+          "type": "default",
+          "url": "/ui/logos/opensearch_dashboards_on_light.svg",
+        },
+        "type": "default",
+        "url": "/ui/logos/opensearch_dashboards_on_light.svg",
+      },
+      "CenterMark": Object {
+        "dark": Object {
+          "type": "default",
+          "url": "/ui/logos/opensearch_center_mark_on_dark.svg",
+        },
+        "light": Object {
+          "type": "default",
+          "url": "/ui/logos/opensearch_center_mark_on_light.svg",
+        },
+        "type": "default",
+        "url": "/ui/logos/opensearch_center_mark_on_light.svg",
+      },
+      "Mark": Object {
+        "dark": Object {
+          "type": "default",
+          "url": "/ui/logos/opensearch_mark_on_dark.svg",
+        },
+        "light": Object {
+          "type": "default",
+          "url": "/ui/logos/opensearch_mark_on_light.svg",
+        },
+        "type": "default",
+        "url": "/ui/logos/opensearch_mark_on_light.svg",
+      },
+      "OpenSearch": Object {
+        "dark": Object {
+          "type": "default",
+          "url": "/ui/logos/opensearch_on_dark.svg",
+        },
+        "light": Object {
+          "type": "default",
+          "url": "/ui/logos/opensearch_on_light.svg",
+        },
+        "type": "default",
+        "url": "/ui/logos/opensearch_on_light.svg",
+      },
+      "colorScheme": "light",
+    }
+  }
+  navControlsCenter$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navControlsExpandedCenter$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [],
+      "thrownError": null,
+    }
+  }
+  navControlsExpandedRight$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [],
+      "thrownError": null,
+    }
+  }
+  navControlsLeft$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navControlsLeftBottom$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [],
+      "thrownError": null,
+    }
+  }
+  navControlsRight$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  navGroupEnabled={false}
+  navGroupsMap$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Object {},
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [],
+      "thrownError": null,
+    }
+  }
+  navLinks$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  onIsLockedUpdate={[Function]}
+  opensearchDashboardsDocLink="/docs"
+  opensearchDashboardsVersion="1.0.0"
+  recentlyAccessed$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  setCurrentNavGroup={[MockFunction]}
+  sidecarConfig$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Object {
+        "dockedMode": "right",
+        "paddingSize": 640,
+      },
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
+  survey="/"
+  workspaceList$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": Array [],
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [],
+      "thrownError": null,
+    }
+  }
+>
+  <header
+    className="hide-for-sharing headerGlobalNav"
+    data-test-subj="headerGlobalNav"
+  >
+    <div
+      id="globalHeaderBars"
+    >
+      <EuiHeader
+        className="primaryHeader"
+        position="fixed"
+        style={
+          Object {
+            "paddingRight": 640,
+          }
+        }
+      >
+        <div
+          className="euiHeader euiHeader--default euiHeader--fixed primaryHeader"
+          style={
+            Object {
+              "paddingRight": 640,
+            }
+          }
+        >
+          <EuiHeaderSection
+            grow={false}
+          >
+            <div
+              className="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--left"
+            >
+              <EuiHeaderSectionItem
+                border="right"
+                className="header__toggleNavButtonSection"
+              >
+                <div
+                  className="euiHeaderSectionItem euiHeaderSectionItem--borderRight header__toggleNavButtonSection"
+                >
+                  <EuiHeaderSectionItemButton
+                    aria-controls="mockId"
+                    aria-expanded={true}
+                    aria-label="Toggle primary navigation"
+                    aria-pressed={true}
+                    data-test-subj="toggleNavButton"
+                    onClick={[Function]}
+                  >
+                    <EuiButtonEmpty
+                      aria-controls="mockId"
+                      aria-expanded={true}
+                      aria-label="Toggle primary navigation"
+                      aria-pressed={true}
+                      buttonRef={
+                        Object {
+                          "current": <button
+                            aria-controls="mockId"
+                            aria-expanded="true"
+                            aria-label="Toggle primary navigation"
+                            aria-pressed="true"
+                            class="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
+                            data-test-subj="toggleNavButton"
+                            type="button"
+                          >
+                            <span
+                              class="euiButtonContent euiButtonEmpty__content"
+                            >
+                              <span
+                                class="euiButtonEmpty__text"
+                              >
+                                <span
+                                  class="euiHeaderSectionItemButton__content"
+                                >
+                                  <span
+                                    data-euiicon-type="menu"
+                                    title="Menu"
+                                  />
+                                </span>
+                              </span>
+                            </span>
+                          </button>,
+                        }
+                      }
+                      className="euiHeaderSectionItemButton"
+                      color="text"
+                      data-test-subj="toggleNavButton"
+                      onClick={[Function]}
+                    >
+                      <button
+                        aria-controls="mockId"
+                        aria-expanded={true}
+                        aria-label="Toggle primary navigation"
+                        aria-pressed={true}
+                        className="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
+                        data-test-subj="toggleNavButton"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <EuiButtonContent
+                          className="euiButtonEmpty__content"
+                          iconSide="left"
+                          iconSize="m"
+                          textProps={
+                            Object {
+                              "className": "euiButtonEmpty__text",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButtonEmpty__content"
+                          >
+                            <span
+                              className="euiButtonEmpty__text"
+                            >
+                              <span
+                                className="euiHeaderSectionItemButton__content"
+                              >
+                                <EuiIcon
+                                  size="m"
+                                  title="Menu"
+                                  type="menu"
+                                >
+                                  <span
+                                    data-euiicon-type="menu"
+                                    size="m"
+                                    title="Menu"
+                                  />
+                                </EuiIcon>
+                              </span>
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonEmpty>
+                  </EuiHeaderSectionItemButton>
+                </div>
+              </EuiHeaderSectionItem>
+              <EuiHeaderSectionItem
+                border="right"
+              >
+                <div
+                  className="euiHeaderSectionItem euiHeaderSectionItem--borderRight"
+                >
+                  <HeaderNavControls
+                    navControls$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": Array [],
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
+                              "_subscriptions": null,
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            "isStopped": false,
+                            "syncErrorThrowable": true,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                        ],
+                        "thrownError": null,
+                      }
+                    }
+                    side="left"
+                  />
+                </div>
+              </EuiHeaderSectionItem>
+              <EuiHeaderSectionItem
+                border="right"
+              >
+                <div
+                  className="euiHeaderSectionItem euiHeaderSectionItem--borderRight"
+                >
+                  <HomeLoader
+                    branding={
+                      Object {
+                        "useExpandedHeader": false,
+                      }
+                    }
+                    forceNavigation$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": false,
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
+                              "_subscriptions": null,
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            "isStopped": false,
+                            "syncErrorThrowable": true,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                        ],
+                        "thrownError": null,
+                      }
+                    }
+                    href="/"
+                    loadingCount$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": 0,
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
+                              "_subscriptions": null,
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            "isStopped": false,
+                            "syncErrorThrowable": true,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
+                              "_subscriptions": null,
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            "isStopped": false,
+                            "syncErrorThrowable": true,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                        ],
+                        "thrownError": null,
+                      }
+                    }
+                    logos={
+                      Object {
+                        "AnimatedMark": Object {
+                          "dark": Object {
+                            "type": "default",
+                            "url": "/ui/logos/opensearch_spinner_on_dark.svg",
+                          },
+                          "light": Object {
+                            "type": "default",
+                            "url": "/ui/logos/opensearch_spinner_on_light.svg",
+                          },
+                          "type": "default",
+                          "url": "/ui/logos/opensearch_spinner_on_light.svg",
+                        },
+                        "Application": Object {
+                          "dark": Object {
+                            "type": "default",
+                            "url": "/ui/logos/opensearch_dashboards_on_dark.svg",
+                          },
+                          "light": Object {
+                            "type": "default",
+                            "url": "/ui/logos/opensearch_dashboards_on_light.svg",
+                          },
+                          "type": "default",
+                          "url": "/ui/logos/opensearch_dashboards_on_light.svg",
+                        },
+                        "CenterMark": Object {
+                          "dark": Object {
+                            "type": "default",
+                            "url": "/ui/logos/opensearch_center_mark_on_dark.svg",
+                          },
+                          "light": Object {
+                            "type": "default",
+                            "url": "/ui/logos/opensearch_center_mark_on_light.svg",
+                          },
+                          "type": "default",
+                          "url": "/ui/logos/opensearch_center_mark_on_light.svg",
+                        },
+                        "Mark": Object {
+                          "dark": Object {
+                            "type": "default",
+                            "url": "/ui/logos/opensearch_mark_on_dark.svg",
+                          },
+                          "light": Object {
+                            "type": "default",
+                            "url": "/ui/logos/opensearch_mark_on_light.svg",
+                          },
+                          "type": "default",
+                          "url": "/ui/logos/opensearch_mark_on_light.svg",
+                        },
+                        "OpenSearch": Object {
+                          "dark": Object {
+                            "type": "default",
+                            "url": "/ui/logos/opensearch_on_dark.svg",
+                          },
+                          "light": Object {
+                            "type": "default",
+                            "url": "/ui/logos/opensearch_on_light.svg",
+                          },
+                          "type": "default",
+                          "url": "/ui/logos/opensearch_on_light.svg",
+                        },
+                        "colorScheme": "light",
+                      }
+                    }
+                    navLinks$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": Array [],
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
+                              "_subscriptions": null,
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            "isStopped": false,
+                            "syncErrorThrowable": true,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
+                              "_subscriptions": null,
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            "isStopped": false,
+                            "syncErrorThrowable": true,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                        ],
+                        "thrownError": null,
+                      }
+                    }
+                    navigateToApp={[MockFunction]}
+                  >
+                    <EuiToolTip
+                      content="Go to home page"
+                      delay="long"
+                      position="top"
+                    >
+                      <span
+                        className="euiToolTipAnchor"
+                        onKeyUp={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <EuiHeaderSectionItemButton
+                          aria-label="Go to home page"
+                          className="header__homeLoaderNavButton"
+                          data-test-subj="homeLoader"
+                          href="/"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                        >
+                          <EuiButtonEmpty
+                            aria-label="Go to home page"
+                            buttonRef={
+                              Object {
+                                "current": <a
+                                  aria-label="Go to home page"
+                                  class="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton header__homeLoaderNavButton"
+                                  data-test-subj="homeLoader"
+                                  href="/"
+                                  rel="noreferrer"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButtonEmpty__content"
+                                  >
+                                    <span
+                                      class="euiButtonEmpty__text"
+                                    >
+                                      <span
+                                        class="euiHeaderSectionItemButton__content"
+                                      >
+                                        <div
+                                          class="homeIconContainer"
+                                        >
+                                          <span
+                                            class="logoImage"
+                                            data-euiicon-type="/ui/logos/opensearch_mark_on_light.svg"
+                                            data-test-image-url="/ui/logos/opensearch_mark_on_light.svg"
+                                            data-test-subj="defaultMark"
+                                            title="opensearch dashboards home"
+                                          />
+                                        </div>
+                                        <div
+                                          class="loaderContainer"
+                                        >
+                                          <span
+                                            aria-hidden="true"
+                                            aria-label="Loading content"
+                                            class="euiLoadingSpinner euiLoadingSpinner--medium osdLoadingIndicator-hidden"
+                                            data-test-subj="globalLoadingIndicator-hidden"
+                                          />
+                                        </div>
+                                      </span>
+                                    </span>
+                                  </span>
+                                </a>,
+                              }
+                            }
+                            className="euiHeaderSectionItemButton header__homeLoaderNavButton"
+                            color="text"
+                            data-test-subj="homeLoader"
+                            href="/"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                          >
+                            <a
+                              aria-label="Go to home page"
+                              className="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton header__homeLoaderNavButton"
+                              data-test-subj="homeLoader"
+                              href="/"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              rel="noreferrer"
+                            >
+                              <EuiButtonContent
+                                className="euiButtonEmpty__content"
+                                iconSide="left"
+                                iconSize="m"
+                                textProps={
+                                  Object {
+                                    "className": "euiButtonEmpty__text",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="euiButtonContent euiButtonEmpty__content"
+                                >
+                                  <span
+                                    className="euiButtonEmpty__text"
+                                  >
+                                    <span
+                                      className="euiHeaderSectionItemButton__content"
+                                    >
+                                      <div
+                                        className="homeIconContainer"
+                                      >
+                                        <HomeIcon
+                                          branding={
+                                            Object {
+                                              "useExpandedHeader": false,
+                                            }
+                                          }
+                                          logos={
+                                            Object {
+                                              "AnimatedMark": Object {
+                                                "dark": Object {
+                                                  "type": "default",
+                                                  "url": "/ui/logos/opensearch_spinner_on_dark.svg",
+                                                },
+                                                "light": Object {
+                                                  "type": "default",
+                                                  "url": "/ui/logos/opensearch_spinner_on_light.svg",
+                                                },
+                                                "type": "default",
+                                                "url": "/ui/logos/opensearch_spinner_on_light.svg",
+                                              },
+                                              "Application": Object {
+                                                "dark": Object {
+                                                  "type": "default",
+                                                  "url": "/ui/logos/opensearch_dashboards_on_dark.svg",
+                                                },
+                                                "light": Object {
+                                                  "type": "default",
+                                                  "url": "/ui/logos/opensearch_dashboards_on_light.svg",
+                                                },
+                                                "type": "default",
+                                                "url": "/ui/logos/opensearch_dashboards_on_light.svg",
+                                              },
+                                              "CenterMark": Object {
+                                                "dark": Object {
+                                                  "type": "default",
+                                                  "url": "/ui/logos/opensearch_center_mark_on_dark.svg",
+                                                },
+                                                "light": Object {
+                                                  "type": "default",
+                                                  "url": "/ui/logos/opensearch_center_mark_on_light.svg",
+                                                },
+                                                "type": "default",
+                                                "url": "/ui/logos/opensearch_center_mark_on_light.svg",
+                                              },
+                                              "Mark": Object {
+                                                "dark": Object {
+                                                  "type": "default",
+                                                  "url": "/ui/logos/opensearch_mark_on_dark.svg",
+                                                },
+                                                "light": Object {
+                                                  "type": "default",
+                                                  "url": "/ui/logos/opensearch_mark_on_light.svg",
+                                                },
+                                                "type": "default",
+                                                "url": "/ui/logos/opensearch_mark_on_light.svg",
+                                              },
+                                              "OpenSearch": Object {
+                                                "dark": Object {
+                                                  "type": "default",
+                                                  "url": "/ui/logos/opensearch_on_dark.svg",
+                                                },
+                                                "light": Object {
+                                                  "type": "default",
+                                                  "url": "/ui/logos/opensearch_on_light.svg",
+                                                },
+                                                "type": "default",
+                                                "url": "/ui/logos/opensearch_on_light.svg",
+                                              },
+                                              "colorScheme": "light",
+                                            }
+                                          }
+                                        >
+                                          <EuiIcon
+                                            className="logoImage"
+                                            data-test-image-url="/ui/logos/opensearch_mark_on_light.svg"
+                                            data-test-subj="defaultMark"
+                                            size="l"
+                                            title="opensearch dashboards home"
+                                            type="/ui/logos/opensearch_mark_on_light.svg"
+                                          >
+                                            <span
+                                              className="logoImage"
+                                              data-euiicon-type="/ui/logos/opensearch_mark_on_light.svg"
+                                              data-test-image-url="/ui/logos/opensearch_mark_on_light.svg"
+                                              data-test-subj="defaultMark"
+                                              size="l"
+                                              title="opensearch dashboards home"
+                                            />
+                                          </EuiIcon>
+                                        </HomeIcon>
+                                      </div>
+                                      <div
+                                        className="loaderContainer"
+                                      >
+                                        <LoadingIndicator
+                                          loadingCount$={
+                                            BehaviorSubject {
+                                              "_isScalar": false,
+                                              "_value": 0,
+                                              "closed": false,
+                                              "hasError": false,
+                                              "isStopped": false,
+                                              "observers": Array [
+                                                Subscriber {
+                                                  "_parentOrParents": null,
+                                                  "_subscriptions": Array [
+                                                    SubjectSubscription {
+                                                      "_parentOrParents": [Circular],
+                                                      "_subscriptions": null,
+                                                      "closed": false,
+                                                      "subject": [Circular],
+                                                      "subscriber": [Circular],
+                                                    },
+                                                  ],
+                                                  "closed": false,
+                                                  "destination": SafeSubscriber {
+                                                    "_complete": undefined,
+                                                    "_context": [Circular],
+                                                    "_error": undefined,
+                                                    "_next": [Function],
+                                                    "_parentOrParents": null,
+                                                    "_parentSubscriber": [Circular],
+                                                    "_subscriptions": null,
+                                                    "closed": false,
+                                                    "destination": Object {
+                                                      "closed": true,
+                                                      "complete": [Function],
+                                                      "error": [Function],
+                                                      "next": [Function],
+                                                    },
+                                                    "isStopped": false,
+                                                    "syncErrorThrowable": false,
+                                                    "syncErrorThrown": false,
+                                                    "syncErrorValue": null,
+                                                  },
+                                                  "isStopped": false,
+                                                  "syncErrorThrowable": true,
+                                                  "syncErrorThrown": false,
+                                                  "syncErrorValue": null,
+                                                },
+                                                Subscriber {
+                                                  "_parentOrParents": null,
+                                                  "_subscriptions": Array [
+                                                    SubjectSubscription {
+                                                      "_parentOrParents": [Circular],
+                                                      "_subscriptions": null,
+                                                      "closed": false,
+                                                      "subject": [Circular],
+                                                      "subscriber": [Circular],
+                                                    },
+                                                  ],
+                                                  "closed": false,
+                                                  "destination": SafeSubscriber {
+                                                    "_complete": undefined,
+                                                    "_context": [Circular],
+                                                    "_error": undefined,
+                                                    "_next": [Function],
+                                                    "_parentOrParents": null,
+                                                    "_parentSubscriber": [Circular],
+                                                    "_subscriptions": null,
+                                                    "closed": false,
+                                                    "destination": Object {
+                                                      "closed": true,
+                                                      "complete": [Function],
+                                                      "error": [Function],
+                                                      "next": [Function],
+                                                    },
+                                                    "isStopped": false,
+                                                    "syncErrorThrowable": false,
+                                                    "syncErrorThrown": false,
+                                                    "syncErrorValue": null,
+                                                  },
+                                                  "isStopped": false,
+                                                  "syncErrorThrowable": true,
+                                                  "syncErrorThrown": false,
+                                                  "syncErrorValue": null,
+                                                },
+                                              ],
+                                              "thrownError": null,
+                                            }
+                                          }
+                                          showAsBar={false}
+                                        >
+                                          <EuiLoadingSpinner
+                                            aria-hidden={true}
+                                            aria-label="Loading content"
+                                            className="osdLoadingIndicator-hidden"
+                                            data-test-subj="globalLoadingIndicator-hidden"
+                                          >
+                                            <span
+                                              aria-hidden={true}
+                                              aria-label="Loading content"
+                                              className="euiLoadingSpinner euiLoadingSpinner--medium osdLoadingIndicator-hidden"
+                                              data-test-subj="globalLoadingIndicator-hidden"
+                                            />
+                                          </EuiLoadingSpinner>
+                                        </LoadingIndicator>
+                                      </div>
+                                    </span>
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </a>
+                          </EuiButtonEmpty>
+                        </EuiHeaderSectionItemButton>
+                      </span>
+                    </EuiToolTip>
+                  </HomeLoader>
+                </div>
+              </EuiHeaderSectionItem>
+            </div>
+          </EuiHeaderSection>
+          <HeaderBreadcrumbs
+            appTitle$={
+              BehaviorSubject {
+                "_isScalar": false,
+                "_value": "test",
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [
+                  Subscriber {
+                    "_parentOrParents": null,
+                    "_subscriptions": Array [
+                      SubjectSubscription {
+                        "_parentOrParents": [Circular],
+                        "_subscriptions": null,
+                        "closed": false,
+                        "subject": [Circular],
+                        "subscriber": [Circular],
+                      },
+                    ],
+                    "closed": false,
+                    "destination": SafeSubscriber {
+                      "_complete": undefined,
+                      "_context": [Circular],
+                      "_error": undefined,
+                      "_next": [Function],
+                      "_parentOrParents": null,
+                      "_parentSubscriber": [Circular],
+                      "_subscriptions": null,
+                      "closed": false,
+                      "destination": Object {
+                        "closed": true,
+                        "complete": [Function],
+                        "error": [Function],
+                        "next": [Function],
+                      },
+                      "isStopped": false,
+                      "syncErrorThrowable": false,
+                      "syncErrorThrown": false,
+                      "syncErrorValue": null,
+                    },
+                    "isStopped": false,
+                    "syncErrorThrowable": true,
+                    "syncErrorThrown": false,
+                    "syncErrorValue": null,
+                  },
+                ],
+                "thrownError": null,
+              }
+            }
+            breadcrumbs$={
+              BehaviorSubject {
+                "_isScalar": false,
+                "_value": Array [],
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [
+                  Subscriber {
+                    "_parentOrParents": null,
+                    "_subscriptions": Array [
+                      SubjectSubscription {
+                        "_parentOrParents": [Circular],
+                        "_subscriptions": null,
+                        "closed": false,
+                        "subject": [Circular],
+                        "subscriber": [Circular],
+                      },
+                    ],
+                    "closed": false,
+                    "destination": SafeSubscriber {
+                      "_complete": undefined,
+                      "_context": [Circular],
+                      "_error": undefined,
+                      "_next": [Function],
+                      "_parentOrParents": null,
+                      "_parentSubscriber": [Circular],
+                      "_subscriptions": null,
+                      "closed": false,
+                      "destination": Object {
+                        "closed": true,
+                        "complete": [Function],
+                        "error": [Function],
+                        "next": [Function],
+                      },
+                      "isStopped": false,
+                      "syncErrorThrowable": false,
+                      "syncErrorThrown": false,
+                      "syncErrorValue": null,
+                    },
+                    "isStopped": false,
+                    "syncErrorThrowable": true,
+                    "syncErrorThrown": false,
+                    "syncErrorValue": null,
+                  },
+                ],
+                "thrownError": null,
+              }
+            }
+            breadcrumbsEnricher$={
+              BehaviorSubject {
+                "_isScalar": false,
+                "_value": undefined,
+                "closed": false,
+                "hasError": false,
+                "isStopped": false,
+                "observers": Array [
+                  Subscriber {
+                    "_parentOrParents": null,
+                    "_subscriptions": Array [
+                      SubjectSubscription {
+                        "_parentOrParents": [Circular],
+                        "_subscriptions": null,
+                        "closed": false,
+                        "subject": [Circular],
+                        "subscriber": [Circular],
+                      },
+                    ],
+                    "closed": false,
+                    "destination": SafeSubscriber {
+                      "_complete": undefined,
+                      "_context": [Circular],
+                      "_error": undefined,
+                      "_next": [Function],
+                      "_parentOrParents": null,
+                      "_parentSubscriber": [Circular],
+                      "_subscriptions": null,
+                      "closed": false,
+                      "destination": Object {
+                        "closed": true,
+                        "complete": [Function],
+                        "error": [Function],
+                        "next": [Function],
+                      },
+                      "isStopped": false,
+                      "syncErrorThrowable": false,
+                      "syncErrorThrown": false,
+                      "syncErrorValue": null,
+                    },
+                    "isStopped": false,
+                    "syncErrorThrowable": true,
+                    "syncErrorThrown": false,
+                    "syncErrorValue": null,
+                  },
+                ],
+                "thrownError": null,
+              }
+            }
+          >
+            <EuiHeaderBreadcrumbs
+              breadcrumbs={
+                Array [
+                  Object {
+                    "data-test-subj": "breadcrumb first last",
+                    "text": "test",
+                  },
+                ]
+              }
+              data-test-subj="breadcrumbs"
+              max={10}
+            >
+              <EuiBreadcrumbs
+                breadcrumbs={
+                  Array [
+                    Object {
+                      "data-test-subj": "breadcrumb first last",
+                      "text": "test",
+                    },
+                  ]
+                }
+                className="euiHeaderBreadcrumbs"
+                data-test-subj="breadcrumbs"
+                max={10}
+                truncate={true}
+              >
+                <nav
+                  aria-label="breadcrumb"
+                  className="euiBreadcrumbs euiHeaderBreadcrumbs euiBreadcrumbs--truncate"
+                  data-test-subj="breadcrumbs"
+                >
+                  <div
+                    className="euiBreadcrumbWall euiBreadcrumbWall--single"
+                  >
+                    <div
+                      className="euiBreadcrumbWrapper euiBreadcrumbWrapper--first euiBreadcrumbWrapper--last"
+                    >
+                      <EuiInnerText>
+                        <span
+                          aria-current="page"
+                          className="euiBreadcrumb euiBreadcrumb--last"
+                          data-test-subj="breadcrumb first last"
+                          title="test"
+                        >
+                          test
+                        </span>
+                      </EuiInnerText>
+                    </div>
+                  </div>
+                </nav>
+              </EuiBreadcrumbs>
+            </EuiHeaderBreadcrumbs>
+          </HeaderBreadcrumbs>
+          <EuiHeaderSectionItem
+            border="none"
+          >
+            <div
+              className="euiHeaderSectionItem"
+            >
+              <HeaderBadge
+                badge$={
+                  BehaviorSubject {
+                    "_isScalar": false,
+                    "_value": undefined,
+                    "closed": false,
+                    "hasError": false,
+                    "isStopped": false,
+                    "observers": Array [
+                      Subscriber {
+                        "_parentOrParents": null,
+                        "_subscriptions": Array [
+                          SubjectSubscription {
+                            "_parentOrParents": [Circular],
+                            "_subscriptions": null,
+                            "closed": false,
+                            "subject": [Circular],
+                            "subscriber": [Circular],
+                          },
+                        ],
+                        "closed": false,
+                        "destination": SafeSubscriber {
+                          "_complete": undefined,
+                          "_context": [Circular],
+                          "_error": undefined,
+                          "_next": [Function],
+                          "_parentOrParents": null,
+                          "_parentSubscriber": [Circular],
+                          "_subscriptions": null,
+                          "closed": false,
+                          "destination": Object {
+                            "closed": true,
+                            "complete": [Function],
+                            "error": [Function],
+                            "next": [Function],
+                          },
+                          "isStopped": false,
+                          "syncErrorThrowable": false,
+                          "syncErrorThrown": false,
+                          "syncErrorValue": null,
+                        },
+                        "isStopped": false,
+                        "syncErrorThrowable": true,
+                        "syncErrorThrown": false,
+                        "syncErrorValue": null,
+                      },
+                    ],
+                    "thrownError": null,
+                  }
+                }
+              />
+            </div>
+          </EuiHeaderSectionItem>
+          <EuiHeaderSection
+            side="right"
+          >
+            <div
+              className="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--right"
+            >
+              <EuiHeaderSectionItem
+                border="none"
+              >
+                <div
+                  className="euiHeaderSectionItem"
+                >
+                  <HeaderActionMenu
+                    actionMenu$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": undefined,
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
+                              "_subscriptions": null,
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            "isStopped": false,
+                            "syncErrorThrowable": true,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                        ],
+                        "thrownError": null,
+                      }
+                    }
+                  >
+                    <div
+                      data-test-subj="headerAppActionMenu"
+                    />
+                  </HeaderActionMenu>
+                </div>
+              </EuiHeaderSectionItem>
+              <EuiHeaderSectionItem
+                border="left"
+              >
+                <div
+                  className="euiHeaderSectionItem euiHeaderSectionItem--borderLeft"
+                >
+                  <HeaderNavControls
+                    navControls$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": Array [],
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
+                              "_subscriptions": null,
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            "isStopped": false,
+                            "syncErrorThrowable": true,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                        ],
+                        "thrownError": null,
+                      }
+                    }
+                  />
+                </div>
+              </EuiHeaderSectionItem>
+              <EuiHeaderSectionItem
+                border="left"
+              >
+                <div
+                  className="euiHeaderSectionItem euiHeaderSectionItem--borderLeft"
+                >
+                  <HeaderNavControls
+                    navControls$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": Array [],
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
+                              "_subscriptions": null,
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            "isStopped": false,
+                            "syncErrorThrowable": true,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                        ],
+                        "thrownError": null,
+                      }
+                    }
+                    side="right"
+                  />
+                </div>
+              </EuiHeaderSectionItem>
+              <EuiHeaderSectionItem
+                border="left"
+              >
+                <div
+                  className="euiHeaderSectionItem euiHeaderSectionItem--borderLeft"
+                >
+                  <InjectIntl(HeaderHelpMenuUI)
+                    helpExtension$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": undefined,
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          InnerSubscriber {
+                            "_parentOrParents": CombineLatestSubscriber {
+                              "_parentOrParents": Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  [Circular],
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "_subscriptions": Array [
+                                [Circular],
+                                InnerSubscriber {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": Array [
+                                    SubjectSubscription {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "subject": BehaviorSubject {
+                                        "_isScalar": false,
+                                        "_value": "",
+                                        "closed": false,
+                                        "hasError": false,
+                                        "isStopped": false,
+                                        "observers": Array [
+                                          [Circular],
+                                        ],
+                                        "thrownError": null,
+                                      },
+                                      "subscriber": [Circular],
+                                    },
+                                  ],
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "index": 1,
+                                  "isStopped": false,
+                                  "outerIndex": 1,
+                                  "outerValue": undefined,
+                                  "parent": [Circular],
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                              ],
+                              "active": 2,
+                              "closed": false,
+                              "destination": Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  [Circular],
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": true,
+                              "observables": Array [
+                                [Circular],
+                                BehaviorSubject {
+                                  "_isScalar": false,
+                                  "_value": "",
+                                  "closed": false,
+                                  "hasError": false,
+                                  "isStopped": false,
+                                  "observers": Array [
+                                    InnerSubscriber {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": Array [
+                                        SubjectSubscription {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": null,
+                                          "closed": false,
+                                          "subject": [Circular],
+                                          "subscriber": [Circular],
+                                        },
+                                      ],
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "index": 1,
+                                      "isStopped": false,
+                                      "outerIndex": 1,
+                                      "outerValue": undefined,
+                                      "parent": [Circular],
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                  ],
+                                  "thrownError": null,
+                                },
+                              ],
+                              "resultSelector": undefined,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                              "toRespond": 0,
+                              "values": Array [
+                                undefined,
+                                "",
+                              ],
+                            },
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": Object {
+                              "closed": true,
+                              "complete": [Function],
+                              "error": [Function],
+                              "next": [Function],
+                            },
+                            "index": 1,
+                            "isStopped": false,
+                            "outerIndex": 0,
+                            "outerValue": undefined,
+                            "parent": CombineLatestSubscriber {
+                              "_parentOrParents": Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  [Circular],
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "_subscriptions": Array [
+                                [Circular],
+                                InnerSubscriber {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": Array [
+                                    SubjectSubscription {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "subject": BehaviorSubject {
+                                        "_isScalar": false,
+                                        "_value": "",
+                                        "closed": false,
+                                        "hasError": false,
+                                        "isStopped": false,
+                                        "observers": Array [
+                                          [Circular],
+                                        ],
+                                        "thrownError": null,
+                                      },
+                                      "subscriber": [Circular],
+                                    },
+                                  ],
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "index": 1,
+                                  "isStopped": false,
+                                  "outerIndex": 1,
+                                  "outerValue": undefined,
+                                  "parent": [Circular],
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                              ],
+                              "active": 2,
+                              "closed": false,
+                              "destination": Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  [Circular],
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": true,
+                              "observables": Array [
+                                [Circular],
+                                BehaviorSubject {
+                                  "_isScalar": false,
+                                  "_value": "",
+                                  "closed": false,
+                                  "hasError": false,
+                                  "isStopped": false,
+                                  "observers": Array [
+                                    InnerSubscriber {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": Array [
+                                        SubjectSubscription {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": null,
+                                          "closed": false,
+                                          "subject": [Circular],
+                                          "subscriber": [Circular],
+                                        },
+                                      ],
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "index": 1,
+                                      "isStopped": false,
+                                      "outerIndex": 1,
+                                      "outerValue": undefined,
+                                      "parent": [Circular],
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                  ],
+                                  "thrownError": null,
+                                },
+                              ],
+                              "resultSelector": undefined,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                              "toRespond": 0,
+                              "values": Array [
+                                undefined,
+                                "",
+                              ],
+                            },
+                            "syncErrorThrowable": false,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                        ],
+                        "thrownError": null,
+                      }
+                    }
+                    helpSupportUrl$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": "",
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          InnerSubscriber {
+                            "_parentOrParents": CombineLatestSubscriber {
+                              "_parentOrParents": Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  [Circular],
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "_subscriptions": Array [
+                                InnerSubscriber {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": Array [
+                                    SubjectSubscription {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "subject": BehaviorSubject {
+                                        "_isScalar": false,
+                                        "_value": undefined,
+                                        "closed": false,
+                                        "hasError": false,
+                                        "isStopped": false,
+                                        "observers": Array [
+                                          [Circular],
+                                        ],
+                                        "thrownError": null,
+                                      },
+                                      "subscriber": [Circular],
+                                    },
+                                  ],
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "index": 1,
+                                  "isStopped": false,
+                                  "outerIndex": 0,
+                                  "outerValue": undefined,
+                                  "parent": [Circular],
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                [Circular],
+                              ],
+                              "active": 2,
+                              "closed": false,
+                              "destination": Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  [Circular],
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": true,
+                              "observables": Array [
+                                BehaviorSubject {
+                                  "_isScalar": false,
+                                  "_value": undefined,
+                                  "closed": false,
+                                  "hasError": false,
+                                  "isStopped": false,
+                                  "observers": Array [
+                                    InnerSubscriber {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": Array [
+                                        SubjectSubscription {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": null,
+                                          "closed": false,
+                                          "subject": [Circular],
+                                          "subscriber": [Circular],
+                                        },
+                                      ],
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "index": 1,
+                                      "isStopped": false,
+                                      "outerIndex": 0,
+                                      "outerValue": undefined,
+                                      "parent": [Circular],
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                  ],
+                                  "thrownError": null,
+                                },
+                                [Circular],
+                              ],
+                              "resultSelector": undefined,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                              "toRespond": 0,
+                              "values": Array [
+                                undefined,
+                                "",
+                              ],
+                            },
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": Object {
+                              "closed": true,
+                              "complete": [Function],
+                              "error": [Function],
+                              "next": [Function],
+                            },
+                            "index": 1,
+                            "isStopped": false,
+                            "outerIndex": 1,
+                            "outerValue": undefined,
+                            "parent": CombineLatestSubscriber {
+                              "_parentOrParents": Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  [Circular],
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "_subscriptions": Array [
+                                InnerSubscriber {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": Array [
+                                    SubjectSubscription {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": null,
+                                      "closed": false,
+                                      "subject": BehaviorSubject {
+                                        "_isScalar": false,
+                                        "_value": undefined,
+                                        "closed": false,
+                                        "hasError": false,
+                                        "isStopped": false,
+                                        "observers": Array [
+                                          [Circular],
+                                        ],
+                                        "thrownError": null,
+                                      },
+                                      "subscriber": [Circular],
+                                    },
+                                  ],
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "index": 1,
+                                  "isStopped": false,
+                                  "outerIndex": 0,
+                                  "outerValue": undefined,
+                                  "parent": [Circular],
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                [Circular],
+                              ],
+                              "active": 2,
+                              "closed": false,
+                              "destination": Subscriber {
+                                "_parentOrParents": null,
+                                "_subscriptions": Array [
+                                  [Circular],
+                                ],
+                                "closed": false,
+                                "destination": SafeSubscriber {
+                                  "_complete": undefined,
+                                  "_context": [Circular],
+                                  "_error": undefined,
+                                  "_next": [Function],
+                                  "_parentOrParents": null,
+                                  "_parentSubscriber": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "destination": Object {
+                                    "closed": true,
+                                    "complete": [Function],
+                                    "error": [Function],
+                                    "next": [Function],
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": false,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": true,
+                              "observables": Array [
+                                BehaviorSubject {
+                                  "_isScalar": false,
+                                  "_value": undefined,
+                                  "closed": false,
+                                  "hasError": false,
+                                  "isStopped": false,
+                                  "observers": Array [
+                                    InnerSubscriber {
+                                      "_parentOrParents": [Circular],
+                                      "_subscriptions": Array [
+                                        SubjectSubscription {
+                                          "_parentOrParents": [Circular],
+                                          "_subscriptions": null,
+                                          "closed": false,
+                                          "subject": [Circular],
+                                          "subscriber": [Circular],
+                                        },
+                                      ],
+                                      "closed": false,
+                                      "destination": Object {
+                                        "closed": true,
+                                        "complete": [Function],
+                                        "error": [Function],
+                                        "next": [Function],
+                                      },
+                                      "index": 1,
+                                      "isStopped": false,
+                                      "outerIndex": 0,
+                                      "outerValue": undefined,
+                                      "parent": [Circular],
+                                      "syncErrorThrowable": false,
+                                      "syncErrorThrown": false,
+                                      "syncErrorValue": null,
+                                    },
+                                  ],
+                                  "thrownError": null,
+                                },
+                                [Circular],
+                              ],
+                              "resultSelector": undefined,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                              "toRespond": 0,
+                              "values": Array [
+                                undefined,
+                                "",
+                              ],
+                            },
+                            "syncErrorThrowable": false,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                        ],
+                        "thrownError": null,
+                      }
+                    }
+                    opensearchDashboardsDocLink="/docs"
+                    opensearchDashboardsVersion="1.0.0"
+                    surveyLink="/"
+                    useDefaultContent={true}
+                  >
+                    <HeaderHelpMenuUI
+                      helpExtension$={
+                        BehaviorSubject {
+                          "_isScalar": false,
+                          "_value": undefined,
+                          "closed": false,
+                          "hasError": false,
+                          "isStopped": false,
+                          "observers": Array [
+                            InnerSubscriber {
+                              "_parentOrParents": CombineLatestSubscriber {
+                                "_parentOrParents": Subscriber {
+                                  "_parentOrParents": null,
+                                  "_subscriptions": Array [
+                                    [Circular],
+                                  ],
+                                  "closed": false,
+                                  "destination": SafeSubscriber {
+                                    "_complete": undefined,
+                                    "_context": [Circular],
+                                    "_error": undefined,
+                                    "_next": [Function],
+                                    "_parentOrParents": null,
+                                    "_parentSubscriber": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "_subscriptions": Array [
+                                  [Circular],
+                                  InnerSubscriber {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": Array [
+                                      SubjectSubscription {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "subject": BehaviorSubject {
+                                          "_isScalar": false,
+                                          "_value": "",
+                                          "closed": false,
+                                          "hasError": false,
+                                          "isStopped": false,
+                                          "observers": Array [
+                                            [Circular],
+                                          ],
+                                          "thrownError": null,
+                                        },
+                                        "subscriber": [Circular],
+                                      },
+                                    ],
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "index": 1,
+                                    "isStopped": false,
+                                    "outerIndex": 1,
+                                    "outerValue": undefined,
+                                    "parent": [Circular],
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                ],
+                                "active": 2,
+                                "closed": false,
+                                "destination": Subscriber {
+                                  "_parentOrParents": null,
+                                  "_subscriptions": Array [
+                                    [Circular],
+                                  ],
+                                  "closed": false,
+                                  "destination": SafeSubscriber {
+                                    "_complete": undefined,
+                                    "_context": [Circular],
+                                    "_error": undefined,
+                                    "_next": [Function],
+                                    "_parentOrParents": null,
+                                    "_parentSubscriber": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": true,
+                                "observables": Array [
+                                  [Circular],
+                                  BehaviorSubject {
+                                    "_isScalar": false,
+                                    "_value": "",
+                                    "closed": false,
+                                    "hasError": false,
+                                    "isStopped": false,
+                                    "observers": Array [
+                                      InnerSubscriber {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": Array [
+                                          SubjectSubscription {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": null,
+                                            "closed": false,
+                                            "subject": [Circular],
+                                            "subscriber": [Circular],
+                                          },
+                                        ],
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "index": 1,
+                                        "isStopped": false,
+                                        "outerIndex": 1,
+                                        "outerValue": undefined,
+                                        "parent": [Circular],
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                    ],
+                                    "thrownError": null,
+                                  },
+                                ],
+                                "resultSelector": undefined,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                                "toRespond": 0,
+                                "values": Array [
+                                  undefined,
+                                  "",
+                                ],
+                              },
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "index": 1,
+                              "isStopped": false,
+                              "outerIndex": 0,
+                              "outerValue": undefined,
+                              "parent": CombineLatestSubscriber {
+                                "_parentOrParents": Subscriber {
+                                  "_parentOrParents": null,
+                                  "_subscriptions": Array [
+                                    [Circular],
+                                  ],
+                                  "closed": false,
+                                  "destination": SafeSubscriber {
+                                    "_complete": undefined,
+                                    "_context": [Circular],
+                                    "_error": undefined,
+                                    "_next": [Function],
+                                    "_parentOrParents": null,
+                                    "_parentSubscriber": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "_subscriptions": Array [
+                                  [Circular],
+                                  InnerSubscriber {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": Array [
+                                      SubjectSubscription {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "subject": BehaviorSubject {
+                                          "_isScalar": false,
+                                          "_value": "",
+                                          "closed": false,
+                                          "hasError": false,
+                                          "isStopped": false,
+                                          "observers": Array [
+                                            [Circular],
+                                          ],
+                                          "thrownError": null,
+                                        },
+                                        "subscriber": [Circular],
+                                      },
+                                    ],
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "index": 1,
+                                    "isStopped": false,
+                                    "outerIndex": 1,
+                                    "outerValue": undefined,
+                                    "parent": [Circular],
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                ],
+                                "active": 2,
+                                "closed": false,
+                                "destination": Subscriber {
+                                  "_parentOrParents": null,
+                                  "_subscriptions": Array [
+                                    [Circular],
+                                  ],
+                                  "closed": false,
+                                  "destination": SafeSubscriber {
+                                    "_complete": undefined,
+                                    "_context": [Circular],
+                                    "_error": undefined,
+                                    "_next": [Function],
+                                    "_parentOrParents": null,
+                                    "_parentSubscriber": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": true,
+                                "observables": Array [
+                                  [Circular],
+                                  BehaviorSubject {
+                                    "_isScalar": false,
+                                    "_value": "",
+                                    "closed": false,
+                                    "hasError": false,
+                                    "isStopped": false,
+                                    "observers": Array [
+                                      InnerSubscriber {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": Array [
+                                          SubjectSubscription {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": null,
+                                            "closed": false,
+                                            "subject": [Circular],
+                                            "subscriber": [Circular],
+                                          },
+                                        ],
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "index": 1,
+                                        "isStopped": false,
+                                        "outerIndex": 1,
+                                        "outerValue": undefined,
+                                        "parent": [Circular],
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                    ],
+                                    "thrownError": null,
+                                  },
+                                ],
+                                "resultSelector": undefined,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                                "toRespond": 0,
+                                "values": Array [
+                                  undefined,
+                                  "",
+                                ],
+                              },
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                          ],
+                          "thrownError": null,
+                        }
+                      }
+                      helpSupportUrl$={
+                        BehaviorSubject {
+                          "_isScalar": false,
+                          "_value": "",
+                          "closed": false,
+                          "hasError": false,
+                          "isStopped": false,
+                          "observers": Array [
+                            InnerSubscriber {
+                              "_parentOrParents": CombineLatestSubscriber {
+                                "_parentOrParents": Subscriber {
+                                  "_parentOrParents": null,
+                                  "_subscriptions": Array [
+                                    [Circular],
+                                  ],
+                                  "closed": false,
+                                  "destination": SafeSubscriber {
+                                    "_complete": undefined,
+                                    "_context": [Circular],
+                                    "_error": undefined,
+                                    "_next": [Function],
+                                    "_parentOrParents": null,
+                                    "_parentSubscriber": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "_subscriptions": Array [
+                                  InnerSubscriber {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": Array [
+                                      SubjectSubscription {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "subject": BehaviorSubject {
+                                          "_isScalar": false,
+                                          "_value": undefined,
+                                          "closed": false,
+                                          "hasError": false,
+                                          "isStopped": false,
+                                          "observers": Array [
+                                            [Circular],
+                                          ],
+                                          "thrownError": null,
+                                        },
+                                        "subscriber": [Circular],
+                                      },
+                                    ],
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "index": 1,
+                                    "isStopped": false,
+                                    "outerIndex": 0,
+                                    "outerValue": undefined,
+                                    "parent": [Circular],
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  [Circular],
+                                ],
+                                "active": 2,
+                                "closed": false,
+                                "destination": Subscriber {
+                                  "_parentOrParents": null,
+                                  "_subscriptions": Array [
+                                    [Circular],
+                                  ],
+                                  "closed": false,
+                                  "destination": SafeSubscriber {
+                                    "_complete": undefined,
+                                    "_context": [Circular],
+                                    "_error": undefined,
+                                    "_next": [Function],
+                                    "_parentOrParents": null,
+                                    "_parentSubscriber": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": true,
+                                "observables": Array [
+                                  BehaviorSubject {
+                                    "_isScalar": false,
+                                    "_value": undefined,
+                                    "closed": false,
+                                    "hasError": false,
+                                    "isStopped": false,
+                                    "observers": Array [
+                                      InnerSubscriber {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": Array [
+                                          SubjectSubscription {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": null,
+                                            "closed": false,
+                                            "subject": [Circular],
+                                            "subscriber": [Circular],
+                                          },
+                                        ],
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "index": 1,
+                                        "isStopped": false,
+                                        "outerIndex": 0,
+                                        "outerValue": undefined,
+                                        "parent": [Circular],
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                    ],
+                                    "thrownError": null,
+                                  },
+                                  [Circular],
+                                ],
+                                "resultSelector": undefined,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                                "toRespond": 0,
+                                "values": Array [
+                                  undefined,
+                                  "",
+                                ],
+                              },
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "index": 1,
+                              "isStopped": false,
+                              "outerIndex": 1,
+                              "outerValue": undefined,
+                              "parent": CombineLatestSubscriber {
+                                "_parentOrParents": Subscriber {
+                                  "_parentOrParents": null,
+                                  "_subscriptions": Array [
+                                    [Circular],
+                                  ],
+                                  "closed": false,
+                                  "destination": SafeSubscriber {
+                                    "_complete": undefined,
+                                    "_context": [Circular],
+                                    "_error": undefined,
+                                    "_next": [Function],
+                                    "_parentOrParents": null,
+                                    "_parentSubscriber": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "_subscriptions": Array [
+                                  InnerSubscriber {
+                                    "_parentOrParents": [Circular],
+                                    "_subscriptions": Array [
+                                      SubjectSubscription {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": null,
+                                        "closed": false,
+                                        "subject": BehaviorSubject {
+                                          "_isScalar": false,
+                                          "_value": undefined,
+                                          "closed": false,
+                                          "hasError": false,
+                                          "isStopped": false,
+                                          "observers": Array [
+                                            [Circular],
+                                          ],
+                                          "thrownError": null,
+                                        },
+                                        "subscriber": [Circular],
+                                      },
+                                    ],
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "index": 1,
+                                    "isStopped": false,
+                                    "outerIndex": 0,
+                                    "outerValue": undefined,
+                                    "parent": [Circular],
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  [Circular],
+                                ],
+                                "active": 2,
+                                "closed": false,
+                                "destination": Subscriber {
+                                  "_parentOrParents": null,
+                                  "_subscriptions": Array [
+                                    [Circular],
+                                  ],
+                                  "closed": false,
+                                  "destination": SafeSubscriber {
+                                    "_complete": undefined,
+                                    "_context": [Circular],
+                                    "_error": undefined,
+                                    "_next": [Function],
+                                    "_parentOrParents": null,
+                                    "_parentSubscriber": [Circular],
+                                    "_subscriptions": null,
+                                    "closed": false,
+                                    "destination": Object {
+                                      "closed": true,
+                                      "complete": [Function],
+                                      "error": [Function],
+                                      "next": [Function],
+                                    },
+                                    "isStopped": false,
+                                    "syncErrorThrowable": false,
+                                    "syncErrorThrown": false,
+                                    "syncErrorValue": null,
+                                  },
+                                  "isStopped": false,
+                                  "syncErrorThrowable": true,
+                                  "syncErrorThrown": false,
+                                  "syncErrorValue": null,
+                                },
+                                "isStopped": true,
+                                "observables": Array [
+                                  BehaviorSubject {
+                                    "_isScalar": false,
+                                    "_value": undefined,
+                                    "closed": false,
+                                    "hasError": false,
+                                    "isStopped": false,
+                                    "observers": Array [
+                                      InnerSubscriber {
+                                        "_parentOrParents": [Circular],
+                                        "_subscriptions": Array [
+                                          SubjectSubscription {
+                                            "_parentOrParents": [Circular],
+                                            "_subscriptions": null,
+                                            "closed": false,
+                                            "subject": [Circular],
+                                            "subscriber": [Circular],
+                                          },
+                                        ],
+                                        "closed": false,
+                                        "destination": Object {
+                                          "closed": true,
+                                          "complete": [Function],
+                                          "error": [Function],
+                                          "next": [Function],
+                                        },
+                                        "index": 1,
+                                        "isStopped": false,
+                                        "outerIndex": 0,
+                                        "outerValue": undefined,
+                                        "parent": [Circular],
+                                        "syncErrorThrowable": false,
+                                        "syncErrorThrown": false,
+                                        "syncErrorValue": null,
+                                      },
+                                    ],
+                                    "thrownError": null,
+                                  },
+                                  [Circular],
+                                ],
+                                "resultSelector": undefined,
+                                "syncErrorThrowable": true,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                                "toRespond": 0,
+                                "values": Array [
+                                  undefined,
+                                  "",
+                                ],
+                              },
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                          ],
+                          "thrownError": null,
+                        }
+                      }
+                      intl={
+                        Object {
+                          "defaultFormats": Object {},
+                          "defaultLocale": "en",
+                          "formatDate": [Function],
+                          "formatHTMLMessage": [Function],
+                          "formatMessage": [Function],
+                          "formatNumber": [Function],
+                          "formatPlural": [Function],
+                          "formatRelative": [Function],
+                          "formatTime": [Function],
+                          "formats": Object {
+                            "date": Object {
+                              "full": Object {
+                                "day": "numeric",
+                                "month": "long",
+                                "weekday": "long",
+                                "year": "numeric",
+                              },
+                              "long": Object {
+                                "day": "numeric",
+                                "month": "long",
+                                "year": "numeric",
+                              },
+                              "medium": Object {
+                                "day": "numeric",
+                                "month": "short",
+                                "year": "numeric",
+                              },
+                              "short": Object {
+                                "day": "numeric",
+                                "month": "numeric",
+                                "year": "2-digit",
+                              },
+                            },
+                            "number": Object {
+                              "currency": Object {
+                                "style": "currency",
+                              },
+                              "percent": Object {
+                                "style": "percent",
+                              },
+                            },
+                            "relative": Object {
+                              "days": Object {
+                                "units": "day",
+                              },
+                              "hours": Object {
+                                "units": "hour",
+                              },
+                              "minutes": Object {
+                                "units": "minute",
+                              },
+                              "months": Object {
+                                "units": "month",
+                              },
+                              "seconds": Object {
+                                "units": "second",
+                              },
+                              "years": Object {
+                                "units": "year",
+                              },
+                            },
+                            "time": Object {
+                              "full": Object {
+                                "hour": "numeric",
+                                "minute": "numeric",
+                                "second": "numeric",
+                                "timeZoneName": "short",
+                              },
+                              "long": Object {
+                                "hour": "numeric",
+                                "minute": "numeric",
+                                "second": "numeric",
+                                "timeZoneName": "short",
+                              },
+                              "medium": Object {
+                                "hour": "numeric",
+                                "minute": "numeric",
+                                "second": "numeric",
+                              },
+                              "short": Object {
+                                "hour": "numeric",
+                                "minute": "numeric",
+                              },
+                            },
+                          },
+                          "formatters": Object {
+                            "getDateTimeFormat": [Function],
+                            "getMessageFormat": [Function],
+                            "getNumberFormat": [Function],
+                            "getPluralFormat": [Function],
+                            "getRelativeFormat": [Function],
+                          },
+                          "locale": "en",
+                          "messages": Object {},
+                          "now": [Function],
+                          "onError": [Function],
+                          "textComponent": Symbol(react.fragment),
+                          "timeZone": null,
+                        }
+                      }
+                      opensearchDashboardsDocLink="/docs"
+                      opensearchDashboardsVersion="1.0.0"
+                      surveyLink="/"
+                      useDefaultContent={true}
+                    >
+                      <EuiPopover
+                        anchorPosition="downRight"
+                        button={
+                          <EuiToolTip
+                            content="Help"
+                            delay="long"
+                            position="bottom"
+                          >
+                            <EuiHeaderSectionItemButton
+                              aria-expanded={false}
+                              aria-haspopup="true"
+                              aria-label="Help menu"
+                              onClick={[Function]}
+                            >
+                              <EuiIcon
+                                size="m"
+                                type="questionInCircle"
+                              />
+                            </EuiHeaderSectionItemButton>
+                          </EuiToolTip>
+                        }
+                        closePopover={[Function]}
+                        data-test-subj="helpMenuButton"
+                        display="inlineBlock"
+                        hasArrow={true}
+                        id="headerHelpMenu"
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
+                        repositionOnScroll={true}
+                      >
+                        <div
+                          className="euiPopover euiPopover--anchorDownRight"
+                          data-test-subj="helpMenuButton"
+                          id="headerHelpMenu"
+                        >
+                          <div
+                            className="euiPopover__anchor"
+                          >
+                            <EuiToolTip
+                              content="Help"
+                              delay="long"
+                              position="bottom"
+                            >
+                              <span
+                                className="euiToolTipAnchor"
+                                onKeyUp={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                              >
+                                <EuiHeaderSectionItemButton
+                                  aria-expanded={false}
+                                  aria-haspopup="true"
+                                  aria-label="Help menu"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                >
+                                  <EuiButtonEmpty
+                                    aria-expanded={false}
+                                    aria-haspopup="true"
+                                    aria-label="Help menu"
+                                    buttonRef={
+                                      Object {
+                                        "current": <button
+                                          aria-expanded="false"
+                                          aria-haspopup="true"
+                                          aria-label="Help menu"
+                                          class="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
+                                          type="button"
+                                        >
+                                          <span
+                                            class="euiButtonContent euiButtonEmpty__content"
+                                          >
+                                            <span
+                                              class="euiButtonEmpty__text"
+                                            >
+                                              <span
+                                                class="euiHeaderSectionItemButton__content"
+                                              >
+                                                <span
+                                                  data-euiicon-type="questionInCircle"
+                                                />
+                                              </span>
+                                            </span>
+                                          </span>
+                                        </button>,
+                                      }
+                                    }
+                                    className="euiHeaderSectionItemButton"
+                                    color="text"
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                  >
+                                    <button
+                                      aria-expanded={false}
+                                      aria-haspopup="true"
+                                      aria-label="Help menu"
+                                      className="euiButtonEmpty euiButtonEmpty--text euiHeaderSectionItemButton"
+                                      disabled={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="left"
+                                        iconSize="m"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonEmpty__content"
+                                        >
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            <span
+                                              className="euiHeaderSectionItemButton__content"
+                                            >
+                                              <EuiIcon
+                                                size="m"
+                                                type="questionInCircle"
+                                              >
+                                                <span
+                                                  data-euiicon-type="questionInCircle"
+                                                  size="m"
+                                                />
+                                              </EuiIcon>
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </EuiHeaderSectionItemButton>
+                              </span>
+                            </EuiToolTip>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </HeaderHelpMenuUI>
+                  </InjectIntl(HeaderHelpMenuUI)>
+                </div>
+              </EuiHeaderSectionItem>
+            </div>
+          </EuiHeaderSection>
+        </div>
+      </EuiHeader>
+    </div>
+    <CollapsibleNav
+      appId$={
+        Observable {
+          "_isScalar": false,
+          "source": Subject {
+            "_isScalar": false,
+            "closed": false,
+            "hasError": false,
+            "isStopped": false,
+            "observers": Array [
+              Subscriber {
+                "_parentOrParents": null,
+                "_subscriptions": Array [
+                  SubjectSubscription {
+                    "_parentOrParents": [Circular],
+                    "_subscriptions": null,
+                    "closed": false,
+                    "subject": [Circular],
+                    "subscriber": [Circular],
+                  },
+                ],
+                "closed": false,
+                "destination": SafeSubscriber {
+                  "_complete": undefined,
+                  "_context": [Circular],
+                  "_error": undefined,
+                  "_next": [Function],
+                  "_parentOrParents": null,
+                  "_parentSubscriber": [Circular],
+                  "_subscriptions": null,
+                  "closed": false,
+                  "destination": Object {
+                    "closed": true,
+                    "complete": [Function],
+                    "error": [Function],
+                    "next": [Function],
+                  },
+                  "isStopped": false,
+                  "syncErrorThrowable": false,
+                  "syncErrorThrown": false,
+                  "syncErrorValue": null,
+                },
+                "isStopped": false,
+                "syncErrorThrowable": true,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              Subscriber {
+                "_parentOrParents": null,
+                "_subscriptions": Array [
+                  SubjectSubscription {
+                    "_parentOrParents": [Circular],
+                    "_subscriptions": null,
+                    "closed": false,
+                    "subject": [Circular],
+                    "subscriber": [Circular],
+                  },
+                ],
+                "closed": false,
+                "destination": SafeSubscriber {
+                  "_complete": undefined,
+                  "_context": [Circular],
+                  "_error": undefined,
+                  "_next": [Function],
+                  "_parentOrParents": null,
+                  "_parentSubscriber": [Circular],
+                  "_subscriptions": null,
+                  "closed": false,
+                  "destination": Object {
+                    "closed": true,
+                    "complete": [Function],
+                    "error": [Function],
+                    "next": [Function],
+                  },
+                  "isStopped": false,
+                  "syncErrorThrowable": false,
+                  "syncErrorThrown": false,
+                  "syncErrorValue": null,
+                },
+                "isStopped": false,
+                "syncErrorThrowable": true,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+            ],
+            "thrownError": null,
+          },
+        }
+      }
+      basePath={
+        BasePath {
+          "basePath": "/test",
+          "clientBasePath": "",
+          "get": [Function],
+          "getBasePath": [Function],
+          "prepend": [Function],
+          "remove": [Function],
+          "serverBasePath": "/test",
+        }
+      }
+      closeNav={[Function]}
+      customNavLink$={
+        BehaviorSubject {
+          "_isScalar": false,
+          "_value": undefined,
+          "closed": false,
+          "hasError": false,
+          "isStopped": false,
+          "observers": Array [
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
+                  "_subscriptions": null,
+                  "closed": false,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+          ],
+          "thrownError": null,
+        }
+      }
+      homeHref="/"
+      id="mockId"
+      isLocked={false}
+      isNavOpen={true}
+      logos={
+        Object {
+          "AnimatedMark": Object {
+            "dark": Object {
+              "type": "default",
+              "url": "/ui/logos/opensearch_spinner_on_dark.svg",
+            },
+            "light": Object {
+              "type": "default",
+              "url": "/ui/logos/opensearch_spinner_on_light.svg",
+            },
+            "type": "default",
+            "url": "/ui/logos/opensearch_spinner_on_light.svg",
+          },
+          "Application": Object {
+            "dark": Object {
+              "type": "default",
+              "url": "/ui/logos/opensearch_dashboards_on_dark.svg",
+            },
+            "light": Object {
+              "type": "default",
+              "url": "/ui/logos/opensearch_dashboards_on_light.svg",
+            },
+            "type": "default",
+            "url": "/ui/logos/opensearch_dashboards_on_light.svg",
+          },
+          "CenterMark": Object {
+            "dark": Object {
+              "type": "default",
+              "url": "/ui/logos/opensearch_center_mark_on_dark.svg",
+            },
+            "light": Object {
+              "type": "default",
+              "url": "/ui/logos/opensearch_center_mark_on_light.svg",
+            },
+            "type": "default",
+            "url": "/ui/logos/opensearch_center_mark_on_light.svg",
+          },
+          "Mark": Object {
+            "dark": Object {
+              "type": "default",
+              "url": "/ui/logos/opensearch_mark_on_dark.svg",
+            },
+            "light": Object {
+              "type": "default",
+              "url": "/ui/logos/opensearch_mark_on_light.svg",
+            },
+            "type": "default",
+            "url": "/ui/logos/opensearch_mark_on_light.svg",
+          },
+          "OpenSearch": Object {
+            "dark": Object {
+              "type": "default",
+              "url": "/ui/logos/opensearch_on_dark.svg",
+            },
+            "light": Object {
+              "type": "default",
+              "url": "/ui/logos/opensearch_on_light.svg",
+            },
+            "type": "default",
+            "url": "/ui/logos/opensearch_on_light.svg",
+          },
+          "colorScheme": "light",
+        }
+      }
+      navLinks$={
+        BehaviorSubject {
+          "_isScalar": false,
+          "_value": Array [],
+          "closed": false,
+          "hasError": false,
+          "isStopped": false,
+          "observers": Array [
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
+                  "_subscriptions": null,
+                  "closed": false,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
+                  "_subscriptions": null,
+                  "closed": false,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+          ],
+          "thrownError": null,
+        }
+      }
+      navigateToApp={[MockFunction]}
+      navigateToUrl={[MockFunction]}
+      onIsLockedUpdate={[Function]}
+      recentlyAccessed$={
+        BehaviorSubject {
+          "_isScalar": false,
+          "_value": Array [],
+          "closed": false,
+          "hasError": false,
+          "isStopped": false,
+          "observers": Array [
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
+                  "_subscriptions": null,
+                  "closed": false,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+          ],
+          "thrownError": null,
+        }
+      }
+    >
+      <EuiCollapsibleNav
+        aria-label="Primary"
+        data-test-subj="collapsibleNav"
+        id="mockId"
+        isDocked={false}
+        isOpen={true}
+        onClose={[Function]}
+        outsideClickCloses={false}
+      >
+        <EuiFlyout
+          aria-label="Primary"
+          as="nav"
+          className="euiCollapsibleNav"
+          closeButtonPosition="outside"
+          data-test-subj="collapsibleNav"
+          hideCloseButton={false}
+          id="mockId"
+          onClose={[Function]}
+          outsideClickCloses={false}
+          ownFocus={true}
+          paddingSize="none"
+          pushMinBreakpoint="l"
+          role={null}
+          side="left"
+          size={320}
+          type="overlay"
+        >
+          <nav
+            data-eui="EuiFlyout"
+            data-test-subj="collapsibleNav"
+            role={null}
+          >
+            <button
+              data-test-subj="euiFlyoutCloseButton"
+              onClick={[Function]}
+              type="button"
+            />
+            <EuiCollapsibleNavGroup
+              background="light"
+              data-test-subj="collapsibleNavGroup-recentlyViewed"
+              initialIsOpen={true}
+              isCollapsible={true}
+              key="recentlyViewed"
+              onToggle={[Function]}
+              title="Recently viewed"
+            >
+              <EuiAccordion
+                arrowDisplay="right"
+                buttonClassName="euiCollapsibleNavGroup__heading"
+                buttonContent={
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="m"
+                    responsive={false}
+                  >
+                    <EuiFlexItem>
+                      <EuiTitle
+                        size="xxs"
+                      >
+                        <h3
+                          className="euiCollapsibleNavGroup__title"
+                          id="mockId__title"
+                        >
+                          Recently viewed
+                        </h3>
+                      </EuiTitle>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                }
+                className="euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                data-test-subj="collapsibleNavGroup-recentlyViewed"
+                id="mockId"
+                initialIsOpen={true}
+                isLoading={false}
+                isLoadingMessage={false}
+                onToggle={[Function]}
+                paddingSize="none"
+              >
+                <div
+                  className="euiAccordion euiAccordion-isOpen euiCollapsibleNavGroup euiCollapsibleNavGroup--light euiCollapsibleNavGroup--withHeading"
+                  data-test-subj="collapsibleNavGroup-recentlyViewed"
+                  onToggle={[Function]}
+                >
+                  <div
+                    className="euiAccordion__triggerWrapper"
+                  >
+                    <button
+                      aria-controls="mockId"
+                      aria-expanded={true}
+                      className="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
+                      id="mockId"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="euiAccordion__iconWrapper"
+                      >
+                        <EuiIcon
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          size="m"
+                          type="arrowRight"
+                        >
+                          <span
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            data-euiicon-type="arrowRight"
+                            size="m"
+                          />
+                        </EuiIcon>
+                      </span>
+                      <span
+                        className="euiIEFlexWrapFix"
+                      >
+                        <EuiFlexGroup
+                          alignItems="center"
+                          gutterSize="m"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiTitle
+                                  size="xxs"
+                                >
+                                  <h3
+                                    className="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+                                    id="mockId__title"
+                                  >
+                                    Recently viewed
+                                  </h3>
+                                </EuiTitle>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-labelledby="mockId"
+                    className="euiAccordion__childWrapper"
+                    id="mockId"
+                    role="region"
+                    tabIndex={-1}
+                  >
+                    <EuiResizeObserver
+                      onResize={[Function]}
+                    >
+                      <div>
+                        <div
+                          className=""
+                        >
+                          <div
+                            className="euiCollapsibleNavGroup__children"
+                          >
+                            <EuiText
+                              color="subdued"
+                              size="s"
+                              style={
+                                Object {
+                                  "padding": "0 8px 8px",
+                                }
+                              }
+                            >
+                              <div
+                                className="euiText euiText--small"
+                                style={
+                                  Object {
+                                    "padding": "0 8px 8px",
+                                  }
+                                }
+                              >
+                                <EuiTextColor
+                                  color="subdued"
+                                  component="div"
+                                >
+                                  <div
+                                    className="euiTextColor euiTextColor--subdued"
+                                  >
+                                    <p>
+                                      No recently viewed items
+                                    </p>
+                                  </div>
+                                </EuiTextColor>
+                              </div>
+                            </EuiText>
+                          </div>
+                        </div>
+                      </div>
+                    </EuiResizeObserver>
+                  </div>
+                </div>
+              </EuiAccordion>
+            </EuiCollapsibleNavGroup>
+            <EuiHorizontalRule
+              margin="none"
+            >
+              <hr
+                className="euiHorizontalRule euiHorizontalRule--full"
+              />
+            </EuiHorizontalRule>
+            <EuiFlexItem
+              className="eui-yScroll"
+            >
+              <div
+                className="euiFlexItem eui-yScroll"
+              >
+                <EuiShowFor
+                  sizes={
+                    Array [
+                      "l",
+                      "xl",
+                    ]
+                  }
+                >
+                  <EuiCollapsibleNavGroup>
+                    <div
+                      className="euiCollapsibleNavGroup"
+                      id="mockId"
+                    >
+                      <div
+                        className="euiCollapsibleNavGroup__children"
+                      >
+                        <EuiListGroup
+                          flush={true}
+                        >
+                          <ul
+                            className="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+                          >
+                            <EuiListGroupItem
+                              aria-label="Dock primary navigation"
+                              buttonRef={
+                                Object {
+                                  "current": <button
+                                    aria-label="Dock primary navigation"
+                                    class="euiListGroupItem__button"
+                                    data-test-subj="collapsible-nav-lock"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="euiListGroupItem__icon"
+                                      color="inherit"
+                                      data-euiicon-type="lockOpen"
+                                    />
+                                    <span
+                                      class="euiListGroupItem__label"
+                                      title="Dock navigation"
+                                    >
+                                      Dock navigation
+                                    </span>
+                                  </button>,
+                                }
+                              }
+                              color="subdued"
+                              data-test-subj="collapsible-nav-lock"
+                              iconType="lockOpen"
+                              label="Dock navigation"
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              <li
+                                className="euiListGroupItem euiListGroupItem--xSmall euiListGroupItem--subdued euiListGroupItem-isClickable"
+                              >
+                                <button
+                                  aria-label="Dock primary navigation"
+                                  className="euiListGroupItem__button"
+                                  data-test-subj="collapsible-nav-lock"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    className="euiListGroupItem__icon"
+                                    color="inherit"
+                                    type="lockOpen"
+                                  >
+                                    <span
+                                      className="euiListGroupItem__icon"
+                                      color="inherit"
+                                      data-euiicon-type="lockOpen"
+                                    />
+                                  </EuiIcon>
+                                  <span
+                                    className="euiListGroupItem__label"
+                                    title="Dock navigation"
+                                  >
+                                    Dock navigation
+                                  </span>
+                                </button>
+                              </li>
+                            </EuiListGroupItem>
+                          </ul>
+                        </EuiListGroup>
+                      </div>
+                    </div>
+                  </EuiCollapsibleNavGroup>
+                </EuiShowFor>
+              </div>
+            </EuiFlexItem>
+          </nav>
+        </EuiFlyout>
+      </EuiCollapsibleNav>
     </CollapsibleNav>
   </header>
 </Header>

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -37,6 +37,7 @@ import { applicationServiceMock, chromeServiceMock } from '../../../mocks';
 import { Header } from './header';
 import { StubBrowserStorage } from 'test_utils/stub_browser_storage';
 import { ISidecarConfig, SIDECAR_DOCKED_MODE } from '../../../overlays';
+import { EuiHeaderSectionItemButton } from '@elastic/eui';
 
 jest.mock('@elastic/eui/lib/services/accessibility/html_id_generator', () => ({
   htmlIdGenerator: () => () => 'mockId',
@@ -204,5 +205,18 @@ describe('Header', () => {
     const component = mountWithIntl(<Header {...props} navGroupEnabled />);
 
     expect(component.find('.header__toggleNavButtonSection').exists()).toBeFalsy();
+  });
+
+  it('toggles primary navigation menu when clicked', () => {
+    const branding = {
+      useExpandedHeader: false,
+    };
+    const props = {
+      ...mockProps(),
+      branding,
+    };
+    const component = mountWithIntl(<Header {...props} />);
+    component.find(EuiHeaderSectionItemButton).first().simulate('click');
+    expect(component).toMatchSnapshot();
   });
 });

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -37,7 +37,6 @@ import {
   EuiHideFor,
   EuiIcon,
   EuiShowFor,
-  EuiToolTip,
   htmlIdGenerator,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
@@ -208,27 +207,25 @@ export function Header({
             <EuiHeaderSection grow={false}>
               {shouldHideExpandIcon ? null : (
                 <EuiHeaderSectionItem border="right" className="header__toggleNavButtonSection">
-                  <EuiToolTip
-                    content={i18n.translate('core.ui.primaryNav.menu', {
-                      defaultMessage: 'Menu',
+                  <EuiHeaderSectionItemButton
+                    data-test-subj="toggleNavButton"
+                    aria-label={i18n.translate('core.ui.primaryNav.toggleNavAriaLabel', {
+                      defaultMessage: 'Toggle primary navigation',
                     })}
-                    delay="long"
-                    position="bottom"
+                    onClick={() => setIsNavOpen(!isNavOpen)}
+                    aria-expanded={isNavOpen}
+                    aria-pressed={isNavOpen}
+                    aria-controls={navId}
+                    ref={toggleCollapsibleNavRef}
                   >
-                    <EuiHeaderSectionItemButton
-                      data-test-subj="toggleNavButton"
-                      aria-label={i18n.translate('core.ui.primaryNav.toggleNavAriaLabel', {
-                        defaultMessage: 'Toggle primary navigation',
+                    <EuiIcon
+                      type="menu"
+                      size="m"
+                      title={i18n.translate('core.ui.primaryNav.menu', {
+                        defaultMessage: 'Menu',
                       })}
-                      onClick={() => setIsNavOpen(!isNavOpen)}
-                      aria-expanded={isNavOpen}
-                      aria-pressed={isNavOpen}
-                      aria-controls={navId}
-                      ref={toggleCollapsibleNavRef}
-                    >
-                      <EuiIcon type="menu" size="m" />
-                    </EuiHeaderSectionItemButton>
-                  </EuiToolTip>
+                    />
+                  </EuiHeaderSectionItemButton>
                 </EuiHeaderSectionItem>
               )}
 

--- a/test/plugin_functional/test_suites/dashboard_listing_plugin/dashboard_listing_plugin.ts
+++ b/test/plugin_functional/test_suites/dashboard_listing_plugin/dashboard_listing_plugin.ts
@@ -55,7 +55,7 @@ export default function ({ getService, getPageObjects }) {
     it('should be able to navigate to edit dashboard', async () => {
       await listingTable.searchForItemWithName(dashboardName);
       const editBttn = await find.allByCssSelector('.euiToolTipAnchor');
-      await editBttn[3].click();
+      await editBttn[2].click();
       await PageObjects.dashboard.clickCancelOutOfEditMode();
       await PageObjects.dashboard.gotoDashboardLandingPage();
     });


### PR DESCRIPTION
### Description

Cherry picked #7493. Manually changed `test/plugin_functional/test_suites/dashboard_listing_plugin/dashboard_listing_plugin.ts` because of lack of User Theme popover button in 2.x.

## Changelog

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
