### PR TITLE
Allow customizing `restrictWidth` and `paddingSize` of `TableListView`

### DIFF
--- a/changelogs/fragments/7691.yml
+++ b/changelogs/fragments/7691.yml
@@ -1,0 +1,2 @@
+feat:
+- Allow customizing `restrictWidth` and `paddingSize` of `TableListView` ([#7691](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7691))

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
@@ -46,6 +46,7 @@ import {
   EuiCallOut,
   EuiBasicTableColumn,
   EuiText,
+  EuiPageProps,
 } from '@elastic/eui';
 import { HttpFetchError, ToastsStart } from 'opensearch-dashboards/public';
 import { toMountPoint } from '../util';
@@ -81,6 +82,8 @@ export interface TableListViewProps {
    * If the table is not empty, this component renders its own h1 element using the same id.
    */
   headingId?: string;
+  restrictWidth?: boolean;
+  paddingSize?: EuiPageProps['paddingSize'];
 }
 
 export interface TableListViewState {
@@ -559,7 +562,8 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
       <EuiPage
         data-test-subj={this.props.entityName + 'LandingPage'}
         className="itemListing__page"
-        restrictWidth
+        restrictWidth={this.props.restrictWidth}
+        paddingSize={this.props.paddingSize}
       >
         <EuiPageBody
           component="main"


### PR DESCRIPTION
### Description

Allow customizing `restrictWidth` and `paddingSize` of `TableListView`


## Changelog
- feat: Allow customizing `restrictWidth` and `paddingSize` of `TableListView`

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
