### PR TITLE
Move set default data source before workspace update

### DIFF
--- a/src/plugins/workspace/server/workspace_client.test.ts
+++ b/src/plugins/workspace/server/workspace_client.test.ts
@@ -181,6 +181,24 @@ describe('#WorkspaceClient', () => {
     expect(mockCheckAndSetDefaultDataSource).toHaveBeenCalledWith(uiSettingsClient, ['id1'], true);
   });
 
+  it('update# should log error when failed set default data source', async () => {
+    const client = new WorkspaceClient(coreSetup, logger);
+    await client.setup(coreSetup);
+    client?.setSavedObjects(savedObjects);
+    client?.setUiSettings(uiSettings);
+    mockCheckAndSetDefaultDataSource.mockRejectedValueOnce(new Error());
+
+    await client.update(mockRequestDetail, mockWorkspaceId, {
+      name: mockWorkspaceName,
+      permissions: {},
+      dataSources: ['id1'],
+    });
+
+    expect(logger.error).toHaveBeenLastCalledWith(
+      'Set default data source error during workspace updating'
+    );
+  });
+
   it('delete# should unassign data source before deleting related saved objects', async () => {
     const client = new WorkspaceClient(coreSetup, logger);
     await client.setup(coreSetup);

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -220,7 +220,7 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
     const { permissions, dataSources: newDataSources, ...attributes } = payload;
     try {
       const client = this.getSavedObjectClientsFromRequestDetail(requestDetail);
-      const workspaceInDB: SavedObject<WorkspaceAttribute> = await client.get(WORKSPACE_TYPE, id);
+      let workspaceInDB: SavedObject<WorkspaceAttribute> = await client.get(WORKSPACE_TYPE, id);
       if (workspaceInDB.attributes.name !== attributes.name) {
         const existingWorkspaceRes = await this.getScopedClientWithoutPermission(
           requestDetail
@@ -265,6 +265,17 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
         }
       }
 
+      if (newDataSources && this.uiSettings && client) {
+        const uiSettingsClient = this.uiSettings.asScopedToClient(client);
+        try {
+          await checkAndSetDefaultDataSource(uiSettingsClient, newDataSources, true);
+          // Doc version may changed after default data source updated.
+          workspaceInDB = await client.get(WORKSPACE_TYPE, id);
+        } catch (error) {
+          this.logger.error('Set default data source error during workspace updating');
+        }
+      }
+
       await client.create<Omit<WorkspaceAttribute, 'id'>>(
         WORKSPACE_TYPE,
         { ...workspaceInDB.attributes, ...attributes },
@@ -275,11 +286,6 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
           version: workspaceInDB.version,
         }
       );
-
-      if (newDataSources && this.uiSettings && client) {
-        const uiSettingsClient = this.uiSettings.asScopedToClient(client);
-        checkAndSetDefaultDataSource(uiSettingsClient, newDataSources, true);
-      }
 
       return {
         success: true,


### PR DESCRIPTION
### Description

This PR is for fixing dev server crash after un-assign self as a workspace owner. In previous implementation, the set default data source will be called after permission updated. The user won't have `write` permission to the workspace. So the set default data source operation will be failed and throw exception. Then there will be a unhandled promise rejection. Move set default data source before workspace update to avoid this issue. 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
No UI Changes.

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: [Workspace] Move set default source order to avoid dev server crash

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
