### PR TITLE
Fix query assist after #7492, #7546, #7540

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
@@ -317,11 +317,13 @@ exports[`Dashboard top nav render in embed mode 1`] = `
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],
-                "dataSet": Object {
+                "dataSetManager": Object {
+                  "fetchDefaultDataSet": [MockFunction],
                   "getDataSet": [MockFunction],
                   "getDefaultDataSet": [MockFunction],
                   "getUpdates$": [MockFunction],
                   "init": [MockFunction],
+                  "initWithIndexPattern": [MockFunction],
                   "setDataSet": [MockFunction],
                 },
                 "filterManager": Object {
@@ -1338,11 +1340,13 @@ exports[`Dashboard top nav render in embed mode, and force hide filter bar 1`] =
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],
-                "dataSet": Object {
+                "dataSetManager": Object {
+                  "fetchDefaultDataSet": [MockFunction],
                   "getDataSet": [MockFunction],
                   "getDefaultDataSet": [MockFunction],
                   "getUpdates$": [MockFunction],
                   "init": [MockFunction],
+                  "initWithIndexPattern": [MockFunction],
                   "setDataSet": [MockFunction],
                 },
                 "filterManager": Object {
@@ -2359,11 +2363,13 @@ exports[`Dashboard top nav render in embed mode, components can be forced show b
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],
-                "dataSet": Object {
+                "dataSetManager": Object {
+                  "fetchDefaultDataSet": [MockFunction],
                   "getDataSet": [MockFunction],
                   "getDefaultDataSet": [MockFunction],
                   "getUpdates$": [MockFunction],
                   "init": [MockFunction],
+                  "initWithIndexPattern": [MockFunction],
                   "setDataSet": [MockFunction],
                 },
                 "filterManager": Object {
@@ -3380,11 +3386,13 @@ exports[`Dashboard top nav render in full screen mode with appended URL param bu
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],
-                "dataSet": Object {
+                "dataSetManager": Object {
+                  "fetchDefaultDataSet": [MockFunction],
                   "getDataSet": [MockFunction],
                   "getDefaultDataSet": [MockFunction],
                   "getUpdates$": [MockFunction],
                   "init": [MockFunction],
+                  "initWithIndexPattern": [MockFunction],
                   "setDataSet": [MockFunction],
                 },
                 "filterManager": Object {
@@ -4401,11 +4409,13 @@ exports[`Dashboard top nav render in full screen mode, no componenets should be 
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],
-                "dataSet": Object {
+                "dataSetManager": Object {
+                  "fetchDefaultDataSet": [MockFunction],
                   "getDataSet": [MockFunction],
                   "getDefaultDataSet": [MockFunction],
                   "getUpdates$": [MockFunction],
                   "init": [MockFunction],
+                  "initWithIndexPattern": [MockFunction],
                   "setDataSet": [MockFunction],
                 },
                 "filterManager": Object {
@@ -5422,11 +5432,13 @@ exports[`Dashboard top nav render with all components 1`] = `
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],
-                "dataSet": Object {
+                "dataSetManager": Object {
+                  "fetchDefaultDataSet": [MockFunction],
                   "getDataSet": [MockFunction],
                   "getDefaultDataSet": [MockFunction],
                   "getUpdates$": [MockFunction],
                   "init": [MockFunction],
+                  "initWithIndexPattern": [MockFunction],
                   "setDataSet": [MockFunction],
                 },
                 "filterManager": Object {

--- a/src/plugins/data/public/query/dataset_manager/dataset_manager.mock.ts
+++ b/src/plugins/data/public/query/dataset_manager/dataset_manager.mock.ts
@@ -12,6 +12,8 @@ const createSetupContractMock = () => {
     setDataSet: jest.fn(),
     getUpdates$: jest.fn(),
     getDefaultDataSet: jest.fn(),
+    fetchDefaultDataSet: jest.fn(),
+    initWithIndexPattern: jest.fn(),
   };
   return dataSetManagerMock;
 };

--- a/src/plugins/data/public/query/dataset_manager/dataset_manager.test.ts
+++ b/src/plugins/data/public/query/dataset_manager/dataset_manager.test.ts
@@ -15,7 +15,7 @@ describe('DataSetManager', () => {
     service = new DataSetManager(uiSettingsMock);
   });
 
-  test('getUpdates$ is a cold emits only after query changes', () => {
+  test('getUpdates$ is a cold emits only after dataset changes', () => {
     const obs$ = service.getUpdates$();
     const emittedValues: SimpleDataSet[] = [];
     obs$.subscribe((v) => {

--- a/src/plugins/data/public/query/dataset_manager/dataset_manager.test.ts
+++ b/src/plugins/data/public/query/dataset_manager/dataset_manager.test.ts
@@ -15,11 +15,11 @@ describe('DataSetManager', () => {
     service = new DataSetManager(uiSettingsMock);
   });
 
-  test('getUpdates$ emits initially and after data set changes', () => {
+  test('getUpdates$ is a cold emits only after query changes', () => {
     const obs$ = service.getUpdates$();
-    const emittedValues: Array<SimpleDataSet | undefined> = [];
+    const emittedValues: SimpleDataSet[] = [];
     obs$.subscribe((v) => {
-      emittedValues.push(v);
+      emittedValues.push(v!);
     });
     expect(emittedValues).toHaveLength(0);
     expect(emittedValues[0]).toEqual(undefined);

--- a/src/plugins/data/public/query/mocks.ts
+++ b/src/plugins/data/public/query/mocks.ts
@@ -42,7 +42,7 @@ const createSetupContractMock = () => {
     filterManager: createFilterManagerMock(),
     timefilter: timefilterServiceMock.createSetupContract(),
     queryString: queryStringManagerMock.createSetupContract(),
-    dataSet: dataSetManagerMock.createSetupContract(),
+    dataSetManager: dataSetManagerMock.createSetupContract(),
     state$: new Observable(),
   };
 
@@ -57,7 +57,7 @@ const createStartContractMock = () => {
     savedQueries: jest.fn() as any,
     state$: new Observable(),
     timefilter: timefilterServiceMock.createStartContract(),
-    dataSet: dataSetManagerMock.createStartContract(),
+    dataSetManager: dataSetManagerMock.createStartContract(),
     getOpenSearchQuery: jest.fn(),
   };
 

--- a/src/plugins/data/public/ui/dataset_navigator/create_dataset_navigator.tsx
+++ b/src/plugins/data/public/ui/dataset_navigator/create_dataset_navigator.tsx
@@ -15,7 +15,7 @@ export function createDataSetNavigator(
   dataSetManager: DataSetContract
 ) {
   // Return a function that takes props, omitting the dependencies from the props type
-  return (props: Omit<DataSetNavigatorProps, 'savedObjectsClient' | 'http' | 'dataSet'>) => (
+  return (props: Omit<DataSetNavigatorProps, 'savedObjectsClient' | 'http' | 'dataSetManager'>) => (
     <DataSetNavigator
       {...props}
       savedObjectsClient={savedObjectsClient}

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -406,6 +406,10 @@ export default class QueryEditorUI extends Component<Props, State> {
           {languageSelector}
           {this.props.queryActions}
         </div>
+        <div
+          ref={this.headerRef}
+          className={classNames('osdQueryEditor__header', this.props.headerClassName)}
+        />
         {!this.state.isCollapsed && (
           <div className="osdQueryEditor__body">{languageEditor.Body()}</div>
         )}
@@ -505,7 +509,6 @@ export default class QueryEditorUI extends Component<Props, State> {
            </EuiFlexItem>
 
            <EuiFlexItem onClick={this.onClickInput} grow={true}>
-             <div ref={this.headerRef} className={headerClassName} />
              {!this.state.isCollapsed && useQueryEditor && (
                <CodeEditor
                  height={70}

--- a/src/plugins/query_enhancements/public/query_assist/_index.scss
+++ b/src/plugins/query_enhancements/public/query_assist/_index.scss
@@ -3,4 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-@import "./query_assist";
+.queryAssist__form {
+  padding: $euiSizeXS;
+}

--- a/src/plugins/query_enhancements/public/query_assist/_index.scss
+++ b/src/plugins/query_enhancements/public/query_assist/_index.scss
@@ -3,6 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-.queryAssist__form {
-  padding: $euiSizeXS;
+.queryAssist {
+  &.queryAssist__form {
+    padding: 0 $euiSizeXS $euiSizeXS;
+  }
+
+  &.queryAssist__callout {
+    margin-top: $euiSizeXS;
+  }
+
+  &.queryAssist__banner {
+    margin: 0 $euiSizeXS $euiSizeXS;
+  }
 }

--- a/src/plugins/query_enhancements/public/query_assist/_index.scss
+++ b/src/plugins/query_enhancements/public/query_assist/_index.scss
@@ -11,8 +11,4 @@
   &.queryAssist__callout {
     margin-top: $euiSizeXS;
   }
-
-  &.queryAssist__banner {
-    margin: 0 $euiSizeXS $euiSizeXS;
-  }
 }

--- a/src/plugins/query_enhancements/public/query_assist/components/__snapshots__/call_outs.test.tsx.snap
+++ b/src/plugins/query_enhancements/public/query_assist/components/__snapshots__/call_outs.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CallOuts spec should display empty_index call out 1`] = `
 <div>
   <div
-    class="euiCallOut euiCallOut--warning euiCallOut--small"
+    class="euiCallOut euiCallOut--warning euiCallOut--small queryAssist queryAssist__callout"
     data-test-subj="query-assist-empty-index-callout"
   >
     <div
@@ -30,7 +30,7 @@ exports[`CallOuts spec should display empty_index call out 1`] = `
 exports[`CallOuts spec should display empty_query call out 1`] = `
 <div>
   <div
-    class="euiCallOut euiCallOut--warning euiCallOut--small"
+    class="euiCallOut euiCallOut--warning euiCallOut--small queryAssist queryAssist__callout"
     data-test-subj="query-assist-empty-query-callout"
   >
     <div
@@ -57,7 +57,7 @@ exports[`CallOuts spec should display empty_query call out 1`] = `
 exports[`CallOuts spec should display invalid_query call out 1`] = `
 <div>
   <div
-    class="euiCallOut euiCallOut--danger euiCallOut--small"
+    class="euiCallOut euiCallOut--danger euiCallOut--small queryAssist queryAssist__callout"
     data-test-subj="query-assist-guard-callout"
   >
     <div
@@ -84,7 +84,7 @@ exports[`CallOuts spec should display invalid_query call out 1`] = `
 exports[`CallOuts spec should display query_generated call out 1`] = `
 <div>
   <div
-    class="euiCallOut euiCallOut--success euiCallOut--small"
+    class="euiCallOut euiCallOut--success euiCallOut--small queryAssist queryAssist__callout"
     data-test-subj="query-assist-query-generated-callout"
   >
     <div

--- a/src/plugins/query_enhancements/public/query_assist/components/call_outs.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/call_outs.tsx
@@ -22,6 +22,7 @@ export type QueryAssistCallOutType =
 
 const EmptyIndexCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
   <EuiCallOut
+    className="queryAssist queryAssist__callout"
     data-test-subj="query-assist-empty-index-callout"
     title={
       <FormattedMessage
@@ -39,6 +40,7 @@ const EmptyIndexCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
 
 const ProhibitedQueryCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
   <EuiCallOut
+    className="queryAssist queryAssist__callout"
     data-test-subj="query-assist-guard-callout"
     title={
       <FormattedMessage
@@ -56,6 +58,7 @@ const ProhibitedQueryCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
 
 const EmptyQueryCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
   <EuiCallOut
+    className="queryAssist queryAssist__callout"
     data-test-subj="query-assist-empty-query-callout"
     title={
       <FormattedMessage
@@ -73,6 +76,7 @@ const EmptyQueryCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
 
 const QueryGeneratedCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
   <EuiCallOut
+    className="queryAssist queryAssist__callout"
     data-test-subj="query-assist-query-generated-callout"
     title={
       <FormattedMessage

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
@@ -40,7 +40,7 @@ export const QueryAssistBanner: React.FC<QueryAssistBannerProps> = (props) => {
 
   return (
     <EuiCallOut
-      className="queryAssist queryAssist__banner"
+      className="queryAssist"
       size="s"
       title={
         <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
@@ -40,6 +40,7 @@ export const QueryAssistBanner: React.FC<QueryAssistBannerProps> = (props) => {
 
   return (
     <EuiCallOut
+      className="queryAssist queryAssist__banner"
       size="s"
       title={
         <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
@@ -87,7 +87,7 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
   if (props.dependencies.isCollapsed) return null;
 
   return (
-    <EuiForm component="form" onSubmit={onSubmit} className="queryAssist__form">
+    <EuiForm component="form" onSubmit={onSubmit} className="queryAssist queryAssist__form">
       <EuiFormRow fullWidth>
         <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
           <EuiFlexItem>

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
@@ -36,7 +36,7 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
   const [callOutType, setCallOutType] = useState<QueryAssistCallOutType>();
   const dismissCallout = () => setCallOutType(undefined);
   const [selectedDataSet, setSelectedDataSet] = useState<SimpleDataSet | undefined>(
-    services.data.query.dataSet.getDataSet()
+    services.data.query.dataSetManager.getDataSet()
   );
   const selectedIndex = selectedDataSet?.title;
   const previousQuestionRef = useRef<string>();

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
@@ -87,7 +87,7 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
   if (props.dependencies.isCollapsed) return null;
 
   return (
-    <EuiForm component="form" onSubmit={onSubmit}>
+    <EuiForm component="form" onSubmit={onSubmit} className="queryAssist__form">
       <EuiFormRow fullWidth>
         <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
           <EuiFlexItem>

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
@@ -35,7 +35,9 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
   const { generateQuery, loading } = useGenerateQuery();
   const [callOutType, setCallOutType] = useState<QueryAssistCallOutType>();
   const dismissCallout = () => setCallOutType(undefined);
-  const [selectedDataSet, setSelectedDataSet] = useState<SimpleDataSet>();
+  const [selectedDataSet, setSelectedDataSet] = useState<SimpleDataSet | undefined>(
+    services.data.query.dataSet.getDataSet()
+  );
   const selectedIndex = selectedDataSet?.title;
   const previousQuestionRef = useRef<string>();
 

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -26,7 +26,7 @@ const getAvailableLanguages$ = (
   data: DataPublicPluginSetup
 ) =>
   data.query.dataSetManager.getUpdates$().pipe(
-    startWith(data.query.dataSet.getDataSet()),
+    startWith(data.query.dataSetManager.getDataSet()),
     distinctUntilChanged(),
     switchMap(async (simpleDataSet) => {
       // currently query assist tool relies on opensearch API to get index

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -5,7 +5,7 @@
 
 import { HttpSetup } from 'opensearch-dashboards/public';
 import React, { useEffect, useState } from 'react';
-import { distinctUntilChanged, map, switchMap } from 'rxjs/operators';
+import { distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators';
 import { SIMPLE_DATA_SOURCE_TYPES } from '../../../../data/common';
 import {
   DataPublicPluginSetup,
@@ -26,6 +26,7 @@ const getAvailableLanguages$ = (
   data: DataPublicPluginSetup
 ) =>
   data.query.dataSetManager.getUpdates$().pipe(
+    startWith(data.query.dataSet.getDataSet()),
     distinctUntilChanged(),
     switchMap(async (simpleDataSet) => {
       // currently query assist tool relies on opensearch API to get index


### PR DESCRIPTION
### Description

- this commit added `skip(1)` back to dataset manager observable: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7492/commits/fef6156f92096e178a3e28a97c221ca344d70d28, we need to revert changes done in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7464#discussion_r1690583570
  - revert dataset manager observable usage in query assist to support `skip(1)`
  - revert dataset manager tests
- #7546 removed query editor header div, this PR adds it back to enable query editor extensions

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
