### PR TITLE
fix: use xs buttons for discover table cell filter buttons

### DIFF
--- a/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
@@ -12,7 +12,7 @@
 import './_table_cell.scss';
 
 import React from 'react';
-import { EuiSmallButtonIcon, EuiToolTip } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { DocViewFilterFn } from '../../doc_views/doc_views_types';
 
@@ -45,7 +45,8 @@ const TableCellUI = ({
             defaultMessage: 'Filter for value',
           })}
         >
-          <EuiSmallButtonIcon
+          <EuiButtonIcon
+            size="xs"
             onClick={() => onFilter?.(columnId, fieldMapping, '+')}
             iconType="plusInCircle"
             aria-label={i18n.translate('discover.filterForValueLabel', {
@@ -60,7 +61,8 @@ const TableCellUI = ({
             defaultMessage: 'Filter out value',
           })}
         >
-          <EuiSmallButtonIcon
+          <EuiButtonIcon
+            size="xs"
             onClick={() => onFilter?.(columnId, fieldMapping, '-')}
             iconType="minusInCircle"
             aria-label={i18n.translate('discover.filterOutValueLabel', {


### PR DESCRIPTION
### Description

Discover table cell buttons got larger, this just makes them match previous size. See screenshots below. 

The positioning difference wrt to border is likely due to padding change (although when I changed padding, I made sure these buttons showed up in the same place, so not sure if something else changed).

### Issues Resolved
N/A

## Screenshot

Change:
![image](https://github.com/user-attachments/assets/5cf37e48-c350-4fc5-b369-8933a49921ec)
![image](https://github.com/user-attachments/assets/6cafad93-55b1-42f3-8289-ae621cb8b60a)

Playground:
![image](https://github.com/user-attachments/assets/5bf263fb-547a-4f02-aa8c-075363edc98b)
![image](https://github.com/user-attachments/assets/56560da2-23fe-404b-a748-a95051d23d70)

## Testing the changes

Validated in discover locally vs playground

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [X] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
