### PR TITLE
Fix browser warnings

### DIFF
--- a/changelogs/fragments/7548.yml
+++ b/changelogs/fragments/7548.yml
@@ -1,2 +1,2 @@
 fix:
-- Resolve some browser warnings ([#7548](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7548))
+- Resolve some browser warnings. ([#7548](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7548))

--- a/changelogs/fragments/7548.yml
+++ b/changelogs/fragments/7548.yml
@@ -1,0 +1,2 @@
+fix:
+- Resolve some browser warnings ([#7548](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7548))

--- a/src/plugins/content_management/public/components/page_render.tsx
+++ b/src/plugins/content_management/public/components/page_render.tsx
@@ -28,7 +28,7 @@ export const PageRender = ({ page, embeddable, savedObjectsClient }: Props) => {
       style={{ margin: '10px 20px' }}
     >
       {sections.map((section) => (
-        <EuiFlexItem>
+        <EuiFlexItem key={section.id}>
           <SectionRender
             key={section.id}
             embeddable={embeddable}

--- a/src/plugins/home/public/application/components/home_list_card.tsx
+++ b/src/plugins/home/public/application/components/home_list_card.tsx
@@ -74,14 +74,14 @@ export const HomeListCard = ({ config }: { config: Config }) => {
         {config.list.length > 0 && (
           <EuiDescriptionList>
             {config.list.map((item) => (
-              <>
+              <React.Fragment key={item.href}>
                 <EuiDescriptionListTitle>
                   <EuiLink href={item.href} target="_blank">
                     {item.label}
                   </EuiLink>
                 </EuiDescriptionListTitle>
                 <EuiDescriptionListDescription>{item.description}</EuiDescriptionListDescription>
-              </>
+              </React.Fragment>
             ))}
           </EuiDescriptionList>
         )}

--- a/src/plugins/home/public/application/home_render.tsx
+++ b/src/plugins/home/public/application/home_render.tsx
@@ -36,7 +36,11 @@ export const setupHome = (contentManagement: ContentManagementPluginSetup) => {
             <>
               {contents.map((content) => {
                 if (content.kind === 'custom') {
-                  return content.render();
+                  return (
+                    <React.Fragment key={content.id}>
+                      {content.render()}
+                    </React.Fragment>
+                  )
                 }
 
                 return null;

--- a/src/plugins/home/public/application/home_render.tsx
+++ b/src/plugins/home/public/application/home_render.tsx
@@ -36,11 +36,7 @@ export const setupHome = (contentManagement: ContentManagementPluginSetup) => {
             <>
               {contents.map((content) => {
                 if (content.kind === 'custom') {
-                  return (
-                    <React.Fragment key={content.id}>
-                      {content.render()}
-                    </React.Fragment>
-                  )
+                  return <React.Fragment key={content.id}>{content.render()}</React.Fragment>;
                 }
 
                 return null;

--- a/src/plugins/workspace/public/components/home_get_start_card/use_case_footer.tsx
+++ b/src/plugins/workspace/public/components/home_get_start_card/use_case_footer.tsx
@@ -94,7 +94,7 @@ export const UseCaseFooter = ({
           onClick={showModal}
           data-test-subj="useCase.footer.createWorkspace.button"
         >
-          {i18n.translate("useCase.footer.createWorkspace", {defaultMessage: "Create workspace"})}
+          {i18n.translate('useCase.footer.createWorkspace', { defaultMessage: 'Create workspace' })}
         </EuiButton>
         {isModalVisible && (
           <EuiModal onClose={closeModal} style={{ width: '450px' }}>
@@ -108,7 +108,7 @@ export const UseCaseFooter = ({
 
             <EuiModalFooter>
               <EuiButton onClick={closeModal} data-test-subj="useCase.footer.modal.close.button">
-                {i18n.translate("useCase.footer.modal.close", {defaultMessage: "Close"})}
+                {i18n.translate('useCase.footer.modal.close', { defaultMessage: 'Close' })}
               </EuiButton>
               {isDashboardAdmin && (
                 <EuiButton
@@ -116,7 +116,9 @@ export const UseCaseFooter = ({
                   data-test-subj="useCase.footer.modal.create.button"
                   fill
                 >
-                  {i18n.translate("useCase.footer.modal.create", {defaultMessage: "Create workspace"})}
+                  {i18n.translate('useCase.footer.modal.create', {
+                    defaultMessage: 'Create workspace',
+                  })}
                 </EuiButton>
               )}
             </EuiModalFooter>
@@ -134,7 +136,7 @@ export const UseCaseFooter = ({
     );
     return (
       <EuiButton href={useCaseURL} data-test-subj="useCase.footer.openWorkspace.button">
-        {i18n.translate("useCase.footer.openWorkspace", {defaultMessage: "Open"})}
+        {i18n.translate('useCase.footer.openWorkspace', { defaultMessage: 'Open' })}
       </EuiButton>
     );
   }
@@ -172,7 +174,7 @@ export const UseCaseFooter = ({
 
   const button = (
     <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
-      {i18n.translate("useCase.footer.selectWorkspace", {defaultMessage: "Select workspace"})}
+      {i18n.translate('useCase.footer.selectWorkspace', { defaultMessage: 'Select workspace' })}
     </EuiButton>
   );
   const panels = [

--- a/src/plugins/workspace/public/components/home_get_start_card/use_case_footer.tsx
+++ b/src/plugins/workspace/public/components/home_get_start_card/use_case_footer.tsx
@@ -22,7 +22,7 @@ import {
   EuiModalHeaderTitle,
 } from '@elastic/eui';
 import React, { useMemo, useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+// import { FormattedMessage } from 'react-intl';
 import { i18n } from '@osd/i18n';
 import { BehaviorSubject } from 'rxjs';
 import { WORKSPACE_DETAIL_APP_ID } from '../../../common/constants';
@@ -94,7 +94,7 @@ export const UseCaseFooter = ({
           onClick={showModal}
           data-test-subj="useCase.footer.createWorkspace.button"
         >
-          <FormattedMessage id="useCase.footer.createWorkspace" defaultMessage="Create workspace" />
+          {i18n.translate("useCase.footer.createWorkspace", {defaultMessage: "Create workspace"})}
         </EuiButton>
         {isModalVisible && (
           <EuiModal onClose={closeModal} style={{ width: '450px' }}>
@@ -108,7 +108,7 @@ export const UseCaseFooter = ({
 
             <EuiModalFooter>
               <EuiButton onClick={closeModal} data-test-subj="useCase.footer.modal.close.button">
-                <FormattedMessage id="useCase.footer.modal.close" defaultMessage="Close" />
+                {i18n.translate("useCase.footer.modal.close", {defaultMessage: "Close"})}
               </EuiButton>
               {isDashboardAdmin && (
                 <EuiButton
@@ -116,10 +116,7 @@ export const UseCaseFooter = ({
                   data-test-subj="useCase.footer.modal.create.button"
                   fill
                 >
-                  <FormattedMessage
-                    id="useCase.footer.modal.create"
-                    defaultMessage="Create workspace"
-                  />
+                  {i18n.translate("useCase.footer.modal.create", {defaultMessage: "Create workspace"})}
                 </EuiButton>
               )}
             </EuiModalFooter>
@@ -137,7 +134,7 @@ export const UseCaseFooter = ({
     );
     return (
       <EuiButton href={useCaseURL} data-test-subj="useCase.footer.openWorkspace.button">
-        <FormattedMessage id="useCase.footer.openWorkspace" defaultMessage="Open" />
+        {i18n.translate("useCase.footer.openWorkspace", {defaultMessage: "Open"})}
       </EuiButton>
     );
   }
@@ -175,7 +172,7 @@ export const UseCaseFooter = ({
 
   const button = (
     <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
-      <FormattedMessage id="useCase.footer.selectWorkspace" defaultMessage="Select workspace" />
+      {i18n.translate("useCase.footer.selectWorkspace", {defaultMessage: "Select workspace"})}
     </EuiButton>
   );
   const panels = [

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -371,7 +371,7 @@ export class WorkspacePlugin
         }),
       },
     ]);
-
+    
 
     /**
      * register workspace column into saved objects table

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -372,14 +372,6 @@ export class WorkspacePlugin
       },
     ]);
 
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.settingsAndSetup, [
-      {
-        id: WORKSPACE_LIST_APP_ID,
-        title: i18n.translate('workspace.settingsAndSetup.workspaceSettings', {
-          defaultMessage: 'workspace settings',
-        }),
-      },
-    ]);
 
     /**
      * register workspace column into saved objects table

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -371,7 +371,6 @@ export class WorkspacePlugin
         }),
       },
     ]);
-    
 
     /**
      * register workspace column into saved objects table


### PR DESCRIPTION
### Description

Added `key` props in ‘PageRender’, ‘setupHome’, and ‘HomeListCard’.

Resolved 'intl' object not found error by using i18n.translate.

Resolved the issue of duplicate 'addNavLinksToGroup' calls to prevent the "Navlink of workspace_list has already been registered in group settingsAndSetup".

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7515

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.


Descriptions following the prefixes must be 100 characters long or less
-->
- fix:  Resolve some browser warnings.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

