### PR TITLE
feat: [contentManagement] allow to update section input after page rendered

### DIFF
--- a/changelogs/fragments/7651.yml
+++ b/changelogs/fragments/7651.yml
@@ -1,0 +1,2 @@
+feat:
+- [contentManagement] allow to update section input after page rendered ([#7651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7651))

--- a/src/plugins/content_management/public/components/card_container/types.ts
+++ b/src/plugins/content_management/public/components/card_container/types.ts
@@ -14,3 +14,8 @@ export interface CardExplicitInput {
 }
 
 export type CardContainerInput = ContainerInput<CardExplicitInput> & { columns?: number };
+
+/**
+ * The props which allow to be updated after card container was created
+ */
+export type CardContainerExplicitInput = Partial<Pick<CardContainerInput, 'title' | 'columns'>>;

--- a/src/plugins/content_management/public/components/section_input.test.ts
+++ b/src/plugins/content_management/public/components/section_input.test.ts
@@ -7,7 +7,7 @@ import { coreMock } from '../../../../core/public/mocks';
 import { Content, Section } from '../services';
 import { createCardInput, createDashboardInput } from './section_input';
 
-test('it should create input for card section', () => {
+test('it should create card section input', () => {
   const section: Section = { id: 'section1', kind: 'card', order: 10 };
   const content: Content = {
     id: 'content1',
@@ -22,6 +22,41 @@ test('it should create input for card section', () => {
     title: '',
     hidePanelTitles: true,
     viewMode: 'view',
+    panels: {
+      content1: {
+        type: 'card_embeddable',
+        explicitInput: {
+          description: 'content description',
+          id: 'content1',
+          onClick: undefined,
+          title: 'content title',
+        },
+      },
+    },
+  });
+});
+
+test('it should create card section input with explicit input specified', () => {
+  const section: Section = {
+    id: 'section1',
+    kind: 'card',
+    order: 10,
+    input: { title: 'new title', columns: 4 },
+  };
+  const content: Content = {
+    id: 'content1',
+    kind: 'card',
+    order: 0,
+    title: 'content title',
+    description: 'content description',
+  };
+  const input = createCardInput(section, [content]);
+  expect(input).toEqual({
+    id: 'section1',
+    title: 'new title',
+    hidePanelTitles: true,
+    viewMode: 'view',
+    columns: 4,
     panels: {
       content1: {
         type: 'card_embeddable',
@@ -79,7 +114,12 @@ test('it should throw error if creating dashboard input with non-dashboard secti
 });
 
 test('it should create dashboard input', async () => {
-  const section: Section = { id: 'section1', kind: 'dashboard', order: 10 };
+  const section: Section = {
+    id: 'section1',
+    kind: 'dashboard',
+    order: 10,
+    input: { timeRange: { from: 'now-1d', to: 'now' } },
+  };
   const staticViz: Content = {
     id: 'content1',
     kind: 'visualization',
@@ -111,6 +151,9 @@ test('it should create dashboard input', async () => {
   const input = await createDashboardInput(section, [staticViz, dynamicViz, customRender], {
     savedObjectsClient: clientMock,
   });
+
+  // with explicit section input
+  expect(input.timeRange).toEqual({ from: 'now-1d', to: 'now' });
 
   expect(input.panels).toEqual({
     content1: {

--- a/src/plugins/content_management/public/components/section_input.ts
+++ b/src/plugins/content_management/public/components/section_input.ts
@@ -32,6 +32,7 @@ export const createCardInput = (
     viewMode: ViewMode.VIEW,
     columns: section.columns,
     panels,
+    ...section.input,
   };
 
   contents.forEach((content) => {
@@ -74,7 +75,7 @@ export const createDashboardInput = async (
   const h = 15;
   const counter = new BehaviorSubject(0);
 
-  contents.forEach(async (content, i) => {
+  contents.forEach(async (content) => {
     counter.next(counter.value + 1);
     try {
       if (content.kind === 'dashboard') {
@@ -164,29 +165,27 @@ export const createDashboardInput = async (
     }
   });
 
-  /**
-   * TODO: the input should be hooked with query input
-   */
   const input: DashboardContainerInput = {
-    viewMode: ViewMode.VIEW,
     panels,
+    id: section.id,
+    title: section.title ?? '',
+    viewMode: ViewMode.VIEW,
+    useMargins: true,
     isFullScreenMode: false,
     filters: [],
-    useMargins: true,
-    id: section.id,
     timeRange: {
       to: 'now',
       from: 'now-7d',
     },
-    title: section.title ?? 'test',
     query: {
       query: '',
-      language: 'lucene',
+      language: 'kuery',
     },
     refreshConfig: {
       pause: true,
       value: 15,
     },
+    ...section.input,
   };
 
   return new Promise<DashboardContainerInput>((resolve) => {

--- a/src/plugins/content_management/public/components/types.ts
+++ b/src/plugins/content_management/public/components/types.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { DashboardContainerInput } from '../../../dashboard/public';
 
 export type DashboardContainerExplicitInput = Partial<

--- a/src/plugins/content_management/public/components/types.ts
+++ b/src/plugins/content_management/public/components/types.ts
@@ -1,0 +1,5 @@
+import { DashboardContainerInput } from '../../../dashboard/public';
+
+export type DashboardContainerExplicitInput = Partial<
+  Pick<DashboardContainerInput, 'filters' | 'timeRange' | 'query'>
+>;

--- a/src/plugins/content_management/public/plugin.ts
+++ b/src/plugins/content_management/public/plugin.ts
@@ -64,6 +64,7 @@ export class ContentManagementPublicPlugin
     this.contentManagementService.start();
     return {
       registerContentProvider: this.contentManagementService.registerContentProvider,
+      updatePageSection: this.contentManagementService.updatePageSection,
       renderPage: (id: string) => {
         const page = this.contentManagementService.getPage(id);
         if (page) {

--- a/src/plugins/content_management/public/services/content_management/content_management_service.test.ts
+++ b/src/plugins/content_management/public/services/content_management/content_management_service.test.ts
@@ -69,3 +69,25 @@ test('it should throw error when register content provider with invalid target a
     })
   ).toThrowError();
 });
+
+test('it should throw error if update page section with invalid target area', () => {
+  const cms = new ContentManagementService();
+  cms.registerPage({ id: 'page1', sections: [{ id: 'section1', kind: 'card', order: 0 }] });
+  expect(() => cms.updatePageSection('invalid_target_area', jest.fn())).toThrowError();
+});
+
+test('it should update page section', () => {
+  const cms = new ContentManagementService();
+  cms.registerPage({ id: 'page1', sections: [{ id: 'section1', kind: 'card', order: 0 }] });
+  cms.updatePageSection(
+    'page1/section1',
+    jest.fn().mockReturnValue({ id: 'section1', kind: 'card', input: { title: 'new title' } })
+  );
+  expect(cms.getPage('page1')?.getSections()).toHaveLength(1);
+  expect(cms.getPage('page1')?.getSections()[0]).toEqual({
+    id: 'section1',
+    kind: 'card',
+    order: 0,
+    input: { title: 'new title' },
+  });
+});

--- a/src/plugins/content_management/public/services/content_management/content_management_service.ts
+++ b/src/plugins/content_management/public/services/content_management/content_management_service.ts
@@ -4,7 +4,7 @@
  */
 
 import { Page } from './page';
-import { ContentProvider, PageConfig } from './types';
+import { ContentProvider, PageConfig, Section } from './types';
 
 export class ContentManagementService {
   contentProviders: Map<string, ContentProvider> = new Map();
@@ -45,6 +45,22 @@ export class ContentManagementService {
     const page = this.getPage(pageId);
     if (page) {
       page.addContent(sectionId, provider.getContent());
+    }
+  };
+
+  updatePageSection = (
+    targetArea: string,
+    callback: (section: Section | null, err?: Error) => Section | null
+  ) => {
+    const [pageId, sectionId] = targetArea.split('/');
+
+    if (!pageId || !sectionId) {
+      throw new Error('getTargetArea() should return a string in format {pageId}/{sectionId}');
+    }
+
+    const page = this.getPage(pageId);
+    if (page) {
+      page.updateSectionInput(sectionId, callback);
     }
   };
 

--- a/src/plugins/content_management/public/services/content_management/page.test.ts
+++ b/src/plugins/content_management/public/services/content_management/page.test.ts
@@ -161,3 +161,106 @@ test('it should only allow to add one dashboard to a section', () => {
     },
   ]);
 });
+
+test('it should update dashboard section with new input', () => {
+  const page = new Page({ id: 'page1' });
+  page.createSection({
+    id: 'section_id',
+    kind: 'dashboard',
+    order: 1000,
+    input: { timeRange: { from: 'now-7d', to: 'now' } },
+  });
+  expect(page.getSections()).toHaveLength(1);
+  expect(page.getSections()[0]).toEqual({
+    id: 'section_id',
+    kind: 'dashboard',
+    order: 1000,
+    input: { timeRange: { from: 'now-7d', to: 'now' } },
+  });
+
+  page.updateSectionInput('section_id', (section) => {
+    if (section?.kind === 'dashboard') {
+      return { ...section, input: { timeRange: { from: 'now-1d', to: 'now' } } };
+    }
+    return section;
+  });
+
+  expect(page.getSections()[0]).toEqual({
+    id: 'section_id',
+    kind: 'dashboard',
+    order: 1000,
+    input: { timeRange: { from: 'now-1d', to: 'now' } },
+  });
+});
+
+test('it should update card section with new input', () => {
+  const page = new Page({ id: 'page1' });
+  page.createSection({
+    id: 'section_id',
+    kind: 'card',
+    order: 1000,
+    input: {},
+  });
+  expect(page.getSections()).toHaveLength(1);
+  expect(page.getSections()[0]).toEqual({
+    id: 'section_id',
+    kind: 'card',
+    order: 1000,
+    input: {},
+  });
+
+  page.updateSectionInput('section_id', (section) => {
+    if (section?.kind === 'card') {
+      return { ...section, input: { title: 'new title' } };
+    }
+    return section;
+  });
+
+  expect(page.getSections()[0]).toEqual({
+    id: 'section_id',
+    kind: 'card',
+    order: 1000,
+    input: { title: 'new title' },
+  });
+});
+
+test('it should not allow to update section property other than `input`', () => {
+  const page = new Page({ id: 'page1' });
+  page.createSection({
+    id: 'section_id',
+    kind: 'dashboard',
+    order: 1000,
+    input: { timeRange: { from: 'now-7d', to: 'now' } },
+  });
+  expect(page.getSections()).toHaveLength(1);
+  expect(page.getSections()[0]).toEqual({
+    id: 'section_id',
+    kind: 'dashboard',
+    order: 1000,
+    input: { timeRange: { from: 'now-7d', to: 'now' } },
+  });
+
+  // update the section with new kind: custom and new id: section_id_new
+  page.updateSectionInput('section_id', (section) => {
+    if (section?.kind === 'dashboard') {
+      return { ...section, id: 'section_id_new', kind: 'custom', render: jest.fn() };
+    }
+    return section;
+  });
+
+  // section should not changed as it only allows to update `section.input` field
+  expect(page.getSections()[0]).toEqual({
+    id: 'section_id',
+    kind: 'dashboard',
+    order: 1000,
+    input: { timeRange: { from: 'now-7d', to: 'now' } },
+  });
+});
+
+test('it should callback with error if section not exist', () => {
+  const page = new Page({ id: 'page1' });
+  const callbackMock = jest.fn();
+  page.updateSectionInput('section_id_not_exist', callbackMock);
+  expect(callbackMock.mock.calls[0][0]).toBe(null);
+  expect(callbackMock.mock.calls[0][1]).toBeInstanceOf(Error);
+});

--- a/src/plugins/content_management/public/services/content_management/page.ts
+++ b/src/plugins/content_management/public/services/content_management/page.ts
@@ -18,9 +18,13 @@ export class Page {
     this.config = pageConfig;
   }
 
-  createSection(section: Section) {
+  private setSection(section: Section) {
     this.sections.set(section.id, section);
     this.sections$.next(this.getSections());
+  }
+
+  createSection(section: Section) {
+    this.setSection(section);
   }
 
   getSections() {
@@ -29,6 +33,28 @@ export class Page {
 
   getSections$() {
     return this.sections$;
+  }
+
+  updateSectionInput(
+    sectionId: string,
+    callback: (section: Section | null, err?: Error) => Section | null
+  ) {
+    const section = this.sections.get(sectionId);
+    if (!section) {
+      callback(null, new Error(`Section id ${sectionId} not found`));
+      return;
+    }
+
+    const updated = callback(section);
+    if (updated) {
+      if (updated.kind === 'dashboard' && section.kind === 'dashboard') {
+        this.setSection({ ...section, input: updated.input });
+      }
+      if (updated.kind === 'card' && section.kind === 'card') {
+        this.setSection({ ...section, input: updated.input });
+      }
+      // TODO: we may need to support update input of `custom` section
+    }
   }
 
   addContent(sectionId: string, content: Content) {

--- a/src/plugins/content_management/public/services/content_management/types.ts
+++ b/src/plugins/content_management/public/services/content_management/types.ts
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { CardContainerExplicitInput } from '../../components/card_container/types';
+import { DashboardContainerExplicitInput } from '../../components/types';
+
 export interface PageConfig {
   id: string;
   title?: string;
@@ -25,6 +28,7 @@ export type Section =
       order: number;
       title?: string;
       description?: string;
+      input?: DashboardContainerExplicitInput;
     }
   | {
       kind: 'card';
@@ -32,6 +36,7 @@ export type Section =
       order: number;
       title?: string;
       columns?: number;
+      input?: CardContainerExplicitInput;
     };
 
 export type Content =

--- a/src/plugins/content_management/public/types.ts
+++ b/src/plugins/content_management/public/types.ts
@@ -6,7 +6,7 @@
 import React from 'react';
 import { CoreStart } from 'opensearch-dashboards/public';
 
-import { ContentManagementService, ContentProvider } from './services';
+import { ContentManagementService, ContentProvider, Section } from './services';
 import { EmbeddableSetup, EmbeddableStart } from '../../embeddable/public';
 
 export interface ContentManagementPluginSetup {
@@ -17,6 +17,14 @@ export interface ContentManagementPluginStart {
    * @experimental this API is experimental and might change in future releases
    */
   registerContentProvider: (provider: ContentProvider) => void;
+
+  /**
+   * @experimental this API is experimental and might change in future releases
+   */
+  updatePageSection: (
+    targetArea: string,
+    callback: (section: Section | null, err?: Error) => Section | null
+  ) => void;
   renderPage: (id: string) => React.ReactNode;
 }
 


### PR DESCRIPTION
This PR makes it possible to update the section input after the page is rendered, for example, when rendering a dashboard on the page, we need to apply the date range, filter and query on the fly.

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- feat: [contentManagement] allow to update section input after page rendered

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
