### PR TITLE
[discover-next] disable show doc links for PPL

### DIFF
--- a/changelogs/fragments/7585.yml
+++ b/changelogs/fragments/7585.yml
@@ -1,0 +1,2 @@
+fix:
+- Do not show surround doc links for PPL ([#7585](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7585))

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -86,6 +86,7 @@ export class QueryEnhancementsPlugin
             filterable: false,
             visualizable: false,
           },
+          showDocLinks: false,
           supportedAppNames: ['discover'],
         },
       },


### PR DESCRIPTION
### Description

Disabling showing the surrounding doc links for PPL that require specific DSL queries.

### Issues Resolved

n/a

## Changelog
- fix: do not show surround doc links for PPL

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
