### PR TITLE
[Look&Feel] Use semantic headers for page, modal, & flyouts across the board

### DIFF
--- a/changelogs/fragments/7616.yml
+++ b/changelogs/fragments/7616.yml
@@ -1,0 +1,2 @@
+Refactor:
+- [Look&Feel] Use semantic headers for page, modal, & flyouts across the board ([#7616](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7616))

--- a/src/plugins/advanced_settings/public/component_registry/page_title/__snapshots__/page_title.test.tsx.snap
+++ b/src/plugins/advanced_settings/public/component_registry/page_title/__snapshots__/page_title.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PageTitle should render normally 1`] = `
-<EuiText>
+<EuiText
+  size="s"
+>
   <h1
     data-test-subj="managementSettingsTitle"
   >

--- a/src/plugins/advanced_settings/public/component_registry/page_title/page_title.tsx
+++ b/src/plugins/advanced_settings/public/component_registry/page_title/page_title.tsx
@@ -34,7 +34,7 @@ import { FormattedMessage } from '@osd/i18n/react';
 
 export const PageTitle = () => {
   return (
-    <EuiText>
+    <EuiText size="s">
       <h1 data-test-subj="managementSettingsTitle">
         <FormattedMessage id="advancedSettings.pageTitle" defaultMessage="Settings" />
       </h1>

--- a/src/plugins/console/public/application/components/__snapshots__/import_flyout.test.tsx.snap
+++ b/src/plugins/console/public/application/components/__snapshots__/import_flyout.test.tsx.snap
@@ -27,23 +27,25 @@ exports[`ImportFlyout Component renders correctly 1`] = `
           <div
             className="euiFlyoutHeader euiFlyoutHeader--hasBorder"
           >
-            <EuiTitle
-              size="m"
+            <EuiText
+              size="s"
             >
-              <h2
-                className="euiTitle euiTitle--medium"
+              <div
+                className="euiText euiText--small"
               >
-                <FormattedMessage
-                  defaultMessage="Import queries"
-                  id="console.ImportFlyout.importQueriesTitle"
-                  values={Object {}}
-                >
-                  <span>
-                    Import queries
-                  </span>
-                </FormattedMessage>
-              </h2>
-            </EuiTitle>
+                <h2>
+                  <FormattedMessage
+                    defaultMessage="Import queries"
+                    id="console.ImportFlyout.importQueriesTitle"
+                    values={Object {}}
+                  >
+                    <span>
+                      Import queries
+                    </span>
+                  </FormattedMessage>
+                </h2>
+              </div>
+            </EuiText>
           </div>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>

--- a/src/plugins/console/public/application/components/help_panel.tsx
+++ b/src/plugins/console/public/application/components/help_panel.tsx
@@ -30,14 +30,7 @@
 
 import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
-import {
-  EuiText,
-  EuiFlyout,
-  EuiFlyoutHeader,
-  EuiFlyoutBody,
-  EuiTitle,
-  EuiSpacer,
-} from '@elastic/eui';
+import { EuiText, EuiFlyout, EuiFlyoutHeader, EuiFlyoutBody, EuiSpacer } from '@elastic/eui';
 import { EditorExample } from './editor_example';
 
 interface Props {
@@ -48,11 +41,11 @@ export function HelpPanel(props: Props) {
   return (
     <EuiFlyout onClose={props.onClose} data-test-subj="helpFlyout" size="s">
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="m">
+        <EuiText size="s">
           <h2>
             <FormattedMessage id="console.helpPage.pageTitle" defaultMessage="Help" />
           </h2>
-        </EuiTitle>
+        </EuiText>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <EuiText>

--- a/src/plugins/console/public/application/components/import_flyout.tsx
+++ b/src/plugins/console/public/application/components/import_flyout.tsx
@@ -6,7 +6,6 @@
 import {
   EuiFlyout,
   EuiFlyoutHeader,
-  EuiTitle,
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiCallOut,
@@ -276,14 +275,14 @@ export const ImportFlyout = ({ close, refresh }: ImportFlyoutProps) => {
   return (
     <EuiFlyout onClose={close} size="s">
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="m">
+        <EuiText size="s">
           <h2>
             <FormattedMessage
               id="console.ImportFlyout.importQueriesTitle"
               defaultMessage="Import queries"
             />
           </h2>
-        </EuiTitle>
+        </EuiText>
       </EuiFlyoutHeader>
 
       <EuiFlyoutBody>

--- a/src/plugins/console/public/application/components/settings_modal.tsx
+++ b/src/plugins/console/public/application/components/settings_modal.tsx
@@ -45,6 +45,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiCompressedSwitch,
+  EuiText,
 } from '@elastic/eui';
 
 import { DevToolsSettings } from '../../services';
@@ -179,7 +180,14 @@ export function DevToolsSettingsModal(props: Props) {
     >
       <EuiModalHeader>
         <EuiModalHeaderTitle>
-          <FormattedMessage id="console.settingsPage.pageTitle" defaultMessage="Console Settings" />
+          <EuiText size="s">
+            <h2>
+              <FormattedMessage
+                id="console.settingsPage.pageTitle"
+                defaultMessage="Console Settings"
+              />
+            </h2>
+          </EuiText>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
 

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/header/header.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/header/header.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 
-import { EuiSpacer, EuiTitle, EuiText, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
+import { EuiSpacer, EuiText, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import { useOpenSearchDashboards } from '../../../../../../opensearch_dashboards_react/public';
@@ -25,7 +25,7 @@ export const Header = () => {
     <EuiFlexGroup justifyContent="spaceBetween">
       <EuiFlexItem grow={false}>
         <div>
-          <EuiTitle>
+          <EuiText size="s">
             <h1 data-test-subj="createDataSourceHeader">
               {
                 <FormattedMessage
@@ -34,7 +34,7 @@ export const Header = () => {
                 />
               }
             </h1>
-          </EuiTitle>
+          </EuiText>
           <EuiSpacer size="s" />
           <EuiText>
             <p>

--- a/src/plugins/data_source_management/public/components/data_source_creation_panel/__snapshots__/create_data_source_panel_header.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_creation_panel/__snapshots__/create_data_source_panel_header.test.tsx.snap
@@ -8,15 +8,17 @@ exports[`CreateDataSourcePanelHeader renders correctly 1`] = `
   <EuiFlexItem
     grow={false}
   >
-    <EuiTitle>
-      <h2>
+    <EuiText
+      size="s"
+    >
+      <h1>
         <FormattedMessage
           defaultMessage="Create Data Source"
           id="dataSourcesManagement.createDataSourcePanel.title"
           values={Object {}}
         />
-      </h2>
-    </EuiTitle>
+      </h1>
+    </EuiText>
     <EuiSpacer
       size="s"
     />

--- a/src/plugins/data_source_management/public/components/data_source_creation_panel/create_data_source_panel_header.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_creation_panel/create_data_source_panel_header.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { CreateDataSourcePanelHeader } from './create_data_source_panel_header';
-import { EuiFlexGroup, EuiTitle, EuiText } from '@elastic/eui';
+import { EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 
 describe('CreateDataSourcePanelHeader', () => {
@@ -20,11 +20,11 @@ describe('CreateDataSourcePanelHeader', () => {
   test('contains correct title and description', () => {
     const wrapper = shallowComponent();
 
-    const titleMessage = wrapper.find(EuiTitle).find(FormattedMessage);
+    const titleMessage = wrapper.find(EuiText).at(0).find(FormattedMessage);
     expect(titleMessage.prop('id')).toEqual('dataSourcesManagement.createDataSourcePanel.title');
     expect(titleMessage.prop('defaultMessage')).toEqual('Create Data Source');
 
-    const descriptionMessage = wrapper.find(EuiText).find(FormattedMessage);
+    const descriptionMessage = wrapper.find(EuiText).at(1).find(FormattedMessage);
     expect(descriptionMessage.prop('id')).toEqual(
       'dataSourcesManagement.createDataSourcePanel.description'
     );

--- a/src/plugins/data_source_management/public/components/data_source_creation_panel/create_data_source_panel_header.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_creation_panel/create_data_source_panel_header.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
 
@@ -11,14 +11,14 @@ export const CreateDataSourcePanelHeader: React.FC = () => {
   return (
     <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiTitle>
-          <h2>
+        <EuiText size="s">
+          <h1>
             <FormattedMessage
               id="dataSourcesManagement.createDataSourcePanel.title"
               defaultMessage="Create Data Source"
             />
-          </h2>
-        </EuiTitle>
+          </h1>
+        </EuiText>
         <EuiSpacer size="s" />
         <EuiText>
           <p>

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/__snapshots__/data_source_page_header.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/__snapshots__/data_source_page_header.test.tsx.snap
@@ -8,15 +8,17 @@ exports[`DataSourceHeader renders correctly 1`] = `
   <EuiFlexItem
     grow={false}
   >
-    <EuiTitle>
-      <h2>
+    <EuiText
+      size="s"
+    >
+      <h1>
         <FormattedMessage
           defaultMessage="Data Sources"
           id="dataSourcesManagement.dataSourcesTable.title"
           values={Object {}}
         />
-      </h2>
-    </EuiTitle>
+      </h1>
+    </EuiText>
     <EuiSpacer
       size="s"
     />

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_page_header.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_page_header.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { DataSourceHeader } from './data_source_page_header';
-import { EuiTitle, EuiText } from '@elastic/eui';
+import { EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 
 describe('DataSourceHeader', () => {
@@ -25,12 +25,11 @@ describe('DataSourceHeader', () => {
 
   test('contains correct title and description', () => {
     const wrapper = shallowComponent();
-
-    const titleMessage = wrapper.find(EuiTitle).find(FormattedMessage);
+    const titleMessage = wrapper.find(EuiText).at(0).find(FormattedMessage);
     expect(titleMessage.prop('id')).toEqual('dataSourcesManagement.dataSourcesTable.title');
     expect(titleMessage.prop('defaultMessage')).toEqual('Data Sources');
 
-    const descriptionMessage = wrapper.find(EuiText).find(FormattedMessage);
+    const descriptionMessage = wrapper.find(EuiText).at(1).find(FormattedMessage);
     expect(descriptionMessage.prop('id')).toEqual(
       'dataSourcesManagement.dataSourcesTable.description'
     );

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_page_header.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_page_header.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
 import { RouteComponentProps } from 'react-router-dom';
@@ -14,14 +14,14 @@ export const DataSourceHeader: React.FC<DataSourceHeaderProps> = () => {
   return (
     <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiTitle>
-          <h2>
+        <EuiText size="s">
+          <h1>
             <FormattedMessage
               id="dataSourcesManagement.dataSourcesTable.title"
               defaultMessage="Data Sources"
             />
-          </h2>
-        </EuiTitle>
+          </h1>
+        </EuiText>
         <EuiSpacer size="s" />
         <EuiText>
           <p>

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/acceleration_creation/create/create_acceleration_header.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/acceleration_creation/create/create_acceleration_header.tsx
@@ -3,14 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  EuiLink,
-  EuiPageHeader,
-  EuiPageHeaderSection,
-  EuiSpacer,
-  EuiText,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiLink, EuiPageHeader, EuiPageHeaderSection, EuiSpacer, EuiText } from '@elastic/eui';
 import React from 'react';
 import { OPENSEARCH_ACC_DOCUMENTATION_URL } from '../../../constants';
 
@@ -19,9 +12,9 @@ export const CreateAccelerationHeader = () => {
     <div>
       <EuiPageHeader>
         <EuiPageHeaderSection>
-          <EuiTitle size="l" data-test-subj="acceleration-header">
+          <EuiText size="s" data-test-subj="acceleration-header">
             <h1>Accelerate data</h1>
-          </EuiTitle>
+          </EuiText>
         </EuiPageHeaderSection>
       </EuiPageHeader>
       <EuiSpacer size="s" />

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/connection_detail/direct_query_connection_detail.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/connection_detail/direct_query_connection_detail.tsx
@@ -11,7 +11,6 @@ import {
   EuiPageHeaderSection,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiTitle,
   EuiPanel,
   EuiSpacer,
   EuiText,
@@ -434,9 +433,9 @@ export const DirectQueryDataConnectionDetail: React.FC<DirectQueryDataConnection
           <EuiPageHeaderSection style={{ width: '100%', justifyContent: 'space-between' }}>
             <EuiFlexGroup>
               <EuiFlexItem grow={false}>
-                <EuiTitle data-test-subj="datasourceTitle" size="l">
+                <EuiText data-test-subj="datasourceTitle" size="s">
                   <h1>{datasourceDetails.name}</h1>
-                </EuiTitle>
+                </EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiPageHeaderSection>

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/amazon_s3/__snapshots__/configure_amazon_s3_data_source.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/amazon_s3/__snapshots__/configure_amazon_s3_data_source.test.tsx.snap
@@ -148,13 +148,17 @@ exports[`ConfigureS3DatasourcePanel renders correctly 1`] = `
             <div
               className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <EuiTitle>
-                <h1
-                  className="euiTitle euiTitle--medium"
+              <EuiText
+                size="s"
+              >
+                <div
+                  className="euiText euiText--small"
                 >
-                  Configure Amazon S3 data source
-                </h1>
-              </EuiTitle>
+                  <h1>
+                    Configure Amazon S3 data source
+                  </h1>
+                </div>
+              </EuiText>
               <EuiSpacer
                 size="s"
               >

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/amazon_s3/__snapshots__/review_amazon_s3_data_source.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/amazon_s3/__snapshots__/review_amazon_s3_data_source.test.tsx.snap
@@ -57,14 +57,19 @@ exports[`ReviewS3Datasource renders correctly 1`] = `
           <div
             className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <EuiTitle>
-              <h1
-                className="euiTitle euiTitle--medium"
-                data-test-subj="reviewTitle"
+            <EuiText
+              size="s"
+            >
+              <div
+                className="euiText euiText--small"
               >
-                Review Amazon S3 data source configuration
-              </h1>
-            </EuiTitle>
+                <h1
+                  data-test-subj="reviewTitle"
+                >
+                  Review Amazon S3 data source configuration
+                </h1>
+              </div>
+            </EuiText>
             <EuiSpacer
               size="s"
             >

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/amazon_s3/configure_amazon_s3_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/amazon_s3/configure_amazon_s3_data_source.tsx
@@ -86,9 +86,9 @@ export const ConfigureS3DatasourcePanel: React.FC<ConfigureS3DatasourceProps> = 
   return (
     <div>
       <EuiPanel>
-        <EuiTitle>
+        <EuiText size="s">
           <h1>{`Configure Amazon S3 data source`}</h1>
-        </EuiTitle>
+        </EuiText>
         <EuiSpacer size="s" />
         <EuiCallOut title="Setup Amazon EMR as execution engine first" iconType="iInCircle">
           <EuiText size="s" color="subdued">

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/amazon_s3/review_amazon_s3_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/amazon_s3/review_amazon_s3_data_source.tsx
@@ -5,7 +5,6 @@
 
 import {
   EuiPanel,
-  EuiTitle,
   EuiSpacer,
   EuiText,
   EuiFlexGroup,
@@ -41,9 +40,9 @@ export const ReviewS3Datasource = (props: ConfigureS3DatasourceProps) => {
   return (
     <div>
       <EuiPanel>
-        <EuiTitle>
+        <EuiText size="s">
           <h1 data-test-subj="reviewTitle">{`Review Amazon S3 data source configuration`}</h1>
-        </EuiTitle>
+        </EuiText>
         <EuiSpacer size="s" />
         <EuiSpacer />
         <EuiFlexGroup justifyContent="spaceBetween">

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/prometheus/__snapshots__/configure_prometheus_data_source.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/prometheus/__snapshots__/configure_prometheus_data_source.test.tsx.snap
@@ -74,13 +74,17 @@ exports[`ConfigurePrometheusDatasourcePanel renders correctly 1`] = `
           <div
             className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <EuiTitle>
-              <h4
-                className="euiTitle euiTitle--medium"
+            <EuiText
+              size="s"
+            >
+              <div
+                className="euiText euiText--small"
               >
-                Configure Prometheus data source
-              </h4>
-            </EuiTitle>
+                <h1>
+                  Configure Prometheus data source
+                </h1>
+              </div>
+            </EuiText>
             <EuiSpacer
               size="s"
             >

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/prometheus/__snapshots__/review_prometheus_data_source.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/prometheus/__snapshots__/review_prometheus_data_source.test.tsx.snap
@@ -57,14 +57,19 @@ exports[`ReviewPrometheusDatasource renders correctly 1`] = `
           <div
             className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <EuiTitle>
-              <h1
-                className="euiTitle euiTitle--medium"
-                data-test-subj="reviewTitle"
+            <EuiText
+              size="s"
+            >
+              <div
+                className="euiText euiText--small"
               >
-                Review Prometheus data source configuration
-              </h1>
-            </EuiTitle>
+                <h1
+                  data-test-subj="reviewTitle"
+                >
+                  Review Prometheus data source configuration
+                </h1>
+              </div>
+            </EuiText>
             <EuiSpacer
               size="s"
             >

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/prometheus/configure_prometheus_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/prometheus/configure_prometheus_data_source.tsx
@@ -5,7 +5,6 @@
 
 import {
   EuiPanel,
-  EuiTitle,
   EuiSpacer,
   EuiText,
   EuiLink,
@@ -88,9 +87,9 @@ export const ConfigurePrometheusDatasourcePanel = (props: ConfigurePrometheusDat
   return (
     <div>
       <EuiPanel>
-        <EuiTitle>
-          <h4>{`Configure Prometheus data source`}</h4>
-        </EuiTitle>
+        <EuiText size="s">
+          <h1>{`Configure Prometheus data source`}</h1>
+        </EuiText>
         <EuiSpacer size="s" />
         <EuiText size="s" color="subdued">
           {`Connect to Prometheus with OpenSearch and OpenSearch Dashboards. `}

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/prometheus/review_prometheus_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_source_configuration/prometheus/review_prometheus_data_source.tsx
@@ -5,7 +5,6 @@
 
 import {
   EuiPanel,
-  EuiTitle,
   EuiSpacer,
   EuiText,
   EuiFlexGroup,
@@ -41,9 +40,9 @@ export const ReviewPrometheusDatasource = (props: ConfigurePrometheusDatasourceP
   return (
     <div>
       <EuiPanel>
-        <EuiTitle>
+        <EuiText size="s">
           <h1 data-test-subj="reviewTitle">{`Review Prometheus data source configuration`}</h1>
-        </EuiTitle>
+        </EuiText>
         <EuiSpacer size="s" />
         <EuiSpacer />
         <EuiFlexGroup justifyContent="spaceBetween">

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.tsx
@@ -7,7 +7,6 @@ import React, { useState } from 'react';
 
 import {
   EuiSpacer,
-  EuiTitle,
   EuiFlexItem,
   EuiFlexGroup,
   EuiToolTip,
@@ -15,6 +14,7 @@ import {
   EuiConfirmModal,
   EuiSmallButton,
   EuiSmallButtonEmpty,
+  EuiText,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
@@ -166,9 +166,9 @@ export const Header = ({
       {/* Title */}
       <EuiFlexItem grow={false}>
         <div>
-          <EuiTitle data-test-subj="editDataSourceTitle">
+          <EuiText size="s" data-test-subj="editDataSourceTitle">
             <h1>{dataSourceName}</h1>
-          </EuiTitle>
+          </EuiText>
           <EuiSpacer size="s" />
         </div>
       </EuiFlexItem>

--- a/src/plugins/home/public/application/components/tutorial_directory.js
+++ b/src/plugins/home/public/application/components/tutorial_directory.js
@@ -44,8 +44,8 @@ import {
   EuiFlexGrid,
   EuiFlexGroup,
   EuiSpacer,
-  EuiTitle,
   EuiPageBody,
+  EuiText,
 } from '@elastic/eui';
 
 import { getTutorials } from '../load_tutorials';
@@ -280,14 +280,14 @@ class TutorialDirectoryUi extends React.Component {
       <>
         <EuiFlexGroup alignItems="center">
           <EuiFlexItem>
-            <EuiTitle size="l">
+            <EuiText size="s">
               <h1>
                 <FormattedMessage
                   id="home.tutorial.addDataToOpenSearchDashboardsTitle"
                   defaultMessage="Add sample data"
                 />
               </h1>
-            </EuiTitle>
+            </EuiText>
           </EuiFlexItem>
           {headerLinks ? <EuiFlexItem grow={false}>{headerLinks}</EuiFlexItem> : null}
         </EuiFlexGroup>

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/__snapshots__/header.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/__snapshots__/header.test.tsx.snap
@@ -23,24 +23,28 @@ exports[`Header should render a different name, prompt, and beta tag if provided
     }
   >
     <div>
-      <EuiTitle>
-        <h1
-          className="euiTitle euiTitle--medium"
+      <EuiText
+        size="s"
+      >
+        <div
+          className="euiText euiText--small"
         >
-          Create test index pattern
-           
-          <EuiBetaBadge
-            label="Beta"
-          >
-            <span
-              className="euiBetaBadge euiBetaBadge--hollow"
-              title="Beta"
+          <h1>
+            Create test index pattern
+             
+            <EuiBetaBadge
+              label="Beta"
             >
-              Beta
-            </span>
-          </EuiBetaBadge>
-        </h1>
-      </EuiTitle>
+              <span
+                className="euiBetaBadge euiBetaBadge--hollow"
+                title="Beta"
+              >
+                Beta
+              </span>
+            </EuiBetaBadge>
+          </h1>
+        </div>
+      </EuiText>
       <EuiSpacer
         size="s"
       >
@@ -158,13 +162,17 @@ exports[`Header should render normally 1`] = `
     indexPatternName="test index pattern"
   >
     <div>
-      <EuiTitle>
-        <h1
-          className="euiTitle euiTitle--medium"
+      <EuiText
+        size="s"
+      >
+        <div
+          className="euiText euiText--small"
         >
-          Create test index pattern
-        </h1>
-      </EuiTitle>
+          <h1>
+            Create test index pattern
+          </h1>
+        </div>
+      </EuiText>
       <EuiSpacer
         size="s"
       >
@@ -272,13 +280,17 @@ exports[`Header should render without including system indices 1`] = `
     indexPatternName="test index pattern"
   >
     <div>
-      <EuiTitle>
-        <h1
-          className="euiTitle euiTitle--medium"
+      <EuiText
+        size="s"
+      >
+        <div
+          className="euiText euiText--small"
         >
-          Create test index pattern
-        </h1>
-      </EuiTitle>
+          <h1>
+            Create test index pattern
+          </h1>
+        </div>
+      </EuiText>
       <EuiSpacer
         size="s"
       >

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/header/header.tsx
@@ -30,7 +30,7 @@
 
 import React from 'react';
 
-import { EuiBetaBadge, EuiSpacer, EuiTitle, EuiText, EuiCode, EuiLink } from '@elastic/eui';
+import { EuiBetaBadge, EuiSpacer, EuiText, EuiCode, EuiLink } from '@elastic/eui';
 
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
@@ -63,7 +63,7 @@ export const Header = ({
 
   return (
     <div>
-      <EuiTitle>
+      <EuiText size="s">
         <h1>
           {createIndexPatternHeader}
           {isBeta ? (
@@ -77,7 +77,7 @@ export const Header = ({
             </>
           ) : null}
         </h1>
-      </EuiTitle>
+      </EuiText>
       <EuiSpacer size="s" />
       <EuiText>
         <p>

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/index_header/index_header.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/index_header/index_header.tsx
@@ -30,7 +30,7 @@
 
 import React from 'react';
 import { i18n } from '@osd/i18n';
-import { EuiFlexGroup, EuiToolTip, EuiFlexItem, EuiTitle, EuiSmallButtonIcon } from '@elastic/eui';
+import { EuiFlexGroup, EuiToolTip, EuiFlexItem, EuiSmallButtonIcon, EuiText } from '@elastic/eui';
 import { IIndexPattern } from 'src/plugins/data/public';
 
 interface IndexHeaderProps {
@@ -81,9 +81,9 @@ export function IndexHeader({
   return (
     <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
       <EuiFlexItem>
-        <EuiTitle>
+        <EuiText size="s">
           <h1 data-test-subj="indexPatternTitle">{indexPattern.title}</h1>
-        </EuiTitle>
+        </EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiFlexGroup responsive={false}>

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -38,7 +38,6 @@ import {
   EuiText,
   EuiBadgeGroup,
   EuiPageContent,
-  EuiTitle,
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
@@ -265,9 +264,9 @@ export const IndexPatternTable = ({ canSave, history }: Props) => {
       <EuiPageContent data-test-subj="indexPatternTable" role="region" aria-label={ariaRegion}>
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem grow={false}>
-            <EuiTitle>
-              <h2>{title}</h2>
-            </EuiTitle>
+            <EuiText size="s">
+              <h1>{title}</h1>
+            </EuiText>
             <EuiSpacer size="s" />
             <EuiText>
               <p>

--- a/src/plugins/management_overview/public/__snapshots__/application.test.tsx.snap
+++ b/src/plugins/management_overview/public/__snapshots__/application.test.tsx.snap
@@ -8,13 +8,15 @@ exports[`Overview page rendering should render normally 1`] = `
   <main
     class="euiPageBody euiPageBody--borderRadiusNone"
   >
-    <h1
-      class="euiTitle euiTitle--large"
+    <div
+      class="euiText euiText--small"
     >
-      <span>
-        Overview
-      </span>
-    </h1>
+      <h1>
+        <span>
+          Overview
+        </span>
+      </h1>
+    </div>
     <div
       class="euiSpacer euiSpacer--l"
     />

--- a/src/plugins/management_overview/public/application.tsx
+++ b/src/plugins/management_overview/public/application.tsx
@@ -6,7 +6,7 @@
 import ReactDOM from 'react-dom';
 import { I18nProvider, FormattedMessage } from '@osd/i18n/react';
 import React, { useMemo } from 'react';
-import { EuiFlexGrid, EuiFlexItem, EuiPage, EuiPageBody, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiFlexGrid, EuiFlexItem, EuiPage, EuiPageBody, EuiSpacer, EuiText } from '@elastic/eui';
 import useObservable from 'react-use/lib/useObservable';
 import { ApplicationStart, AppNavLinkStatus, CoreStart } from '../../../core/public';
 import { OverviewApp } from '.';
@@ -31,11 +31,11 @@ export function ManagementOverviewWrapper(props: ManagementOverviewProps) {
   return (
     <EuiPage restrictWidth={1200}>
       <EuiPageBody component="main">
-        <EuiTitle size="l">
+        <EuiText size="s">
           <h1>
             <FormattedMessage id="management.overview.overviewTitle" defaultMessage="Overview" />
           </h1>
-        </EuiTitle>
+        </EuiText>
         <EuiSpacer />
         <EuiFlexGrid columns={3}>
           {availableApps?.map((app) => (

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
@@ -837,15 +837,21 @@ exports[`SavedObjectsTable export should allow the user to choose when exporting
 >
   <EuiModalHeader>
     <EuiModalHeaderTitle>
-      <FormattedMessage
-        defaultMessage="Export {filteredItemCount, plural, one{# object} other {# objects}}"
-        id="savedObjectsManagement.objectsTable.exportObjectsConfirmModalTitle"
-        values={
-          Object {
-            "filteredItemCount": 4,
-          }
-        }
-      />
+      <EuiText
+        size="s"
+      >
+        <h2>
+          <FormattedMessage
+            defaultMessage="Export {filteredItemCount, plural, one{# object} other {# objects}}"
+            id="savedObjectsManagement.objectsTable.exportObjectsConfirmModalTitle"
+            values={
+              Object {
+                "filteredItemCount": 4,
+              }
+            }
+          />
+        </h2>
+      </EuiText>
     </EuiModalHeaderTitle>
   </EuiModalHeader>
   <EuiModalBody>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/flyout.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/flyout.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`Flyout conflicts should allow conflict resolution 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
-      size="m"
+    <EuiText
+      size="s"
     >
       <h2>
         <FormattedMessage
@@ -18,7 +18,7 @@ exports[`Flyout conflicts should allow conflict resolution 1`] = `
           values={Object {}}
         />
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <EuiSpacer
@@ -272,8 +272,8 @@ exports[`Flyout legacy conflicts should allow conflict resolution 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
-      size="m"
+    <EuiText
+      size="s"
     >
       <h2>
         <FormattedMessage
@@ -282,7 +282,7 @@ exports[`Flyout legacy conflicts should allow conflict resolution 1`] = `
           values={Object {}}
         />
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <EuiSpacer
@@ -536,8 +536,8 @@ exports[`Flyout should render cluster selector and import options when datasourc
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
-      size="m"
+    <EuiText
+      size="s"
     >
       <h2>
         <FormattedMessage
@@ -546,7 +546,7 @@ exports[`Flyout should render cluster selector and import options when datasourc
           values={Object {}}
         />
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <EuiForm>
@@ -692,8 +692,8 @@ exports[`Flyout should render import step 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
-      size="m"
+    <EuiText
+      size="s"
     >
       <h2>
         <FormattedMessage
@@ -702,7 +702,7 @@ exports[`Flyout should render import step 1`] = `
           values={Object {}}
         />
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <EuiForm>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/relationships.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/relationships.test.tsx.snap
@@ -7,14 +7,14 @@ exports[`Relationships from legacy app should render dashboards normally 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
+    <EuiText
       className="eui-textBreakWord"
-      size="m"
+      size="s"
     >
       <h2>
         MyDashboard
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <div>
@@ -155,14 +155,14 @@ exports[`Relationships from legacy app should render errors 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
+    <EuiText
       className="eui-textBreakWord"
-      size="m"
+      size="s"
     >
       <h2>
         MyDashboard
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <EuiCallOut
@@ -190,14 +190,14 @@ exports[`Relationships from legacy app should render index patterns normally 1`]
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
+    <EuiText
       className="eui-textBreakWord"
-      size="m"
+      size="s"
     >
       <h2>
         MyIndexPattern*
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <div>
@@ -343,14 +343,14 @@ exports[`Relationships from legacy app should render searches normally 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
+    <EuiText
       className="eui-textBreakWord"
-      size="m"
+      size="s"
     >
       <h2>
         MySearch
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <div>
@@ -496,14 +496,14 @@ exports[`Relationships from legacy app should render visualizations normally 1`]
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
+    <EuiText
       className="eui-textBreakWord"
-      size="m"
+      size="s"
     >
       <h2>
         MyViz
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <div>
@@ -644,14 +644,14 @@ exports[`Relationships should render augment-vis objects normally 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
+    <EuiText
       className="eui-textBreakWord"
-      size="m"
+      size="s"
     >
       <h2>
         MyAugmentVisObject
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <div>
@@ -778,14 +778,14 @@ exports[`Relationships should render dashboards normally 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
+    <EuiText
       className="eui-textBreakWord"
-      size="m"
+      size="s"
     >
       <h2>
         MyDashboard
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <div>
@@ -926,14 +926,14 @@ exports[`Relationships should render errors 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
+    <EuiText
       className="eui-textBreakWord"
-      size="m"
+      size="s"
     >
       <h2>
         MyDashboard
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <EuiCallOut
@@ -961,14 +961,14 @@ exports[`Relationships should render index patterns normally 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
+    <EuiText
       className="eui-textBreakWord"
-      size="m"
+      size="s"
     >
       <h2>
         MyIndexPattern*
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <div>
@@ -1114,14 +1114,14 @@ exports[`Relationships should render searches normally 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
+    <EuiText
       className="eui-textBreakWord"
-      size="m"
+      size="s"
     >
       <h2>
         MySearch
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <div>
@@ -1267,14 +1267,14 @@ exports[`Relationships should render visualizations normally 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle
+    <EuiText
       className="eui-textBreakWord"
-      size="m"
+      size="s"
     >
       <h2>
         MyViz
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <div>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
@@ -1027,14 +1027,14 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
     return (
       <EuiFlyout onClose={close} size="s">
         <EuiFlyoutHeader hasBorder>
-          <EuiTitle size="m">
+          <EuiText size="s">
             <h2>
               <FormattedMessage
                 id="savedObjectsManagement.objectsTable.flyout.importSavedObjectTitle"
                 defaultMessage="Import saved objects"
               />
             </h2>
-          </EuiTitle>
+          </EuiText>
         </EuiFlyoutHeader>
 
         <EuiFlyoutBody>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/relationships.tsx
@@ -30,7 +30,6 @@
 
 import React, { Component } from 'react';
 import {
-  EuiTitle,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
@@ -336,9 +335,9 @@ export class Relationships extends Component<RelationshipsProps, RelationshipsSt
     return (
       <EuiFlyout onClose={close}>
         <EuiFlyoutHeader hasBorder>
-          <EuiTitle size="m" className="eui-textBreakWord">
+          <EuiText size="s" className="eui-textBreakWord">
             <h2>{savedObject.meta.title || getDefaultTitle(savedObject)}</h2>
-          </EuiTitle>
+          </EuiText>
         </EuiFlyoutHeader>
 
         <EuiFlyoutBody>{this.renderRelationships()}</EuiFlyoutBody>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -960,13 +960,17 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
       <EuiModal onClose={this.closeExportAllModal}>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <FormattedMessage
-              id="savedObjectsManagement.objectsTable.exportObjectsConfirmModalTitle"
-              defaultMessage="Export {filteredItemCount, plural, one{# object} other {# objects}}"
-              values={{
-                filteredItemCount,
-              }}
-            />
+            <EuiText size="s">
+              <h2>
+                <FormattedMessage
+                  id="savedObjectsManagement.objectsTable.exportObjectsConfirmModalTitle"
+                  defaultMessage="Export {filteredItemCount, plural, one{# object} other {# objects}}"
+                  values={{
+                    filteredItemCount,
+                  }}
+                />
+              </h2>
+            </EuiText>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
         <EuiModalBody>


### PR DESCRIPTION
### Description

This PR updates headers to be within small OuiText in pages, modals, and flyouts across OSD experiences.

## Screenshot

### Index Patterns
| Scope | Before (Inspect) | After (Inspect) | After |
| ----- | ----- | ----- | ----- |
| Create | <img width="554" alt="Create Before" src="https://github.com/user-attachments/assets/6523823e-e7ad-40be-bddd-334ee0be6e21"> | <img width="554" alt="Create Post 1" src="https://github.com/user-attachments/assets/5632c6ab-668f-4a60-b5b7-8bfdd0fad293"> | <img width="554" alt="Create Post 2" src="https://github.com/user-attachments/assets/4ebcd4f1-13bb-4b76-a630-ab07b4d4c206"> |
| Page | <img width="554" alt="Index Pattern Page Before" src="https://github.com/user-attachments/assets/ebbda8d5-b8bd-4e01-bbbe-8fc845ed7d8c"> | <img width="554" alt="Index Pattern Page Post 1" src="https://github.com/user-attachments/assets/81cd040a-bf2f-4155-b824-1bd4c544759a"> | <img width="554" alt="Index Pattern Page Post 2" src="https://github.com/user-attachments/assets/bf6f5c1a-7bbc-45f1-adcb-6c1fcc7f6555"> |
| Table | <img width="569" alt="Index Patterns Table Before" src="https://github.com/user-attachments/assets/04d67907-d11a-4c2e-8f35-d2ef3547b8db"> |  <img width="690" alt="Table Post 1" src="https://github.com/user-attachments/assets/404c4edb-bdba-464a-aad4-10fa62937e68"> | <img width="690" alt="Table Post 2" src="https://github.com/user-attachments/assets/e8d8d225-e49a-46ab-9ec3-6e25b2e2a554"> |

### Data Sources
| Scope | Before (Inspect) | After (Inspect) | After |
| ----- | ----- | ----- | ----- |
| Accelerate | <img width="428" alt="Accelerate Data Before" src="https://github.com/user-attachments/assets/99f20aa3-23ab-4c11-a697-ef0bb0cdf7df"> | <img width="428" alt="Accelerate Data Post 1" src="https://github.com/user-attachments/assets/f4255240-ad77-4a2e-815b-977f2000b3ca"> | <img width="428" alt="Accelerate Data Post 2" src="https://github.com/user-attachments/assets/3a923bac-c8cf-4436-b861-374f8602efa6"> |
| Connection | <img width="455" alt="Connection Before" src="https://github.com/user-attachments/assets/68ddfdf5-c01d-4ee7-813e-b7d84fbe1979"> | <img width="455" alt="Connection Post 1" src="https://github.com/user-attachments/assets/285dcab2-0fa9-4d88-84e7-bfa34f149a25"> | <img width="455" alt="Connection Post 2" src="https://github.com/user-attachments/assets/bbda2cbd-6fae-4c2d-bed5-9eef33e2b70e"> |
| Connection: Create | <img width="640" alt="Create connection Before" src="https://github.com/user-attachments/assets/dd36becb-cbf3-4d49-b183-aa6e2d3ca79f"> | <img width="640" alt="Create connection Post 1" src="https://github.com/user-attachments/assets/ad8c6893-0833-45ae-8ec8-10bbf0346906"> | <img width="640" alt="Create connection Post 2" src="https://github.com/user-attachments/assets/8449e22b-8f77-47a7-938f-7b9f2af21198"> |
| Create Data Source | <img width="690" alt="Create Before" src="https://github.com/user-attachments/assets/9871968d-4806-4600-b0e6-946884b6bfb9"> | <img width="690" alt="Create Post 1" src="https://github.com/user-attachments/assets/c773977d-b0d9-4d9c-81b7-119c43e8c10c"> | <img width="690" alt="Create Post 2" src="https://github.com/user-attachments/assets/183a4bbc-d557-44df-8990-ef4bdb4b9d63"> |
| Direct | <img width="428" alt="Direct Before" src="https://github.com/user-attachments/assets/e2b65ab1-b4f6-41b6-8a8e-295d7ff3567d"> | <img width="428" alt="Direct Post 1" src="https://github.com/user-attachments/assets/5cdbad67-6678-4aa0-b2e5-6dabc3e03cfd"> | <img width="428" alt="Direct Post 2" src="https://github.com/user-attachments/assets/dc0cdd95-4996-4168-bcf0-9f5061a17c9a"> | 
| Home | <img width="690" alt="Home Before" src="https://github.com/user-attachments/assets/e5b3ffe3-0855-41a3-be5a-7bb217ed198b"> | <img width="690" alt="Home Post 1" src="https://github.com/user-attachments/assets/3d55544b-f26a-45df-a4d1-548c033dade2"> | <img width="690" alt="Home Post 2" src="https://github.com/user-attachments/assets/88bb9491-ff9d-45b2-8a67-dacb58ceba74"> |
| S3 | <img width="513" alt="S3 Before Inspect" src="https://github.com/user-attachments/assets/d96a6511-e585-4eed-a57e-72f94f3afa83"> | <img width="513" alt="S3 Post Inspect" src="https://github.com/user-attachments/assets/c9913030-f3b6-4a3a-8078-632e2740a632"> | <img width="513" alt="S3 Post " src="https://github.com/user-attachments/assets/aed490d4-19b3-4dd9-8601-e0b596a16e35"> 
| Prometheus: Configure | <img width="690" alt="Prometheus Configure Before" src="https://github.com/user-attachments/assets/27ea8256-94e7-44e4-9867-374d7a563497"> | <img width="690" alt="Prometheus Configure Post 1" src="https://github.com/user-attachments/assets/a4a0cbc6-b668-428b-9763-45bbdbb17406"> | <img width="690" alt="Prometheus Configure Post 2" src="https://github.com/user-attachments/assets/9a210756-d5c2-4674-9623-7685c83b08e0"> |
| Prometheus: Review | <img width="690" alt="Prometheus Review Before" src="https://github.com/user-attachments/assets/26b50f40-c4f7-4e10-87fc-63dcafa0f09e"> | <img width="690" alt="Prometheus Review Post 1" src="https://github.com/user-attachments/assets/87dcfb79-8ce4-4e43-a141-40a574d96967"> | <img width="690" alt="Prometheus Review Post 2" src="https://github.com/user-attachments/assets/72696117-1a4f-4704-8b9e-f285470f9ea0"> |



### Saved Objects
| Scope | Before (Inspect) | After (Inspect) | After |
| ----- | ----- | ----- | ----- |
| Import | <img width="393" alt="Import Before Inspect" src="https://github.com/user-attachments/assets/2620859f-aec7-4098-becb-1251f5a5d997"> | <img width="393" alt="Import Post Inspect" src="https://github.com/user-attachments/assets/fa1776d7-bb17-4ad5-a69a-f5ba9a6fa0a8"> | <img width="393" alt="Import Post" src="https://github.com/user-attachments/assets/baa87689-612c-4c7e-9cdd-ea9eb4140b70"> | 
| Export | <img width="427" alt="Export Before" src="https://github.com/user-attachments/assets/62385e37-ee77-4321-9439-6df474187ca0"> | <img width="427" alt="Export Post 1" src="https://github.com/user-attachments/assets/c95f2d06-b2b2-4376-8fd5-931f2f68476f"> | <img width="427" alt="Export Post 2" src="https://github.com/user-attachments/assets/8b2cb170-87ba-4043-9c6e-2bfb2bdcb5d1"> |
| Flyout | <img width="554" alt="Flyout Before" src="https://github.com/user-attachments/assets/f50a65e1-1285-4c4f-9c83-bef0632abc3d"> | <img width="554" alt="Flyout Post 1" src="https://github.com/user-attachments/assets/79e9ed12-6679-473a-a29e-c75884d4387a"> | <img width="554" alt="Flyout Post 2" src="https://github.com/user-attachments/assets/cd528861-12cd-4b42-8090-a378676ffba7"> |

### Other
| Scope | Before (Inspect) | After (Inspect) | After |
| ----- | ----- | ----- | ----- |
| Overview | <img width="640" alt="Overview Before" src="https://github.com/user-attachments/assets/3e91343d-7098-457e-94b6-fa860752fece"> | <img width="640" alt="Overview Post 1" src="https://github.com/user-attachments/assets/c0966e68-fe65-4cd0-b3a3-61091b6f1ae8"> | <img width="640" alt="Overview Post 2" src="https://github.com/user-attachments/assets/0958bba7-0e0c-43eb-b947-568741f7c4aa"> |
| Settings | <img width="615" alt="Settings Before Inspect" src="https://github.com/user-attachments/assets/892d9581-cdb7-494b-9220-27312dd5d240"> | <img width="615" alt="Settings Post Inspect" src="https://github.com/user-attachments/assets/06c3f1eb-acba-4ad5-9b38-21d437b77869"> | <img width="615" alt="Settings Post" src="https://github.com/user-attachments/assets/e4371f61-4d07-4962-9df1-5cbfa97d0cca"> |
| Sample Data | <img width="506" alt="Sample Data Before" src="https://github.com/user-attachments/assets/6b12251d-b984-40d0-9f12-3ad5f0a12e5f"> | <img width="506" alt="Sample Data Post 1" src="https://github.com/user-attachments/assets/3777c9f8-036c-4bce-b4c3-35ef23a50451"> | <img width="506" alt="Sample Data Post 2" src="https://github.com/user-attachments/assets/156f566d-dad6-43d3-8123-bfae117680ff"> |

## Changelog
- Refactor: [Look&Feel] Use semantic headers for page, modal, & flyouts across the board

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
