### PR TITLE
fix: do not throw exception if content provider id exists

### DIFF
--- a/changelogs/fragments/7633.yml
+++ b/changelogs/fragments/7633.yml
@@ -1,0 +1,2 @@
+feat:
+- Register section and content with the same id will not throw error but overrides the exist one ([#7633](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7633))

--- a/src/plugins/content_management/public/components/section_input.test.ts
+++ b/src/plugins/content_management/public/components/section_input.test.ts
@@ -246,7 +246,7 @@ test('it should create section with a dashboard as content', async () => {
       id: 'dashboard-id-static',
       attributes: {
         panelsJSON:
-          '[{"version":"3.0.0","gridData":{"x":0,"y":0,"w":48,"h":5,"i":"debc95ec-7d43-49ee-84c8-95ad7b0b03ea"},"panelIndex":"debc95ec-7d43-49ee-84c8-95ad7b0b03ea","embeddableConfig":{"hidePanelTitles":true},"panelRefName":"panel_0"}]',
+          '[{"version":"3.0.0","gridData":{"x":0,"y":0,"w":48,"h":5,"i":"i"},"panelIndex":"1","embeddableConfig":{"hidePanelTitles":true},"panelRefName":"panel_0"}]',
       },
       references: [
         { id: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2', name: 'panel_0', type: 'visualization' },
@@ -258,14 +258,14 @@ test('it should create section with a dashboard as content', async () => {
     savedObjectsClient: clientMock,
   });
   expect(input.panels).toEqual({
-    'debc95ec-7d43-49ee-84c8-95ad7b0b03ea': {
+    'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2': {
       explicitInput: {
-        id: 'debc95ec-7d43-49ee-84c8-95ad7b0b03ea',
+        id: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
         savedObjectId: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
       },
       gridData: {
         h: 5,
-        i: 'debc95ec-7d43-49ee-84c8-95ad7b0b03ea',
+        i: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
         w: 48,
         x: 0,
         y: 0,
@@ -292,7 +292,7 @@ test('it should create section with a dynamic dashboard as content', async () =>
       id: 'dashboard-id-static',
       attributes: {
         panelsJSON:
-          '[{"version":"3.0.0","gridData":{"x":0,"y":0,"w":48,"h":5,"i":"debc95ec-7d43-49ee-84c8-95ad7b0b03ea"},"panelIndex":"debc95ec-7d43-49ee-84c8-95ad7b0b03ea","embeddableConfig":{"hidePanelTitles":true},"panelRefName":"panel_0"}]',
+          '[{"version":"3.0.0","gridData":{"x":0,"y":0,"w":48,"h":5,"i":"1"},"panelIndex":"1","embeddableConfig":{"hidePanelTitles":true},"panelRefName":"panel_0"}]',
       },
       references: [
         { id: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2', name: 'panel_0', type: 'visualization' },
@@ -304,14 +304,14 @@ test('it should create section with a dynamic dashboard as content', async () =>
     savedObjectsClient: clientMock,
   });
   expect(input.panels).toEqual({
-    'debc95ec-7d43-49ee-84c8-95ad7b0b03ea': {
+    'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2': {
       explicitInput: {
-        id: 'debc95ec-7d43-49ee-84c8-95ad7b0b03ea',
+        id: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
         savedObjectId: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
       },
       gridData: {
         h: 5,
-        i: 'debc95ec-7d43-49ee-84c8-95ad7b0b03ea',
+        i: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
         w: 48,
         x: 0,
         y: 0,

--- a/src/plugins/content_management/public/components/section_input.ts
+++ b/src/plugins/content_management/public/components/section_input.ts
@@ -103,11 +103,11 @@ export const createDashboardInput = async (
                 }
                 const reference = references.find((ref) => ref.name === panel.panelRefName);
                 if (reference) {
-                  panels[panel.panelIndex] = {
-                    gridData: panel.gridData,
+                  panels[reference.id] = {
+                    gridData: { ...panel.gridData, i: reference.id },
                     type: reference.type,
                     explicitInput: {
-                      id: panel.panelIndex,
+                      id: reference.id,
                       savedObjectId: reference.id,
                     },
                   };

--- a/src/plugins/content_management/public/services/content_management/content_management_service.ts
+++ b/src/plugins/content_management/public/services/content_management/content_management_service.ts
@@ -33,10 +33,6 @@ export class ContentManagementService {
   };
 
   registerContentProvider = (provider: ContentProvider) => {
-    if (this.contentProviders.get(provider.id)) {
-      throw new Error(`Cannot register content provider with the same id ${provider.id}`);
-    }
-
     this.contentProviders.set(provider.id, provider);
 
     const targetArea = provider.getTargetArea();

--- a/src/plugins/content_management/public/services/content_management/page.test.ts
+++ b/src/plugins/content_management/public/services/content_management/page.test.ts
@@ -17,12 +17,12 @@ test('it should create sections', () => {
   expect(page.getSections()).toHaveLength(2);
 });
 
-test('it should not create section with existing id', () => {
+test('creating section with the same id should override the previous section', () => {
   const page = new Page({ id: 'page1' });
   page.createSection({ id: 'section1', kind: 'dashboard', order: 2000 });
-  expect(() =>
-    page.createSection({ id: 'section1', kind: 'dashboard', order: 1000 })
-  ).toThrowError();
+  page.createSection({ id: 'section1', kind: 'card', order: 1000 });
+  expect(page.getSections()).toHaveLength(1);
+  expect(page.getSections()[0]).toEqual({ id: 'section1', kind: 'card', order: 1000 });
 });
 
 test('it should return sections in order', () => {
@@ -99,6 +99,65 @@ test('it should return contents in order', () => {
       kind: 'visualization',
       order: 10,
       input: { kind: 'static', id: 'viz-id-1' },
+    },
+  ]);
+});
+
+test('it should only allow to add one dashboard to a section', () => {
+  const page = new Page({ id: 'page1' });
+  page.createSection({ id: 'dashboard-section', kind: 'dashboard', order: 1000 });
+
+  page.addContent('dashboard-section', {
+    id: 'dashboard-content-1',
+    kind: 'dashboard',
+    order: 10,
+    input: { kind: 'static', id: 'dashboard-id-1' },
+  });
+
+  // add another dashboard to the same section
+  page.addContent('dashboard-section', {
+    id: 'dashboard-content-1',
+    kind: 'dashboard',
+    order: 10,
+    input: { kind: 'static', id: 'dashboard-id-1' },
+  });
+
+  // but it should only have one dashboard content
+  expect(page.getContents('dashboard-section')).toHaveLength(1);
+  expect(page.getContents('dashboard-section')).toEqual([
+    {
+      id: 'dashboard-content-1',
+      kind: 'dashboard',
+      order: 10,
+      input: { kind: 'static', id: 'dashboard-id-1' },
+    },
+  ]);
+
+  // add non-dashboard content to a section which already has a dashboard will override the dashboard
+  page.addContent('dashboard-section', {
+    id: 'vis-content-1',
+    kind: 'visualization',
+    order: 10,
+    input: { kind: 'static', id: 'vis-id-1' },
+  });
+  page.addContent('dashboard-section', {
+    id: 'vis-content-2',
+    kind: 'visualization',
+    order: 20,
+    input: { kind: 'static', id: 'vis-id-2' },
+  });
+  expect(page.getContents('dashboard-section')).toEqual([
+    {
+      id: 'vis-content-1',
+      kind: 'visualization',
+      order: 10,
+      input: { kind: 'static', id: 'vis-id-1' },
+    },
+    {
+      id: 'vis-content-2',
+      kind: 'visualization',
+      order: 20,
+      input: { kind: 'static', id: 'vis-id-2' },
     },
   ]);
 });

--- a/src/plugins/content_management/public/services/content_management/page.ts
+++ b/src/plugins/content_management/public/services/content_management/page.ts
@@ -41,7 +41,6 @@ export class Page {
        */
       if (content.kind === 'dashboard' || sectionContents.some((c) => c.kind === 'dashboard')) {
         sectionContents.length = 0;
-        console.warn('Section type "dashboard" can only have one content type of "dashboard"');
       }
       sectionContents.push(content);
       // sort content by order


### PR DESCRIPTION
Instead of throw error when register section or content with the same id, now changed to override the existing ones.

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- feat: register section and content with the same id will not throw error but overrides the exist one

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
