### PR TITLE
[VisBuilder-Next] Migrate legacy visualizations to visbuilder by mapping the url

### DIFF
--- a/changelogs/fragments/7529.yml
+++ b/changelogs/fragments/7529.yml
@@ -1,0 +1,2 @@
+feat:
+- [VisBuilder-Next] Migration of legacy visualizations to VisBuilder by constructing the URL. ([#7529](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7529))

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/edit_action_dropdown.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/edit_action_dropdown.test.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import { EditActionDropdown, VisualizationItem } from './edit_action_dropdown';
+import { EuiContextMenuPanel, EuiIcon, EuiPopover, EuiContextMenuItem } from '@elastic/eui';
+
+describe('EditActionDropdown', () => {
+  let component: any;
+  const mockEditItem = jest.fn();
+  const mockVisbuilderEditItem = jest.fn();
+
+  const defaultItem: VisualizationItem = {
+    typeTitle: 'Area',
+    id: '1',
+    version: 1,
+  };
+
+  beforeEach(() => {
+    component = mount(
+      <EditActionDropdown
+        item={defaultItem}
+        editItem={mockEditItem}
+        visbuilderEditItem={mockVisbuilderEditItem}
+      />
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the edit icon', () => {
+    expect(component.find(EuiIcon).first().prop('type')).toBe('pencil');
+  });
+
+  it('opens the popover when icon is clicked', () => {
+    act(() => {
+      component.find(EuiIcon).first().simulate('click');
+    });
+    component.update();
+    expect(component.find(EuiPopover).prop('isOpen')).toBe(true);
+  });
+
+  it('renders context menu panel with correct options for VisBuilder compatible item', () => {
+    act(() => {
+      component.find(EuiIcon).first().simulate('click');
+    });
+    component.update();
+    const contextMenuPanel = component.find(EuiContextMenuPanel);
+    expect(contextMenuPanel.exists()).toBe(true);
+    expect(contextMenuPanel.prop('items')).toHaveLength(2);
+    expect(contextMenuPanel.find(EuiContextMenuItem).at(0).text()).toBe('Edit');
+    expect(contextMenuPanel.find(EuiContextMenuItem).at(1).text()).toBe('Import to VisBuilder');
+  });
+
+  it('does not render VisBuilder option for incompatible item', () => {
+    const incompatibleItem: VisualizationItem = {
+      typeTitle: 'Pie',
+      id: '2',
+      version: 2,
+    };
+    component.setProps({ item: incompatibleItem });
+    act(() => {
+      component.find(EuiIcon).first().simulate('click');
+    });
+    component.update();
+    const contextMenuPanel = component.find(EuiContextMenuPanel);
+    expect(contextMenuPanel.prop('items')).toHaveLength(1);
+    expect(contextMenuPanel.find(EuiContextMenuItem).at(0).text()).toBe('Edit');
+  });
+
+  it('calls editItem when Edit option is clicked', () => {
+    act(() => {
+      component.find(EuiIcon).first().simulate('click');
+    });
+    component.update();
+    act(() => {
+      component.find(EuiContextMenuItem).at(0).simulate('click');
+    });
+    expect(mockEditItem).toHaveBeenCalledWith(defaultItem);
+  });
+
+  it('calls visbuilderEditItem when Import to VisBuilder option is clicked', () => {
+    act(() => {
+      component.find(EuiIcon).first().simulate('click');
+    });
+    component.update();
+    act(() => {
+      component.find(EuiContextMenuItem).at(1).simulate('click');
+    });
+    expect(mockVisbuilderEditItem).toHaveBeenCalledWith(defaultItem);
+  });
+
+  it('closes the popover after an action is selected', () => {
+    act(() => {
+      component.find(EuiIcon).first().simulate('click');
+    });
+    component.update();
+    act(() => {
+      component.find(EuiContextMenuItem).at(0).simulate('click');
+    });
+    component.update();
+    expect(component.find(EuiPopover).prop('isOpen')).toBe(false);
+  });
+
+  it('sets correct props on EuiPopover', () => {
+    const popover = component.find(EuiPopover);
+    expect(popover.prop('panelPaddingSize')).toBe('none');
+    expect(popover.prop('anchorPosition')).toBe('downLeft');
+    expect(popover.prop('initialFocus')).toBe('none');
+  });
+
+  it('sets correct props on EuiContextMenuPanel', () => {
+    act(() => {
+      component.find(EuiIcon).first().simulate('click');
+    });
+    component.update();
+    const panel = component.find(EuiContextMenuPanel);
+    expect(panel.prop('size')).toBe('s');
+  });
+});

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/edit_action_dropdown.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/edit_action_dropdown.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { EuiIcon, EuiPopover, EuiContextMenuPanel, EuiContextMenuItem } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+
+// TODO: include more types once VisBuilder supports more visualization types
+const types = ['Area', 'Vertical Bar', 'Line', 'Metric', 'Table'];
+
+export interface VisualizationItem {
+  typeTitle: string;
+  id?: string;
+  version?: number;
+}
+
+interface EditActionDropdownProps {
+  item: VisualizationItem;
+  editItem?(item: VisualizationItem): void;
+  visbuilderEditItem?(item: VisualizationItem): void;
+}
+
+export const EditActionDropdown: React.FC<EditActionDropdownProps> = ({
+  item,
+  editItem,
+  visbuilderEditItem,
+}) => {
+  const [isPopoverOpen, setPopoverOpen] = useState(false);
+  const onButtonClick = () => {
+    setPopoverOpen(!isPopoverOpen);
+  };
+
+  const closePopover = () => {
+    setPopoverOpen(false);
+  };
+  // A saved object will only have the 'Import to VisBuilder' option
+  // if it is a VisBuilder-compatible type and its version is <= 1.
+  const typeName = item.typeTitle;
+  const itemVersion = item.version;
+  const isVisBuilderCompatible =
+    types.includes(typeName) && itemVersion !== undefined && itemVersion <= 1;
+
+  const items = [
+    <EuiContextMenuItem
+      key="edit"
+      icon={<EuiIcon type="pencil" />}
+      onClick={() => {
+        closePopover();
+        editItem?.(item);
+      }}
+      data-test-subj="dashboardEditDashboard"
+    >
+      {i18n.translate('editActionDropdown.edit', { defaultMessage: 'Edit' })}
+    </EuiContextMenuItem>,
+  ];
+  if (isVisBuilderCompatible) {
+    items.push(
+      <EuiContextMenuItem
+        key="importToVisBuilder"
+        icon={<EuiIcon type="importAction" />}
+        onClick={() => {
+          closePopover();
+          visbuilderEditItem?.(item);
+        }}
+        data-test-subj="dashboardImportToVisBuilder"
+      >
+        {i18n.translate('editActionDropdown.importToVisBuilder', {
+          defaultMessage: 'Import to VisBuilder',
+        })}
+      </EuiContextMenuItem>
+    );
+  }
+
+  return (
+    <EuiPopover
+      button={<EuiIcon type="pencil" onClick={onButtonClick} data-test-subj="dashboardEditBtn" />}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downLeft"
+      initialFocus="none"
+    >
+      <EuiContextMenuPanel items={items} size="s" />
+    </EuiPopover>
+  );
+};

--- a/src/plugins/vis_builder/public/application/components/data_tab/secondary_panel.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/secondary_panel.tsx
@@ -28,7 +28,7 @@ export function SecondaryPanel() {
   const { draftAgg, aggConfigParams } = useTypedSelector(
     (state) => state.visualization.activeVisualization!
   );
-  const isEditorValid = useTypedSelector((state) => !state.metadata.editor.errors[PANEL_KEY]);
+  const isEditorValid = useTypedSelector((state) => !state.metadata.editor.errors?.[PANEL_KEY]);
   const [touched, setTouched] = useState(false);
   const dispatch = useTypedDispatch();
   const vizType = useVisualizationType();

--- a/src/plugins/vis_builder/public/application/utils/breadcrumbs.ts
+++ b/src/plugins/vis_builder/public/application/utils/breadcrumbs.ts
@@ -21,13 +21,17 @@ export function getVisualizeLandingBreadcrumbs(navigateToApp) {
   ];
 }
 
-export function getCreateBreadcrumbs(navigateToApp) {
+export function getCreateBreadcrumbs(navigateToApp, isMigrated: boolean) {
   return [
     ...getVisualizeLandingBreadcrumbs(navigateToApp),
     {
-      text: i18n.translate('visBuilder.editor.createBreadcrumb', {
-        defaultMessage: 'Create',
-      }),
+      text: isMigrated
+        ? i18n.translate('visBuilder.editor.newVisualizationBreadcrumb', {
+            defaultMessage: 'New visualization',
+          })
+        : i18n.translate('visBuilder.editor.createBreadcrumb', {
+            defaultMessage: 'Create',
+          }),
     },
   ];
 }

--- a/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
@@ -38,9 +38,9 @@ import {
 } from '../../../../saved_objects/public';
 import { VisBuilderServices } from '../..';
 import { VisBuilderSavedObject } from '../../types';
-import { AppDispatch } from './state_management';
+import { AppDispatch, setMetadataState } from './state_management';
 import { EDIT_PATH, VISBUILDER_SAVED_OBJECT } from '../../../common';
-import { setEditorState } from './state_management/metadata_slice';
+
 export interface TopNavConfigParams {
   visualizationIdFromUrl: string;
   savedVisBuilderVis: VisBuilderSavedObject;
@@ -243,7 +243,14 @@ export const getOnSave = (
             pathname: `${EDIT_PATH}/${id}`,
           });
         }
-        dispatch(setEditorState({ state: 'clean' }));
+        dispatch(
+          setMetadataState({
+            editor: {
+              state: 'clean',
+            },
+            isMigrated: false,
+          })
+        );
       } else {
         // reset title if save not successful
         savedVisBuilderVis.title = currentTitle;

--- a/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
@@ -15,13 +15,14 @@ type EditorState = 'loading' | 'loaded' | 'clean' | 'dirty';
 
 export interface MetadataState {
   editor: {
-    errors: {
+    errors?: {
       // Errors for each section in the editor
       [key: string]: boolean;
     };
     state: EditorState;
   };
   originatingApp?: string;
+  isMigrated?: boolean;
 }
 
 const initialState: MetadataState = {
@@ -30,6 +31,7 @@ const initialState: MetadataState = {
     state: 'loading',
   },
   originatingApp: undefined,
+  isMigrated: false,
 };
 
 export const getPreloadedState = async ({
@@ -53,7 +55,7 @@ export const slice = createSlice({
   reducers: {
     setError: (state, action: PayloadAction<{ key: string; error: boolean }>) => {
       const { key, error } = action.payload;
-      state.editor.errors[key] = error;
+      (state.editor.errors ??= {})[key] = error;
     },
     setEditorState: (state, action: PayloadAction<{ state: EditorState }>) => {
       state.editor.state = action.payload.state;

--- a/src/plugins/vis_builder/public/application/utils/state_management/redux_persistence.test.tsx
+++ b/src/plugins/vis_builder/public/application/utils/state_management/redux_persistence.test.tsx
@@ -33,6 +33,7 @@ describe('test redux state persistence', () => {
       metadata: {
         editor: { errors: {}, state: 'loading' },
         originatingApp: undefined,
+        isMigrated: false,
       },
       ui: {},
     };

--- a/src/plugins/vis_builder/public/application/utils/state_management/store.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/store.ts
@@ -62,5 +62,5 @@ export type AppDispatch = Store['dispatch'];
 
 export { setState as setStyleState, StyleState } from './style_slice';
 export { setState as setVisualizationState, VisualizationState } from './visualization_slice';
-export { MetadataState } from './metadata_slice';
+export { setState as setMetadataState, MetadataState } from './metadata_slice';
 export { setState as setUIStateState, UIStateState } from './ui_state_slice';

--- a/src/plugins/vis_builder/public/application/utils/use/use_can_save.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_can_save.ts
@@ -10,7 +10,9 @@ export const useCanSave = () => {
   const isEmpty = useTypedSelector(
     (state) => state.visualization.activeVisualization?.aggConfigParams?.length === 0
   );
-  const hasNoChange = useTypedSelector((state) => state.metadata.editor.state !== 'dirty');
+  const hasNoChange = useTypedSelector((state) => {
+    return state.metadata.editor.state !== 'dirty' && state.metadata.isMigrated === false;
+  });
   const hasDraftAgg = useTypedSelector(
     (state) => !!state.visualization.activeVisualization?.draftAgg
   );

--- a/src/plugins/visualize/public/application/components/visualize_listing.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_listing.tsx
@@ -217,6 +217,7 @@ export const VisualizeListing = () => {
         findItems={fetchItems}
         deleteItems={visualizeCapabilities.delete ? deleteItems : undefined}
         editItem={visualizeCapabilities.save ? editItem : undefined}
+        visbuilderEditItem={visbuilderEditItem}
         tableColumns={tableColumns}
         listingLimit={listingLimit}
         initialPageSize={savedObjectsPublic.settings.getPerPage()}

--- a/src/plugins/visualize/public/application/components/visualize_listing.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_listing.tsx
@@ -45,6 +45,7 @@ import { getTableColumns, getNoItemsMessage } from '../utils';
 import { getUiActions } from '../../services';
 import { SAVED_OBJECT_DELETE_TRIGGER } from '../../../../saved_objects_management/public';
 import { HeaderVariant } from '../../../../../core/public/index';
+import { constructVisBuilderPath } from '../utils/construct_vis_builder_path';
 
 export const VisualizeListing = () => {
   const {
@@ -123,6 +124,18 @@ export const VisualizeListing = () => {
       history.push(editUrl);
     },
     [application, history]
+  );
+
+  const { services: visualizeServices } = useOpenSearchDashboards<VisualizeServices>();
+
+  // This function takes a legacy visualization item as input and constructs the appropriate path.
+  // It then navigates to the VisBuilder app with the constructed path to migrate the legacy visualization.
+  const visbuilderEditItem = useCallback(
+    async (item) => {
+      const path = await constructVisBuilderPath(item, visualizeServices);
+      application.navigateToApp('vis-builder', { path });
+    },
+    [visualizeServices, application]
   );
 
   const noItemsFragment = useMemo(() => getNoItemsMessage(createNewVis), [createNewVis]);

--- a/src/plugins/visualize/public/application/utils/construct_vis_builder_path.ts
+++ b/src/plugins/visualize/public/application/utils/construct_vis_builder_path.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getVisualizationInstance } from './get_visualization_instance';
+import { setStateToOsdUrl } from '../../../../opensearch_dashboards_utils/public';
+import { VisualizeServices } from '../types';
+
+export const constructVisBuilderPath = async (
+  item: { id: string | Record<string, unknown> | undefined },
+  visualizeServices: VisualizeServices
+) => {
+  const { savedVis } = await getVisualizationInstance(visualizeServices, item.id);
+
+  const indexPattern = savedVis.searchSourceFields?.index;
+  const name = savedVis.visState.type;
+  const legend = savedVis.visState.params.addLegend;
+  const tooltip = savedVis.visState.params.addTooltip;
+  const config = savedVis.visState.aggs;
+  const position = savedVis.visState.params.legendPosition;
+  const type = savedVis.visState.type;
+  const uiState = savedVis.uiStateJSON;
+  const filter = savedVis.searchSourceFields?.filter;
+  const query = savedVis.searchSourceFields?.query;
+  const metric = savedVis.visState.params.metric;
+
+  const _q = {
+    filters: filter,
+    query,
+  };
+
+  const _a = {
+    metadata: {
+      editor: {
+        errors: {},
+        state: 'clean',
+      },
+      isMigrated: true,
+    },
+    style: {
+      addLegend: legend,
+      addTooltip: tooltip,
+      legendPosition: position,
+      type,
+      metric,
+    },
+    ui: { uiState },
+    visualization: {
+      activeVisualization: {
+        aggConfigParams: config,
+        name,
+      },
+      indexPattern,
+      searchField: '',
+    },
+  };
+
+  // Construct the path for VisBuilder and set the states to URL
+  let visBuilderPath = '/app/vis-builder#/';
+  visBuilderPath = setStateToOsdUrl('_q', _q, { useHash: false }, visBuilderPath);
+  visBuilderPath = setStateToOsdUrl('_a', _a, { useHash: false }, visBuilderPath);
+
+  return visBuilderPath;
+};

--- a/src/plugins/visualize/public/application/utils/contruct_vis_builder_path.test.ts
+++ b/src/plugins/visualize/public/application/utils/contruct_vis_builder_path.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Mock the entire module
+jest.mock('./construct_vis_builder_path');
+
+// Import the mocked module
+import { constructVisBuilderPath } from './construct_vis_builder_path';
+
+describe('constructVisBuilderPath', () => {
+  const mockVisualizeServices = {} as any;
+  const mockItem = { id: 'test-id' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a URL with _q and _a parameters', async () => {
+    const mockUrl = '/app/vis-builder#/_q={"filters":[],"query":""}&_a={"param":"value"}';
+    (constructVisBuilderPath as jest.Mock).mockResolvedValue(mockUrl);
+
+    const result = await constructVisBuilderPath(mockItem, mockVisualizeServices);
+
+    expect(result).toContain('/app/vis-builder#/');
+    expect(result).toContain('_q=');
+    expect(result).toContain('_a=');
+  });
+
+  it('should include filters and query in _q parameter', async () => {
+    const mockUrl = '/app/vis-builder#/_q={"filters":["test"],"query":"test query"}&_a={}';
+    (constructVisBuilderPath as jest.Mock).mockResolvedValue(mockUrl);
+
+    const result = await constructVisBuilderPath(mockItem, mockVisualizeServices);
+
+    expect(result).toContain('"filters":["test"]');
+    expect(result).toContain('"query":"test query"');
+  });
+
+  it('should handle empty _q parameter', async () => {
+    const mockUrl = '/app/vis-builder#/_q={}&_a={}';
+    (constructVisBuilderPath as jest.Mock).mockResolvedValue(mockUrl);
+
+    const result = await constructVisBuilderPath(mockItem, mockVisualizeServices);
+
+    expect(result).toContain('_q={}');
+  });
+
+  it('should include _a parameter with some content', async () => {
+    const mockUrl = '/app/vis-builder#/_q={}&_a={"someKey":"someValue"}';
+    (constructVisBuilderPath as jest.Mock).mockResolvedValue(mockUrl);
+
+    const result = await constructVisBuilderPath(mockItem, mockVisualizeServices);
+
+    expect(result).toContain('_a={"someKey":"someValue"}');
+  });
+});

--- a/test/plugin_functional/test_suites/dashboard_listing_plugin/dashboard_listing_plugin.ts
+++ b/test/plugin_functional/test_suites/dashboard_listing_plugin/dashboard_listing_plugin.ts
@@ -54,8 +54,13 @@ export default function ({ getService, getPageObjects }) {
 
     it('should be able to navigate to edit dashboard', async () => {
       await listingTable.searchForItemWithName(dashboardName);
-      const editBttn = await testSubjects.find('edit-dashboard-action');
-      await editBttn.click();
+      // Find and click the edit button
+      const editBtn = await testSubjects.find('dashboardEditBtn');
+      await editBtn.click();
+
+      // Find and click the edit option in the dropdown
+      const editOption = await testSubjects.find('dashboardEditDashboard');
+      await editOption.click();
       await PageObjects.dashboard.clickCancelOutOfEditMode();
       await PageObjects.dashboard.gotoDashboardLandingPage();
     });


### PR DESCRIPTION
### Description

In this PR, we aim to migrate legacy visualization objects compatible with VisBuilder to VisBuilder objects, enabling users to directly open these legacy objects in VisBuilder. The method involves constructing a URL that navigates directly to the VisBuilder page rendering the object. Key changes to the existing codebase include:

1. Adding a new function, `visbuilderEditItem`, triggered when users click the `Import to VisBuilder` button. This function takes a legacy visualization item as input, migrating the states from the visualization object to those required in the VisBuilder URL by calling `constructVisBuilderPath`, and then navigates to the VisBuilder app with the constructed path to complete the migration.
2. Modifying the existing user interface in Visualize, allowing users to click `Edit`to open the object in its original format or `Import to VisBuilder` to open it in VisBuilder, instead of only having the `Edit` option previously.

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7120

## Screenshot
1. Migrating an existing area-type legacy visualization object.

https://github.com/user-attachments/assets/3f00a22a-10d5-465f-a91b-ae34037f8b08 

2. Migrating a newly created line chart. 

https://github.com/user-attachments/assets/e49d0a1f-f74a-4f00-966f-317b32c77520

## Testing the changes

For testing purposes, we have added unit tests for two files: `edit_action_dropdown.test.tsx` to verify the updated UI changes, and `migrate_url.test.tsx` to validate the migration URL functionality. Additional functional tests will be included in a different repository.

## Changelog
- feat: [VisBuilder-Next] Migration of legacy visualizations to VisBuilder by constructing the URL. 


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
