### PR TITLE
fix: get start section cards not aligned

### DIFF
--- a/changelogs/fragments/7624.yml
+++ b/changelogs/fragments/7624.yml
@@ -1,0 +1,2 @@
+fix:
+- [contentManagement] display cards by specifying a column size or display all cards in one row ([#7624](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7624))

--- a/src/plugins/content_management/public/components/card_container/card_container.tsx
+++ b/src/plugins/content_management/public/components/card_container/card_container.tsx
@@ -5,17 +5,11 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Container, ContainerInput, EmbeddableStart } from '../../../../embeddable/public';
+import { Container, EmbeddableStart } from '../../../../embeddable/public';
 import { CardList } from './card_list';
+import { CardContainerInput } from './types';
 
 export const CARD_CONTAINER = 'CARD_CONTAINER';
-
-export type CardContainerInput = ContainerInput<{
-  description: string;
-  onClick?: () => void;
-  getIcon?: () => React.ReactElement;
-  getFooter?: () => React.ReactElement;
-}>;
 
 export class CardContainer extends Container<{}, CardContainerInput> {
   public readonly type = CARD_CONTAINER;

--- a/src/plugins/content_management/public/components/card_container/card_embeddable.tsx
+++ b/src/plugins/content_management/public/components/card_container/card_embeddable.tsx
@@ -13,8 +13,8 @@ export const CARD_EMBEDDABLE = 'card_embeddable';
 export type CardEmbeddableInput = EmbeddableInput & {
   description: string;
   onClick?: () => void;
-  getIcon: () => React.ReactElement;
-  getFooter: () => React.ReactElement;
+  getIcon?: () => React.ReactElement;
+  getFooter?: () => React.ReactElement;
 };
 
 export class CardEmbeddable extends Embeddable<CardEmbeddableInput> {
@@ -37,8 +37,8 @@ export class CardEmbeddable extends Embeddable<CardEmbeddableInput> {
         description={this.input.description}
         display="plain"
         onClick={this.input.onClick}
-        icon={this.input?.getIcon()}
-        footer={this.input?.getFooter()}
+        icon={this.input?.getIcon?.()}
+        footer={this.input?.getFooter?.()}
       />,
       node
     );

--- a/src/plugins/content_management/public/components/card_container/card_list.tsx
+++ b/src/plugins/content_management/public/components/card_container/card_list.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiFlexGrid, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 import {
   IContainer,
@@ -13,11 +13,20 @@ import {
   ContainerOutput,
   EmbeddableStart,
 } from '../../../../embeddable/public';
+import { CardContainerInput } from './types';
 
 interface Props {
   embeddable: IContainer;
-  input: ContainerInput;
+  input: CardContainerInput;
   embeddableServices: EmbeddableStart;
+}
+
+export interface CardExplicitInput {
+  title: string;
+  description: string;
+  onClick?: () => void;
+  getIcon?: () => React.ReactElement;
+  getFooter?: () => React.ReactElement;
 }
 
 const CardListInner = ({ embeddable, input, embeddableServices }: Props) => {
@@ -30,9 +39,9 @@ const CardListInner = ({ embeddable, input, embeddableServices }: Props) => {
     );
   });
   return (
-    <EuiFlexGrid gutterSize="s" columns={4}>
-      {cards}
-    </EuiFlexGrid>
+    <EuiFlexGroup gutterSize="s">
+      {input.columns ? cards.slice(0, input.columns) : cards}
+    </EuiFlexGroup>
   );
 };
 

--- a/src/plugins/content_management/public/components/card_container/card_list.tsx
+++ b/src/plugins/content_management/public/components/card_container/card_list.tsx
@@ -30,6 +30,8 @@ const CardListInner = ({ embeddable, input, embeddableServices }: Props) => {
       </EuiFlexItem>
     );
   });
+
+  // TODO: we should perhaps display the cards in multiple rows when the actual number of cards exceed the column size
   return (
     <EuiFlexGroup gutterSize="s">
       {input.columns ? cards.slice(0, input.columns) : cards}

--- a/src/plugins/content_management/public/components/card_container/card_list.tsx
+++ b/src/plugins/content_management/public/components/card_container/card_list.tsx
@@ -21,14 +21,6 @@ interface Props {
   embeddableServices: EmbeddableStart;
 }
 
-export interface CardExplicitInput {
-  title: string;
-  description: string;
-  onClick?: () => void;
-  getIcon?: () => React.ReactElement;
-  getFooter?: () => React.ReactElement;
-}
-
 const CardListInner = ({ embeddable, input, embeddableServices }: Props) => {
   const cards = Object.values(input.panels).map((panel) => {
     const child = embeddable.getChild(panel.explicitInput.id);

--- a/src/plugins/content_management/public/components/card_container/types.ts
+++ b/src/plugins/content_management/public/components/card_container/types.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { ContainerInput } from '../../../../embeddable/public';
 
 export interface CardExplicitInput {

--- a/src/plugins/content_management/public/components/card_container/types.ts
+++ b/src/plugins/content_management/public/components/card_container/types.ts
@@ -1,0 +1,4 @@
+import { ContainerInput } from '../../../../embeddable/public';
+import { CardExplicitInput } from './card_list';
+
+export type CardContainerInput = ContainerInput<CardExplicitInput> & { columns?: number };

--- a/src/plugins/content_management/public/components/card_container/types.ts
+++ b/src/plugins/content_management/public/components/card_container/types.ts
@@ -1,4 +1,11 @@
 import { ContainerInput } from '../../../../embeddable/public';
-import { CardExplicitInput } from './card_list';
+
+export interface CardExplicitInput {
+  title: string;
+  description: string;
+  onClick?: () => void;
+  getIcon?: () => React.ReactElement;
+  getFooter?: () => React.ReactElement;
+}
 
 export type CardContainerInput = ContainerInput<CardExplicitInput> & { columns?: number };

--- a/src/plugins/content_management/public/components/section_input.ts
+++ b/src/plugins/content_management/public/components/section_input.ts
@@ -10,8 +10,8 @@ import { Content, Section } from '../services';
 import { ViewMode } from '../../../embeddable/public';
 import { DashboardContainerInput, SavedObjectDashboard } from '../../../dashboard/public';
 import { CUSTOM_CONTENT_EMBEDDABLE } from './custom_content_embeddable';
-import { CardContainerInput } from './card_container/card_container';
 import { CARD_EMBEDDABLE } from './card_container/card_embeddable';
+import { CardContainerInput } from './card_container/types';
 
 const DASHBOARD_GRID_COLUMN_COUNT = 48;
 
@@ -30,6 +30,7 @@ export const createCardInput = (
     title: section.title ?? '',
     hidePanelTitles: true,
     viewMode: ViewMode.VIEW,
+    columns: section.columns,
     panels,
   };
 

--- a/src/plugins/content_management/public/services/content_management/types.ts
+++ b/src/plugins/content_management/public/services/content_management/types.ts
@@ -31,6 +31,7 @@ export type Section =
       id: string;
       order: number;
       title?: string;
+      columns?: number;
     };
 
 export type Content =


### PR DESCRIPTION
The column size was hard coded to 4 previously, now changed so that it can be configured, this addressed the issue when there are more than 4 cards, cards will be displayed in multiple rows

### Description

Before
![image](https://github.com/user-attachments/assets/5514c8f4-a7c4-4c69-a254-c1e8569981a8)


After
![image](https://github.com/user-attachments/assets/3dff0528-e544-45c4-a202-471328e1a216)


<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: [contentManagement] display cards by specifying a column size or display all cards in one row

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
