### PR TITLE
[Vis-Builder] Fix Droppable Areas not highlighting while dragging a Field

### DIFF
--- a/changelogs/fragments/7527.yml
+++ b/changelogs/fragments/7527.yml
@@ -1,0 +1,2 @@
+fix:
+- Not highlighting Droppable Areas while dragging a field ([#7527](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7527))

--- a/src/plugins/vis_builder/public/application/components/data_tab/config_panel.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/config_panel.tsx
@@ -31,6 +31,7 @@ export interface ConfigPanelProps {
   aggProps: AggProps;
   activeSchemaFields: SchemaDisplayStates;
   setActiveSchemaFields: React.Dispatch<React.SetStateAction<SchemaDisplayStates>>;
+  isDragging: boolean;
 }
 
 export function ConfigPanel({
@@ -39,6 +40,7 @@ export function ConfigPanel({
   aggProps,
   activeSchemaFields,
   setActiveSchemaFields,
+  isDragging,
 }: ConfigPanelProps) {
   if (!schemas) return null;
 
@@ -46,7 +48,8 @@ export function ConfigPanel({
     schemas,
     aggProps,
     activeSchemaFields,
-    setActiveSchemaFields
+    setActiveSchemaFields,
+    isDragging
   );
 
   return (

--- a/src/plugins/vis_builder/public/application/components/data_tab/constants.ts
+++ b/src/plugins/vis_builder/public/application/components/data_tab/constants.ts
@@ -9,3 +9,4 @@ export enum FIELD_SELECTOR_ID {
   NUMERICAL = 'numericalFields',
   META = 'metaFields',
 }
+export const ADD_PANEL_PREFIX = 'AddPanel_';

--- a/src/plugins/vis_builder/public/application/components/data_tab/dropbox.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/dropbox.tsx
@@ -53,6 +53,7 @@ const DropboxComponent = ({
   isValidDropTarget,
   canDrop,
   dropProps,
+  isDragging,
 }: DropboxProps) => {
   const prefersReducedMotion = usePrefersReducedMotion();
   const [closing, setClosing] = useState<boolean | string>(false);
@@ -79,58 +80,74 @@ const DropboxComponent = ({
           droppableId={dropboxId}
           isCombineEnabled={true}
         >
-          {fields.map(({ id, label }, index) => (
-            <EuiDraggable
-              className={`dropBox__draggable ${id === closing && 'closing'}`}
-              key={id}
-              draggableId={id}
-              index={index}
-            >
-              <EuiPanel
-                key={index}
-                paddingSize="s"
-                className="dropBox__field"
-                data-test-subj={`dropBoxField-${dropboxId}-${index}`}
-              >
-                <EuiText size="s" className="dropBox__field_text" onClick={() => onEditField(id)}>
-                  <a role="button" tabIndex={0}>
-                    {label}
-                  </a>
-                </EuiText>
-                <EuiSmallButtonIcon
-                  color="subdued"
-                  iconType="cross"
-                  aria-label="clear-field"
-                  iconSize="s"
-                  onClick={() => animateDelete(id)}
-                  data-test-subj="dropBoxRemoveBtn"
-                />
-              </EuiPanel>
-            </EuiDraggable>
-          ))}
+          {(provided, snapshot) => (
+            <div ref={provided.innerRef} {...provided.droppableProps}>
+              {fields.map(({ id, label }, index) => (
+                <EuiDraggable
+                  className={`dropBox__draggable ${id === closing && 'closing'}`}
+                  key={id}
+                  draggableId={id}
+                  index={index}
+                >
+                  <EuiPanel
+                    key={index}
+                    paddingSize="s"
+                    className={`dropBox__field dropBox__dropTarget ${
+                      isDragging ? 'validField' : ''
+                    } ${snapshot.isDraggingOver ? 'canDrop' : ''}`}
+                    data-test-subj={`dropBoxField-${dropboxId}-${index}`}
+                  >
+                    <EuiText
+                      size="s"
+                      className="dropBox__field_text"
+                      onClick={() => onEditField(id)}
+                    >
+                      <a role="button" tabIndex={0}>
+                        {label}
+                      </a>
+                    </EuiText>
+                    <EuiSmallButtonIcon
+                      color="subdued"
+                      iconType="cross"
+                      aria-label="clear-field"
+                      iconSize="s"
+                      onClick={() => animateDelete(id)}
+                      data-test-subj="dropBoxRemoveBtn"
+                    />
+                  </EuiPanel>
+                </EuiDraggable>
+              ))}
+            </div>
+          )}
         </EuiDroppable>
-        {fields.length < limit && (
-          <EuiPanel
-            data-test-subj={`dropBoxAddField-${dropboxId}`}
-            className={`dropBox__field dropBox__dropTarget ${
-              isValidDropTarget ? 'validField' : ''
-            } ${canDrop ? 'canDrop' : ''}`}
-            {...(isValidDropTarget && dropProps)}
-          >
-            <EuiText size="s">
-              {i18n.translate('visBuilder.dropbox.addField.title', {
-                defaultMessage: 'Click or drop to add',
-              })}
-            </EuiText>
-            <EuiSmallButtonIcon
-              iconType="plusInCircle"
-              aria-label="clear-field"
-              iconSize="s"
-              onClick={() => onAddField()}
-              data-test-subj="dropBoxAddBtn"
-            />
-          </EuiPanel>
-        )}
+        <EuiDroppable droppableId={`AddPanel_${dropboxId}`}>
+          {(provided, snapshot) => (
+            <div ref={provided.innerRef} {...provided.droppableProps}>
+              {fields.length < limit && (
+                <EuiPanel
+                  data-test-subj={`dropBoxAddField-${dropboxId}`}
+                  className={`dropBox__field dropBox__dropTarget ${
+                    isDragging ? 'validField' : ''
+                  } ${snapshot.isDraggingOver ? 'canDrop' : ''}`}
+                  {...(isValidDropTarget && dropProps)}
+                >
+                  <EuiText size="s">
+                    {i18n.translate('visBuilder.dropbox.addField.title', {
+                      defaultMessage: 'Click or drop to add',
+                    })}
+                  </EuiText>
+                  <EuiSmallButtonIcon
+                    iconType="plusInCircle"
+                    aria-label="clear-field"
+                    iconSize="s"
+                    onClick={() => onAddField()}
+                    data-test-subj="dropBoxAddBtn"
+                  />
+                </EuiPanel>
+              )}
+            </div>
+          )}
+        </EuiDroppable>
       </div>
     </EuiCompressedFormRow>
   );

--- a/src/plugins/vis_builder/public/application/components/data_tab/schema_to_dropbox.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/schema_to_dropbox.tsx
@@ -13,7 +13,8 @@ export const mapSchemaToAggPanel = (
   schemas: Schemas,
   aggProps: AggProps,
   activeSchemaFields: SchemaDisplayStates,
-  setActiveSchemaFields: React.Dispatch<React.SetStateAction<SchemaDisplayStates>>
+  setActiveSchemaFields: React.Dispatch<React.SetStateAction<SchemaDisplayStates>>,
+  isDragging: boolean
 ) => {
   const panelComponents = schemas.all.map((schema) => {
     return (
@@ -25,6 +26,7 @@ export const mapSchemaToAggPanel = (
         aggProps={aggProps}
         activeSchemaFields={activeSchemaFields}
         setActiveSchemaFields={setActiveSchemaFields}
+        isDragging={isDragging}
       />
     );
   });

--- a/src/plugins/vis_builder/public/application/components/data_tab/use/use_dropbox.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/use/use_dropbox.tsx
@@ -26,6 +26,7 @@ export interface UseDropboxProps extends Pick<DropboxProps, 'id' | 'label'> {
   aggProps: AggProps;
   activeSchemaFields: SchemaDisplayStates;
   setActiveSchemaFields: React.Dispatch<React.SetStateAction<SchemaDisplayStates>>;
+  isDragging: boolean;
 }
 
 export const useDropbox = (props: UseDropboxProps): DropboxProps => {
@@ -36,6 +37,7 @@ export const useDropbox = (props: UseDropboxProps): DropboxProps => {
     aggProps,
     activeSchemaFields,
     setActiveSchemaFields,
+    isDragging,
   } = props;
   const [validAggTypes, setValidAggTypes] = useState<string[]>([]);
   const { aggConfigs, indexPattern, aggs, timeRange } = aggProps;
@@ -209,5 +211,6 @@ export const useDropbox = (props: UseDropboxProps): DropboxProps => {
     dragData,
     isValidDropTarget: canDrop,
     dropProps,
+    isDragging,
   };
 };


### PR DESCRIPTION
### Description

This PR aims to enhance the user experience in Vis Builder by highlighting the droppable areas when a user starts dragging a field and fixing the bug which removed this feature. 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

https://github.com/user-attachments/assets/48a915a2-886a-44e2-8412-d93604c4b31b


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Navigate to Vis Builder Page 
- Start Dragging a Field from the left side field panel 
- You should see all the droppable areas highlighted

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Not highlighting Droppable Areas while dragging a field 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
